### PR TITLE
fix: tab title followups from PR #111

### DIFF
--- a/packages/web/src/app/icon.tsx
+++ b/packages/web/src/app/icon.tsx
@@ -15,7 +15,7 @@ function stringToHue(s: string): number {
 
 export default function Icon() {
   const name = getProjectName();
-  const initial = name.charAt(0).toUpperCase();
+  const initial = (name.charAt(0) || "A").toUpperCase();
   const hue = stringToHue(name);
 
   return new ImageResponse(

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -6,6 +6,10 @@ import { SessionDetail } from "@/components/SessionDetail";
 import type { DashboardSession } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
 
+function truncate(s: string, max: number): string {
+  return s.length > max ? s.slice(0, max) + "..." : s;
+}
+
 /** Build a descriptive tab title from session data. */
 function buildSessionTitle(session: DashboardSession): string {
   const id = session.id;
@@ -17,18 +21,9 @@ function buildSessionTitle(session: DashboardSession): string {
   if (isOrchestrator) {
     detail = "Orchestrator Terminal";
   } else if (session.pr) {
-    const prNum = `#${session.pr.number}`;
-    const branch = session.pr.branch;
-    const maxBranch = 30;
-    const truncated = branch.length > maxBranch ? branch.slice(0, maxBranch) + "..." : branch;
-    detail = `${prNum} ${truncated}`;
+    detail = `#${session.pr.number} ${truncate(session.pr.branch, 30)}`;
   } else if (session.branch) {
-    const maxBranch = 30;
-    const truncated =
-      session.branch.length > maxBranch
-        ? session.branch.slice(0, maxBranch) + "..."
-        : session.branch;
-    detail = truncated;
+    detail = truncate(session.branch, 30);
   } else {
     detail = "Session Detail";
   }

--- a/packages/web/src/lib/project-name.ts
+++ b/packages/web/src/lib/project-name.ts
@@ -14,7 +14,8 @@ export const getProjectName = cache((): string => {
     const config = loadConfig();
     const firstKey = Object.keys(config.projects)[0];
     if (firstKey) {
-      return config.projects[firstKey].name ?? firstKey;
+      const name = config.projects[firstKey].name ?? firstKey;
+      return name || firstKey || "ao";
     }
   } catch {
     // Config not available


### PR DESCRIPTION
## Summary
- Guard against empty project name in `getProjectName()` and `icon.tsx` favicon — falls back to config key or "A" initial
- Extract duplicated branch truncation into shared `truncate()` helper in session detail page
- Addresses 3 unresolved bugbot comments from #111: empty favicon initial, duplicated truncation, and title format (the `ao | project` format was intentional per user request — dismissed that one)

## Context
Follow-up to #111 (dynamic tab titles and health-aware favicons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)