### PR TITLE
fix: remove sessions/ subdirectory from metadata paths

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -60,7 +60,7 @@ function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
 
 beforeEach(() => {
   dataDir = join(tmpdir(), `ao-test-lifecycle-${randomUUID()}`);
-  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
 
   mockRuntime = {
     name: "mock",

--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -16,7 +16,7 @@ let dataDir: string;
 
 beforeEach(() => {
   dataDir = join(tmpdir(), `ao-test-metadata-${randomUUID()}`);
-  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
 });
 
 afterEach(() => {
@@ -74,7 +74,7 @@ describe("writeMetadata + readMetadata", () => {
       issue: "https://linear.app/team/issue/INT-123",
     });
 
-    const content = readFileSync(join(dataDir, "sessions", "app-3"), "utf-8");
+    const content = readFileSync(join(dataDir,"app-3"), "utf-8");
     expect(content).toContain("worktree=/tmp/w\n");
     expect(content).toContain("branch=feat/INT-123\n");
     expect(content).toContain("status=working\n");
@@ -88,7 +88,7 @@ describe("writeMetadata + readMetadata", () => {
       status: "spawning",
     });
 
-    const content = readFileSync(join(dataDir, "sessions", "app-4"), "utf-8");
+    const content = readFileSync(join(dataDir,"app-4"), "utf-8");
     expect(content).not.toContain("issue=");
     expect(content).not.toContain("pr=");
     expect(content).not.toContain("summary=");
@@ -98,7 +98,7 @@ describe("writeMetadata + readMetadata", () => {
 describe("readMetadataRaw", () => {
   it("reads arbitrary key=value pairs", () => {
     writeFileSync(
-      join(dataDir, "sessions", "raw-1"),
+      join(dataDir,"raw-1"),
       "worktree=/tmp/w\nbranch=main\ncustom_key=custom_value\n",
       "utf-8",
     );
@@ -115,7 +115,7 @@ describe("readMetadataRaw", () => {
 
   it("handles comments and empty lines", () => {
     writeFileSync(
-      join(dataDir, "sessions", "raw-2"),
+      join(dataDir,"raw-2"),
       "# This is a comment\n\nkey1=value1\n\n# Another comment\nkey2=value2\n",
       "utf-8",
     );
@@ -126,7 +126,7 @@ describe("readMetadataRaw", () => {
 
   it("handles values containing equals signs", () => {
     writeFileSync(
-      join(dataDir, "sessions", "raw-3"),
+      join(dataDir,"raw-3"),
       'runtimeHandle={"id":"foo","data":{"key":"val"}}\n',
       "utf-8",
     );
@@ -203,8 +203,8 @@ describe("deleteMetadata", () => {
 
     deleteMetadata(dataDir, "del-1", true);
 
-    expect(existsSync(join(dataDir, "sessions", "del-1"))).toBe(false);
-    const archiveDir = join(dataDir, "sessions", "archive");
+    expect(existsSync(join(dataDir,"del-1"))).toBe(false);
+    const archiveDir = join(dataDir,"archive");
     expect(existsSync(archiveDir)).toBe(true);
     const files = readdirSync(archiveDir);
     expect(files.length).toBe(1);
@@ -220,8 +220,8 @@ describe("deleteMetadata", () => {
 
     deleteMetadata(dataDir, "del-2", false);
 
-    expect(existsSync(join(dataDir, "sessions", "del-2"))).toBe(false);
-    expect(existsSync(join(dataDir, "sessions", "archive"))).toBe(false);
+    expect(existsSync(join(dataDir,"del-2"))).toBe(false);
+    expect(existsSync(join(dataDir,"archive"))).toBe(false);
   });
 
   it("is a no-op for nonexistent session", () => {
@@ -242,8 +242,8 @@ describe("listMetadata", () => {
 
   it("excludes archive directory and dotfiles", () => {
     writeMetadata(dataDir, "app-1", { worktree: "/tmp", branch: "a", status: "s" });
-    mkdirSync(join(dataDir, "sessions", "archive"), { recursive: true });
-    writeFileSync(join(dataDir, "sessions", ".hidden"), "x", "utf-8");
+    mkdirSync(join(dataDir,"archive"), { recursive: true });
+    writeFileSync(join(dataDir,".hidden"), "x", "utf-8");
 
     const list = listMetadata(dataDir);
     expect(list).toEqual(["app-1"]);

--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -116,7 +116,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   dataDir = join(tmpdir(), `ao-test-plugin-int-${randomUUID()}`);
-  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
 
   mockRuntime = {
     name: "mock",

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -29,7 +29,7 @@ function makeHandle(id: string): RuntimeHandle {
 
 beforeEach(() => {
   dataDir = join(tmpdir(), `ao-test-session-mgr-${randomUUID()}`);
-  mkdirSync(join(dataDir, "sessions"), { recursive: true });
+  mkdirSync(dataDir, { recursive: true });
 
   mockRuntime = {
     name: "mock",

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -68,7 +68,7 @@ function validateSessionId(sessionId: SessionId): void {
 /** Get the metadata file path for a session. */
 function metadataPath(dataDir: string, sessionId: SessionId): string {
   validateSessionId(sessionId);
-  return join(dataDir, "sessions", sessionId);
+  return join(dataDir, sessionId);
 }
 
 /**
@@ -173,7 +173,7 @@ export function deleteMetadata(dataDir: string, sessionId: SessionId, archive = 
   if (!existsSync(path)) return;
 
   if (archive) {
-    const archiveDir = join(dataDir, "sessions", "archive");
+    const archiveDir = join(dataDir, "archive");
     mkdirSync(archiveDir, { recursive: true });
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const archivePath = join(archiveDir, `${sessionId}_${timestamp}`);
@@ -187,7 +187,7 @@ export function deleteMetadata(dataDir: string, sessionId: SessionId, archive = 
  * List all session IDs that have metadata files.
  */
 export function listMetadata(dataDir: string): SessionId[] {
-  const dir = join(dataDir, "sessions");
+  const dir = dataDir;
   if (!existsSync(dir)) return [];
 
   return readdirSync(dir).filter((name) => {


### PR DESCRIPTION
## Summary
- Core metadata module expected files at `{dataDir}/sessions/{id}` but bash scripts write directly to `{dataDir}/{id}` (no `sessions/` subdirectory), requiring a manual symlink to bridge the gap
- Removed the intermediate `sessions/` subdirectory from `metadataPath()`, `deleteMetadata()` archive path, and `listMetadata()` directory scan
- Updated all 4 test files that set up the `sessions/` subdirectory in `beforeEach`

## Test plan
- [x] All 107 core tests pass
- [x] Lint clean (0 errors)
- [x] Core typecheck clean

Closes INT-1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)