### PR TITLE
feat(web): add /proxydash quick-access session jump page

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -1,10 +1,11 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { CIBadge, CICheckList } from "@/components/CIBadge";
 import { PRStatus } from "@/components/PRStatus";
 import { SessionCard } from "@/components/SessionCard";
 import { AttentionZone } from "@/components/AttentionZone";
 import { ActivityDot } from "@/components/ActivityDot";
+import { ProxyDash } from "@/components/ProxyDash";
 import { makeSession, makePR } from "./helpers";
 
 // ── ActivityDot ───────────────────────────────────────────────────────
@@ -492,5 +493,73 @@ describe("AttentionZone", () => {
     render(<AttentionZone level="respond" sessions={sessions} onRestore={onRestore} />);
     fireEvent.click(screen.getByText("restore"));
     expect(onRestore).toHaveBeenCalledWith("s1");
+  });
+});
+
+// ── ProxyDash ────────────────────────────────────────────────────────
+
+describe("ProxyDash", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+  });
+
+  it("renders the proxydash heading and back link", () => {
+    render(<ProxyDash initialSessions={[]} projectName="myapp" />);
+    expect(screen.getByText("proxydash")).toBeInTheDocument();
+    expect(screen.getByText("← myapp")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no sessions", () => {
+    render(<ProxyDash initialSessions={[]} projectName="myapp" />);
+    expect(screen.getByText("No sessions found")).toBeInTheDocument();
+    expect(screen.getByText("Go to dashboard")).toBeInTheDocument();
+  });
+
+  it("renders session rows for active sessions", () => {
+    const sessions = [
+      makeSession({ id: "scio-1", branch: "feat/auth", status: "working", activity: "active" }),
+      makeSession({ id: "scio-2", branch: "feat/search", status: "working", activity: "idle" }),
+    ];
+    render(<ProxyDash initialSessions={sessions} projectName="myapp" />);
+    expect(screen.getAllByText("scio-1").length).toBeGreaterThan(0);
+    expect(screen.getByText("scio-2")).toBeInTheDocument();
+  });
+
+  it("shows most urgent session in the Most Urgent section", () => {
+    const urgent = makeSession({
+      id: "scio-urgent",
+      status: "needs_input",
+      activity: "waiting_input",
+    });
+    const normal = makeSession({ id: "scio-normal", status: "working", activity: "active" });
+    render(<ProxyDash initialSessions={[normal, urgent]} projectName="myapp" />);
+    expect(screen.getByText("Most Urgent")).toBeInTheDocument();
+    // The urgent session id should appear in the Most Urgent section
+    expect(screen.getAllByText("scio-urgent").length).toBeGreaterThan(0);
+  });
+
+  it("links sessions to their terminal page", () => {
+    const session = makeSession({ id: "scio-3", status: "working", activity: "active" });
+    render(<ProxyDash initialSessions={[session]} projectName="myapp" />);
+    const links = screen.getAllByRole("link", { name: /scio-3/i });
+    expect(links[0]).toHaveAttribute("href", "/sessions/scio-3");
+  });
+
+  it("shows PR number with link when session has PR", () => {
+    const pr = makePR({ number: 42, url: "https://github.com/org/repo/pull/42" });
+    const session = makeSession({ id: "scio-4", pr, status: "working", activity: "active" });
+    render(<ProxyDash initialSessions={[session]} projectName="myapp" />);
+    // Session may appear in both "Most Urgent" and "Active" sections — use first match
+    const prLinks = screen.getAllByText("#42");
+    expect(prLinks.length).toBeGreaterThan(0);
+    expect(prLinks[0].closest("a")).toHaveAttribute("href", "https://github.com/org/repo/pull/42");
+  });
+
+  it("shows Active and Done section labels with counts", () => {
+    const active = makeSession({ id: "scio-a", status: "working", activity: "active" });
+    const done = makeSession({ id: "scio-d", status: "merged", activity: "idle" });
+    render(<ProxyDash initialSessions={[active, done]} projectName="myapp" />);
+    expect(screen.getByText(/Active · 1/)).toBeInTheDocument();
+    expect(screen.getByText(/Done · 1/)).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/helpers.ts
+++ b/packages/web/src/__tests__/helpers.ts
@@ -11,6 +11,7 @@ export function makeSession(overrides: Partial<DashboardSession> = {}): Dashboar
     issueId: "https://linear.app/test/issue/INT-100",
     issueUrl: "https://linear.app/test/issue/INT-100",
     issueLabel: "INT-100",
+    issueTitle: null,
     summary: "Test session",
     summaryIsFallback: false,
     createdAt: new Date().toISOString(),

--- a/packages/web/src/app/proxydash/page.tsx
+++ b/packages/web/src/app/proxydash/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { ProxyDash } from "@/components/ProxyDash";
+import type { DashboardSession } from "@/lib/types";
+import { getServices } from "@/lib/services";
+import { sessionToDashboard } from "@/lib/serialize";
+import { getProjectName } from "@/lib/project-name";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const projectName = getProjectName();
+  return { title: `proxydash | ${projectName}` };
+}
+
+export default async function ProxyDashPage() {
+  let sessions: DashboardSession[] = [];
+  let projectName = "ao";
+
+  try {
+    projectName = getProjectName();
+    const { sessionManager } = await getServices();
+    const allSessions = await sessionManager.list();
+    const coreSessions = allSessions.filter((s) => !s.id.endsWith("-orchestrator"));
+    sessions = coreSessions.map(sessionToDashboard);
+  } catch {
+    // Config not found or services unavailable — show empty state
+  }
+
+  return <ProxyDash initialSessions={sessions} projectName={projectName} />;
+}

--- a/packages/web/src/components/ProxyDash.tsx
+++ b/packages/web/src/components/ProxyDash.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { type DashboardSession, type AttentionLevel, getAttentionLevel } from "@/lib/types";
+import { ActivityDot } from "./ActivityDot";
+import { cn } from "@/lib/cn";
+
+interface ProxyDashProps {
+  initialSessions: DashboardSession[];
+  projectName: string;
+}
+
+const URGENCY_ORDER: AttentionLevel[] = ["merge", "respond", "review", "pending", "working", "done"];
+
+const zoneStyle: Record<AttentionLevel, { label: string; color: string }> = {
+  merge:   { label: "Merge",   color: "var(--color-status-ready)" },
+  respond: { label: "Respond", color: "var(--color-status-error)" },
+  review:  { label: "Review",  color: "var(--color-accent-orange)" },
+  pending: { label: "Pending", color: "var(--color-status-attention)" },
+  working: { label: "Working", color: "var(--color-status-working)" },
+  done:    { label: "Done",    color: "var(--color-text-tertiary)" },
+};
+
+function relativeTime(iso: string): string {
+  const ms = new Date(iso).getTime();
+  if (!iso || isNaN(ms)) return "—";
+  const diff = Date.now() - ms;
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
+}
+
+function sortByUrgency(sessions: DashboardSession[]): DashboardSession[] {
+  return [...sessions].sort((a, b) => {
+    const ai = URGENCY_ORDER.indexOf(getAttentionLevel(a));
+    const bi = URGENCY_ORDER.indexOf(getAttentionLevel(b));
+    if (ai !== bi) return ai - bi;
+    // Secondary: most recent activity first
+    return new Date(b.lastActivityAt).getTime() - new Date(a.lastActivityAt).getTime();
+  });
+}
+
+function mostUrgentSession(sessions: DashboardSession[]): DashboardSession | null {
+  const sorted = sortByUrgency(sessions.filter((s) => getAttentionLevel(s) !== "done"));
+  return sorted[0] ?? null;
+}
+
+interface SessionRowProps {
+  session: DashboardSession;
+  isTop: boolean;
+}
+
+function SessionRow({ session, isTop }: SessionRowProps) {
+  const level = getAttentionLevel(session);
+  const { color } = zoneStyle[level];
+
+  return (
+    <a
+      href={`/sessions/${encodeURIComponent(session.id)}`}
+      className={cn(
+        "group flex items-center gap-3 rounded-[6px] px-3 py-2.5 text-[12px] transition-colors hover:no-underline",
+        isTop
+          ? "border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)]"
+          : "hover:bg-[var(--color-bg-subtle)]",
+      )}
+    >
+      {/* Urgency indicator */}
+      <span
+        className="h-2 w-2 shrink-0 rounded-full"
+        style={{ background: color }}
+      />
+
+      {/* Session ID */}
+      <span className="w-[80px] shrink-0 truncate font-mono text-[11px] text-[var(--color-text-secondary)]">
+        {session.id}
+      </span>
+
+      {/* Issue label */}
+      <span className="w-[70px] shrink-0 truncate text-[var(--color-text-muted)]">
+        {session.issueLabel ?? "—"}
+      </span>
+
+      {/* Branch */}
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[var(--color-text-secondary)]">
+        {session.branch ?? "—"}
+      </span>
+
+      {/* Summary (if available and not fallback) */}
+      {session.summary && !session.summaryIsFallback && (
+        <span className="hidden min-w-0 max-w-[200px] truncate text-[11px] text-[var(--color-text-muted)] md:block">
+          {session.summary}
+        </span>
+      )}
+
+      {/* PR link */}
+      {session.pr ? (
+        <a
+          href={session.pr.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 text-[var(--color-accent)] hover:underline"
+          onClick={(e) => e.stopPropagation()}
+        >
+          #{session.pr.number}
+        </a>
+      ) : (
+        <span className="w-[30px] shrink-0 text-center text-[var(--color-text-tertiary)]">—</span>
+      )}
+
+      {/* Activity */}
+      <span className="shrink-0">
+        <ActivityDot activity={session.activity} dotOnly />
+      </span>
+
+      {/* Time since last activity */}
+      <span className="w-[28px] shrink-0 text-right text-[10px] text-[var(--color-text-tertiary)]">
+        {relativeTime(session.lastActivityAt)}
+      </span>
+
+      {/* Arrow */}
+      <svg
+        className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-tertiary)] transition-colors group-hover:text-[var(--color-accent)]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+      >
+        <path d="M9 18l6-6-6-6" />
+      </svg>
+    </a>
+  );
+}
+
+export function ProxyDash({ initialSessions, projectName }: ProxyDashProps) {
+  const [sessions, setSessions] = useState<DashboardSession[]>(initialSessions);
+  const [lastRefresh, setLastRefresh] = useState(Date.now());
+  const [tick, setTick] = useState(0);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions");
+      if (!res.ok) return;
+      const body = (await res.json()) as { sessions: DashboardSession[] };
+      const all = body.sessions ?? [];
+      setSessions(all.filter((s) => !s.id.endsWith("-orchestrator")));
+      setLastRefresh(Date.now());
+    } catch {
+      // Ignore transient errors — stale data is fine
+    }
+  }, []);
+
+  // Poll every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      refresh();
+      setTick((t) => t + 1);
+    }, 5_000);
+    return () => clearInterval(interval);
+  }, [refresh]);
+
+  // Tick every second to update relative times
+  useEffect(() => {
+    const interval = setInterval(() => setTick((t) => t + 1), 1_000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const sorted = sortByUrgency(sessions);
+  const topSession = mostUrgentSession(sessions);
+  const activeSessions = sorted.filter((s) => getAttentionLevel(s) !== "done");
+  const doneSessions = sorted.filter((s) => getAttentionLevel(s) === "done");
+  const secondsAgo = Math.floor((Date.now() - lastRefresh) / 1000);
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg-base)] px-6 py-5">
+      {/* Header */}
+      <div className="mb-5 flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <a
+            href="/"
+            className="text-[12px] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+          >
+            ← {projectName}
+          </a>
+          <span className="text-[var(--color-border-default)]">/</span>
+          <h1 className="text-[13px] font-semibold text-[var(--color-text-primary)]">
+            proxydash
+          </h1>
+        </div>
+        <span className="text-[10px] text-[var(--color-text-tertiary)]">
+          {tick > 0 && secondsAgo < 5 ? "refreshed just now" : `${secondsAgo}s ago`}
+        </span>
+      </div>
+
+      {/* Jump to most urgent */}
+      {topSession && (
+        <div className="mb-5">
+          <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
+            Most Urgent
+          </div>
+          <SessionRow session={topSession} isTop />
+        </div>
+      )}
+
+      {/* Active sessions */}
+      {activeSessions.length > 0 && (
+        <div className="mb-4">
+          <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
+            Active · {activeSessions.length}
+          </div>
+          <div className="flex flex-col gap-0.5">
+            {activeSessions.map((session) => (
+              <SessionRow key={session.id} session={session} isTop={false} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Done sessions (collapsed by default via scrolling) */}
+      {doneSessions.length > 0 && (
+        <div>
+          <div className="mb-1.5 text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
+            Done · {doneSessions.length}
+          </div>
+          <div className="flex flex-col gap-0.5 opacity-50">
+            {doneSessions.map((session) => (
+              <SessionRow key={session.id} session={session} isTop={false} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Empty state */}
+      {sessions.length === 0 && (
+        <div className="flex flex-col items-center justify-center py-20 text-center">
+          <p className="text-[13px] text-[var(--color-text-muted)]">No sessions found</p>
+          <a
+            href="/"
+            className="mt-2 text-[12px] text-[var(--color-accent)] hover:underline"
+          >
+            Go to dashboard
+          </a>
+        </div>
+      )}
+
+      {/* Column header */}
+      {sessions.length > 0 && (
+        <div className="mt-6 flex items-center gap-3 border-t border-[var(--color-border-subtle)] px-3 pt-3 text-[10px] text-[var(--color-text-tertiary)]">
+          <span className="w-2 shrink-0" />
+          <span className="w-[80px] shrink-0">session</span>
+          <span className="w-[70px] shrink-0">issue</span>
+          <span className="flex-1">branch</span>
+          <span className="w-[30px] shrink-0 text-center">pr</span>
+          <span className="shrink-0">activity</span>
+          <span className="w-[28px] shrink-0 text-right">age</span>
+          <span className="w-3.5 shrink-0" />
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a new `/proxydash` route to the web dashboard for quick-access navigation to the most urgent active agent session
- Sessions are sorted by urgency: merge → respond → review → pending → working → done
- "Most Urgent" section highlights the session needing human attention first
- Direct terminal links for each session row
- Auto-refreshes every 5 seconds via `/api/sessions` polling

## Details

The page is designed as a lightweight, embeddable/bookmarkable companion to the main dashboard. Unlike the main `/` page (kanban board + PR table), `/proxydash` is optimized for:
- Quickly jumping to the right terminal when you return to the computer
- Monitoring active sessions at a glance from a bookmark or external tool
- A minimal view that loads fast and updates continuously

### Columns
- **Urgency dot** — color-coded by zone (merge=green, respond=red, review=orange, pending=yellow, working=blue)
- **Session ID** — monospace for easy scanning
- **Issue label** — short issue ID (e.g., INT-1234, #42)
- **Branch** — feature branch name
- **PR link** — direct link to pull request on GitHub
- **Activity dot** — current agent activity state
- **Age** — time since last activity

### Behavior
- Polls `/api/sessions` every 5s to refresh session list
- Relative times update every second (no SSE dependency — simpler for embeds)
- Done/terminal sessions shown separately with reduced opacity

## Test plan
- [x] All existing tests pass (345 → 352, +7 new tests)
- [x] TypeScript builds without errors
- [x] ESLint shows no new errors
- [x] `/proxydash` route visible in Next.js build output (3.32 kB)
- [x] Renders empty state when no sessions
- [x] Renders session list sorted by urgency
- [x] "Most Urgent" section shows highest-priority session
- [x] PR links point to correct GitHub URLs
- [x] Section labels show correct counts