### PR TITLE
revert: undo PR #320 workspace cleanup changes

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { createSessionManager } from "../session-manager.js";
 import { writeMetadata, readMetadata, readMetadataRaw, deleteMetadata } from "../metadata.js";
-import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
+import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import {
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -193,8 +193,7 @@ describe("spawn", () => {
 
     const session = await sm.spawn({
       projectId: "my-app",
-      issueId:
-        "this is a very long issue description that should be truncated to sixty characters maximum",
+      issueId: "this is a very long issue description that should be truncated to sixty characters maximum",
     });
 
     expect(session.branch!.replace("feat/", "").length).toBeLessThanOrEqual(60);
@@ -342,9 +341,9 @@ describe("spawn", () => {
     it("throws when agent override plugin is not found", async () => {
       const sm = createSessionManager({ config, registry: registryWithMultipleAgents });
 
-      await expect(sm.spawn({ projectId: "my-app", agent: "nonexistent" })).rejects.toThrow(
-        "Agent plugin 'nonexistent' not found",
-      );
+      await expect(
+        sm.spawn({ projectId: "my-app", agent: "nonexistent" }),
+      ).rejects.toThrow("Agent plugin 'nonexistent' not found");
     });
 
     it("uses default agent when no override specified", async () => {
@@ -958,27 +957,6 @@ describe("get", () => {
 
 describe("kill", () => {
   it("destroys runtime, workspace, and archives metadata", async () => {
-    const managedWorktree = join(
-      getWorktreesDir(config.configPath, config.projects["my-app"]!.path),
-      "ws-1",
-    );
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: managedWorktree,
-      branch: "main",
-      status: "working",
-      project: "my-app",
-      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
-    });
-
-    const sm = createSessionManager({ config, registry: mockRegistry });
-    await sm.kill("app-1");
-
-    expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-1"));
-    expect(mockWorkspace.destroy).toHaveBeenCalledWith(managedWorktree);
-    expect(readMetadata(sessionsDir, "app-1")).toBeNull(); // archived + deleted
-  });
-
-  it("does not destroy workspace outside AO-managed worktree root", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp/ws",
       branch: "main",
@@ -990,7 +968,9 @@ describe("kill", () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
     await sm.kill("app-1");
 
-    expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+    expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-1"));
+    expect(mockWorkspace.destroy).toHaveBeenCalledWith("/tmp/ws");
+    expect(readMetadata(sessionsDir, "app-1")).toBeNull(); // archived + deleted
   });
 
   it("throws for nonexistent session", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,8 +11,8 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, realpathSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import {
   isIssueNotFoundError,
   isRestorable,
@@ -50,7 +50,6 @@ import {
 import { buildPrompt } from "./prompt-builder.js";
 import {
   getSessionsDir,
-  getWorktreesDir,
   getProjectBaseDir,
   generateTmuxName,
   generateConfigHash,
@@ -174,38 +173,6 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
     return getSessionsDir(config.configPath, project.path);
   }
 
-  function getProjectWorktreesDir(project: ProjectConfig): string {
-    return getWorktreesDir(config.configPath, project.path);
-  }
-
-  function canonicalPath(path: string): string {
-    try {
-      return realpathSync(path);
-    } catch {
-      return resolve(path);
-    }
-  }
-
-  function normalizePath(path: string): string {
-    return canonicalPath(path).replace(/\/$/, "");
-  }
-
-  function isPathInside(path: string, parentPath: string): boolean {
-    const normalizedPath = normalizePath(path);
-    const normalizedParent = normalizePath(parentPath);
-    return normalizedPath === normalizedParent || normalizedPath.startsWith(`${normalizedParent}/`);
-  }
-
-  function shouldDestroyWorkspacePath(
-    project: ProjectConfig | undefined,
-    workspacePath: string,
-  ): boolean {
-    if (!project) return true;
-    const isProjectPath = normalizePath(workspacePath) === normalizePath(project.path);
-    if (isProjectPath) return false;
-    return isPathInside(workspacePath, getProjectWorktreesDir(project));
-  }
-
   /**
    * List all session files across all projects (or filtered by projectId).
    * Scans project-specific directories under ~/.agent-orchestrator/{hash}-{projectId}/sessions/
@@ -246,10 +213,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
   /** Resolve which plugins to use for a project. */
   function resolvePlugins(project: ProjectConfig, agentOverride?: string) {
     const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
-    const agent = registry.get<Agent>(
-      "agent",
-      agentOverride ?? project.agent ?? config.defaults.agent,
-    );
+    const agent = registry.get<Agent>("agent", agentOverride ?? project.agent ?? config.defaults.agent);
     const workspace = registry.get<Workspace>(
       "workspace",
       project.workspace ?? config.defaults.workspace,
@@ -287,7 +251,9 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
    * Enrich session with live runtime state (alive/exited) and activity detection.
    * Mutates the session object in place.
    */
-  const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
+  const TERMINAL_SESSION_STATUSES = new Set([
+    "killed", "done", "merged", "terminated", "cleanup",
+  ]);
 
   async function enrichSessionWithRuntimeState(
     session: Session,
@@ -432,7 +398,8 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       // If the issueId is already branch-safe (e.g. "INT-9999"), use as-is.
       // Otherwise sanitize free-text (e.g. "fix login bug") into a valid slug.
       const id = spawnConfig.issueId;
-      const isBranchSafe = /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
+      const isBranchSafe =
+        /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(id) && !id.includes("..");
       const slug = isBranchSafe
         ? id
         : id
@@ -462,7 +429,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
           try {
             await plugins.workspace.postCreate(wsInfo, project);
           } catch (err) {
-            if (shouldDestroyWorkspacePath(project, workspacePath)) {
+            if (workspacePath !== project.path) {
               try {
                 await plugins.workspace.destroy(workspacePath);
               } catch {
@@ -531,7 +498,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       });
     } catch (err) {
       // Clean up workspace and reserved ID if agent config or runtime creation failed
-      if (plugins.workspace && shouldDestroyWorkspacePath(project, workspacePath)) {
+      if (plugins.workspace && workspacePath !== project.path) {
         try {
           await plugins.workspace.destroy(workspacePath);
         } catch {
@@ -586,7 +553,7 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       } catch {
         /* best effort */
       }
-      if (plugins.workspace && shouldDestroyWorkspacePath(project, workspacePath)) {
+      if (plugins.workspace && workspacePath !== project.path) {
         try {
           await plugins.workspace.destroy(workspacePath);
         } catch {
@@ -745,41 +712,36 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
   async function list(projectId?: string): Promise<Session[]> {
     const allSessions = listAllSessions(projectId);
 
-    const sessionPromises = allSessions.map(
-      async ({ sessionName, projectId: sessionProjectId }) => {
-        const project = config.projects[sessionProjectId];
-        if (!project) return null;
+    const sessionPromises = allSessions.map(async ({ sessionName, projectId: sessionProjectId }) => {
+      const project = config.projects[sessionProjectId];
+      if (!project) return null;
 
-        const sessionsDir = getProjectSessionsDir(project);
-        const raw = readMetadataRaw(sessionsDir, sessionName);
-        if (!raw) return null;
+      const sessionsDir = getProjectSessionsDir(project);
+      const raw = readMetadataRaw(sessionsDir, sessionName);
+      if (!raw) return null;
 
-        // Get file timestamps for createdAt/lastActivityAt
-        let createdAt: Date | undefined;
-        let modifiedAt: Date | undefined;
-        try {
-          const metaPath = join(sessionsDir, sessionName);
-          const stats = statSync(metaPath);
-          createdAt = stats.birthtime;
-          modifiedAt = stats.mtime;
-        } catch {
-          // If stat fails, timestamps will fall back to current time
-        }
+      // Get file timestamps for createdAt/lastActivityAt
+      let createdAt: Date | undefined;
+      let modifiedAt: Date | undefined;
+      try {
+        const metaPath = join(sessionsDir, sessionName);
+        const stats = statSync(metaPath);
+        createdAt = stats.birthtime;
+        modifiedAt = stats.mtime;
+      } catch {
+        // If stat fails, timestamps will fall back to current time
+      }
 
-        const session = metadataToSession(sessionName, raw, createdAt, modifiedAt);
+      const session = metadataToSession(sessionName, raw, createdAt, modifiedAt);
 
-        const plugins = resolvePlugins(project, raw["agent"]);
-        // Cap per-session enrichment at 2s — subprocess calls (tmux/ps) can be
-        // slow under load. If we time out, session keeps its metadata values.
-        const enrichTimeout = new Promise<void>((resolve) => setTimeout(resolve, 2_000));
-        await Promise.race([
-          ensureHandleAndEnrich(session, sessionName, project, plugins),
-          enrichTimeout,
-        ]);
+      const plugins = resolvePlugins(project, raw["agent"]);
+      // Cap per-session enrichment at 2s — subprocess calls (tmux/ps) can be
+      // slow under load. If we time out, session keeps its metadata values.
+      const enrichTimeout = new Promise<void>((resolve) => setTimeout(resolve, 2_000));
+      await Promise.race([ensureHandleAndEnrich(session, sessionName, project, plugins), enrichTimeout]);
 
-        return session;
-      },
-    );
+      return session;
+    });
 
     const results = await Promise.all(sessionPromises);
     return results.filter((s): s is Session => s !== null);
@@ -855,8 +817,10 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
       }
     }
 
+    // Destroy workspace — skip if worktree is the project path (no isolation was used)
     const worktree = raw["worktree"];
-    if (worktree && shouldDestroyWorkspacePath(project, worktree)) {
+    const isProjectPath = project && worktree === project.path;
+    if (worktree && !isProjectPath) {
       const workspacePlugin = project
         ? resolvePlugins(project).workspace
         : registry.get<Workspace>("workspace", config.defaults.workspace);
@@ -885,7 +849,10 @@ export function createSessionManager(deps: SessionManagerDeps): SessionManager {
         // Never clean up orchestrator sessions — they manage the lifecycle.
         // Check explicit role metadata first, fall back to naming convention
         // for pre-existing sessions spawned before the role field was added.
-        if (session.metadata["role"] === "orchestrator" || session.id.endsWith("-orchestrator")) {
+        if (
+          session.metadata["role"] === "orchestrator" ||
+          session.id.endsWith("-orchestrator")
+        ) {
           result.skipped.push(session.id);
           continue;
         }


### PR DESCRIPTION
## Summary
- Revert the three commits from PR #320 that changed workspace cleanup safety logic in `session-manager`.
- Restore the pre-#320 behavior in `kill()`/spawn cleanup while we address the reported regression with a safer redesign.
- Keep the rollback scoped to `packages/core/src/session-manager.ts` and its tests.

## Verification
- `pnpm --filter @composio/ao-core typecheck`
- `pnpm --filter @composio/ao-core test -- session-manager`