### PR TITLE
fix: expand WORKING attention zone by default

### DIFF
--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -50,7 +50,7 @@ const zoneConfig: Record<
     label: "WORKING",
     description: "Agents working normally",
     color: "var(--color-accent-blue)",
-    defaultCollapsed: true,
+    defaultCollapsed: false,
   },
   done: {
     label: "DONE",


### PR DESCRIPTION
## Summary
- One-line change: `defaultCollapsed: false` for the WORKING zone
- Working agents are the most important to monitor — shouldn't be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)