### PR TITLE
fix: clean up hash-based test directories in afterEach

### DIFF
--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -40,11 +40,12 @@ vi.mock("@composio/ao-core", async (importOriginal) => {
 });
 
 let tmpDir: string;
+let configPath: string;
 let sessionsDir: string;
 
 import { Command } from "commander";
 import { registerSession } from "../../src/commands/session.js";
-import { getSessionsDir } from "@composio/ao-core";
+import { getSessionsDir, getProjectBaseDir } from "@composio/ao-core";
 
 let program: Command;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -52,7 +53,7 @@ let consoleSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "ao-session-test-"));
 
-  const configPath = join(tmpDir, "agent-orchestrator.yaml");
+  configPath = join(tmpDir, "agent-orchestrator.yaml");
   writeFileSync(configPath, "projects: {}");
 
   mockConfigRef.current = {
@@ -100,7 +101,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Clean up hash-based directories in ~/.agent-orchestrator
+  const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "main-repo"));
+  if (existsSync(projectBaseDir)) {
+    rmSync(projectBaseDir, { recursive: true, force: true });
+  }
+
+  // Clean up tmpDir
   rmSync(tmpDir, { recursive: true, force: true });
+
   vi.restoreAllMocks();
 });
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { writeMetadata, readMetadataRaw } from "../metadata.js";
-import { getSessionsDir } from "../paths.js";
+import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -146,6 +146,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Clean up hash-based directories in ~/.agent-orchestrator
+  const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
+  if (existsSync(projectBaseDir)) {
+    rmSync(projectBaseDir, { recursive: true, force: true });
+  }
+
+  // Clean up tmpDir
   rmSync(tmpDir, { recursive: true, force: true });
 });
 

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createSessionManager } from "../session-manager.js";
 import { writeMetadata, readMetadata } from "../metadata.js";
-import { getSessionsDir } from "../paths.js";
+import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -120,6 +120,13 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Clean up hash-based directories in ~/.agent-orchestrator
+  const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
+  if (existsSync(projectBaseDir)) {
+    rmSync(projectBaseDir, { recursive: true, force: true });
+  }
+
+  // Clean up tmpDir
   rmSync(tmpDir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
Fixes the bugbot issue from PR #58: "Tests leak directories under home directory without cleanup"

## The Problem

Tests that call `getSessionsDir()` create directories under `~/.agent-orchestrator/{hash}-{projectId}/` where the hash is based on the tmpDir path. Since each test run uses a new random tmpDir:
- Each run generates a unique hash
- Creates new orphaned directories in `~/.agent-orchestrator/`
- Only tmpDir was cleaned up in afterEach, leaving hash-based directories

## The Fix

Added cleanup for hash-based directories in afterEach for all affected tests:
1. Calculate the project base directory using `getProjectBaseDir()`
2. Remove it before cleaning tmpDir  
3. All 61 tests pass (13 CLI + 48 core)

## Files Changed

- `packages/cli/__tests__/commands/session.test.ts`
- `packages/core/src/__tests__/session-manager.test.ts`
- `packages/core/src/__tests__/lifecycle-manager.test.ts`

## Testing

```bash
pnpm test # All tests pass
```

Closes bugbot comment from #58