### PR TITLE
feat(cli): add `ao self-update` command

### DIFF
--- a/packages/cli/src/commands/self-update.ts
+++ b/packages/cli/src/commands/self-update.ts
@@ -1,0 +1,165 @@
+/**
+ * `ao self-update` — pull latest changes from origin/main, rebuild, and restart.
+ *
+ * Performs preflight checks (dirty tree, pending commits), then spawns a
+ * detached bash script that outlives the Node process. The script handles:
+ * stop → git pull → pnpm install → pnpm build → optional restart.
+ *
+ * Detached script is necessary because `ao self-update` may be invoked from
+ * a tmux session or dashboard terminal managed by ao itself.
+ */
+
+import { spawn } from "node:child_process";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline";
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig } from "@composio/ao-core";
+import { exec } from "../lib/shell.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Repo root — four levels up from packages/cli/src/commands/ */
+const REPO_DIR = resolve(__dirname, "../../../..");
+
+function resolveProject(
+  config: { projects: Record<string, { name: string; sessionPrefix: string }> },
+  projectArg?: string,
+): string | undefined {
+  const ids = Object.keys(config.projects);
+  if (projectArg) {
+    if (!config.projects[projectArg]) {
+      throw new Error(
+        `Project "${projectArg}" not found. Available: ${ids.join(", ")}`,
+      );
+    }
+    return projectArg;
+  }
+  return ids.length === 1 ? ids[0] : undefined;
+}
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((res) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      res(answer.trim().toLowerCase().startsWith("y"));
+    });
+  });
+}
+
+export function registerSelfUpdate(program: Command): void {
+  program
+    .command("self-update [project]")
+    .description("Pull latest changes, rebuild, and restart the orchestrator")
+    .option("--no-restart", "Pull and rebuild only — do not restart")
+    .option("--force", "Skip confirmation prompt")
+    .option("--dry-run", "Show what would be updated without doing it")
+    .action(
+      async (
+        projectArg?: string,
+        opts?: { restart?: boolean; force?: boolean; dryRun?: boolean },
+      ) => {
+        try {
+          // ── Load config ──────────────────────────────────────────
+          const config = loadConfig();
+          const projectId = resolveProject(config, projectArg);
+          const port = config.port ?? 3000;
+
+          // ── Preflight: verify git repo ───────────────────────────
+          try {
+            await exec("git", ["rev-parse", "--git-dir"], { cwd: REPO_DIR });
+          } catch {
+            console.error(chalk.red("Not a git repository:"), REPO_DIR);
+            process.exit(1);
+          }
+
+          // ── Preflight: check for uncommitted changes ─────────────
+          const { stdout: status } = await exec("git", ["status", "--porcelain"], {
+            cwd: REPO_DIR,
+          });
+          if (status.length > 0) {
+            console.error(chalk.red("Uncommitted changes detected. Commit or stash first.\n"));
+            console.error(status);
+            process.exit(1);
+          }
+
+          // ── Preflight: fetch and compare ─────────────────────────
+          await exec("git", ["fetch", "origin", "main"], { cwd: REPO_DIR });
+
+          const { stdout: countStr } = await exec(
+            "git",
+            ["rev-list", "--count", "HEAD..origin/main"],
+            { cwd: REPO_DIR },
+          );
+          const behindCount = parseInt(countStr, 10);
+
+          if (behindCount === 0) {
+            console.log(chalk.green("Already up-to-date with origin/main."));
+            process.exit(0);
+          }
+
+          // ── Show pending commits ─────────────────────────────────
+          const { stdout: log } = await exec(
+            "git",
+            ["log", "--oneline", "HEAD..origin/main"],
+            { cwd: REPO_DIR },
+          );
+          console.log(
+            chalk.bold(`\n${behindCount} new commit${behindCount > 1 ? "s" : ""} from origin/main:\n`),
+          );
+          console.log(chalk.dim(log));
+          console.log();
+
+          // ── Dry run: stop here ───────────────────────────────────
+          if (opts?.dryRun) {
+            console.log(chalk.yellow("Dry run — no changes made."));
+            process.exit(0);
+          }
+
+          // ── Confirmation ─────────────────────────────────────────
+          if (!opts?.force) {
+            const restart = opts?.restart !== false;
+            const action = restart ? "stop, update, rebuild, and restart" : "stop, update, and rebuild";
+            const ok = await confirm(
+              chalk.bold(`Proceed to ${action}? [y/N] `),
+            );
+            if (!ok) {
+              console.log("Aborted.");
+              process.exit(0);
+            }
+          }
+
+          // ── Spawn detached update script ─────────────────────────
+          const scriptPath = resolve(REPO_DIR, "scripts/ao-self-update");
+
+          const child = spawn("bash", [scriptPath], {
+            cwd: REPO_DIR,
+            detached: true,
+            stdio: "ignore",
+            env: {
+              ...process.env,
+              AO_REPO_DIR: REPO_DIR,
+              AO_PORT: String(port),
+              AO_PROJECT: projectId ?? "",
+              AO_RESTART: opts?.restart !== false ? "true" : "false",
+            },
+          });
+          child.unref();
+
+          console.log(chalk.bold.green("\nUpdate started in background."));
+          console.log(
+            chalk.dim("Log: ~/.agent-orchestrator/self-update.log"),
+          );
+          process.exit(0);
+        } catch (err) {
+          console.error(
+            chalk.red("\nError:"),
+            err instanceof Error ? err.message : String(err),
+          );
+          process.exit(1);
+        }
+      },
+    );
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { registerReviewCheck } from "./commands/review-check.js";
 import { registerDashboard } from "./commands/dashboard.js";
 import { registerOpen } from "./commands/open.js";
 import { registerStart, registerStop } from "./commands/start.js";
+import { registerSelfUpdate } from "./commands/self-update.js";
 
 const program = new Command();
 
@@ -29,5 +30,6 @@ registerSend(program);
 registerReviewCheck(program);
 registerDashboard(program);
 registerOpen(program);
+registerSelfUpdate(program);
 
 program.parse();

--- a/scripts/ao-self-update
+++ b/scripts/ao-self-update
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# ao-self-update — detached updater script
+#
+# Spawned by `ao self-update`. Runs independently of the Node process so it
+# survives ao stop. Expects env vars:
+#   AO_REPO_DIR  — path to the agent-orchestrator repo
+#   AO_PORT      — dashboard port (for fallback kill)
+#   AO_PROJECT   — project id to restart (may be empty)
+#   AO_RESTART   — "true" to restart after build
+#
+
+set -euo pipefail
+
+LOG_DIR="$HOME/.agent-orchestrator"
+LOG_FILE="$LOG_DIR/self-update.log"
+mkdir -p "$LOG_DIR"
+
+exec &> >(tee -a "$LOG_FILE")
+
+echo ""
+echo "========================================"
+echo "ao self-update — $(date)"
+echo "========================================"
+echo "REPO_DIR:  $AO_REPO_DIR"
+echo "PORT:      $AO_PORT"
+echo "PROJECT:   $AO_PROJECT"
+echo "RESTART:   $AO_RESTART"
+echo ""
+
+cd "$AO_REPO_DIR"
+
+# ── Stop ao ────────────────────────────────────────────────────────
+echo ">> Stopping ao..."
+if [ -n "$AO_PROJECT" ]; then
+  ./packages/cli/dist/index.js stop "$AO_PROJECT" 2>&1 || true
+else
+  ./packages/cli/dist/index.js stop 2>&1 || true
+fi
+
+# Fallback: kill anything still on the port
+echo ">> Killing any remaining processes on port $AO_PORT..."
+lsof -ti ":$AO_PORT" | xargs kill 2>/dev/null || true
+sleep 1
+
+# ── Pull ───────────────────────────────────────────────────────────
+echo ">> Pulling latest from origin/main..."
+git pull origin main
+
+# ── Install + Build ────────────────────────────────────────────────
+echo ">> Installing dependencies..."
+pnpm install
+
+echo ">> Building..."
+pnpm build
+
+# ── Restart ────────────────────────────────────────────────────────
+if [ "$AO_RESTART" = "true" ]; then
+  echo ">> Restarting ao..."
+  if [ -n "$AO_PROJECT" ]; then
+    ./packages/cli/dist/index.js start "$AO_PROJECT" &
+  else
+    ./packages/cli/dist/index.js start &
+  fi
+  echo ">> Restart initiated."
+else
+  echo ">> Skipping restart (--no-restart)."
+fi
+
+echo ""
+echo "========================================"
+echo "ao self-update complete — $(date)"
+echo "========================================"


### PR DESCRIPTION
## Summary
- Adds `ao self-update [project]` command to pull latest from origin/main, rebuild, and optionally restart
- Uses a detached bash script that survives the Node process being killed during `ao stop`
- Preflight checks: dirty tree, pending commits, already up-to-date
- Supports `--dry-run`, `--force`, `--no-restart` flags

## Test plan
- [ ] Run `ao self-update --dry-run` — shows pending commits without making changes
- [ ] Run `ao self-update` — pulls, builds, restarts
- [ ] Run `ao self-update --no-restart` — pulls and builds without restart
- [ ] Verify self-update log at `~/.agent-orchestrator/self-update.log`
- [ ] Verify uncommitted changes are rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)