### PR TITLE
feat: support Fire Team agent spawning via dispatch labels

### DIFF
--- a/packages/core/src/__tests__/label-parser.test.ts
+++ b/packages/core/src/__tests__/label-parser.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { parseDispatchLabels } from "../session-manager.js";
+
+describe("parseDispatchLabels", () => {
+  it("parses a dispatch: label", () => {
+    const result = parseDispatchLabels(["dispatch:cli-single", "bug", "priority:high"]);
+    expect(result).toEqual({ dispatch: "dispatch:cli-single" });
+  });
+
+  it("parses a mode: label", () => {
+    const result = parseDispatchLabels(["mode:plan-first", "enhancement"]);
+    expect(result).toEqual({ mode: "mode:plan-first" });
+  });
+
+  it("parses a model: label", () => {
+    const result = parseDispatchLabels(["model:sonnet", "frontend"]);
+    expect(result).toEqual({ model: "model:sonnet" });
+  });
+
+  it("parses all three prefix types together", () => {
+    const result = parseDispatchLabels([
+      "dispatch:cli-team-3",
+      "mode:direct",
+      "model:opus",
+      "cat:platform",
+    ]);
+    expect(result).toEqual({
+      dispatch: "dispatch:cli-team-3",
+      mode: "mode:direct",
+      model: "model:opus",
+    });
+  });
+
+  it("returns empty object for empty labels", () => {
+    expect(parseDispatchLabels([])).toEqual({});
+  });
+
+  it("returns empty object when no dispatch labels present", () => {
+    const result = parseDispatchLabels(["bug", "priority:high", "cat:platform"]);
+    expect(result).toEqual({});
+  });
+
+  it("first-wins when duplicate prefixes exist", () => {
+    const result = parseDispatchLabels([
+      "dispatch:cli-single",
+      "dispatch:cli-team-3",
+      "model:sonnet",
+      "model:opus",
+    ]);
+    expect(result).toEqual({
+      dispatch: "dispatch:cli-single",
+      model: "model:sonnet",
+    });
+  });
+
+  it("metadata is passed through to AgentLaunchConfig in spawn", () => {
+    // This test validates the shape — the integration with spawn() is
+    // tested in session-manager.test.ts
+    const labels = ["dispatch:cli-single", "mode:direct", "model:sonnet"];
+    const metadata = parseDispatchLabels(labels);
+    expect(metadata).toHaveProperty("dispatch");
+    expect(metadata).toHaveProperty("mode");
+    expect(metadata).toHaveProperty("model");
+    expect(Object.keys(metadata)).toHaveLength(3);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,7 +44,7 @@ export {
 } from "./tmux.js";
 
 // Session manager — session CRUD
-export { createSessionManager } from "./session-manager.js";
+export { createSessionManager, parseDispatchLabels } from "./session-manager.js";
 export type { SessionManagerDeps } from "./session-manager.js";
 
 // Lifecycle manager — state machine + reaction engine

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -61,6 +61,25 @@ function escapeRegex(str: string): string {
   return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+/**
+ * Parse dispatch labels from issue labels.
+ * Recognises `dispatch:`, `mode:`, and `model:` prefixes.
+ * First occurrence wins when duplicates exist.
+ */
+export function parseDispatchLabels(labels: string[]): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const label of labels) {
+    if (label.startsWith("dispatch:") && !result["dispatch"]) {
+      result["dispatch"] = label;
+    } else if (label.startsWith("mode:") && !result["mode"]) {
+      result["mode"] = label;
+    } else if (label.startsWith("model:") && !result["model"]) {
+      result["model"] = label;
+    }
+  }
+  return result;
+}
+
 /** Get the next session number for a project. */
 function getNextSessionNumber(existingSessions: string[], prefix: string): number {
   let max = 0;
@@ -355,6 +374,11 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       }
     }
 
+    // Parse dispatch labels from issue (dispatch:, mode:, model:)
+    const dispatchMetadata = resolvedIssue?.labels
+      ? parseDispatchLabels(resolvedIssue.labels)
+      : {};
+
     // Get the sessions directory for this project
     const sessionsDir = getProjectSessionsDir(project);
 
@@ -477,6 +501,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       prompt: composedPrompt ?? spawnConfig.prompt,
       permissions: project.agentConfig?.permissions,
       model: project.agentConfig?.model,
+      ...(Object.keys(dispatchMetadata).length > 0 ? { metadata: dispatchMetadata } : {}),
     };
 
     let handle: RuntimeHandle;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -352,6 +352,11 @@ export interface AgentLaunchConfig {
    * - Codex/Aider: similar shell substitution
    */
   systemPromptFile?: string;
+  /**
+   * Parsed dispatch labels from the issue (e.g. dispatch:, mode:, model:).
+   * Populated by parseDispatchLabels() in session-manager when an issue has labels.
+   */
+  metadata?: Record<string, string>;
 }
 
 export interface WorkspaceHooksConfig {

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -203,6 +203,22 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toMatch(/\s-p\s/);
     expect(cmd).not.toContain("Do the task");
   });
+
+  it("appends team composition prompt for fire team dispatch", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ metadata: { dispatch: "dispatch:cli-team-5" } }),
+    );
+    expect(cmd).toContain("--append-system-prompt");
+    expect(cmd).toContain("team of 5 agents");
+    expect(cmd).toContain("own specific files");
+  });
+
+  it("does not append team prompt for non-team dispatch", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ metadata: { dispatch: "dispatch:cli-single" } }),
+    );
+    expect(cmd).not.toContain("team of");
+  });
 });
 
 // =========================================================================
@@ -230,6 +246,25 @@ describe("getEnvironment", () => {
   it("does not set AO_ISSUE_ID when not provided", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
+  });
+
+  it("sets CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS for fire team dispatch", () => {
+    const env = agent.getEnvironment(
+      makeLaunchConfig({ metadata: { dispatch: "dispatch:cli-team-3" } }),
+    );
+    expect(env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"]).toBe("1");
+  });
+
+  it("does not set AGENT_TEAMS for non-team dispatch", () => {
+    const env = agent.getEnvironment(
+      makeLaunchConfig({ metadata: { dispatch: "dispatch:cli-single" } }),
+    );
+    expect(env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"]).toBeUndefined();
+  });
+
+  it("does not set AGENT_TEAMS when no dispatch metadata", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"]).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` when dispatch label is `dispatch:cli-team-N`
- Append team composition system prompt with team size parsed from label
- Non-team dispatch labels are unaffected

**Depends on PR #258** (dispatch label parsing)

## Changes

| File | Change |
|---|---|
| `packages/plugins/agent-claude-code/src/index.ts` | Add team env var and system prompt in getEnvironment/getLaunchCommand |
| `packages/plugins/agent-claude-code/src/index.test.ts` | 5 new tests |

## Test plan

- [x] Team env var set for dispatch:cli-team-N
- [x] Non-team dispatch unaffected
- [x] No dispatch metadata unaffected
- [x] Team size extracted from label into prompt
- [x] All 113 claude-code tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)