### PR TITLE
fix: pass notifier config to plugins via extractPluginConfig

### DIFF
--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -51,11 +51,21 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
 
 /** Extract plugin-specific config from orchestrator config */
 function extractPluginConfig(
-  _slot: PluginSlot,
-  _name: string,
-  _config: OrchestratorConfig,
+  slot: PluginSlot,
+  name: string,
+  config: OrchestratorConfig,
 ): Record<string, unknown> | undefined {
-  // Reserved for future plugin-specific config mapping
+  if (slot === "notifier" && config.notifiers) {
+    // Match by plugin name or by notifier key that uses this plugin
+    for (const [_key, notifierConfig] of Object.entries(config.notifiers)) {
+      if (
+        notifierConfig.plugin === name ||
+        _key === name
+      ) {
+        return notifierConfig as Record<string, unknown>;
+      }
+    }
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary
- The `extractPluginConfig` stub was a no-op — custom notifier configs (e.g. webhook URL) were never passed to plugins at load time
- Now matches notifier config by plugin name or by the user-defined alias key in `notifiers:`
- Fixes silent config loss for any notifier plugin that needs runtime config (webhook, slack, etc.)

## Test plan
- [ ] Configure a webhook notifier with custom URL in `agent-orchestrator.yaml`
- [ ] Verify the webhook plugin receives the URL via its config at creation time
- [ ] Verify other plugin slots (runtime, agent, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)