### PR TITLE
fix: increase delays in spawn prompt submission to ensure Enter is processed

### DIFF
--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -221,7 +221,9 @@ async function spawnSession(
     });
 
     if (composedPrompt) {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      // Wait for agent to be fully ready (permission prompts, initialization, etc.)
+      // Longer delay ensures Claude is ready to receive input before sending prompt
+      await new Promise((resolve) => setTimeout(resolve, 2000));
       await tmuxSendKeys(sessionName, composedPrompt);
     }
 

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -129,6 +129,8 @@ export async function sendKeys(
 ): Promise<void> {
   // Clear any partial input first (matches bash reference scripts)
   await tmux("send-keys", "-t", sessionName, "Escape");
+  // Small delay to ensure Escape is processed before pasting
+  await new Promise((resolve) => setTimeout(resolve, 100));
 
   if (text.includes("\n") || text.length > 200) {
     // Use a named buffer to avoid global paste buffer race conditions
@@ -158,9 +160,11 @@ export async function sendKeys(
   }
 
   if (pressEnter) {
-    // Small delay for paste to complete before sending Enter
+    // Delay for paste to complete before sending Enter
+    // Higher delay needed when using paste-buffer to ensure tmux processes the paste
+    // before receiving the Enter keystroke (especially with Claude permission prompts)
     if (text.includes("\n") || text.length > 200) {
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
     }
     await tmux("send-keys", "-t", sessionName, "Enter");
   }


### PR DESCRIPTION
## Summary
Fixes issue where spawned sessions would send the prompt text but the Enter keystroke would not be submitted, requiring manual Enter press by the user.

## Changes
- **tmux.ts sendKeys()**: Increase delay after paste-buffer from 300ms to 1000ms to ensure tmux processes the paste before receiving the Enter keystroke
- **tmux.ts sendKeys()**: Add 100ms delay after Escape key to ensure it's processed before pasting begins
- **spawn.ts**: Increase wait time from 1s to 2s before sending initial prompt to allow Claude to fully initialize

## Root Cause
The issue occurred due to race conditions in tmux's paste buffer processing:
1. paste-buffer command queues the paste operation
2. If Enter is sent too quickly, it may be processed before the paste completes
3. This leaves the prompt unsent in the input buffer
4. Claude's permission prompts during initialization can also delay input readiness

## Testing Recommendations
Test by spawning sessions with different prompt lengths:
- Short single-line prompts (< 200 chars)
- Long multi-line prompts (> 200 chars, uses paste-buffer)
- Verify Enter is automatically submitted without manual intervention

Closes FIX-SPAWN-PROMPT-SUBMIT

🤖 Generated with [Claude Code](https://claude.com/claude-code)