### PR TITLE
fix: detect agent exit for all agent types

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -203,13 +203,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const activity = agent.detectActivity(terminalOutput);
           if (activity === "waiting_input") return "needs_input";
 
-          // If the terminal looks idle, check whether the agent process is
-          // still running. An idle terminal with no agent process means the
-          // agent has exited (e.g. finished its task or crashed).
-          if (activity === "idle") {
-            const processAlive = await agent.isProcessRunning(session.runtimeHandle);
-            if (!processAlive) return "killed";
-          }
+          // Check whether the agent process is still alive. Some agents
+          // (codex, aider, opencode) return "active" for any non-empty
+          // terminal output, including the shell prompt visible after exit.
+          // Checking isProcessRunning for both "idle" and "active" ensures
+          // exit detection works regardless of the agent's classifier.
+          const processAlive = await agent.isProcessRunning(session.runtimeHandle);
+          if (!processAlive) return "killed";
         }
       } catch {
         // On probe failure, preserve current stuck/needs_input state rather

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -155,10 +155,12 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
     expect(exitedRunning).toBe(false);
   });
 
-  it("detectActivity → idle after agent exits", () => {
-    // detectActivity is a pure terminal-text classifier; it returns "idle"
-    // for empty/shell-prompt output. Process exit is detected by isProcessRunning.
-    expect(exitedActivity).toBe("idle");
+  it("detectActivity → idle or active after agent exits", () => {
+    // Aider's stub classifier returns "active" for any non-empty output and
+    // "idle" for empty output. After exit the terminal usually shows a shell
+    // prompt (non-empty → "active"), but may be empty depending on timing.
+    // Process exit is detected by isProcessRunning, not detectActivity.
+    expect(["idle", "active"]).toContain(exitedActivity);
   });
 
   it("getSessionInfo → null (not implemented for aider)", () => {

--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -128,10 +128,12 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
     expect(exitedRunning).toBe(false);
   });
 
-  it("detectActivity → idle after agent exits", () => {
-    // detectActivity is a pure terminal-text classifier; it returns "idle"
-    // for empty/shell-prompt output. Process exit is detected by isProcessRunning.
-    expect(exitedActivity).toBe("idle");
+  it("detectActivity → idle or active after agent exits", () => {
+    // Codex's stub classifier returns "active" for any non-empty output and
+    // "idle" for empty output. After exit the terminal usually shows a shell
+    // prompt (non-empty → "active"), but may be empty depending on timing.
+    // Process exit is detected by isProcessRunning, not detectActivity.
+    expect(["idle", "active"]).toContain(exitedActivity);
   });
 
   it("getSessionInfo → null (not implemented for codex)", () => {

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -146,10 +146,12 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
     expect(exitedRunning).toBe(false);
   });
 
-  it("detectActivity → idle after agent exits", () => {
-    // detectActivity is a pure terminal-text classifier; it returns "idle"
-    // for empty/shell-prompt output. Process exit is detected by isProcessRunning.
-    expect(exitedActivity).toBe("idle");
+  it("detectActivity → idle or active after agent exits", () => {
+    // OpenCode's stub classifier returns "active" for any non-empty output and
+    // "idle" for empty output. After exit the terminal usually shows a shell
+    // prompt (non-empty → "active"), but may be empty depending on timing.
+    // Process exit is detected by isProcessRunning, not detectActivity.
+    expect(["idle", "active"]).toContain(exitedActivity);
   });
 
   it("getSessionInfo → null (not implemented for opencode)", () => {


### PR DESCRIPTION
## Summary

- **Lifecycle manager exit detection**: Changed `isProcessRunning` check from only-when-idle to always-when-not-waiting_input, fixing exit detection for codex/aider/opencode agents whose `detectActivity` returns "active" for any non-empty terminal output
- **Integration test assertions**: Updated agent-codex, agent-aider, and agent-opencode integration tests to accept either "idle" or "active" after agent exits (stub classifiers return "active" for non-empty terminal)
- **Unit test coverage**: Added test for "active terminal + dead process → killed" path and fixed default mock to return `isProcessRunning: true`

Fixes issues identified in bugbot review threads on PR #6.

## Test plan
- [x] All 203 core tests pass (including 20 lifecycle-manager tests)
- [x] All 129 CLI tests pass
- [x] Lint clean (only pre-existing runtime-process warning)
- [x] Typecheck clean (only pre-existing runtime-process issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)