### PR TITLE
feat(core): add strict WorkPlan schema + validator

### DIFF
--- a/packages/core/src/__tests__/work-plan.test.ts
+++ b/packages/core/src/__tests__/work-plan.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { validateWorkPlan, WorkPlanValidationError } from "../work-plan.js";
+import type { WorkPlan } from "../types.js";
+
+function makeValidPlan(): WorkPlan {
+  return {
+    schemaVersion: "1.0",
+    goal: "Ship strict planning schema",
+    assumptions: ["Core package is available"],
+    acceptance: {
+      definitionOfDone: "All acceptance checks pass",
+      checks: [
+        {
+          id: "ac-tests",
+          description: "Tests cover valid and invalid plan cases",
+          verification: "vitest",
+          required: true,
+        },
+        {
+          id: "ac-validator",
+          description: "Validator rejects invalid references",
+          verification: "unit assertions",
+          required: true,
+        },
+      ],
+    },
+    tasks: [
+      {
+        id: "task-schema",
+        title: "Add plan types",
+        description: "Add WorkPlan, TaskNode, and AcceptanceContract",
+        priority: "critical",
+        dependencies: [],
+        risks: ["Type drift"],
+        acceptanceChecks: ["ac-validator"],
+      },
+      {
+        id: "task-tests",
+        title: "Add tests",
+        description: "Cover valid and invalid plans",
+        priority: "high",
+        dependencies: ["task-schema"],
+        risks: [],
+        acceptanceChecks: ["ac-tests", "ac-validator"],
+      },
+    ],
+  };
+}
+
+describe("validateWorkPlan", () => {
+  it("accepts a valid plan", () => {
+    const result = validateWorkPlan(makeValidPlan());
+    expect(result.goal).toBe("Ship strict planning schema");
+    expect(result.tasks).toHaveLength(2);
+  });
+
+  it("returns actionable errors for missing required fields", () => {
+    expect.assertions(3);
+
+    try {
+      validateWorkPlan({
+        schemaVersion: "1.0",
+        goal: "Missing fields plan",
+        tasks: [{}],
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(WorkPlanValidationError);
+      const message = (err as Error).message;
+      expect(message).toContain("tasks[0].id: is required");
+      expect(message).toContain("acceptance: is required");
+    }
+  });
+
+  it("rejects unknown task dependencies with explicit IDs", () => {
+    const plan = makeValidPlan();
+    plan.tasks[1]!.dependencies = ["task-schema", "task-missing"];
+
+    expect(() => validateWorkPlan(plan)).toThrow(WorkPlanValidationError);
+    expect(() => validateWorkPlan(plan)).toThrow(/unknown task dependency "task-missing"/);
+  });
+
+  it("rejects unknown acceptance checks on tasks", () => {
+    const plan = makeValidPlan();
+    plan.tasks[0]!.acceptanceChecks = ["ac-unknown"];
+
+    expect(() => validateWorkPlan(plan)).toThrow(/unknown acceptance check "ac-unknown"/);
+  });
+
+  it("rejects duplicate task IDs", () => {
+    const plan = makeValidPlan();
+    plan.tasks.push({
+      id: "task-schema",
+      title: "Duplicate id",
+      description: "Should fail",
+      priority: "low",
+      dependencies: [],
+      risks: [],
+      acceptanceChecks: ["ac-tests"],
+    });
+
+    expect(() => validateWorkPlan(plan)).toThrow(/duplicate task id "task-schema"/);
+  });
+
+  it("does not check dependency cycles in this validator", () => {
+    const plan = makeValidPlan();
+    plan.tasks = [
+      {
+        id: "task-a",
+        title: "Task A",
+        description: "Depends on B",
+        priority: "high",
+        dependencies: ["task-b"],
+        risks: [],
+        acceptanceChecks: ["ac-validator"],
+      },
+      {
+        id: "task-b",
+        title: "Task B",
+        description: "Depends on A",
+        priority: "medium",
+        dependencies: ["task-a"],
+        risks: [],
+        acceptanceChecks: ["ac-tests"],
+      },
+    ];
+
+    expect(() => validateWorkPlan(plan)).not.toThrow();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,16 @@ export type { PromptBuildConfig } from "./prompt-builder.js";
 export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
+// Work plan schema + validator
+export {
+  validateWorkPlan,
+  WorkPlanSchema,
+  TaskNodeSchema,
+  AcceptanceContractSchema,
+  WorkPlanValidationError,
+} from "./work-plan.js";
+export type { WorkPlanValidationIssue } from "./work-plan.js";
+
 // Shared utilities
 export { shellEscape, escapeAppleScript, validateUrl, readLastJsonlEntry } from "./utils.js";
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -910,6 +910,67 @@ export interface AgentSpecificConfig {
 }
 
 // =============================================================================
+// WORK PLAN SCHEMA
+// =============================================================================
+
+/** Task priority used by planning output. */
+export type TaskPriority = "critical" | "high" | "medium" | "low";
+
+/** A single acceptance check in the plan-level acceptance contract. */
+export interface AcceptanceCheck {
+  /** Stable ID used by tasks to reference this check. */
+  id: string;
+  /** What must be true for this check to pass. */
+  description: string;
+  /** How the check will be verified (test, manual check, metric, etc.). */
+  verification: string;
+  /** Whether this check is required for completion. */
+  required: boolean;
+}
+
+/** Plan-level acceptance contract shared by all tasks. */
+export interface AcceptanceContract {
+  /** Definition of done for the complete plan. */
+  definitionOfDone: string;
+  /** Concrete checks that validate the definition of done. */
+  checks: AcceptanceCheck[];
+}
+
+/** A single executable task node in a work plan. */
+export interface TaskNode {
+  /** Stable task ID, unique across the full plan tree. */
+  id: string;
+  /** Short task title. */
+  title: string;
+  /** Detailed task intent and scope. */
+  description: string;
+  /** Relative execution priority. */
+  priority: TaskPriority;
+  /** Task IDs that must complete before this task can start. */
+  dependencies: string[];
+  /** Known risks for this task. */
+  risks: string[];
+  /** Acceptance check IDs that this task contributes to. */
+  acceptanceChecks: string[];
+  /** Optional nested subtasks. */
+  subtasks?: TaskNode[];
+}
+
+/** Machine-validated planning payload produced by orchestrator planning. */
+export interface WorkPlan {
+  /** Schema version for forward compatibility. */
+  schemaVersion: "1.0";
+  /** High-level goal of the plan. */
+  goal: string;
+  /** Optional plan assumptions. */
+  assumptions?: string[];
+  /** Executable tasks. Must include at least one root task. */
+  tasks: TaskNode[];
+  /** Plan-level acceptance contract. */
+  acceptance: AcceptanceContract;
+}
+
+// =============================================================================
 // PLUGIN SYSTEM
 // =============================================================================
 

--- a/packages/core/src/work-plan.ts
+++ b/packages/core/src/work-plan.ts
@@ -1,0 +1,220 @@
+import { z, type ZodIssue } from "zod";
+import type { AcceptanceContract, TaskNode, WorkPlan } from "./types.js";
+
+export interface WorkPlanValidationIssue {
+  path: string;
+  message: string;
+}
+
+export class WorkPlanValidationError extends Error {
+  constructor(public readonly issues: WorkPlanValidationIssue[]) {
+    super(
+      `WorkPlan validation failed with ${issues.length} issue${issues.length === 1 ? "" : "s"}:\n` +
+        issues.map((issue) => `- ${issue.path}: ${issue.message}`).join("\n"),
+    );
+    this.name = "WorkPlanValidationError";
+  }
+}
+
+const TaskPrioritySchema = z.enum(["critical", "high", "medium", "low"]);
+
+const AcceptanceCheckSchema = z
+  .object({
+    id: z.string().min(1, "acceptance check id cannot be empty"),
+    description: z.string().min(1, "acceptance check description cannot be empty"),
+    verification: z.string().min(1, "acceptance check verification cannot be empty"),
+    required: z.boolean(),
+  })
+  .strict();
+
+export const AcceptanceContractSchema: z.ZodType<AcceptanceContract> = z
+  .object({
+    definitionOfDone: z.string().min(1, "acceptance.definitionOfDone cannot be empty"),
+    checks: z.array(AcceptanceCheckSchema).min(1, "acceptance.checks must contain at least one check"),
+  })
+  .strict();
+
+export const TaskNodeSchema: z.ZodType<TaskNode> = z.lazy(() =>
+  z
+    .object({
+      id: z.string().min(1, "task id cannot be empty"),
+      title: z.string().min(1, "task title cannot be empty"),
+      description: z.string().min(1, "task description cannot be empty"),
+      priority: TaskPrioritySchema,
+      dependencies: z.array(z.string().min(1, "dependency id cannot be empty")),
+      risks: z.array(z.string().min(1, "risk entries cannot be empty")),
+      acceptanceChecks: z.array(z.string().min(1, "acceptance check id cannot be empty")),
+      subtasks: z.array(TaskNodeSchema).optional(),
+    })
+    .strict(),
+);
+
+export const WorkPlanSchema: z.ZodType<WorkPlan> = z
+  .object({
+    schemaVersion: z.literal("1.0"),
+    goal: z.string().min(1, "goal cannot be empty"),
+    assumptions: z.array(z.string().min(1, "assumption entries cannot be empty")).optional(),
+    tasks: z.array(TaskNodeSchema).min(1, "tasks must contain at least one task"),
+    acceptance: AcceptanceContractSchema,
+  })
+  .strict();
+
+interface FlattenedTask {
+  task: TaskNode;
+  path: string;
+}
+
+function formatPath(path: (string | number)[]): string {
+  if (path.length === 0) return "(root)";
+
+  let formatted = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      formatted += `[${segment}]`;
+      continue;
+    }
+
+    formatted += formatted.length === 0 ? segment : `.${segment}`;
+  }
+
+  return formatted;
+}
+
+function issueFromZod(issue: ZodIssue): WorkPlanValidationIssue {
+  const path = formatPath(issue.path);
+
+  if (issue.code === "invalid_type" && issue.received === "undefined") {
+    return { path, message: "is required" };
+  }
+
+  return { path, message: issue.message };
+}
+
+function flattenTasks(tasks: TaskNode[], parentPath = "tasks"): FlattenedTask[] {
+  const flattened: FlattenedTask[] = [];
+
+  for (let i = 0; i < tasks.length; i += 1) {
+    const task = tasks[i];
+    const path = `${parentPath}[${i}]`;
+    if (!task) continue;
+    flattened.push({ task, path });
+
+    if (task.subtasks) {
+      flattened.push(...flattenTasks(task.subtasks, `${path}.subtasks`));
+    }
+  }
+
+  return flattened;
+}
+
+function validateReferentialIntegrity(plan: WorkPlan): WorkPlanValidationIssue[] {
+  const issues: WorkPlanValidationIssue[] = [];
+
+  const acceptanceIdToPath = new Map<string, string>();
+  for (let i = 0; i < plan.acceptance.checks.length; i += 1) {
+    const check = plan.acceptance.checks[i];
+    const path = `acceptance.checks[${i}].id`;
+    if (!check) continue;
+
+    if (acceptanceIdToPath.has(check.id)) {
+      issues.push({
+        path,
+        message: `duplicate acceptance check id "${check.id}" (first declared at ${acceptanceIdToPath.get(check.id)})`,
+      });
+      continue;
+    }
+
+    acceptanceIdToPath.set(check.id, path);
+  }
+
+  const tasks = flattenTasks(plan.tasks);
+  const taskIdToPath = new Map<string, string>();
+
+  for (const { task, path } of tasks) {
+    const idPath = `${path}.id`;
+    if (taskIdToPath.has(task.id)) {
+      issues.push({
+        path: idPath,
+        message: `duplicate task id "${task.id}" (first declared at ${taskIdToPath.get(task.id)})`,
+      });
+      continue;
+    }
+
+    taskIdToPath.set(task.id, idPath);
+  }
+
+  const knownTaskIds = Array.from(taskIdToPath.keys()).sort();
+  const knownChecks = Array.from(acceptanceIdToPath.keys()).sort();
+
+  for (const { task, path } of tasks) {
+    const seenDeps = new Set<string>();
+    for (let i = 0; i < task.dependencies.length; i += 1) {
+      const depId = task.dependencies[i];
+      const depPath = `${path}.dependencies[${i}]`;
+      if (!depId) continue;
+
+      if (seenDeps.has(depId)) {
+        issues.push({
+          path: depPath,
+          message: `duplicate dependency "${depId}" in the same task`,
+        });
+        continue;
+      }
+      seenDeps.add(depId);
+
+      if (depId === task.id) {
+        issues.push({
+          path: depPath,
+          message: `task "${task.id}" cannot depend on itself`,
+        });
+        continue;
+      }
+
+      if (!taskIdToPath.has(depId)) {
+        issues.push({
+          path: depPath,
+          message: `unknown task dependency "${depId}". Known task IDs: ${knownTaskIds.join(", ") || "(none)"}`,
+        });
+      }
+    }
+
+    const seenChecks = new Set<string>();
+    for (let i = 0; i < task.acceptanceChecks.length; i += 1) {
+      const checkId = task.acceptanceChecks[i];
+      const checkPath = `${path}.acceptanceChecks[${i}]`;
+      if (!checkId) continue;
+
+      if (seenChecks.has(checkId)) {
+        issues.push({
+          path: checkPath,
+          message: `duplicate acceptance check reference "${checkId}" in the same task`,
+        });
+        continue;
+      }
+      seenChecks.add(checkId);
+
+      if (!acceptanceIdToPath.has(checkId)) {
+        issues.push({
+          path: checkPath,
+          message: `unknown acceptance check "${checkId}". Known checks: ${knownChecks.join(", ") || "(none)"}`,
+        });
+      }
+    }
+  }
+
+  return issues;
+}
+
+export function validateWorkPlan(raw: unknown): WorkPlan {
+  const parsed = WorkPlanSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new WorkPlanValidationError(parsed.error.issues.map(issueFromZod));
+  }
+
+  const referentialIssues = validateReferentialIntegrity(parsed.data);
+  if (referentialIssues.length > 0) {
+    throw new WorkPlanValidationError(referentialIssues);
+  }
+
+  return parsed.data;
+}


### PR DESCRIPTION
## Summary
- add `WorkPlan`, `TaskNode`, `AcceptanceContract`, and related planning types
- add strict Zod schemas for plan structure validation
- add semantic referential validation for dependency and acceptance-check ID integrity
- export validator + schema symbols from core index
- add focused unit tests for valid plan, missing fields, unknown references, and duplicate IDs

## Validation
- `pnpm --filter @composio/ao-core typecheck`
- `HOME=/tmp pnpm --filter @composio/ao-core test -- src/__tests__/work-plan.test.ts`
- `HOME=/tmp pnpm --filter @composio/ao-core test`

## Notes
- Full core tests require writable `HOME`; in this sandbox that is set to `/tmp` during verification.
