### PR TITLE
feat(plugins): add Cline CLI agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,7 @@
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-aider": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
+    "@composio/ao-plugin-agent-cline": "workspace:*",
     "@composio/ao-plugin-agent-codex": "workspace:*",
     "@composio/ao-plugin-notifier-composio": "workspace:*",
     "@composio/ao-plugin-notifier-desktop": "workspace:*",

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -2,12 +2,14 @@ import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
+import clinePlugin from "@composio/ao-plugin-agent-cline";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
   aider: aiderPlugin,
+  cline: clinePlugin,
 };
 
 const scmPlugins: Record<string, { create(): SCM }> = {

--- a/packages/plugins/agent-cline/package.json
+++ b/packages/plugins/agent-cline/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-agent-cline",
+  "version": "0.1.0",
+  "description": "Agent plugin: Cline CLI",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-cline"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-cline/src/index.test.ts
+++ b/packages/plugins/agent-cline/src/index.test.ts
@@ -1,0 +1,395 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Session, RuntimeHandle, AgentLaunchConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Hoisted mocks
+// ---------------------------------------------------------------------------
+const { mockExecFileAsync, mockReaddir, mockReadFile, mockStat } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+  mockReaddir: vi.fn(),
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => {
+  const fn = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return { execFile: fn };
+});
+
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readdir: mockReaddir,
+    readFile: mockReadFile,
+    stat: mockStat,
+  };
+});
+
+import { create, manifest, default as defaultExport } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("agent-cline plugin", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // Manifest & exports
+  // -------------------------------------------------------------------------
+  describe("manifest", () => {
+    it("has correct name and slot", () => {
+      expect(manifest.name).toBe("cline");
+      expect(manifest.slot).toBe("agent");
+    });
+
+    it("default export satisfies PluginModule shape", () => {
+      expect(defaultExport.manifest).toBe(manifest);
+      expect(typeof defaultExport.create).toBe("function");
+    });
+  });
+
+  describe("create()", () => {
+    it("returns an agent with correct name and processName", () => {
+      const agent = create();
+      expect(agent.name).toBe("cline");
+      expect(agent.processName).toBe("cline");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getLaunchCommand
+  // -------------------------------------------------------------------------
+  describe("getLaunchCommand", () => {
+    it("builds basic command with --act flag", () => {
+      const agent = create();
+      const cmd = agent.getLaunchCommand(makeLaunchConfig());
+      expect(cmd).toBe("cline --act");
+    });
+
+    it("adds --yolo when permissions=skip", () => {
+      const agent = create();
+      const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "skip" }));
+      expect(cmd).toContain("--yolo");
+      expect(cmd).toContain("--act");
+    });
+
+    it("adds -m flag for model", () => {
+      const agent = create();
+      const cmd = agent.getLaunchCommand(makeLaunchConfig({ model: "gpt-4o" }));
+      expect(cmd).toContain("-m");
+      expect(cmd).toContain("gpt-4o");
+    });
+
+    it("appends prompt", () => {
+      const agent = create();
+      const cmd = agent.getLaunchCommand(makeLaunchConfig({ prompt: "Fix the bug" }));
+      expect(cmd).toContain("Fix the bug");
+    });
+
+    it("combines all options", () => {
+      const agent = create();
+      const cmd = agent.getLaunchCommand(
+        makeLaunchConfig({ permissions: "skip", model: "claude-sonnet-4-5-20250929", prompt: "Do stuff" }),
+      );
+      expect(cmd).toContain("--yolo");
+      expect(cmd).toContain("--act");
+      expect(cmd).toContain("-m");
+      expect(cmd).toContain("claude-sonnet-4-5-20250929");
+      expect(cmd).toContain("Do stuff");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getEnvironment
+  // -------------------------------------------------------------------------
+  describe("getEnvironment", () => {
+    it("sets AO_SESSION_ID", () => {
+      const agent = create();
+      const env = agent.getEnvironment(makeLaunchConfig({ sessionId: "s-42" }));
+      expect(env["AO_SESSION_ID"]).toBe("s-42");
+    });
+
+    it("sets AO_ISSUE_ID when provided", () => {
+      const agent = create();
+      const env = agent.getEnvironment(makeLaunchConfig({ issueId: "ISSUE-99" }));
+      expect(env["AO_ISSUE_ID"]).toBe("ISSUE-99");
+    });
+
+    it("omits AO_ISSUE_ID when not provided", () => {
+      const agent = create();
+      const env = agent.getEnvironment(makeLaunchConfig());
+      expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // detectActivity
+  // -------------------------------------------------------------------------
+  describe("detectActivity", () => {
+    it("returns idle for empty output", () => {
+      const agent = create();
+      expect(agent.detectActivity("")).toBe("idle");
+      expect(agent.detectActivity("   ")).toBe("idle");
+    });
+
+    it("returns waiting_input for Y/n prompt", () => {
+      const agent = create();
+      expect(agent.detectActivity("Do you want to proceed? [Y/n]")).toBe("waiting_input");
+    });
+
+    it("returns waiting_input for approval prompt", () => {
+      const agent = create();
+      expect(agent.detectActivity("Approve this change? ")).toBe("waiting_input");
+    });
+
+    it("returns blocked for Error:", () => {
+      const agent = create();
+      expect(agent.detectActivity("Error: connection refused")).toBe("blocked");
+    });
+
+    it("returns blocked for API Error", () => {
+      const agent = create();
+      expect(agent.detectActivity("API Error: unauthorized")).toBe("blocked");
+    });
+
+    it("returns blocked for rate limit", () => {
+      const agent = create();
+      expect(agent.detectActivity("rate limit exceeded")).toBe("blocked");
+    });
+
+    it("returns blocked for authentication failure", () => {
+      const agent = create();
+      expect(agent.detectActivity("Authentication failed")).toBe("blocked");
+    });
+
+    it("returns idle for task completed", () => {
+      const agent = create();
+      expect(agent.detectActivity("Task completed successfully")).toBe("idle");
+    });
+
+    it("returns active for normal output", () => {
+      const agent = create();
+      expect(agent.detectActivity("Reading file: src/index.ts")).toBe("active");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isProcessRunning — tmux
+  // -------------------------------------------------------------------------
+  describe("isProcessRunning (tmux)", () => {
+    it("returns true when cline process is on the tmux tty", async () => {
+      const agent = create();
+      mockExecFileAsync
+        .mockResolvedValueOnce({ stdout: "/dev/ttys001\n", stderr: "" })
+        .mockResolvedValueOnce({
+          stdout: "  123 ttys001 /usr/local/bin/cline --act\n",
+          stderr: "",
+        });
+      expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+    });
+
+    it("returns false when no cline process found", async () => {
+      const agent = create();
+      mockExecFileAsync
+        .mockResolvedValueOnce({ stdout: "/dev/ttys001\n", stderr: "" })
+        .mockResolvedValueOnce({
+          stdout: "  123 ttys001 /usr/bin/bash\n",
+          stderr: "",
+        });
+      expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    });
+
+    it("returns false when tmux lists no panes", async () => {
+      const agent = create();
+      mockExecFileAsync.mockResolvedValueOnce({ stdout: "\n", stderr: "" });
+      expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // isProcessRunning — pid-based
+  // -------------------------------------------------------------------------
+  describe("isProcessRunning (pid)", () => {
+    it("returns true when process.kill(pid, 0) succeeds", async () => {
+      const agent = create();
+      const handle = makeProcessHandle(99999);
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+      expect(await agent.isProcessRunning(handle)).toBe(true);
+      killSpy.mockRestore();
+    });
+
+    it("returns false when process.kill throws ESRCH", async () => {
+      const agent = create();
+      const handle = makeProcessHandle(99999);
+      const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        throw err;
+      });
+      expect(await agent.isProcessRunning(handle)).toBe(false);
+      killSpy.mockRestore();
+    });
+
+    it("returns false when no pid in handle data", async () => {
+      const agent = create();
+      const handle = makeProcessHandle();
+      expect(await agent.isProcessRunning(handle)).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getActivityState
+  // -------------------------------------------------------------------------
+  describe("getActivityState", () => {
+    it("returns exited when no runtimeHandle", async () => {
+      const agent = create();
+      const result = await agent.getActivityState!(makeSession({ runtimeHandle: null }));
+      expect(result).not.toBeNull();
+      expect(result!.state).toBe("exited");
+    });
+
+    it("returns exited when process not running", async () => {
+      const agent = create();
+      mockExecFileAsync.mockRejectedValue(new Error("no session"));
+      const session = makeSession({ runtimeHandle: makeTmuxHandle() });
+      const result = await agent.getActivityState!(session);
+      expect(result).not.toBeNull();
+      expect(result!.state).toBe("exited");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getSessionInfo
+  // -------------------------------------------------------------------------
+  describe("getSessionInfo", () => {
+    it("returns null when tasks dir does not exist", async () => {
+      const agent = create();
+      mockReaddir.mockRejectedValue(new Error("ENOENT"));
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).toBeNull();
+    });
+
+    it("returns null when tasks dir is empty", async () => {
+      const agent = create();
+      mockReaddir.mockResolvedValue([]);
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).toBeNull();
+    });
+
+    it("returns task summary and id from latest task", async () => {
+      const agent = create();
+      mockReaddir.mockResolvedValue([
+        { name: "task-abc", isDirectory: () => true },
+      ]);
+      mockStat.mockResolvedValue({ mtimeMs: Date.now() });
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({ task: "Fix the login bug", totalCost: 0.05 }),
+      );
+
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).not.toBeNull();
+      expect(result!.summary).toBe("Fix the login bug");
+      expect(result!.agentSessionId).toBe("task-abc");
+      expect(result!.cost).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0.05,
+      });
+    });
+
+    it("returns null summary when metadata has no task field", async () => {
+      const agent = create();
+      mockReaddir.mockResolvedValue([
+        { name: "task-xyz", isDirectory: () => true },
+      ]);
+      mockStat.mockResolvedValue({ mtimeMs: Date.now() });
+      mockReadFile.mockResolvedValue(JSON.stringify({}));
+
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).not.toBeNull();
+      expect(result!.summary).toBeNull();
+      expect(result!.agentSessionId).toBe("task-xyz");
+      expect(result!.cost).toBeUndefined();
+    });
+
+    it("truncates long summaries to 120 chars", async () => {
+      const agent = create();
+      const longTask = "A".repeat(200);
+      mockReaddir.mockResolvedValue([
+        { name: "task-long", isDirectory: () => true },
+      ]);
+      mockStat.mockResolvedValue({ mtimeMs: Date.now() });
+      mockReadFile.mockResolvedValue(JSON.stringify({ task: longTask }));
+
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).not.toBeNull();
+      expect(result!.summary!.length).toBe(120);
+    });
+
+    it("picks the most recently modified task directory", async () => {
+      const agent = create();
+      mockReaddir.mockResolvedValue([
+        { name: "task-old", isDirectory: () => true },
+        { name: "task-new", isDirectory: () => true },
+      ]);
+      mockStat
+        .mockResolvedValueOnce({ mtimeMs: 1000 }) // task-old
+        .mockResolvedValueOnce({ mtimeMs: 9000 }); // task-new
+      mockReadFile.mockResolvedValue(
+        JSON.stringify({ task: "New task" }),
+      );
+
+      const result = await agent.getSessionInfo(makeSession());
+      expect(result).not.toBeNull();
+      expect(result!.agentSessionId).toBe("task-new");
+    });
+  });
+});

--- a/packages/plugins/agent-cline/src/index.test.ts
+++ b/packages/plugins/agent-cline/src/index.test.ts
@@ -376,13 +376,14 @@ describe("agent-cline plugin", () => {
 
     it("picks the most recently modified task directory", async () => {
       const agent = create();
+      const now = Date.now();
       mockReaddir.mockResolvedValue([
         { name: "task-old", isDirectory: () => true },
         { name: "task-new", isDirectory: () => true },
       ]);
       mockStat
-        .mockResolvedValueOnce({ mtimeMs: 1000 }) // task-old
-        .mockResolvedValueOnce({ mtimeMs: 9000 }); // task-new
+        .mockResolvedValueOnce({ mtimeMs: now + 1000 }) // task-old
+        .mockResolvedValueOnce({ mtimeMs: now + 9000 }); // task-new
       mockReadFile.mockResolvedValue(
         JSON.stringify({ task: "New task" }),
       );

--- a/packages/plugins/agent-cline/src/index.ts
+++ b/packages/plugins/agent-cline/src/index.ts
@@ -46,8 +46,14 @@ interface ClineTaskMetadata {
 /**
  * Find the most recently modified Cline task directory.
  * Tasks are stored in ~/.cline/data/tasks/{taskId}/
+ *
+ * WARNING: Cline stores all tasks in a single global directory without
+ * per-workspace or per-session scoping. When multiple Cline sessions run
+ * in parallel, this may return a task from a different session. We mitigate
+ * this by optionally accepting a session creation time to filter tasks that
+ * were modified after the session started.
  */
-async function findLatestTask(): Promise<ClineTaskMetadata | null> {
+async function findLatestTask(sessionCreatedAt?: Date): Promise<ClineTaskMetadata | null> {
   try {
     const tasksDir = getClineTasksDir();
     const entries = await readdir(tasksDir, { withFileTypes: true });
@@ -58,10 +64,13 @@ async function findLatestTask(): Promise<ClineTaskMetadata | null> {
     let latestDir: string | null = null;
     let latestMtime = 0;
 
+    const sessionStartMs = sessionCreatedAt?.getTime() ?? 0;
     for (const dir of dirs) {
       try {
         const dirPath = join(tasksDir, dir.name);
         const stats = await stat(dirPath);
+        // Skip tasks modified before this session started (multi-session mitigation)
+        if (sessionStartMs > 0 && stats.mtimeMs < sessionStartMs) continue;
         if (stats.mtimeMs > latestMtime) {
           latestMtime = stats.mtimeMs;
           latestDir = dir.name;
@@ -185,7 +194,7 @@ function createClineAgent(): Agent {
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // Check latest task metadata for activity signals
-      const task = await findLatestTask();
+      const task = await findLatestTask(session.createdAt);
       if (!task?.updatedAt) return null;
 
       // Classify by age
@@ -247,8 +256,8 @@ function createClineAgent(): Agent {
       }
     },
 
-    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
-      const task = await findLatestTask();
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      const task = await findLatestTask(session.createdAt);
       if (!task) return null;
 
       return {

--- a/packages/plugins/agent-cline/src/index.ts
+++ b/packages/plugins/agent-cline/src/index.ts
@@ -1,0 +1,273 @@
+import {
+  shellEscape,
+  DEFAULT_READY_THRESHOLD_MS,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+} from "@composio/ao-core";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const execFileAsync = promisify(execFile);
+
+// =============================================================================
+// Cline Data Paths
+// =============================================================================
+
+/** Default Cline data directory. Overridable via CLINE_DIR env var. */
+function getClineDataDir(): string {
+  return process.env["CLINE_DIR"] ?? join(homedir(), ".cline", "data");
+}
+
+/** Cline tasks directory: ~/.cline/data/tasks/ */
+function getClineTasksDir(): string {
+  return join(getClineDataDir(), "tasks");
+}
+
+// =============================================================================
+// Cline Task Metadata Parsing
+// =============================================================================
+
+interface ClineTaskMetadata {
+  id: string;
+  summary: string | null;
+  totalCost: number | null;
+  updatedAt: Date | null;
+}
+
+/**
+ * Find the most recently modified Cline task directory.
+ * Tasks are stored in ~/.cline/data/tasks/{taskId}/
+ */
+async function findLatestTask(): Promise<ClineTaskMetadata | null> {
+  try {
+    const tasksDir = getClineTasksDir();
+    const entries = await readdir(tasksDir, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory());
+    if (dirs.length === 0) return null;
+
+    // Find most recently modified task directory
+    let latestDir: string | null = null;
+    let latestMtime = 0;
+
+    for (const dir of dirs) {
+      try {
+        const dirPath = join(tasksDir, dir.name);
+        const stats = await stat(dirPath);
+        if (stats.mtimeMs > latestMtime) {
+          latestMtime = stats.mtimeMs;
+          latestDir = dir.name;
+        }
+      } catch {
+        continue;
+      }
+    }
+
+    if (!latestDir) return null;
+
+    // Try to read task metadata
+    const metaPath = join(tasksDir, latestDir, "task_metadata.json");
+    try {
+      const raw = await readFile(metaPath, "utf-8");
+      const meta = JSON.parse(raw) as Record<string, unknown>;
+      return {
+        id: latestDir,
+        summary: typeof meta["task"] === "string" ? meta["task"].slice(0, 120) : null,
+        totalCost: typeof meta["totalCost"] === "number" ? meta["totalCost"] : null,
+        updatedAt: latestMtime ? new Date(latestMtime) : null,
+      };
+    } catch {
+      // Metadata file may not exist yet
+      return {
+        id: latestDir,
+        summary: null,
+        totalCost: null,
+        updatedAt: latestMtime ? new Date(latestMtime) : null,
+      };
+    }
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// Plugin Manifest
+// =============================================================================
+
+export const manifest = {
+  name: "cline",
+  slot: "agent" as const,
+  description: "Agent plugin: Cline CLI",
+  version: "0.1.0",
+};
+
+// =============================================================================
+// Agent Implementation
+// =============================================================================
+
+function createClineAgent(): Agent {
+  return {
+    name: "cline",
+    processName: "cline",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const parts: string[] = ["cline"];
+
+      // Autonomous mode: --yolo auto-approves all actions
+      if (config.permissions === "skip") {
+        parts.push("--yolo");
+      }
+
+      // Default to act mode for non-interactive use
+      parts.push("--act");
+
+      if (config.model) {
+        parts.push("-m", shellEscape(config.model));
+      }
+
+      if (config.prompt) {
+        parts.push(shellEscape(config.prompt));
+      }
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      // NOTE: AO_PROJECT_ID is the caller's responsibility (spawn.ts sets it)
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+
+      const lastChunk = terminalOutput.slice(-2000);
+
+      // Cline asking for user input / confirmation
+      if (/\bDo you want to proceed\b/i.test(lastChunk)) return "waiting_input";
+      if (/\bApprove\b.*\?\s*$/m.test(lastChunk)) return "waiting_input";
+      if (/\[Y\/n\]/i.test(lastChunk)) return "waiting_input";
+
+      // Error / blocked states
+      if (/\bError:\s/i.test(lastChunk)) return "blocked";
+      if (/\bAPI Error\b/i.test(lastChunk)) return "blocked";
+      if (/\brate limit/i.test(lastChunk)) return "blocked";
+      if (/\bAuthentication failed\b/i.test(lastChunk)) return "blocked";
+
+      // Task completion indicators
+      if (/\bTask completed\b/i.test(lastChunk)) return "idle";
+
+      return "active";
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+
+      // Check if process is running first
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      // Check latest task metadata for activity signals
+      const task = await findLatestTask();
+      if (!task?.updatedAt) return null;
+
+      // Classify by age
+      const ageMs = Date.now() - task.updatedAt.getTime();
+      const activeWindowMs = Math.min(30_000, threshold);
+      if (ageMs < activeWindowMs) return { state: "active", timestamp: task.updatedAt };
+      if (ageMs < threshold) return { state: "ready", timestamp: task.updatedAt };
+      return { state: "idle", timestamp: task.updatedAt };
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|\/)cline(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && "code" in err && err.code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      const task = await findLatestTask();
+      if (!task) return null;
+
+      return {
+        summary: task.summary,
+        agentSessionId: task.id,
+        cost: task.totalCost !== null && task.totalCost !== undefined
+          ? { inputTokens: 0, outputTokens: 0, estimatedCostUsd: task.totalCost }
+          : undefined,
+      };
+    },
+  };
+}
+
+// =============================================================================
+// Plugin Export
+// =============================================================================
+
+export function create(): Agent {
+  return createClineAgent();
+}
+
+export default { manifest, create } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-cline/tsconfig.json
+++ b/packages/plugins/agent-cline/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       '@composio/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@composio/ao-plugin-agent-cline':
+        specifier: workspace:*
+        version: link:../plugins/agent-cline
       '@composio/ao-plugin-agent-codex':
         specifier: workspace:*
         version: link:../plugins/agent-codex
@@ -215,6 +218,22 @@ importers:
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/agent-claude-code:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/agent-cline:
     dependencies:
       '@composio/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
Add new agent plugin @composio/ao-plugin-agent-cline with:
- Launch command builder: --yolo (autonomous), --act, -m (model), prompt
- Environment setup: AO_SESSION_ID, AO_ISSUE_ID
- Activity detection from terminal output: waiting_input, blocked, idle, active
- Activity state detection via Cline task metadata (~/.cline/data/tasks/)
- Process detection via tmux TTY matching and PID-based fallback
- Session info extraction: summary, cost, and task ID from task_metadata.json

Registered in CLI plugin loader alongside claude-code, codex, and aider.

Includes 34 tests covering all agent interface methods, edge cases, and metadata parsing.

Closes #171