### PR TITLE
fix: address remaining bugbot issues from PR #26

### DIFF
--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -123,10 +123,7 @@ export function computeStats(sessions: DashboardSession[]): DashboardStats {
     workingSessions: sessions.filter((s) => s.activity === "active").length,
     openPRs: sessions.filter((s) => s.pr?.state === "open").length,
     needsReview: sessions.filter(
-      (s) =>
-        s.pr &&
-        !s.pr.isDraft &&
-        (s.pr.reviewDecision === "pending" || s.pr.reviewDecision === "none"),
+      (s) => s.pr && !s.pr.isDraft && s.pr.reviewDecision === "pending",
     ).length,
   };
 }


### PR DESCRIPTION
## Summary

Follow-up to #26 — addresses the 3 remaining Bugbot review comments:

- **High: SSE stream permanently dies on transient service errors** — Separated service errors (transient, skip and retry) from `controller.enqueue()` errors (stream closed, clear intervals). Previously any error killed the SSE stream permanently.
- **Medium: SSE polling sends per-session activity events unconditionally** — Changed from sending N individual `session.activity` events per poll to a single `snapshot` event (matching the `SSESnapshotEvent` type already defined in `types.ts`). Constant-size traffic per interval regardless of session count.
- **Medium: Home page shows inflated stats from unenriched PRs** — `computeStats` no longer counts `reviewDecision === "none"` (the unenriched default) as "needs review". Only `"pending"` (a real review state from SCM enrichment) is counted.

## Test plan

- [x] All 24 API route tests pass
- [x] SSE snapshot event test still validates correct shape
- [x] No new lint errors (0 errors, 7 pre-existing warnings)
- [ ] Manual: verify SSE stream recovers after transient service error
- [ ] Manual: verify dashboard stats show correct needsReview count

🤖 Generated with [Claude Code](https://claude.com/claude-code)