### PR TITLE
fix(scm-github): return empty checks when gh reports 'no checks repor…

### DIFF
--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -233,6 +233,15 @@ function createGitHubSCM(): SCM {
           };
         });
       } catch (err) {
+        // `gh pr checks` exits with code 1 and "no checks reported on the
+        // '<branch>' branch" when a PR simply has no CI checks configured.
+        // This is not an error — return an empty list so callers (getCISummary)
+        // correctly report CI status as "none" instead of "failing".
+        const msg = (err as Error).message?.toLowerCase() ?? "";
+        if (msg.includes("no checks reported")) {
+          return [];
+        }
+
         // Propagate so callers (getCISummary) can decide how to handle.
         // Do NOT silently return [] — that causes a fail-open where CI
         // appears healthy when we simply failed to fetch check status.

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -284,6 +284,11 @@ describe("scm-github plugin", () => {
       expect(await scm.getCIChecks(pr)).toEqual([]);
     });
 
+    it('returns empty array when gh reports "no checks reported" (issue #117)', async () => {
+      mockGhError("no checks reported on the 'feat/my-feature' branch");
+      expect(await scm.getCIChecks(pr)).toEqual([]);
+    });
+
     it("handles missing optional fields gracefully", async () => {
       mockGh([{ name: "test", state: "SUCCESS" }]);
       const checks = await scm.getCIChecks(pr);
@@ -328,6 +333,11 @@ describe("scm-github plugin", () => {
     it('returns "failing" on error (fail-closed)', async () => {
       mockGhError();
       expect(await scm.getCISummary(pr)).toBe("failing");
+    });
+
+    it('returns "none" when gh reports "no checks reported" (issue #117)', async () => {
+      mockGhError("no checks reported on the 'feat/my-feature' branch");
+      expect(await scm.getCISummary(pr)).toBe("none");
     });
 
     it('returns "none" when all checks are skipped', async () => {


### PR DESCRIPTION
…ted'

When a PR has no CI checks configured, `gh pr checks` exits with code 1 and message 'no checks reported on the <branch> branch'. Previously this was treated as a generic error, causing getCISummary() to fail-closed and report CI as 'failing' — misleading the dashboard into showing red CI status for PRs that simply have no checks.

Now getCIChecks() detects this specific error message and returns an empty array, which correctly flows through getCISummary() as 'none'.

Fixes #117