### PR TITLE
feat(agent-codex): parse rollout logs for session summary and cost

### DIFF
--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -131,7 +131,8 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
     expect(exitedActivityState?.state).toBe("exited");
   });
 
-  it("getSessionInfo → null (not implemented for codex)", () => {
-    expect(sessionInfo).toBeNull();
+  it("getSessionInfo → returns parsed session metadata from rollout logs", () => {
+    expect(sessionInfo).not.toBeNull();
+    expect(sessionInfo?.agentSessionId).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
- implement `agent-codex.getSessionInfo()` by scanning Codex rollout JSONL files under `~/.codex/sessions`
- map rollout files to the current AO session using `cwd` matching against `session.workspacePath`
- extract assistant/user summary candidates, session id, and token/cost estimates from `token_count` events
- gracefully handle missing directories, unreadable files, and malformed JSON lines without throwing

## Tests
- add focused unit coverage for Codex session parsing, cwd matching, fallback summary behavior, token usage extraction, malformed data handling, and recursive date-directory scanning
- update Codex integration expectation to assert parsed session metadata is returned when mapping succeeds

## Validation
- `pnpm --filter @composio/ao-core build`
- `pnpm --filter @composio/ao-plugin-agent-codex typecheck`
- `pnpm --filter @composio/ao-plugin-agent-codex test`
- `pnpm --filter @composio/ao-plugin-agent-codex build`

Closes #176

Tracking: #12