### PR TITLE
feat: add spawn-reviewer reaction for automatic PR code review

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,13 +24,14 @@ import { generateSessionPrefix } from "./paths.js";
 
 const ReactionConfigSchema = z.object({
   auto: z.boolean().default(true),
-  action: z.enum(["send-to-agent", "notify", "auto-merge"]).default("notify"),
+  action: z.enum(["send-to-agent", "notify", "auto-merge", "spawn-reviewer"]).default("notify"),
   message: z.string().optional(),
   priority: z.enum(["urgent", "action", "warning", "info"]).optional(),
   retries: z.number().optional(),
   escalateAfter: z.union([z.number(), z.string()]).optional(),
   threshold: z.string().optional(),
   includeSummary: z.boolean().optional(),
+  script: z.string().optional(),
 });
 
 const TrackerConfigSchema = z

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -11,6 +11,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { spawn as spawnChild } from "node:child_process";
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -149,6 +150,8 @@ function eventToReactionKey(eventType: EventType): string | null {
       return "agent-needs-input";
     case "session.killed":
       return "agent-exited";
+    case "review.pending":
+      return "auto-review";
     case "summary.all_complete":
       return "all-complete";
     default:
@@ -404,6 +407,55 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           action: "auto-merge",
           escalated: false,
         };
+      }
+
+      case "spawn-reviewer": {
+        if (!reactionConfig.script) break;
+
+        const session = await sessionManager.get(sessionId);
+        const project = session ? config.projects[session.projectId] : null;
+        const pr = session?.pr;
+
+        const env: Record<string, string> = {
+          ...process.env as Record<string, string>,
+          SESSION_ID: sessionId,
+        };
+        if (pr) {
+          env["PR_NUMBER"] = String(pr.number);
+          env["PR_URL"] = pr.url;
+          env["REPO"] = `${pr.owner}/${pr.repo}`;
+          env["BASE_BRANCH"] = pr.baseBranch;
+        }
+        if (project) {
+          env["PROJECT_PATH"] = project.path;
+        }
+
+        try {
+          const child = spawnChild(reactionConfig.script, [], {
+            detached: true,
+            stdio: "ignore",
+            env,
+          });
+          child.on("error", () => {
+            // Prevent unhandled error from crashing the process
+            // (e.g. ENOENT when script path doesn't exist)
+          });
+          child.unref();
+
+          return {
+            reactionType: reactionKey,
+            success: true,
+            action: "spawn-reviewer",
+            escalated: false,
+          };
+        } catch {
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "spawn-reviewer",
+            escalated: false,
+          };
+        }
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -757,7 +757,7 @@ export interface ReactionConfig {
   auto: boolean;
 
   /** What to do: send message to agent, notify human, auto-merge */
-  action: "send-to-agent" | "notify" | "auto-merge";
+  action: "send-to-agent" | "notify" | "auto-merge" | "spawn-reviewer";
 
   /** Message to send (for send-to-agent) */
   message?: string;
@@ -776,6 +776,9 @@ export interface ReactionConfig {
 
   /** Whether to include a summary in the notification */
   includeSummary?: boolean;
+
+  /** Path to an external script to run (for spawn-reviewer action) */
+  script?: string;
 }
 
 export interface ReactionResult {

--- a/scripts/pr-auto-review
+++ b/scripts/pr-auto-review
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# pr-auto-review — Automatic senior-dev code review for agent PRs.
+#
+# Required env vars: PR_NUMBER, REPO, PROJECT_PATH
+# Optional: BASE_BRANCH, SESSION_ID, PR_URL
+#
+# De-duplicates via sentinel comment, fetches diff, calls Claude for
+# structured review, posts via gh pr review.
+
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${REPO:?REPO is required}"
+: "${PROJECT_PATH:?PROJECT_PATH is required}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+SENTINEL="<!-- ao-auto-review -->"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ── De-duplicate: skip if we already posted a review ──────────────────────
+existing=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[].body' 2>/dev/null || true)
+if echo "$existing" | grep -qF "$SENTINEL"; then
+  echo "Auto-review already posted for PR #${PR_NUMBER}, skipping."
+  exit 0
+fi
+
+existing_comments=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --jq '.[].body' 2>/dev/null || true)
+if echo "$existing_comments" | grep -qF "$SENTINEL"; then
+  echo "Auto-review comment already posted for PR #${PR_NUMBER}, skipping."
+  exit 0
+fi
+
+# ── Fetch PR diff (truncated for context limits) ──────────────────────────
+diff=$(gh pr diff "$PR_NUMBER" --repo "$REPO" 2>/dev/null | head -c 8000 || true)
+if [ -z "$diff" ]; then
+  echo "No diff found for PR #${PR_NUMBER}, skipping review."
+  exit 0
+fi
+
+# ── Detect frontend files ─────────────────────────────────────────────────
+has_frontend=false
+changed_files=$(gh pr diff "$PR_NUMBER" --repo "$REPO" --name-only 2>/dev/null || true)
+if echo "$changed_files" | grep -qE '\.(tsx|jsx|css|html|vue|svelte)$'; then
+  has_frontend=true
+fi
+
+# ── Load project CUPID rules if available ─────────────────────────────────
+cupid_rules=""
+if [ -f "${PROJECT_PATH}/.agent-rules.md" ]; then
+  cupid_rules=$(head -c 3000 "${PROJECT_PATH}/.agent-rules.md")
+fi
+
+# ── Build the review prompt ───────────────────────────────────────────────
+review_prompt="You are a senior software engineer doing a thorough code review.
+
+Review this PR diff and provide structured feedback covering:
+
+1. **Logic & Correctness** — bugs, edge cases, off-by-one errors, null handling
+2. **Security** — injection risks, auth issues, data exposure, OWASP top 10
+3. **Performance** — N+1 queries, unnecessary re-renders, memory leaks, missing indexes
+4. **Accessibility** — if frontend: ARIA, keyboard nav, color contrast, semantic HTML
+5. **Code Quality** — naming, duplication, complexity, missing error handling"
+
+if [ -n "$cupid_rules" ]; then
+  review_prompt="${review_prompt}
+6. **CUPID / Project Rules Compliance** — check against these project rules:
+
+${cupid_rules}"
+fi
+
+review_prompt="${review_prompt}
+
+Format your review as markdown. Start with a one-line summary verdict (APPROVE / REQUEST CHANGES / COMMENT).
+Then list findings grouped by category. Be specific — reference file names and line numbers from the diff.
+If the code looks good, say so briefly. Don't nitpick style if it's consistent.
+
+PR diff:
+\`\`\`
+${diff}
+\`\`\`"
+
+# ── Call Claude for the review ────────────────────────────────────────────
+echo "Generating review for ${REPO}#${PR_NUMBER}..."
+unset CLAUDECODE 2>/dev/null || true
+review_body=$(claude --print --model claude-sonnet-4-20250514 --dangerously-skip-permissions <<< "$review_prompt" 2>/dev/null || true)
+
+if [ -z "$review_body" ]; then
+  echo "Claude returned empty review, skipping."
+  exit 1
+fi
+
+# ── Determine review action from verdict ──────────────────────────────────
+review_action="COMMENT"
+if echo "$review_body" | head -5 | grep -qi "APPROVE"; then
+  review_action="APPROVE"
+elif echo "$review_body" | head -5 | grep -qi "REQUEST CHANGES"; then
+  review_action="REQUEST_CHANGES"
+fi
+
+# Prepend sentinel for de-duplication
+full_body="${SENTINEL}
+## Auto Review (Agent Orchestrator)
+
+${review_body}"
+
+# ── Post the review ───────────────────────────────────────────────────────
+echo "Posting ${review_action} review on ${REPO}#${PR_NUMBER}..."
+
+# gh pr review may fail if the PR author is the same as the token owner (self-review)
+if ! gh pr review "$PR_NUMBER" --repo "$REPO" --body "$full_body" --"$(echo "$review_action" | tr '[:upper:]' '[:lower:]' | tr '_' '-')" 2>/dev/null; then
+  echo "gh pr review failed (possibly self-review), falling back to comment..."
+  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$full_body"
+fi
+
+echo "Review posted successfully."
+
+# ── Trigger screenshots if frontend files changed ─────────────────────────
+if [ "$has_frontend" = true ] && [ -x "${SCRIPT_DIR}/pr-screenshot" ]; then
+  echo "Frontend files detected, triggering screenshot capture..."
+  PR_NUMBER="$PR_NUMBER" REPO="$REPO" PROJECT_PATH="$PROJECT_PATH" BASE_BRANCH="$BASE_BRANCH" \
+    "${SCRIPT_DIR}/pr-screenshot" &
+fi
+
+echo "Done."

--- a/scripts/pr-screenshot
+++ b/scripts/pr-screenshot
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# pr-screenshot — Capture before/after screenshots for frontend PRs.
+#
+# Required env vars: PR_NUMBER, REPO, PROJECT_PATH
+# Optional: BASE_BRANCH (default: main)
+#
+# Detects dev server type, starts it on base + PR branches, captures
+# screenshots via Playwright, and posts them as a PR comment.
+
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${REPO:?REPO is required}"
+: "${PROJECT_PATH:?PROJECT_PATH is required}"
+BASE_BRANCH="${BASE_BRANCH:-main}"
+
+SCREENSHOT_DIR=$(mktemp -d)
+BEFORE_IMG="${SCREENSHOT_DIR}/before.png"
+AFTER_IMG="${SCREENSHOT_DIR}/after.png"
+DEV_PORT=3987  # Unlikely to conflict
+
+cleanup() {
+  # Kill any dev server we started
+  if [ -n "${DEV_PID:-}" ]; then
+    kill "$DEV_PID" 2>/dev/null || true
+    wait "$DEV_PID" 2>/dev/null || true
+  fi
+  rm -rf "$SCREENSHOT_DIR"
+}
+trap cleanup EXIT
+
+# ── Detect dev server command ─────────────────────────────────────────────
+detect_dev_command() {
+  local pkg_json="$1/package.json"
+  if [ ! -f "$pkg_json" ]; then
+    echo ""
+    return
+  fi
+
+  local scripts
+  scripts=$(python3 -c "import json; d=json.load(open('$pkg_json')); print(json.dumps(d.get('scripts',{})))" 2>/dev/null || echo "{}")
+
+  # Check for common dev server patterns
+  if echo "$scripts" | grep -q '"dev"'; then
+    local dev_cmd
+    dev_cmd=$(python3 -c "import json; print(json.loads('$scripts').get('dev',''))" 2>/dev/null || echo "")
+
+    if echo "$dev_cmd" | grep -qE '(vite|next|nuxt|turbo)'; then
+      echo "pnpm dev"
+      return
+    fi
+    # Generic dev script
+    echo "pnpm dev"
+    return
+  fi
+
+  echo ""
+}
+
+# ── Take screenshot via Playwright ────────────────────────────────────────
+take_screenshot() {
+  local url="$1"
+  local output_path="$2"
+  local max_wait=30
+
+  python3 - "$url" "$output_path" "$max_wait" << 'PYEOF'
+import sys
+from playwright.sync_api import sync_playwright
+
+url = sys.argv[1]
+output = sys.argv[2]
+timeout = int(sys.argv[3]) * 1000
+
+with sync_playwright() as p:
+    browser = p.chromium.launch()
+    page = browser.new_page(viewport={"width": 1280, "height": 720})
+    try:
+        page.goto(url, wait_until="networkidle", timeout=timeout)
+        page.wait_for_timeout(2000)  # Extra settle time
+        page.screenshot(path=output, full_page=False)
+    finally:
+        browser.close()
+PYEOF
+}
+
+# ── Wait for dev server to be ready ───────────────────────────────────────
+wait_for_server() {
+  local port="$1"
+  local max_attempts=30
+  local attempt=0
+
+  while [ $attempt -lt $max_attempts ]; do
+    if curl -s -o /dev/null -w "%{http_code}" "http://localhost:${port}" 2>/dev/null | grep -qE '^(200|304|301|302)'; then
+      return 0
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+  done
+  return 1
+}
+
+# ── Start dev server on a branch ──────────────────────────────────────────
+start_dev_server() {
+  local branch="$1"
+  local work_dir="$PROJECT_PATH"
+
+  # Checkout the branch
+  git -C "$work_dir" checkout "$branch" --quiet 2>/dev/null || git -C "$work_dir" checkout "origin/$branch" --quiet 2>/dev/null || return 1
+
+  # Install deps if needed
+  if [ -f "$work_dir/pnpm-lock.yaml" ]; then
+    (cd "$work_dir" && pnpm install --frozen-lockfile --silent 2>/dev/null || true)
+  elif [ -f "$work_dir/package-lock.json" ]; then
+    (cd "$work_dir" && npm ci --silent 2>/dev/null || true)
+  fi
+
+  # Start dev server with custom port
+  (cd "$work_dir" && PORT=$DEV_PORT npx --yes cross-env PORT=$DEV_PORT $DEV_CMD &)
+  DEV_PID=$!
+
+  if ! wait_for_server "$DEV_PORT"; then
+    echo "Dev server failed to start on branch $branch"
+    kill "$DEV_PID" 2>/dev/null || true
+    return 1
+  fi
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────
+
+# Check if we have a package.json
+if [ ! -f "${PROJECT_PATH}/package.json" ]; then
+  echo "No package.json found at ${PROJECT_PATH}, skipping screenshots."
+  exit 0
+fi
+
+# Detect dev server command
+DEV_CMD=$(detect_dev_command "$PROJECT_PATH")
+if [ -z "$DEV_CMD" ]; then
+  echo "No dev server detected in ${PROJECT_PATH}, skipping screenshots."
+  exit 0
+fi
+
+# Get the PR branch name
+PR_BRANCH=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json headRefName --jq '.headRefName' 2>/dev/null || true)
+if [ -z "$PR_BRANCH" ]; then
+  echo "Could not determine PR branch, skipping screenshots."
+  exit 0
+fi
+
+# Save current branch to restore later
+ORIGINAL_BRANCH=$(git -C "$PROJECT_PATH" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "$BASE_BRANCH")
+
+# Fetch latest
+git -C "$PROJECT_PATH" fetch --quiet 2>/dev/null || true
+
+echo "Capturing BEFORE screenshot (${BASE_BRANCH})..."
+if start_dev_server "$BASE_BRANCH"; then
+  take_screenshot "http://localhost:${DEV_PORT}" "$BEFORE_IMG" || echo "Before screenshot failed"
+  kill "$DEV_PID" 2>/dev/null || true
+  wait "$DEV_PID" 2>/dev/null || true
+  unset DEV_PID
+else
+  echo "Could not start dev server on base branch, skipping before screenshot."
+fi
+
+echo "Capturing AFTER screenshot (${PR_BRANCH})..."
+if start_dev_server "$PR_BRANCH"; then
+  take_screenshot "http://localhost:${DEV_PORT}" "$AFTER_IMG" || echo "After screenshot failed"
+  kill "$DEV_PID" 2>/dev/null || true
+  wait "$DEV_PID" 2>/dev/null || true
+  unset DEV_PID
+else
+  echo "Could not start dev server on PR branch, skipping after screenshot."
+fi
+
+# Restore original branch
+git -C "$PROJECT_PATH" checkout "$ORIGINAL_BRANCH" --quiet 2>/dev/null || true
+
+# ── Post screenshots as PR comment ────────────────────────────────────────
+if [ -f "$BEFORE_IMG" ] || [ -f "$AFTER_IMG" ]; then
+  echo "Uploading screenshots..."
+
+  comment_body="<!-- ao-auto-screenshot -->
+## Visual Diff (Agent Orchestrator)
+"
+
+  if [ -f "$BEFORE_IMG" ]; then
+    before_url=$(gh gist create "$BEFORE_IMG" --public --desc "PR #${PR_NUMBER} before screenshot" 2>/dev/null | tail -1 || true)
+    if [ -n "$before_url" ]; then
+      # Convert gist URL to raw file URL
+      gist_id=$(echo "$before_url" | grep -oE '[a-f0-9]{32}' || true)
+      if [ -n "$gist_id" ]; then
+        comment_body="${comment_body}
+### Before (\`${BASE_BRANCH}\`)
+![before](https://gist.githubusercontent.com/raw/${gist_id}/before.png)
+"
+      fi
+    fi
+  fi
+
+  if [ -f "$AFTER_IMG" ]; then
+    after_url=$(gh gist create "$AFTER_IMG" --public --desc "PR #${PR_NUMBER} after screenshot" 2>/dev/null | tail -1 || true)
+    if [ -n "$after_url" ]; then
+      gist_id=$(echo "$after_url" | grep -oE '[a-f0-9]{32}' || true)
+      if [ -n "$gist_id" ]; then
+        comment_body="${comment_body}
+### After (\`${PR_BRANCH}\`)
+![after](https://gist.githubusercontent.com/raw/${gist_id}/after.png)
+"
+      fi
+    fi
+  fi
+
+  gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$comment_body"
+  echo "Screenshots posted."
+else
+  echo "No screenshots captured, skipping comment."
+fi
+
+echo "Done."


### PR DESCRIPTION
## Summary
- New reaction type `spawn-reviewer` that runs an external script when a PR enters `review_pending` state
- Adds `script` field to `ReactionConfig` for custom reviewer scripts
- Includes `pr-auto-review` script: fetches diff, calls Claude for structured review (logic, security, performance, accessibility, CUPID rules), posts via `gh pr review`
- Includes `pr-screenshot` script: captures before/after screenshots for frontend changes via Playwright
- Adds error handler on detached child process to prevent ENOENT crash when script path is invalid

### Example config
```yaml
reactions:
  auto-review:
    auto: true
    action: spawn-reviewer
    script: ./scripts/pr-auto-review
```

## Test plan
- [ ] Configure `auto-review` reaction with `spawn-reviewer` action pointing to `scripts/pr-auto-review`
- [ ] Open a PR and verify the lifecycle manager triggers the script on `review_pending`
- [ ] Verify review is posted via `gh pr review` with structured feedback
- [ ] Verify de-duplication: re-running does not post a second review
- [ ] Verify invalid script path does not crash the orchestrator (error handler)
- [ ] Verify frontend PR triggers screenshot capture when `pr-screenshot` is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)