### PR TITLE
fix: don't show 'Ready to merge' badge on merged/closed PRs

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import { type DashboardSession, type DashboardPR } from "@/lib/types";
+import { type DashboardSession, type DashboardPR, isPRMergeReady } from "@/lib/types";
 import { CI_STATUS } from "@composio/ao-core/types";
 import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
@@ -467,11 +467,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
     );
   };
 
-  const allGreen =
-    pr.mergeability.mergeable &&
-    pr.mergeability.ciPassing &&
-    pr.mergeability.approved &&
-    pr.mergeability.noConflicts;
+  const allGreen = isPRMergeReady(pr);
 
   const failedChecks = pr.ciChecks.filter((c) => c.status === "failed");
 

--- a/packages/web/src/lib/__tests__/types.test.ts
+++ b/packages/web/src/lib/__tests__/types.test.ts
@@ -5,10 +5,12 @@
 import { describe, it, expect } from "vitest";
 import {
   getAttentionLevel,
+  isPRMergeReady,
   TERMINAL_STATUSES,
   TERMINAL_ACTIVITIES,
   NON_RESTORABLE_STATUSES,
   type DashboardSession,
+  type DashboardPR,
 } from "../types";
 import {
   TERMINAL_STATUSES as CORE_TERMINAL_STATUSES,
@@ -470,6 +472,105 @@ describe("getAttentionLevel", () => {
       });
       expect(getAttentionLevel(session)).toBe("working");
     });
+  });
+});
+
+// Helper to create a minimal DashboardPR for testing
+function createPR(overrides?: Partial<DashboardPR>): DashboardPR {
+  return {
+    number: 1,
+    url: "https://github.com/test/repo/pull/1",
+    title: "Test PR",
+    owner: "test",
+    repo: "repo",
+    branch: "feat/test",
+    baseBranch: "main",
+    isDraft: false,
+    state: "open",
+    additions: 10,
+    deletions: 5,
+    ciStatus: "passing",
+    ciChecks: [],
+    reviewDecision: "approved",
+    mergeability: {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    },
+    unresolvedThreads: 0,
+    unresolvedComments: [],
+    ...overrides,
+  };
+}
+
+describe("isPRMergeReady", () => {
+  it("returns true for open PR with all criteria met", () => {
+    const pr = createPR();
+    expect(isPRMergeReady(pr)).toBe(true);
+  });
+
+  it("returns false for merged PR even with all criteria met", () => {
+    const pr = createPR({ state: "merged" });
+    expect(isPRMergeReady(pr)).toBe(false);
+  });
+
+  it("returns false for closed PR even with all criteria met", () => {
+    const pr = createPR({ state: "closed" });
+    expect(isPRMergeReady(pr)).toBe(false);
+  });
+
+  it("returns false for open PR that is not mergeable", () => {
+    const pr = createPR({
+      mergeability: {
+        mergeable: false,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: ["Not mergeable"],
+      },
+    });
+    expect(isPRMergeReady(pr)).toBe(false);
+  });
+
+  it("returns false for open PR with failing CI", () => {
+    const pr = createPR({
+      mergeability: {
+        mergeable: true,
+        ciPassing: false,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      },
+    });
+    expect(isPRMergeReady(pr)).toBe(false);
+  });
+
+  it("returns false for open PR that is not approved", () => {
+    const pr = createPR({
+      mergeability: {
+        mergeable: true,
+        ciPassing: true,
+        approved: false,
+        noConflicts: true,
+        blockers: [],
+      },
+    });
+    expect(isPRMergeReady(pr)).toBe(false);
+  });
+
+  it("returns false for open PR with merge conflicts", () => {
+    const pr = createPR({
+      mergeability: {
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: false,
+        blockers: [],
+      },
+    });
+    expect(isPRMergeReady(pr)).toBe(false);
   });
 });
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -158,6 +158,20 @@ export function isPRRateLimited(pr: DashboardPR): boolean {
   return pr.mergeability.blockers.includes("API rate limited or unavailable");
 }
 
+/**
+ * Returns true when a PR is open and all merge criteria are met.
+ * Does NOT return true for merged or closed PRs — those are already done.
+ */
+export function isPRMergeReady(pr: DashboardPR): boolean {
+  return (
+    pr.state === "open" &&
+    pr.mergeability.mergeable &&
+    pr.mergeability.ciPassing &&
+    pr.mergeability.approved &&
+    pr.mergeability.noConflicts
+  );
+}
+
 /** Determines which attention zone a session belongs to */
 export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   // ── Done: terminal states ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extracted `isPRMergeReady()` helper in `packages/web/src/lib/types.ts` that gates merge-readiness on `pr.state === "open"`, preventing the "Ready to merge" banner from showing on merged or closed PRs
- Updated `PRCard` in `SessionDetail.tsx` to use the new helper instead of inline mergeability checks
- Added 7 tests covering all merge-readiness scenarios (open/merged/closed states, each mergeability flag)

Fixes #76

## Test plan
- [x] `isPRMergeReady()` returns `true` for open PR with all criteria met
- [x] `isPRMergeReady()` returns `false` for merged PR (even with all criteria met)
- [x] `isPRMergeReady()` returns `false` for closed PR (even with all criteria met)
- [x] `isPRMergeReady()` returns `false` when any single mergeability flag is false
- [x] All 352 web tests pass
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)