### PR TITLE
Add spacing between demo button and article section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 </a>
 <br><br>
 <a href="https://x.com/agent_wrapper/status/2026329204405723180"><img src="docs/assets/btn-watch-demo.png" alt="Watch the Demo on X" height="48"></a>
-
-</div>
-
-<div align="center">
-
+<br><br><br>
 <a href="https://x.com/agent_wrapper/status/2025986105485733945">
   <img src="docs/assets/article-tweet.png" alt="The Self-Improving AI System That Built Itself" width="560">
 </a>


### PR DESCRIPTION
## Summary
- Add `<br><br><br>` between the "Watch the Demo on X" button and the article screenshot below
- Merges the two separate `<div align="center">` blocks into one to keep spacing inline

## Test plan
- [ ] Verify spacing between demo CTA and article screenshot on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)