### PR TITLE
fix(web): deduplicate PRs by composite key in Dashboard

### DIFF
--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -41,9 +41,16 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
   }, [sessions]);
 
   const openPRs = useMemo(() => {
+    const seen = new Set<string>();
     return sessions
       .filter((s): s is DashboardSession & { pr: DashboardPR } => s.pr?.state === "open")
       .map((s) => s.pr)
+      .filter((pr) => {
+        const key = `${pr.owner}/${pr.repo}#${pr.number}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      })
       .sort((a, b) => mergeScore(a) - mergeScore(b));
   }, [sessions]);
 
@@ -208,7 +215,7 @@ export function Dashboard({ sessions, stats, orchestratorId, projectName }: Dash
               </thead>
               <tbody>
                 {openPRs.map((pr) => (
-                  <PRTableRow key={pr.number} pr={pr} />
+                  <PRTableRow key={`${pr.owner}/${pr.repo}#${pr.number}`} pr={pr} />
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Deduplicate PRs in Dashboard using `owner/repo#number` composite key instead of `pr.number` alone
- PR numbers are only unique within a single repo — with multi-project setups, different repos can share the same PR number
- Also fixes React duplicate key warning by using the composite key as `key` prop

Closes #1

## Test plan
- [ ] Verify no duplicate key console warnings when multiple sessions reference the same PR
- [ ] Verify PRs from different repos with the same number are both displayed
- [ ] Verify PR table still renders correctly with unique PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)