### PR TITLE
feat: add merge queue support to GitHub SCM plugin

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -519,8 +519,8 @@ export interface SCM {
     deletions: number;
   }>;
 
-  /** Merge a PR */
-  mergePR(pr: PRInfo, method?: MergeMethod): Promise<void>;
+  /** Merge a PR. When options.useQueue is true, uses `--auto` for merge queue support. */
+  mergePR(pr: PRInfo, method?: MergeMethod, options?: MergeOptions): Promise<void>;
 
   /** Close a PR without merging */
   closePR(pr: PRInfo): Promise<void>;
@@ -576,6 +576,11 @@ export const PR_STATE = {
 } satisfies Record<string, PRState>;
 
 export type MergeMethod = "merge" | "squash" | "rebase";
+
+export interface MergeOptions {
+  /** When true, use `gh pr merge --auto` for merge queue support. */
+  useQueue?: boolean;
+}
 
 // --- CI Types ---
 

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -15,6 +15,7 @@ import {
   type PRInfo,
   type PRState,
   type MergeMethod,
+  type MergeOptions,
   type CICheck,
   type CIStatus,
   type Review,
@@ -168,10 +169,15 @@ function createGitHubSCM(): SCM {
       };
     },
 
-    async mergePR(pr: PRInfo, method: MergeMethod = "squash"): Promise<void> {
+    async mergePR(pr: PRInfo, method: MergeMethod = "squash", options?: MergeOptions): Promise<void> {
       const flag = method === "rebase" ? "--rebase" : method === "merge" ? "--merge" : "--squash";
+      const useQueue = options?.useQueue ?? false;
 
-      await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), flag, "--delete-branch"]);
+      if (useQueue) {
+        await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), "--auto", flag]);
+      } else {
+        await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), flag, "--delete-branch"]);
+      }
     },
 
     async closePR(pr: PRInfo): Promise<void> {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -220,6 +220,34 @@ describe("scm-github plugin", () => {
         expect.any(Object),
       );
     });
+
+    it("uses --auto for merge queue when useQueue is true", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "squash", { useQueue: true });
+      expect(ghMock).toHaveBeenCalledWith(
+        "gh",
+        ["pr", "merge", "42", "--repo", "acme/repo", "--auto", "--squash"],
+        expect.any(Object),
+      );
+    });
+
+    it("uses --delete-branch without queue when useQueue is false", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "squash", { useQueue: false });
+      expect(ghMock).toHaveBeenCalledWith(
+        "gh",
+        ["pr", "merge", "42", "--repo", "acme/repo", "--squash", "--delete-branch"],
+        expect.any(Object),
+      );
+    });
+
+    it("defaults to non-queue (--delete-branch) when options omitted", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr);
+      const args = ghMock.mock.calls[0][1];
+      expect(args).toContain("--delete-branch");
+      expect(args).not.toContain("--auto");
+    });
   });
 
   // ---- closePR -----------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `MergeOptions` with `useQueue` boolean to `SCM.mergePR()`
- When `useQueue: true`, uses `gh pr merge --auto` for merge queue support
- Defaults to existing behavior (`--delete-branch`) — fully backwards-compatible

## Changes

| File | Change |
|---|---|
| `packages/core/src/types.ts` | Add `MergeOptions` interface, update `mergePR` signature |
| `packages/plugins/scm-github/src/index.ts` | Implement queue/non-queue merge path |
| `packages/plugins/scm-github/test/index.test.ts` | 3 new tests |

## Test plan

- [x] Queue mode uses `--auto` flag
- [x] Non-queue mode uses `--delete-branch`
- [x] Default (no options) matches existing behavior
- [x] All 57 scm-github tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)