### PR TITLE
chore: remove unused makeActions helper

### DIFF
--- a/packages/integration-tests/src/helpers/event-factory.ts
+++ b/packages/integration-tests/src/helpers/event-factory.ts
@@ -1,7 +1,6 @@
 import type {
   OrchestratorEvent,
   Session,
-  NotifyAction,
   EventPriority,
   EventType,
   SessionStatus,
@@ -47,21 +46,4 @@ export function makeSession(overrides: Partial<Session> = {}): Session {
     metadata: {},
     ...overrides,
   };
-}
-
-/**
- * Create a set of test NotifyActions.
- */
-export function makeActions(overrides?: Partial<NotifyAction>[]): NotifyAction[] {
-  const defaults: NotifyAction[] = [
-    { label: "View PR", url: "https://github.com/org/repo/pull/42" },
-    { label: "Kill Session", callbackEndpoint: "/api/sessions/app-1/kill" },
-  ];
-
-  if (!overrides) return defaults;
-
-  return overrides.map((o, i) => ({
-    ...defaults[i % defaults.length],
-    ...o,
-  }));
 }


### PR DESCRIPTION
## Summary
- Remove unused `makeActions` export from `event-factory.ts` (and its `NotifyAction` import)
- The function was never imported by any integration test — all define actions inline

Addresses unresolved bugbot thread from PR #7.

## Test plan
- [ ] Verify no imports of `makeActions` exist (already confirmed via grep)
- [ ] CI passes (lint, typecheck, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)