### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the release workflow so it can be manually triggered for testing NPM publishing

## Test plan
- [ ] Merge this PR
- [ ] Trigger workflow manually via `gh workflow run release.yml`
- [ ] Verify NPM_TOKEN auth works and packages publish under `@composio/` scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)