### PR TITLE
docs: update hardcoded port 3000 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ ao spawn my-project
 ao status
 
 # Web dashboard
-open http://localhost:3000
+ao dashboard
 ```
 
 ### Manage Sessions

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -40,7 +40,7 @@ pnpm build
 cd packages/web
 pnpm dev
 
-# Open http://localhost:3000
+# Open http://localhost:<port> (port from agent-orchestrator.yaml)
 ```
 
 ### Project Structure
@@ -319,7 +319,7 @@ cat ~/.agent-orchestrator/my-app-3
 **Check session status:**
 
 ```bash
-curl http://localhost:3000/api/sessions/my-app-3
+curl http://localhost:<port>/api/sessions/my-app-3
 ```
 
 ## Environment Variables

--- a/examples/README.md
+++ b/examples/README.md
@@ -108,6 +108,6 @@ After copying an example:
 1. **Edit the config** - Update repo paths, team IDs, etc.
 2. **Validate** - Run `ao start` to check for config errors
 3. **Spawn an agent** - Try `ao spawn project-id ISSUE-123`
-4. **Monitor** - Use `ao status` or open the dashboard at http://localhost:3000
+4. **Monitor** - Use `ao status` or `ao dashboard` to open the web UI
 
 See [SETUP.md](../SETUP.md) for detailed configuration reference and troubleshooting.


### PR DESCRIPTION
## Summary
- Updates all hardcoded `localhost:3000` references in docs to reflect that `ao init` now auto-detects a free port
- Replaces `open http://localhost:3000` with `ao dashboard` where appropriate
- Uses `<port>` placeholder in dev docs where a literal URL is needed

Follows up on #120 which added port auto-detection to `ao init`.

## Test plan
- [ ] Verify no remaining hardcoded port 3000 references in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)