### PR TITLE
Fix spacing between screenshots and CTA buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 <a href="https://x.com/agent_wrapper/status/2026329204405723180">
   <img src="docs/assets/demo-video-tweet.png" alt="Agent Orchestrator demo — AI agents building their own orchestrator" width="560">
 </a>
-
-<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" height="8">
-
+<br><br>
 <a href="https://x.com/agent_wrapper/status/2026329204405723180"><img src="docs/assets/btn-watch-demo.png" alt="Watch the Demo on X" height="48"></a>
 
 </div>
@@ -36,9 +34,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 <a href="https://x.com/agent_wrapper/status/2025986105485733945">
   <img src="docs/assets/article-tweet.png" alt="The Self-Improving AI System That Built Itself" width="560">
 </a>
-
-<img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" height="8">
-
+<br><br>
 <a href="https://x.com/agent_wrapper/status/2025986105485733945"><img src="docs/assets/btn-read-article.png" alt="Read the Full Article on X" height="48"></a>
 
 </div>


### PR DESCRIPTION
## Summary
- Use `<br><br>` on the same line (no surrounding blank lines) for moderate vertical spacing
- Previous attempts: `<br>` (collapsed), `<p>&nbsp;</p>` (too much), `data:` URI (stripped by GitHub)
- The key: GitHub collapses `<br>` when surrounded by blank lines in HTML blocks, but keeps them when inline

## Test plan
- [x] Verified on GitHub branch — buttons have subtle gap from screenshot, closer to their image than to content below

🤖 Generated with [Claude Code](https://claude.com/claude-code)