### PR TITLE
fix(cli): show correct message when no dashboard is running on ao stop

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -564,4 +564,32 @@ describe("stop command", () => {
     const output = vi.mocked(console.log).mock.calls.map((c) => c.join(" ")).join("\n");
     expect(output).toContain("is not running");
   });
+
+  it("shows 'not running' when no dashboard process is on port (fixes #92)", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.get.mockResolvedValue(null);
+    // lsof exits with code 1 when no process is found on port
+    mockExec.mockRejectedValue(new Error("lsof: no process found"));
+
+    await program.parseAsync(["node", "test", "stop"]);
+
+    const output = vi.mocked(console.log).mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("Dashboard not running on port");
+  });
+
+  it("shows 'Dashboard stopped' only when processes were killed", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.get.mockResolvedValue({ id: "app-orchestrator", status: "running" });
+    mockSessionManager.kill.mockResolvedValue(undefined);
+    // First exec call is lsof (returns PID), second is kill (succeeds)
+    mockExec
+      .mockResolvedValueOnce({ stdout: "12345", stderr: "" })  // lsof
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });       // kill
+
+    await program.parseAsync(["node", "test", "stop"]);
+
+    const output = vi.mocked(console.log).mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("Dashboard stopped");
+    expect(output).not.toContain("not running on port");
+  });
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -377,23 +377,30 @@ async function runStartup(
  * Best effort — if it fails, just warn the user.
  */
 async function stopDashboard(port: number): Promise<void> {
+  // Find PIDs listening on the port. lsof exits with code 1 when no
+  // process is found, so we catch that and report cleanly. (fixes #92)
+  let pids: string[];
   try {
-    // Find PIDs listening on the port (can be multiple: parent + children)
     const { stdout } = await exec("lsof", ["-ti", `:${port}`]);
-    const pids = stdout
+    pids = stdout
       .trim()
       .split("\n")
       .filter((p) => p.length > 0);
-
-    if (pids.length > 0) {
-      // Kill all processes (pass PIDs as separate arguments)
-      await exec("kill", pids);
-      console.log(chalk.green("Dashboard stopped"));
-    } else {
-      console.log(chalk.yellow(`Dashboard not running on port ${port}`));
-    }
   } catch {
-    console.log(chalk.yellow("Could not stop dashboard (may not be running)"));
+    // lsof exit code 1 → no process on port (normal case)
+    pids = [];
+  }
+
+  if (pids.length === 0) {
+    console.log(chalk.yellow(`Dashboard not running on port ${port}`));
+    return;
+  }
+
+  try {
+    await exec("kill", pids);
+    console.log(chalk.green("Dashboard stopped"));
+  } catch {
+    console.log(chalk.yellow("Could not stop dashboard processes"));
   }
 }
 


### PR DESCRIPTION
lsof exits with code 1 when no process is found on the port, which caused exec() to throw. The catch block then printed the ambiguous message 'Could not stop dashboard (may not be running)' regardless of whether a dashboard was actually running.

Fix: catch the lsof error gracefully and check the PID list. When empty, show 'Dashboard not running on port N' (yellow). When PIDs are found and killed, show 'Dashboard stopped' (green).

Added two regression tests:
- No dashboard running → shows 'Dashboard not running on port'
- Dashboard running → shows 'Dashboard stopped' only

Closes #92