### PR TITLE
fix: clean Next.js build artifacts in setup script

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -16,6 +16,9 @@ fi
 echo "📦 Installing dependencies..."
 pnpm install
 
+echo "🧹 Cleaning stale build artifacts..."
+rm -rf packages/web/.next
+
 echo "🔨 Building all packages..."
 pnpm build
 


### PR DESCRIPTION
## Problem

The setup script (`scripts/setup.sh`) can fail during the build phase when stale Next.js build artifacts exist in `packages/web/.next`. This happens when:

- Running setup after rebasing or switching branches
- Running setup after a failed previous build
- Running setup in a fresh clone that had artifacts committed (shouldn't happen, but can)

Error seen:
```
Error: Cannot find module './705.js'
packages/web build: Failed
```

## Solution

Add cleanup step before building:
```bash
echo "🧹 Cleaning stale build artifacts..."
rm -rf packages/web/.next
```

This ensures a clean build every time the setup script runs, preventing module resolution errors from webpack's internal chunk files.

## Testing

✅ Tested setup script end-to-end - completes successfully
✅ All packages build without errors  
✅ No impact on normal build workflow (Next.js will recreate .next)

## Related

- Discovered during verification of PR #66
- This fix ensures seamless onboarding works reliably for new users