### PR TITLE
Add vertical spacing between screenshots and buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
   <img src="docs/assets/demo-video-tweet.png" alt="Agent Orchestrator demo — AI agents building their own orchestrator" width="560">
 </a>
 
-<br>
+<p>&nbsp;</p>
 
 <a href="https://x.com/agent_wrapper/status/2026329204405723180"><img src="docs/assets/btn-watch-demo.png" alt="Watch the Demo on X" height="48"></a>
 
@@ -37,7 +37,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
   <img src="docs/assets/article-tweet.png" alt="The Self-Improving AI System That Built Itself" width="560">
 </a>
 
-<br>
+<p>&nbsp;</p>
 
 <a href="https://x.com/agent_wrapper/status/2025986105485733945"><img src="docs/assets/btn-read-article.png" alt="Read the Full Article on X" height="48"></a>
 


### PR DESCRIPTION
## Summary
- Replace `<br>` with `<p>&nbsp;</p>` between tweet screenshots and CTA buttons
- GitHub markdown collapses `<br>` inside `<div>` blocks — `<p>` with a non-breaking space renders as reliable vertical space

## Test plan
- [x] Verified on GitHub branch preview — spacing now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)