### PR TITLE
fix: auto-detect free port in ao init

### DIFF
--- a/packages/cli/__tests__/commands/init.test.ts
+++ b/packages/cli/__tests__/commands/init.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { createServer } from "node:net";
 
 import { Command } from "commander";
 import { registerInit } from "../../src/commands/init.js";
@@ -34,5 +35,54 @@ describe("init command", () => {
 
     // Original file should be untouched
     expect(existsSync(outputPath)).toBe(true);
+  });
+
+  it("auto mode uses port 3000 when it is available", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ao-init-test-"));
+    const outputPath = join(tmpDir, "agent-orchestrator.yaml");
+
+    const program = new Command();
+    program.exitOverride();
+    registerInit(program);
+
+    vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await program.parseAsync(["node", "test", "init", "--auto", "--output", outputPath]);
+
+    const content = readFileSync(outputPath, "utf-8");
+    expect(content).toContain("port: 3000");
+  });
+
+  it("auto mode picks next free port when 3000 is occupied", async () => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ao-init-test-"));
+    const outputPath = join(tmpDir, "agent-orchestrator.yaml");
+
+    // Occupy port 3000
+    const blocker = createServer();
+    await new Promise<void>((resolve) => {
+      blocker.listen(3000, "127.0.0.1", () => resolve());
+    });
+
+    try {
+      const program = new Command();
+      program.exitOverride();
+      registerInit(program);
+
+      vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await program.parseAsync(["node", "test", "init", "--auto", "--output", outputPath]);
+
+      const content = readFileSync(outputPath, "utf-8");
+      // Should NOT be 3000 since we're occupying it
+      expect(content).not.toContain("port: 3000");
+      // Should pick 3001 (or higher if 3001 is also taken)
+      const portMatch = content.match(/port: (\d+)/);
+      expect(portMatch).toBeTruthy();
+      const port = parseInt(portMatch![1], 10);
+      expect(port).toBeGreaterThan(3000);
+      expect(port).toBeLessThan(3100);
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
   });
 });

--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -20,7 +20,7 @@ const DEFAULT_TERMINAL_PORT = 14800;
  * Check if a TCP port is available by attempting to bind to it.
  * Returns true if the port is free, false if in use.
  */
-function isPortAvailable(port: number): Promise<boolean> {
+export function isPortAvailable(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     const server = createServer();
     server.once("error", () => {


### PR DESCRIPTION
## Summary
- `ao init` now scans for a free port starting at 3000 instead of blindly hardcoding it
- Applies to both interactive mode (default prompt value) and `--auto` mode
- Reuses the existing `isPortAvailable()` from `web-dir.ts` (exported it)

## Test plan
- [x] New test: auto mode uses 3000 when available
- [x] New test: auto mode picks next free port when 3000 is occupied (binds a real server on 3000, verifies config gets 3001+)
- [x] Existing test: rejects when config already exists (still passes)
- [x] Full CLI test suite (131 tests pass)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)