### PR TITLE
fix: address Bugbot followup from PR #5

### DIFF
--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for the Aider agent plugin.
  *
  * Requires:
- *   - `aider` binary on PATH (or at /Users/equinox/Library/Python/3.9/bin/aider)
+ *   - `aider` binary on PATH
  *   - tmux installed and running
  *   - ANTHROPIC_API_KEY or OPENAI_API_KEY set (aider may open a browser if missing)
  *

--- a/packages/integration-tests/src/agent-claude-code.integration.test.ts
+++ b/packages/integration-tests/src/agent-claude-code.integration.test.ts
@@ -2,7 +2,7 @@
  * Integration tests for the Claude Code agent plugin.
  *
  * Requires:
- *   - `claude` binary on PATH (or at /Users/equinox/.local/bin/claude)
+ *   - `claude` binary on PATH
  *   - tmux installed and running
  *   - ANTHROPIC_API_KEY set (Claude will make a real API call)
  *

--- a/packages/integration-tests/src/helpers/tmux.ts
+++ b/packages/integration-tests/src/helpers/tmux.ts
@@ -87,27 +87,3 @@ export async function killSession(name: string): Promise<void> {
   }
 }
 
-/** Check whether a tmux session exists. */
-export async function sessionExists(name: string): Promise<boolean> {
-  try {
-    await execFileAsync("tmux", ["has-session", "-t", name], {
-      timeout: TIMEOUT,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/** Capture the visible pane output from a tmux session. */
-export async function capturePane(
-  name: string,
-  lines = 50,
-): Promise<string> {
-  const { stdout } = await execFileAsync(
-    "tmux",
-    ["capture-pane", "-t", name, "-p", "-S", `-${lines}`],
-    { timeout: TIMEOUT },
-  );
-  return stdout;
-}


### PR DESCRIPTION
## Summary

- Remove stale developer-specific paths from JSDoc comments in integration tests
- Remove unused `sessionExists` and `capturePane` helper exports from tmux helpers

Fixes Bugbot comments left on PR #5 after merge.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — all packages pass
- [x] `pnpm build` — all packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)