### PR TITLE
fix(gitlab): handle closed MR state and deduplicate glab helpers

### DIFF
--- a/packages/plugins/scm-gitlab/package.json
+++ b/packages/plugins/scm-gitlab/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@composio/ao-plugin-scm-gitlab",
+  "version": "0.1.0",
+  "description": "SCM plugin: GitLab (MRs, CI, reviews)",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./glab-utils": {
+      "types": "./dist/glab-utils.d.ts",
+      "import": "./dist/glab-utils.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/scm-gitlab"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/scm-gitlab/src/glab-utils.ts
+++ b/packages/plugins/scm-gitlab/src/glab-utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared helpers for GitLab plugins that use the `glab` CLI.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export async function glab(args: string[], hostname?: string): Promise<string> {
+  if (hostname && args[0] === "api") {
+    args = [args[0], "--hostname", hostname, ...args.slice(1)];
+  }
+  try {
+    const { stdout } = await execFileAsync("glab", args, {
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 30_000,
+    });
+    return stdout.trim();
+  } catch (err) {
+    throw new Error(`glab ${args.slice(0, 3).join(" ")} failed: ${(err as Error).message}`, {
+      cause: err,
+    });
+  }
+}
+
+export function parseJSON<T>(raw: string, context: string): T {
+  try {
+    return JSON.parse(raw) as T;
+  } catch (err) {
+    throw new Error(`${context}: expected JSON but got: ${raw.slice(0, 200)}`, { cause: err });
+  }
+}
+
+export function extractHost(repo: string): string | undefined {
+  const parts = repo.split("/");
+  const first = parts[0];
+  return first && first.includes(".") && parts.length >= 3 ? first : undefined;
+}
+
+export function stripHost(fullPath: string): string {
+  const parts = fullPath.split("/");
+  if (parts[0] && parts[0].includes(".") && parts.length >= 3) {
+    return parts.slice(1).join("/");
+  }
+  return fullPath;
+}

--- a/packages/plugins/scm-gitlab/src/index.ts
+++ b/packages/plugins/scm-gitlab/src/index.ts
@@ -1,0 +1,548 @@
+/**
+ * scm-gitlab plugin — GitLab MRs, CI pipelines, reviews, merge readiness.
+ *
+ * Uses the `glab` CLI for GitLab API interactions.
+ */
+
+import {
+  CI_STATUS,
+  type PluginModule,
+  type SCM,
+  type Session,
+  type ProjectConfig,
+  type PRInfo,
+  type PRState,
+  type MergeMethod,
+  type CICheck,
+  type CIStatus,
+  type Review,
+  type ReviewDecision,
+  type ReviewComment,
+  type AutomatedComment,
+  type MergeReadiness,
+} from "@composio/ao-core";
+
+import { glab, parseJSON, stripHost } from "./glab-utils.js";
+
+const BOT_AUTHORS = new Set([
+  "gitlab-bot",
+  "ghost",
+  "dependabot[bot]",
+  "renovate[bot]",
+  "sast-bot",
+  "codeclimate[bot]",
+  "sonarcloud[bot]",
+  "snyk-bot",
+]);
+
+function isBot(username: string): boolean {
+  return BOT_AUTHORS.has(username) || /^project_\d+_bot/.test(username) || username.endsWith("[bot]");
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function repoFlag(pr: PRInfo): string {
+  return `${pr.owner}/${pr.repo}`;
+}
+
+function parseDate(val: string | undefined | null): Date {
+  if (!val) return new Date(0);
+  const d = new Date(val);
+  return isNaN(d.getTime()) ? new Date(0) : d;
+}
+
+function extractHostFromOwner(owner: string): string | undefined {
+  const parts = owner.split("/");
+  const first = parts[0];
+  return first && first.includes(".") && parts.length >= 2 ? first : undefined;
+}
+
+function encodeProjectId(owner: string, repo: string): string {
+  return encodeURIComponent(stripHost(`${owner}/${repo}`));
+}
+
+function mapJobStatus(status: string): CICheck["status"] {
+  switch (status) {
+    case "pending":
+    case "waiting_for_resource":
+    case "preparing":
+    case "created":
+    case "scheduled":
+    case "manual":
+      return "pending";
+    case "running":
+      return "running";
+    case "success":
+      return "passed";
+    case "failed":
+    case "canceled":
+      return "failed";
+    case "skipped":
+      return "skipped";
+    default:
+      return "failed";
+  }
+}
+
+function mapPRState(state: string): PRState {
+  const s = state.toLowerCase();
+  if (s === "merged") return "merged";
+  if (s === "closed") return "closed";
+  return "open";
+}
+
+function inferSeverity(body: string): AutomatedComment["severity"] {
+  const lower = body.toLowerCase();
+  if (
+    lower.includes("error") ||
+    lower.includes("bug") ||
+    lower.includes("critical") ||
+    lower.includes("potential issue")
+  ) {
+    return "error";
+  }
+  if (
+    lower.includes("warning") ||
+    lower.includes("suggest") ||
+    lower.includes("consider")
+  ) {
+    return "warning";
+  }
+  return "info";
+}
+
+interface GitLabNote {
+  id: number;
+  author: { username: string };
+  body: string;
+  resolvable: boolean;
+  resolved: boolean;
+  position?: { new_path?: string; new_line?: number | null };
+  created_at: string;
+}
+
+interface GitLabDiscussion {
+  id: string;
+  notes: GitLabNote[];
+}
+
+function mrApiPath(pr: PRInfo): string {
+  return `projects/${encodeProjectId(pr.owner, pr.repo)}/merge_requests/${pr.number}`;
+}
+
+async function fetchDiscussions(
+  pr: PRInfo,
+  hostname: string | undefined,
+  context: string,
+): Promise<GitLabDiscussion[]> {
+  const raw = await glab(
+    ["api", `${mrApiPath(pr)}/discussions?per_page=100`],
+    hostname,
+  );
+  return parseJSON<GitLabDiscussion[]>(raw, context);
+}
+
+// ---------------------------------------------------------------------------
+// SCM implementation
+// ---------------------------------------------------------------------------
+
+function createGitLabSCM(config?: Record<string, unknown>): SCM {
+  const configHostname = typeof config?.host === "string" ? config.host : undefined;
+
+  function resolveHostname(pr?: PRInfo): string | undefined {
+    return configHostname ?? (pr ? extractHostFromOwner(pr.owner) : undefined);
+  }
+
+  return {
+    name: "gitlab",
+
+    async detectPR(session: Session, project: ProjectConfig): Promise<PRInfo | null> {
+      if (!session.branch) return null;
+
+      const parts = project.repo.split("/");
+      if (parts.length < 2 || !parts[0] || !parts[1]) {
+        throw new Error(`Invalid repo format "${project.repo}", expected "owner/repo"`);
+      }
+      const owner = parts.slice(0, -1).join("/");
+      const repo = parts[parts.length - 1];
+
+      try {
+        const raw = await glab(
+          [
+            "mr",
+            "list",
+            "--source-branch",
+            session.branch,
+            "--repo",
+            project.repo,
+            "-F",
+            "json",
+            "-P",
+            "1",
+          ],
+          resolveHostname(),
+        );
+
+        const mrs = parseJSON<
+          Array<{
+            iid: number;
+            web_url: string;
+            title: string;
+            source_branch: string;
+            target_branch: string;
+            draft: boolean;
+          }>
+        >(raw, `detectPR for branch "${session.branch}"`);
+
+        if (mrs.length === 0) return null;
+
+        const mr = mrs[0];
+        return {
+          number: mr.iid,
+          url: mr.web_url,
+          title: mr.title,
+          owner,
+          repo,
+          branch: mr.source_branch,
+          baseBranch: mr.target_branch,
+          isDraft: mr.draft ?? false,
+        };
+      } catch (err) {
+        console.warn(`detectPR: failed for branch "${session.branch}": ${(err as Error).message}`);
+        return null;
+      }
+    },
+
+    async getPRState(pr: PRInfo): Promise<PRState> {
+      const raw = await glab(
+        ["mr", "view", String(pr.number), "--repo", repoFlag(pr), "-F", "json"],
+        resolveHostname(pr),
+      );
+      const data = parseJSON<{ state: string }>(raw, `getPRState for MR !${pr.number}`);
+      return mapPRState(data.state);
+    },
+
+    async getPRSummary(pr: PRInfo) {
+      const raw = await glab(
+        ["mr", "view", String(pr.number), "--repo", repoFlag(pr), "-F", "json"],
+        resolveHostname(pr),
+      );
+      const data = parseJSON<{ state: string; title: string }>(
+        raw,
+        `getPRSummary for MR !${pr.number}`,
+      );
+      return {
+        state: mapPRState(data.state),
+        title: data.title ?? "",
+        additions: 0,
+        deletions: 0,
+      };
+    },
+
+    async mergePR(pr: PRInfo, method: MergeMethod = "squash"): Promise<void> {
+      const args = ["mr", "merge", String(pr.number), "--repo", repoFlag(pr)];
+      if (method === "squash") args.push("--squash");
+      else if (method === "rebase") args.push("--rebase");
+      args.push("-d", "-y");
+      await glab(args, resolveHostname(pr));
+    },
+
+    async closePR(pr: PRInfo): Promise<void> {
+      await glab(["mr", "close", String(pr.number), "--repo", repoFlag(pr)], resolveHostname(pr));
+    },
+
+    async getCIChecks(pr: PRInfo): Promise<CICheck[]> {
+      try {
+        const apiBase = mrApiPath(pr);
+        const hostname = resolveHostname(pr);
+
+        const pipelinesRaw = await glab(
+          ["api", `${apiBase}/pipelines`],
+          hostname,
+        );
+        const pipelines = parseJSON<Array<{ id: number }>>(
+          pipelinesRaw,
+          `getCIChecks pipelines for MR !${pr.number}`,
+        );
+        if (pipelines.length === 0) return [];
+
+        const latestPipelineId = pipelines[0].id;
+        const projectId = encodeProjectId(pr.owner, pr.repo);
+
+        const jobsRaw = await glab(
+          ["api", `projects/${projectId}/pipelines/${latestPipelineId}/jobs`],
+          hostname,
+        );
+        const jobs = parseJSON<
+          Array<{
+            name: string;
+            status: string;
+            web_url: string;
+            started_at: string | null;
+            finished_at: string | null;
+          }>
+        >(jobsRaw, `getCIChecks jobs for pipeline ${latestPipelineId}`);
+
+        return jobs.map((j) => ({
+          name: j.name,
+          status: mapJobStatus(j.status),
+          url: j.web_url || undefined,
+          conclusion: j.status || undefined,
+          startedAt: j.started_at ? new Date(j.started_at) : undefined,
+          completedAt: j.finished_at ? new Date(j.finished_at) : undefined,
+        }));
+      } catch (err) {
+        throw new Error("Failed to fetch CI checks", { cause: err });
+      }
+    },
+
+    async getCISummary(pr: PRInfo): Promise<CIStatus> {
+      let checks: CICheck[];
+      try {
+        checks = await this.getCIChecks(pr);
+      } catch (err) {
+        console.warn(`getCISummary: CI check fetch failed for MR !${pr.number}: ${(err as Error).message}`);
+        try {
+          const state = await this.getPRState(pr);
+          if (state === "merged" || state === "closed") return "none";
+        } catch (innerErr) {
+          console.warn(`getCISummary: PR state fallback also failed for MR !${pr.number}: ${(innerErr as Error).message}`);
+        }
+        return "failing";
+      }
+      if (checks.length === 0) return "none";
+
+      const hasFailing = checks.some((c) => c.status === "failed");
+      if (hasFailing) return "failing";
+
+      const hasPending = checks.some((c) => c.status === "pending" || c.status === "running");
+      if (hasPending) return "pending";
+
+      const hasPassing = checks.some((c) => c.status === "passed");
+      if (!hasPassing) return "none";
+
+      return "passing";
+    },
+
+    async getReviews(pr: PRInfo): Promise<Review[]> {
+      const hostname = resolveHostname(pr);
+      const reviews: Review[] = [];
+
+      const approvalsRaw = await glab(
+        ["api", `${mrApiPath(pr)}/approvals`],
+        hostname,
+      );
+      const approvals = parseJSON<{
+        approved_by: Array<{ user: { username: string } }>;
+      }>(approvalsRaw, `getReviews approvals for MR !${pr.number}`);
+
+      const approvedUsers = new Set<string>();
+      for (const a of approvals.approved_by ?? []) {
+        const author = a.user?.username ?? "unknown";
+        approvedUsers.add(author);
+        reviews.push({ author, state: "approved", submittedAt: new Date(0) });
+      }
+
+      try {
+        const discussions = await fetchDiscussions(
+          pr,
+          hostname,
+          `getReviews discussions for MR !${pr.number}`,
+        );
+
+        const requestedAuthors = new Set<string>();
+        for (const d of discussions) {
+          const note = d.notes[0];
+          if (!note) continue;
+          if (!note.resolvable || note.resolved) continue;
+          const author = note.author?.username ?? "";
+          if (isBot(author) || approvedUsers.has(author) || requestedAuthors.has(author)) continue;
+          requestedAuthors.add(author);
+          reviews.push({
+            author,
+            state: "changes_requested",
+            submittedAt: parseDate(note.created_at),
+          });
+        }
+      } catch (err) {
+        console.warn(`getReviews: discussions fetch failed for MR !${pr.number}: ${(err as Error).message}`);
+      }
+
+      return reviews;
+    },
+
+    async getReviewDecision(pr: PRInfo): Promise<ReviewDecision> {
+      const raw = await glab(
+        ["api", `${mrApiPath(pr)}/approvals`],
+        resolveHostname(pr),
+      );
+      const data = parseJSON<{ approved: boolean; approvals_left: number }>(
+        raw,
+        `getReviewDecision for MR !${pr.number}`,
+      );
+
+      if (data.approved) return "approved";
+      if (data.approvals_left > 0) return "pending";
+      return "none";
+    },
+
+    async getPendingComments(pr: PRInfo): Promise<ReviewComment[]> {
+      const discussions = await fetchDiscussions(
+        pr,
+        resolveHostname(pr),
+        `getPendingComments for MR !${pr.number}`,
+      );
+
+      const comments: ReviewComment[] = [];
+      for (const d of discussions) {
+        const note = d.notes[0];
+        if (!note) continue;
+        if (!note.resolvable || note.resolved) continue;
+        if (isBot(note.author?.username ?? "")) continue;
+
+        comments.push({
+          id: String(note.id),
+          author: note.author?.username ?? "unknown",
+          body: note.body,
+          path: note.position?.new_path || undefined,
+          line: note.position?.new_line ?? undefined,
+          isResolved: false,
+          createdAt: parseDate(note.created_at),
+          url: "",
+        });
+      }
+      return comments;
+    },
+
+    async getAutomatedComments(pr: PRInfo): Promise<AutomatedComment[]> {
+      const discussions = await fetchDiscussions(
+        pr,
+        resolveHostname(pr),
+        `getAutomatedComments for MR !${pr.number}`,
+      );
+
+      const comments: AutomatedComment[] = [];
+      for (const d of discussions) {
+        const note = d.notes[0];
+        if (!note) continue;
+        const author = note.author?.username ?? "";
+        if (!isBot(author)) continue;
+
+        comments.push({
+          id: String(note.id),
+          botName: author,
+          body: note.body,
+          path: note.position?.new_path || undefined,
+          line: note.position?.new_line ?? undefined,
+          severity: inferSeverity(note.body),
+          createdAt: parseDate(note.created_at),
+          url: "",
+        });
+      }
+      return comments;
+    },
+
+    async getMergeability(pr: PRInfo): Promise<MergeReadiness> {
+      const hostname = resolveHostname(pr);
+
+      const mrRaw = await glab(
+        ["mr", "view", String(pr.number), "--repo", repoFlag(pr), "-F", "json"],
+        hostname,
+      );
+      const mrData = parseJSON<{ state: string; draft: boolean }>(
+        mrRaw,
+        `getMergeability mr view for MR !${pr.number}`,
+      );
+
+      const state = mapPRState(mrData.state);
+      if (state === "merged") {
+        return {
+          mergeable: true,
+          ciPassing: true,
+          approved: true,
+          noConflicts: true,
+          blockers: [],
+        };
+      }
+      if (state === "closed") {
+        return {
+          mergeable: false,
+          ciPassing: false,
+          approved: false,
+          noConflicts: true,
+          blockers: ["MR is closed"],
+        };
+      }
+
+      const apiRaw = await glab(
+        ["api", mrApiPath(pr)],
+        hostname,
+      );
+      const apiData = parseJSON<{
+        merge_status: string;
+        has_conflicts: boolean;
+        blocking_discussions_resolved: boolean;
+      }>(apiRaw, `getMergeability api for MR !${pr.number}`);
+
+      const blockers: string[] = [];
+
+      const ciStatus = await this.getCISummary(pr);
+      const ciPassing = ciStatus === CI_STATUS.PASSING || ciStatus === CI_STATUS.NONE;
+      if (!ciPassing) {
+        blockers.push(`CI is ${ciStatus}`);
+      }
+
+      const reviewDecision = await this.getReviewDecision(pr);
+      const approved = reviewDecision === "approved";
+      if (reviewDecision === "pending") {
+        blockers.push("Approval required");
+      }
+
+      const noConflicts = !apiData.has_conflicts;
+      if (!noConflicts) {
+        blockers.push("Merge conflicts");
+      }
+
+      if (apiData.merge_status === "cannot_be_merged" && noConflicts) {
+        blockers.push("Merge status: cannot be merged");
+      } else if (apiData.merge_status === "checking") {
+        blockers.push("Merge status unknown (GitLab is computing)");
+      }
+
+      if (!apiData.blocking_discussions_resolved) {
+        blockers.push("Unresolved discussions blocking merge");
+      }
+
+      if (mrData.draft) {
+        blockers.push("MR is still a draft");
+      }
+
+      return {
+        mergeable: blockers.length === 0,
+        ciPassing,
+        approved,
+        noConflicts,
+        blockers,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "gitlab",
+  slot: "scm" as const,
+  description: "SCM plugin: GitLab MRs, CI pipelines, reviews, merge readiness",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): SCM {
+  return createGitLabSCM(config);
+}
+
+export default { manifest, create } satisfies PluginModule<SCM>;

--- a/packages/plugins/scm-gitlab/test/index.test.ts
+++ b/packages/plugins/scm-gitlab/test/index.test.ts
@@ -1,0 +1,1047 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process — glab CLI calls go through execFileAsync
+// ---------------------------------------------------------------------------
+const { glabMock } = vi.hoisted(() => ({ glabMock: vi.fn() }));
+
+vi.mock("node:child_process", () => {
+  const execFile = Object.assign(vi.fn(), {
+    [Symbol.for("nodejs.util.promisify.custom")]: glabMock,
+  });
+  return { execFile };
+});
+
+import { create, manifest } from "../src/index.js";
+import type { PRInfo, Session, ProjectConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const pr: PRInfo = {
+  number: 42,
+  url: "https://gitlab.com/acme/repo/-/merge_requests/42",
+  title: "feat: add feature",
+  owner: "acme",
+  repo: "repo",
+  branch: "feat/my-feature",
+  baseBranch: "main",
+  isDraft: false,
+};
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/repo",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+};
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test",
+    status: "working",
+    activity: "active",
+    branch: "feat/my-feature",
+    issueId: null,
+    pr: null,
+    workspacePath: "/tmp/repo",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function mockGlab(result: unknown) {
+  glabMock.mockResolvedValueOnce({ stdout: JSON.stringify(result) });
+}
+
+function mockGlabError(msg = "Command failed") {
+  glabMock.mockRejectedValueOnce(new Error(msg));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("scm-gitlab plugin", () => {
+  let scm: ReturnType<typeof create>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    scm = create();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  // ---- manifest ----------------------------------------------------------
+
+  describe("manifest", () => {
+    it("has correct metadata", () => {
+      expect(manifest.name).toBe("gitlab");
+      expect(manifest.slot).toBe("scm");
+      expect(manifest.version).toBe("0.1.0");
+    });
+  });
+
+  // ---- create() ----------------------------------------------------------
+
+  describe("create()", () => {
+    it("returns an SCM with correct name", () => {
+      expect(scm.name).toBe("gitlab");
+    });
+
+    it("accepts host config for self-hosted GitLab", () => {
+      const selfHosted = create({ host: "gitlab.internal.corp" });
+      expect(selfHosted.name).toBe("gitlab");
+    });
+  });
+
+  // ---- detectPR ----------------------------------------------------------
+
+  describe("detectPR", () => {
+    it("returns PRInfo when an MR exists", async () => {
+      mockGlab([
+        {
+          iid: 42,
+          web_url: "https://gitlab.com/acme/repo/-/merge_requests/42",
+          title: "feat: add feature",
+          source_branch: "feat/my-feature",
+          target_branch: "main",
+          draft: false,
+        },
+      ]);
+
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result).toEqual({
+        number: 42,
+        url: "https://gitlab.com/acme/repo/-/merge_requests/42",
+        title: "feat: add feature",
+        owner: "acme",
+        repo: "repo",
+        branch: "feat/my-feature",
+        baseBranch: "main",
+        isDraft: false,
+      });
+    });
+
+    it("returns null when no MR found", async () => {
+      mockGlab([]);
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result).toBeNull();
+    });
+
+    it("returns null when session has no branch", async () => {
+      const result = await scm.detectPR(makeSession({ branch: null }), project);
+      expect(result).toBeNull();
+      expect(glabMock).not.toHaveBeenCalled();
+    });
+
+    it("returns null and warns on glab CLI error", async () => {
+      mockGlabError("glab: not found");
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result).toBeNull();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('detectPR: failed for branch "feat/my-feature"'),
+      );
+    });
+
+    it("throws on invalid repo format", async () => {
+      const badProject = { ...project, repo: "no-slash" };
+      await expect(scm.detectPR(makeSession(), badProject)).rejects.toThrow(
+        "Invalid repo format",
+      );
+    });
+
+    it("correctly splits owner for subgroup repos", async () => {
+      const subgroupProject = { ...project, repo: "org/sub-group/repo" };
+      mockGlab([
+        {
+          iid: 10,
+          web_url: "https://gitlab.com/org/sub-group/repo/-/merge_requests/10",
+          title: "feat: subgroup",
+          source_branch: "feat/my-feature",
+          target_branch: "main",
+          draft: false,
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), subgroupProject);
+      expect(result?.owner).toBe("org/sub-group");
+      expect(result?.repo).toBe("repo");
+    });
+
+    it("handles self-hosted repo with hostname prefix", async () => {
+      const selfHostedProject = { ...project, repo: "gitlab.corp.com/org/repo" };
+      mockGlab([
+        {
+          iid: 5,
+          web_url: "https://gitlab.corp.com/org/repo/-/merge_requests/5",
+          title: "feat: self-hosted",
+          source_branch: "feat/my-feature",
+          target_branch: "main",
+          draft: false,
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), selfHostedProject);
+      expect(result?.owner).toBe("gitlab.corp.com/org");
+      expect(result?.repo).toBe("repo");
+    });
+
+    it("detects draft MRs", async () => {
+      mockGlab([
+        {
+          iid: 99,
+          web_url: "https://gitlab.com/acme/repo/-/merge_requests/99",
+          title: "WIP: draft feature",
+          source_branch: "feat/my-feature",
+          target_branch: "main",
+          draft: true,
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result?.isDraft).toBe(true);
+    });
+  });
+
+  // ---- getPRState --------------------------------------------------------
+
+  describe("getPRState", () => {
+    it('returns "open" for opened MR', async () => {
+      mockGlab({ state: "opened" });
+      expect(await scm.getPRState(pr)).toBe("open");
+    });
+
+    it('returns "merged" for merged MR', async () => {
+      mockGlab({ state: "merged" });
+      expect(await scm.getPRState(pr)).toBe("merged");
+    });
+
+    it('returns "closed" for closed MR', async () => {
+      mockGlab({ state: "closed" });
+      expect(await scm.getPRState(pr)).toBe("closed");
+    });
+
+    it("handles uppercase state strings", async () => {
+      mockGlab({ state: "Merged" });
+      expect(await scm.getPRState(pr)).toBe("merged");
+    });
+  });
+
+  // ---- getPRSummary ------------------------------------------------------
+
+  describe("getPRSummary", () => {
+    it("returns summary with zero additions/deletions", async () => {
+      mockGlab({ state: "opened", title: "My MR" });
+      const summary = await scm.getPRSummary!(pr);
+      expect(summary).toEqual({
+        state: "open",
+        title: "My MR",
+        additions: 0,
+        deletions: 0,
+      });
+    });
+  });
+
+  // ---- mergePR -----------------------------------------------------------
+
+  describe("mergePR", () => {
+    it("uses --squash by default", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["mr", "merge", "42", "--repo", "acme/repo", "--squash", "-d", "-y"],
+        expect.any(Object),
+      );
+    });
+
+    it("uses --rebase when specified", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "rebase");
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["--rebase"]),
+        expect.any(Object),
+      );
+    });
+
+    it("omits --squash and --rebase for merge method", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "merge");
+      const args = glabMock.mock.calls[0][1] as string[];
+      expect(args).not.toContain("--squash");
+      expect(args).not.toContain("--rebase");
+    });
+  });
+
+  // ---- closePR -----------------------------------------------------------
+
+  describe("closePR", () => {
+    it("calls glab mr close", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.closePR(pr);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["mr", "close", "42", "--repo", "acme/repo"],
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ---- getCIChecks -------------------------------------------------------
+
+  describe("getCIChecks", () => {
+    it("maps GitLab job statuses correctly", async () => {
+      mockGlab([{ id: 100 }]);
+      mockGlab([
+        {
+          name: "build",
+          status: "success",
+          web_url: "https://ci/1",
+          started_at: "2025-01-01T00:00:00Z",
+          finished_at: "2025-01-01T00:05:00Z",
+        },
+        { name: "lint", status: "failed", web_url: "", started_at: null, finished_at: null },
+        { name: "deploy", status: "pending", web_url: "", started_at: null, finished_at: null },
+        { name: "e2e", status: "running", web_url: "", started_at: null, finished_at: null },
+        { name: "optional", status: "skipped", web_url: "", started_at: null, finished_at: null },
+        { name: "manual", status: "manual", web_url: "", started_at: null, finished_at: null },
+        { name: "canceled", status: "canceled", web_url: "", started_at: null, finished_at: null },
+        { name: "created", status: "created", web_url: "", started_at: null, finished_at: null },
+        {
+          name: "waiting",
+          status: "waiting_for_resource",
+          web_url: "",
+          started_at: null,
+          finished_at: null,
+        },
+        {
+          name: "preparing",
+          status: "preparing",
+          web_url: "",
+          started_at: null,
+          finished_at: null,
+        },
+        {
+          name: "scheduled",
+          status: "scheduled",
+          web_url: "",
+          started_at: null,
+          finished_at: null,
+        },
+      ]);
+
+      const checks = await scm.getCIChecks(pr);
+      expect(checks).toHaveLength(11);
+      expect(checks[0].status).toBe("passed");
+      expect(checks[0].url).toBe("https://ci/1");
+      expect(checks[1].status).toBe("failed");
+      expect(checks[2].status).toBe("pending");
+      expect(checks[3].status).toBe("running");
+      expect(checks[4].status).toBe("skipped");
+      expect(checks[5].status).toBe("pending"); // manual
+      expect(checks[6].status).toBe("failed"); // canceled
+      expect(checks[7].status).toBe("pending"); // created
+      expect(checks[8].status).toBe("pending"); // waiting_for_resource
+      expect(checks[9].status).toBe("pending"); // preparing
+      expect(checks[10].status).toBe("pending"); // scheduled
+    });
+
+    it("returns empty array when no pipelines exist", async () => {
+      mockGlab([]);
+      expect(await scm.getCIChecks(pr)).toEqual([]);
+    });
+
+    it("throws on error (fail-closed)", async () => {
+      mockGlabError("no pipelines");
+      await expect(scm.getCIChecks(pr)).rejects.toThrow("Failed to fetch CI checks");
+    });
+
+    it("correctly encodes project ID with subgroups in API path", async () => {
+      const subgroupPr = { ...pr, owner: "org/sub-group", repo: "repo" };
+      mockGlab([{ id: 100 }]);
+      mockGlab([]);
+      await scm.getCIChecks(subgroupPr);
+      const firstCallArgs = glabMock.mock.calls[0][1] as string[];
+      expect(firstCallArgs).toContain(
+        "projects/org%2Fsub-group%2Frepo/merge_requests/42/pipelines",
+      );
+    });
+
+    it("handles unknown job status as failed (fail-closed)", async () => {
+      mockGlab([{ id: 100 }]);
+      mockGlab([
+        { name: "mystery", status: "new_status", web_url: "", started_at: null, finished_at: null },
+      ]);
+      const checks = await scm.getCIChecks(pr);
+      expect(checks[0].status).toBe("failed");
+    });
+
+    it("passes --hostname to glab api for self-hosted GitLab", async () => {
+      const selfHosted = create({ host: "gitlab.corp.com" });
+      mockGlab([{ id: 100 }]);
+      mockGlab([]);
+      await selfHosted.getCIChecks(pr);
+      const firstCallArgs = glabMock.mock.calls[0][1] as string[];
+      expect(firstCallArgs[0]).toBe("api");
+      expect(firstCallArgs[1]).toBe("--hostname");
+      expect(firstCallArgs[2]).toBe("gitlab.corp.com");
+    });
+
+    it("strips hostname from project ID and infers --hostname from pr.owner", async () => {
+      const selfHostedPr = { ...pr, owner: "gitlab.corp.com/acme", repo: "repo" };
+      mockGlab([{ id: 100 }]);
+      mockGlab([]);
+      await scm.getCIChecks(selfHostedPr);
+      const firstCallArgs = glabMock.mock.calls[0][1] as string[];
+      expect(firstCallArgs).toContain("--hostname");
+      expect(firstCallArgs).toContain("gitlab.corp.com");
+      expect(firstCallArgs).toContain("projects/acme%2Frepo/merge_requests/42/pipelines");
+    });
+
+    it("does not treat dotted group name as hostname (owner/repo = 2 segments)", async () => {
+      const dottedGroupPr = { ...pr, owner: "my.company", repo: "repo" };
+      mockGlab([{ id: 100 }]);
+      mockGlab([]);
+      await scm.getCIChecks(dottedGroupPr);
+      const firstCallArgs = glabMock.mock.calls[0][1] as string[];
+      expect(firstCallArgs).not.toContain("--hostname");
+      expect(firstCallArgs).toContain("projects/my.company%2Frepo/merge_requests/42/pipelines");
+    });
+  });
+
+  // ---- getCISummary ------------------------------------------------------
+
+  describe("getCISummary", () => {
+    it('returns "failing" when any job failed', async () => {
+      mockGlab([{ id: 1 }]);
+      mockGlab([
+        { name: "a", status: "success", web_url: "", started_at: null, finished_at: null },
+        { name: "b", status: "failed", web_url: "", started_at: null, finished_at: null },
+      ]);
+      expect(await scm.getCISummary(pr)).toBe("failing");
+    });
+
+    it('returns "pending" when jobs are running', async () => {
+      mockGlab([{ id: 1 }]);
+      mockGlab([
+        { name: "a", status: "success", web_url: "", started_at: null, finished_at: null },
+        { name: "b", status: "running", web_url: "", started_at: null, finished_at: null },
+      ]);
+      expect(await scm.getCISummary(pr)).toBe("pending");
+    });
+
+    it('returns "passing" when all jobs passed', async () => {
+      mockGlab([{ id: 1 }]);
+      mockGlab([
+        { name: "a", status: "success", web_url: "", started_at: null, finished_at: null },
+        { name: "b", status: "success", web_url: "", started_at: null, finished_at: null },
+      ]);
+      expect(await scm.getCISummary(pr)).toBe("passing");
+    });
+
+    it('returns "none" when no pipelines', async () => {
+      mockGlab([]);
+      expect(await scm.getCISummary(pr)).toBe("none");
+    });
+
+    it('returns "failing" and warns on error (fail-closed)', async () => {
+      mockGlabError();
+      mockGlabError(); // getPRState also fails
+      expect(await scm.getCISummary(pr)).toBe("failing");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("getCISummary: CI check fetch failed for MR !42"),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("getCISummary: PR state fallback also failed for MR !42"),
+      );
+    });
+
+    it('returns "none" when CI fetch fails but MR is merged', async () => {
+      mockGlabError("pipeline error");
+      mockGlab({ state: "merged" });
+      expect(await scm.getCISummary(pr)).toBe("none");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("getCISummary: CI check fetch failed"),
+      );
+    });
+
+    it('returns "none" when CI fetch fails but MR is closed', async () => {
+      mockGlabError("pipeline error");
+      mockGlab({ state: "closed" });
+      expect(await scm.getCISummary(pr)).toBe("none");
+    });
+
+    it('returns "failing" when both CI fetch and PR state fail', async () => {
+      mockGlabError("pipeline error");
+      mockGlabError("network error");
+      expect(await scm.getCISummary(pr)).toBe("failing");
+    });
+
+    it('returns "none" when all jobs are skipped', async () => {
+      mockGlab([{ id: 1 }]);
+      mockGlab([
+        { name: "a", status: "skipped", web_url: "", started_at: null, finished_at: null },
+      ]);
+      expect(await scm.getCISummary(pr)).toBe("none");
+    });
+  });
+
+  // ---- getReviews --------------------------------------------------------
+
+  describe("getReviews", () => {
+    it("maps approvals to reviews", async () => {
+      mockGlab({
+        approved_by: [{ user: { username: "alice" } }, { user: { username: "bob" } }],
+      });
+      mockGlab([]); // discussions
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(2);
+      expect(reviews[0]).toMatchObject({ author: "alice", state: "approved" });
+      expect(reviews[1]).toMatchObject({ author: "bob", state: "approved" });
+    });
+
+    it("uses epoch date for approval timestamps (no timestamp available from API)", async () => {
+      mockGlab({
+        approved_by: [{ user: { username: "alice" } }],
+      });
+      mockGlab([]); // discussions
+      const reviews = await scm.getReviews(pr);
+      expect(reviews[0].submittedAt).toEqual(new Date(0));
+    });
+
+    it("handles empty approvals", async () => {
+      mockGlab({ approved_by: [] });
+      mockGlab([]); // discussions
+      expect(await scm.getReviews(pr)).toEqual([]);
+    });
+
+    it("handles null approved_by", async () => {
+      mockGlab({ approved_by: null });
+      mockGlab([]); // discussions
+      expect(await scm.getReviews(pr)).toEqual([]);
+    });
+
+    it('defaults to "unknown" author when user is null', async () => {
+      mockGlab({ approved_by: [{ user: null }] });
+      mockGlab([]); // discussions
+      const reviews = await scm.getReviews(pr);
+      expect(reviews[0].author).toBe("unknown");
+    });
+
+    it("detects changes_requested from unresolved discussions", async () => {
+      mockGlab({ approved_by: [] });
+      mockGlab([
+        {
+          notes: [
+            {
+              author: { username: "carol" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]).toMatchObject({ author: "carol", state: "changes_requested" });
+    });
+
+    it("does not duplicate approved users as changes_requested", async () => {
+      mockGlab({ approved_by: [{ user: { username: "alice" } }] });
+      mockGlab([
+        {
+          notes: [
+            {
+              author: { username: "alice" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]).toMatchObject({ author: "alice", state: "approved" });
+    });
+
+    it("returns approvals only and warns when discussions fetch fails", async () => {
+      mockGlab({
+        approved_by: [{ user: { username: "alice" } }],
+      });
+      mockGlabError("discussions fetch failed");
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]).toMatchObject({ author: "alice", state: "approved" });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("getReviews: discussions fetch failed for MR !42"),
+      );
+    });
+
+    it("filters bot authors from discussions", async () => {
+      mockGlab({ approved_by: [] });
+      mockGlab([
+        {
+          notes: [
+            {
+              author: { username: "gitlab-bot" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              author: { username: "project_99_bot" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              author: { username: "carol" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0].author).toBe("carol");
+    });
+
+    it("deduplicates same author across multiple discussions", async () => {
+      mockGlab({ approved_by: [] });
+      mockGlab([
+        {
+          notes: [
+            {
+              author: { username: "carol" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              author: { username: "carol" },
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-02T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const reviews = await scm.getReviews(pr);
+      expect(reviews).toHaveLength(1);
+      expect(reviews[0]).toMatchObject({ author: "carol", state: "changes_requested" });
+    });
+  });
+
+  // ---- getReviewDecision -------------------------------------------------
+
+  describe("getReviewDecision", () => {
+    it('returns "approved" when MR is approved', async () => {
+      mockGlab({ approved: true, approvals_left: 0 });
+      expect(await scm.getReviewDecision(pr)).toBe("approved");
+    });
+
+    it('returns "pending" when approvals are left', async () => {
+      mockGlab({ approved: false, approvals_left: 2 });
+      expect(await scm.getReviewDecision(pr)).toBe("pending");
+    });
+
+    it('returns "none" when no approval rules', async () => {
+      mockGlab({ approved: false, approvals_left: 0 });
+      expect(await scm.getReviewDecision(pr)).toBe("none");
+    });
+
+    it("passes --hostname to glab api for self-hosted GitLab", async () => {
+      const selfHosted = create({ host: "gitlab.corp.com" });
+      mockGlab({ approved: true, approvals_left: 0 });
+      await selfHosted.getReviewDecision(pr);
+      const args = glabMock.mock.calls[0][1] as string[];
+      expect(args[0]).toBe("api");
+      expect(args[1]).toBe("--hostname");
+      expect(args[2]).toBe("gitlab.corp.com");
+    });
+  });
+
+  // ---- getPendingComments ------------------------------------------------
+
+  describe("getPendingComments", () => {
+    it("returns unresolved non-bot discussion notes", async () => {
+      mockGlab([
+        {
+          id: "d1",
+          notes: [
+            {
+              id: 101,
+              author: { username: "alice" },
+              body: "Fix this",
+              resolvable: true,
+              resolved: false,
+              position: { new_path: "src/foo.ts", new_line: 10 },
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          id: "d2",
+          notes: [
+            {
+              id: 102,
+              author: { username: "bob" },
+              body: "Resolved",
+              resolvable: true,
+              resolved: true,
+              position: { new_path: "src/bar.ts", new_line: 20 },
+              created_at: "2025-01-02T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0]).toMatchObject({ id: "101", author: "alice", isResolved: false });
+    });
+
+    it("filters out bot comments", async () => {
+      mockGlab([
+        {
+          id: "d1",
+          notes: [
+            {
+              id: 101,
+              author: { username: "alice" },
+              body: "Human comment",
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          id: "d2",
+          notes: [
+            {
+              id: 102,
+              author: { username: "gitlab-bot" },
+              body: "Bot comment",
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          id: "d3",
+          notes: [
+            {
+              id: 103,
+              author: { username: "project_42_bot" },
+              body: "Project bot",
+              resolvable: true,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].author).toBe("alice");
+    });
+
+    it("skips non-resolvable discussions", async () => {
+      mockGlab([
+        {
+          id: "d1",
+          notes: [
+            {
+              id: 101,
+              author: { username: "alice" },
+              body: "System note",
+              resolvable: false,
+              resolved: false,
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(0);
+    });
+
+    it("throws on error (fail-closed)", async () => {
+      mockGlabError("API rate limit");
+      await expect(scm.getPendingComments(pr)).rejects.toThrow("API rate limit");
+    });
+  });
+
+  // ---- getAutomatedComments ----------------------------------------------
+
+  describe("getAutomatedComments", () => {
+    it("returns bot discussion notes with severity", async () => {
+      mockGlab([
+        {
+          notes: [
+            {
+              id: 101,
+              author: { username: "gitlab-bot" },
+              body: "Found a critical error",
+              position: { new_path: "a.ts", new_line: 5 },
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              id: 102,
+              author: { username: "alice" },
+              body: "Human comment",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const comments = await scm.getAutomatedComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].botName).toBe("gitlab-bot");
+      expect(comments[0].severity).toBe("error");
+    });
+
+    it("classifies severity from body content", async () => {
+      mockGlab([
+        {
+          notes: [
+            {
+              id: 1,
+              author: { username: "sast-bot" },
+              body: "Error: build failed",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              id: 2,
+              author: { username: "sast-bot" },
+              body: "Warning: deprecated API",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+        {
+          notes: [
+            {
+              id: 3,
+              author: { username: "sast-bot" },
+              body: "Deployed to staging",
+              created_at: "2025-01-01T00:00:00Z",
+            },
+          ],
+        },
+      ]);
+
+      const comments = await scm.getAutomatedComments(pr);
+      expect(comments).toHaveLength(3);
+      expect(comments[0].severity).toBe("error");
+      expect(comments[1].severity).toBe("warning");
+      expect(comments[2].severity).toBe("info");
+    });
+
+    it("throws on error (fail-closed)", async () => {
+      mockGlabError("network failure");
+      await expect(scm.getAutomatedComments(pr)).rejects.toThrow("network failure");
+    });
+  });
+
+  // ---- getMergeability ---------------------------------------------------
+
+  describe("getMergeability", () => {
+    it("returns clean result for merged MRs", async () => {
+      mockGlab({ state: "merged", draft: false }); // mr view
+      const result = await scm.getMergeability(pr);
+      expect(result).toEqual({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      });
+      expect(glabMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns not mergeable for closed MRs", async () => {
+      mockGlab({ state: "closed", draft: false }); // mr view
+      const result = await scm.getMergeability(pr);
+      expect(result).toEqual({
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["MR is closed"],
+      });
+      expect(glabMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns mergeable when everything is clear", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "can_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API MR detail
+      mockGlab([]); // getCIChecks: pipelines (none)
+      mockGlab({ approved: true, approvals_left: 0 }); // getReviewDecision
+
+      const result = await scm.getMergeability(pr);
+      expect(result).toEqual({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      });
+    });
+
+    it("reports CI failures as blockers", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "can_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([{ id: 1 }]); // pipelines
+      mockGlab([
+        { name: "build", status: "failed", web_url: "", started_at: null, finished_at: null },
+      ]); // jobs
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.ciPassing).toBe(false);
+      expect(result.mergeable).toBe(false);
+      expect(result.blockers).toContain("CI is failing");
+    });
+
+    it("reports merge conflicts as blockers", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "cannot_be_merged",
+        has_conflicts: true,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.noConflicts).toBe(false);
+      expect(result.blockers).toContain("Merge conflicts");
+    });
+
+    it("reports cannot_be_merged without conflicts as blocker", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "cannot_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.blockers).toContain("Merge status: cannot be merged");
+      expect(result.noConflicts).toBe(true);
+    });
+
+    it("reports checking merge status as blocker", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "checking",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.blockers).toContain("Merge status unknown (GitLab is computing)");
+    });
+
+    it("reports unresolved discussions as blockers", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "can_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: false,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.blockers).toContain("Unresolved discussions blocking merge");
+    });
+
+    it("reports draft status as blocker", async () => {
+      mockGlab({ state: "opened", draft: true }); // mr view
+      mockGlab({
+        merge_status: "can_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: true, approvals_left: 0 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.blockers).toContain("MR is still a draft");
+    });
+
+    it("reports approval required as blocker", async () => {
+      mockGlab({ state: "opened", draft: false }); // mr view
+      mockGlab({
+        merge_status: "can_be_merged",
+        has_conflicts: false,
+        blocking_discussions_resolved: true,
+      }); // API
+      mockGlab([]); // no pipelines
+      mockGlab({ approved: false, approvals_left: 2 }); // approvals
+
+      const result = await scm.getMergeability(pr);
+      expect(result.approved).toBe(false);
+      expect(result.blockers).toContain("Approval required");
+    });
+  });
+});

--- a/packages/plugins/scm-gitlab/tsconfig.json
+++ b/packages/plugins/scm-gitlab/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/plugins/tracker-gitlab/package.json
+++ b/packages/plugins/tracker-gitlab/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@composio/ao-plugin-tracker-gitlab",
+  "version": "0.1.0",
+  "description": "Tracker plugin: GitLab Issues",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/tracker-gitlab"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*",
+    "@composio/ao-plugin-scm-gitlab": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/tracker-gitlab/src/index.ts
+++ b/packages/plugins/tracker-gitlab/src/index.ts
@@ -1,0 +1,221 @@
+/**
+ * tracker-gitlab plugin — GitLab Issues as an issue tracker.
+ *
+ * Uses the `glab` CLI for all GitLab API interactions.
+ */
+
+import type {
+  PluginModule,
+  Tracker,
+  Issue,
+  IssueFilters,
+  IssueUpdate,
+  CreateIssueInput,
+  ProjectConfig,
+} from "@composio/ao-core";
+
+import { glab, parseJSON, extractHost, stripHost } from "@composio/ao-plugin-scm-gitlab/glab-utils";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface GitLabIssueData {
+  iid: number;
+  title: string;
+  description: string;
+  web_url: string;
+  state: string;
+  labels: string[];
+  assignees: Array<{ username: string }>;
+}
+
+function toIssue(data: GitLabIssueData): Issue {
+  return {
+    id: String(data.iid),
+    title: data.title,
+    description: data.description ?? "",
+    url: data.web_url,
+    state: data.state.toLowerCase() === "closed" ? "closed" : "open",
+    labels: data.labels ?? [],
+    assignee: data.assignees?.[0]?.username,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tracker implementation
+// ---------------------------------------------------------------------------
+
+function createGitLabTracker(config?: Record<string, unknown>): Tracker {
+  const hostname = typeof config?.host === "string" ? config.host : undefined;
+  const defaultHost = hostname ?? "gitlab.com";
+
+  return {
+    name: "gitlab",
+
+    async getIssue(identifier: string, project: ProjectConfig): Promise<Issue> {
+      const raw = await glab(
+        ["issue", "view", identifier, "--repo", project.repo, "-F", "json"],
+        hostname,
+      );
+      return toIssue(parseJSON<GitLabIssueData>(raw, `getIssue for issue ${identifier}`));
+    },
+
+    async isCompleted(identifier: string, project: ProjectConfig): Promise<boolean> {
+      const raw = await glab(
+        ["issue", "view", identifier, "--repo", project.repo, "-F", "json"],
+        hostname,
+      );
+      const data = parseJSON<{ state: string }>(raw, `isCompleted for issue ${identifier}`);
+      return data.state.toLowerCase() === "closed";
+    },
+
+    issueUrl(identifier: string, project: ProjectConfig): string {
+      const num = identifier.replace(/^#/, "");
+      const host = extractHost(project.repo) ?? defaultHost;
+      return `https://${host}/${stripHost(project.repo)}/-/issues/${num}`;
+    },
+
+    issueLabel(url: string, _project: ProjectConfig): string {
+      const match = url.match(/\/-\/issues\/(\d+)/);
+      if (match) return `#${match[1]}`;
+      const parts = url.split("/");
+      const lastPart = parts[parts.length - 1];
+      return lastPart ? `#${lastPart}` : url;
+    },
+
+    branchName(identifier: string, _project: ProjectConfig): string {
+      return `feat/issue-${identifier.replace(/^#/, "")}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      const lines = [
+        `You are working on GitLab issue #${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Labels: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this issue. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
+      const args = [
+        "issue",
+        "list",
+        "--repo",
+        project.repo,
+        "-O",
+        "json",
+        "-P",
+        String(filters.limit ?? 30),
+      ];
+
+      if (filters.state === "closed") {
+        args.push("--closed");
+      } else if (filters.state === "all") {
+        args.push("--all");
+      }
+
+      if (filters.labels && filters.labels.length > 0) {
+        for (const label of filters.labels) {
+          args.push("--label", label);
+        }
+      }
+
+      if (filters.assignee) {
+        args.push("--assignee", filters.assignee);
+      }
+
+      const raw = await glab(args, hostname);
+      const issues = parseJSON<GitLabIssueData[]>(raw, "listIssues");
+      return issues.map(toIssue);
+    },
+
+    async updateIssue(
+      identifier: string,
+      update: IssueUpdate,
+      project: ProjectConfig,
+    ): Promise<void> {
+      if (update.state === "closed") {
+        await glab(["issue", "close", identifier, "--repo", project.repo], hostname);
+      } else if (update.state === "open") {
+        await glab(["issue", "reopen", identifier, "--repo", project.repo], hostname);
+      }
+
+      if (update.labels && update.labels.length > 0) {
+        await glab(
+          ["issue", "update", identifier, "--repo", project.repo, "--label", update.labels.join(",")],
+          hostname,
+        );
+      }
+
+      if (update.comment) {
+        await glab(
+          ["issue", "note", identifier, "--repo", project.repo, "-m", update.comment],
+          hostname,
+        );
+      }
+    },
+
+    async createIssue(input: CreateIssueInput, project: ProjectConfig): Promise<Issue> {
+      const args = [
+        "issue",
+        "create",
+        "--repo",
+        project.repo,
+        "--title",
+        input.title,
+        "--description",
+        input.description ?? "",
+      ];
+
+      if (input.labels && input.labels.length > 0) {
+        args.push("--label", input.labels.join(","));
+      }
+
+      if (input.assignee) {
+        args.push("--assignee", input.assignee);
+      }
+
+      const url = await glab(args, hostname);
+
+      const match = url.match(/\/-\/issues\/(\d+)/);
+      if (!match?.[1]) {
+        throw new Error(`Failed to parse issue URL from glab output: ${url}`);
+      }
+
+      return this.getIssue(match[1], project);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin module export
+// ---------------------------------------------------------------------------
+
+export const manifest = {
+  name: "gitlab",
+  slot: "tracker" as const,
+  description: "Tracker plugin: GitLab Issues",
+  version: "0.1.0",
+};
+
+export function create(config?: Record<string, unknown>): Tracker {
+  return createGitLabTracker(config);
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-gitlab/test/index.test.ts
+++ b/packages/plugins/tracker-gitlab/test/index.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process
+// ---------------------------------------------------------------------------
+const { glabMock } = vi.hoisted(() => ({ glabMock: vi.fn() }));
+
+vi.mock("node:child_process", () => {
+  const execFile = Object.assign(vi.fn(), {
+    [Symbol.for("nodejs.util.promisify.custom")]: glabMock,
+  });
+  return { execFile };
+});
+
+import { create, manifest } from "../src/index.js";
+import type { ProjectConfig } from "@composio/ao-core";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const project: ProjectConfig = {
+  name: "test",
+  repo: "acme/repo",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+};
+
+function mockGlab(result: unknown) {
+  glabMock.mockResolvedValueOnce({ stdout: JSON.stringify(result) });
+}
+
+function mockGlabRaw(stdout: string) {
+  glabMock.mockResolvedValueOnce({ stdout });
+}
+
+function mockGlabError(msg = "Command failed") {
+  glabMock.mockRejectedValueOnce(new Error(msg));
+}
+
+const sampleIssue = {
+  iid: 123,
+  title: "Fix login bug",
+  description: "Users can't log in with SSO",
+  web_url: "https://gitlab.com/acme/repo/-/issues/123",
+  state: "opened",
+  labels: ["bug", "priority-high"],
+  assignees: [{ username: "alice" }],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("tracker-gitlab plugin", () => {
+  let tracker: ReturnType<typeof create>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tracker = create();
+  });
+
+  // ---- manifest ----------------------------------------------------------
+
+  describe("manifest", () => {
+    it("has correct metadata", () => {
+      expect(manifest.name).toBe("gitlab");
+      expect(manifest.slot).toBe("tracker");
+      expect(manifest.version).toBe("0.1.0");
+    });
+  });
+
+  describe("create()", () => {
+    it("returns a Tracker with correct name", () => {
+      expect(tracker.name).toBe("gitlab");
+    });
+  });
+
+  // ---- getIssue ----------------------------------------------------------
+
+  describe("getIssue", () => {
+    it("returns Issue with correct fields", async () => {
+      mockGlab(sampleIssue);
+      const issue = await tracker.getIssue("123", project);
+      expect(issue).toEqual({
+        id: "123",
+        title: "Fix login bug",
+        description: "Users can't log in with SSO",
+        url: "https://gitlab.com/acme/repo/-/issues/123",
+        state: "open",
+        labels: ["bug", "priority-high"],
+        assignee: "alice",
+      });
+    });
+
+    it("maps closed state to closed", async () => {
+      mockGlab({ ...sampleIssue, state: "closed" });
+      const issue = await tracker.getIssue("123", project);
+      expect(issue.state).toBe("closed");
+    });
+
+    it("handles missing description gracefully", async () => {
+      mockGlab({ ...sampleIssue, description: null });
+      const issue = await tracker.getIssue("123", project);
+      expect(issue.description).toBe("");
+    });
+
+    it("handles empty assignees", async () => {
+      mockGlab({ ...sampleIssue, assignees: [] });
+      const issue = await tracker.getIssue("123", project);
+      expect(issue.assignee).toBeUndefined();
+    });
+
+    it("handles labels as string array (GitLab format)", async () => {
+      mockGlab({ ...sampleIssue, labels: ["bug", "urgent"] });
+      const issue = await tracker.getIssue("123", project);
+      expect(issue.labels).toEqual(["bug", "urgent"]);
+    });
+
+    it("propagates glab CLI errors", async () => {
+      mockGlabError("issue not found");
+      await expect(tracker.getIssue("999", project)).rejects.toThrow("issue not found");
+    });
+
+    it("throws on malformed JSON response", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "not json{" });
+      await expect(tracker.getIssue("123", project)).rejects.toThrow();
+    });
+  });
+
+  // ---- isCompleted -------------------------------------------------------
+
+  describe("isCompleted", () => {
+    it("returns true for closed issues", async () => {
+      mockGlab({ state: "closed" });
+      expect(await tracker.isCompleted("123", project)).toBe(true);
+    });
+
+    it("returns false for opened issues", async () => {
+      mockGlab({ state: "opened" });
+      expect(await tracker.isCompleted("123", project)).toBe(false);
+    });
+
+    it("handles uppercase state", async () => {
+      mockGlab({ state: "Closed" });
+      expect(await tracker.isCompleted("123", project)).toBe(true);
+    });
+  });
+
+  // ---- issueUrl ----------------------------------------------------------
+
+  describe("issueUrl", () => {
+    it("generates correct URL for gitlab.com", () => {
+      expect(tracker.issueUrl("42", project)).toBe(
+        "https://gitlab.com/acme/repo/-/issues/42",
+      );
+    });
+
+    it("strips # prefix from identifier", () => {
+      expect(tracker.issueUrl("#42", project)).toBe(
+        "https://gitlab.com/acme/repo/-/issues/42",
+      );
+    });
+
+    it("uses custom host when configured", () => {
+      const customTracker = create({ host: "gitlab.example.com" });
+      expect(customTracker.issueUrl("42", project)).toBe(
+        "https://gitlab.example.com/acme/repo/-/issues/42",
+      );
+    });
+
+    it("infers host from project.repo when config.host is unset", () => {
+      const selfHostedProject = { ...project, repo: "gitlab.corp.com/org/repo" };
+      expect(tracker.issueUrl("42", selfHostedProject)).toBe(
+        "https://gitlab.corp.com/org/repo/-/issues/42",
+      );
+    });
+
+    it("strips hostname from project.repo with custom host", () => {
+      const customTracker = create({ host: "gitlab.corp.com" });
+      const selfHostedProject = { ...project, repo: "gitlab.corp.com/org/repo" };
+      expect(customTracker.issueUrl("42", selfHostedProject)).toBe(
+        "https://gitlab.corp.com/org/repo/-/issues/42",
+      );
+    });
+
+    it("does not treat dotted group name as hostname (only 2 segments)", () => {
+      const dottedGroupProject = { ...project, repo: "my.company/repo" };
+      expect(tracker.issueUrl("42", dottedGroupProject)).toBe(
+        "https://gitlab.com/my.company/repo/-/issues/42",
+      );
+    });
+  });
+
+  // ---- issueLabel --------------------------------------------------------
+
+  describe("issueLabel", () => {
+    it("extracts issue number from GitLab URL", () => {
+      expect(
+        tracker.issueLabel!("https://gitlab.com/acme/repo/-/issues/42", project),
+      ).toBe("#42");
+    });
+
+    it("falls back to last URL segment", () => {
+      expect(tracker.issueLabel!("https://example.com/something/42", project)).toBe("#42");
+    });
+  });
+
+  // ---- branchName --------------------------------------------------------
+
+  describe("branchName", () => {
+    it("generates feat/issue-N format", () => {
+      expect(tracker.branchName("42", project)).toBe("feat/issue-42");
+    });
+
+    it("strips # prefix", () => {
+      expect(tracker.branchName("#42", project)).toBe("feat/issue-42");
+    });
+  });
+
+  // ---- generatePrompt ----------------------------------------------------
+
+  describe("generatePrompt", () => {
+    it("includes title and URL", async () => {
+      mockGlab(sampleIssue);
+      const prompt = await tracker.generatePrompt("123", project);
+      expect(prompt).toContain("Fix login bug");
+      expect(prompt).toContain("https://gitlab.com/acme/repo/-/issues/123");
+      expect(prompt).toContain("GitLab issue #123");
+    });
+
+    it("includes labels when present", async () => {
+      mockGlab(sampleIssue);
+      const prompt = await tracker.generatePrompt("123", project);
+      expect(prompt).toContain("bug, priority-high");
+    });
+
+    it("includes description", async () => {
+      mockGlab(sampleIssue);
+      const prompt = await tracker.generatePrompt("123", project);
+      expect(prompt).toContain("Users can't log in with SSO");
+    });
+
+    it("omits labels section when no labels", async () => {
+      mockGlab({ ...sampleIssue, labels: [] });
+      const prompt = await tracker.generatePrompt("123", project);
+      expect(prompt).not.toContain("Labels:");
+    });
+
+    it("omits description section when body is empty", async () => {
+      mockGlab({ ...sampleIssue, description: null });
+      const prompt = await tracker.generatePrompt("123", project);
+      expect(prompt).not.toContain("## Description");
+    });
+  });
+
+  // ---- listIssues --------------------------------------------------------
+
+  describe("listIssues", () => {
+    it("returns mapped issues", async () => {
+      mockGlab([sampleIssue, { ...sampleIssue, iid: 456, title: "Another" }]);
+      const issues = await tracker.listIssues!({}, project);
+      expect(issues).toHaveLength(2);
+      expect(issues[0].id).toBe("123");
+      expect(issues[1].id).toBe("456");
+    });
+
+    it("passes --closed filter for closed issues", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({ state: "closed" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["--closed"]),
+        expect.any(Object),
+      );
+    });
+
+    it("passes --all filter for all issues", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({ state: "all" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["--all"]),
+        expect.any(Object),
+      );
+    });
+
+    it("defaults to open state (no --closed or --all)", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({}, project);
+      const args = glabMock.mock.calls[0][1] as string[];
+      expect(args).not.toContain("--closed");
+      expect(args).not.toContain("--all");
+    });
+
+    it("passes label filter", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({ labels: ["bug", "urgent"] }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["--label", "bug", "--label", "urgent"]),
+        expect.any(Object),
+      );
+    });
+
+    it("passes assignee filter", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({ assignee: "alice" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["--assignee", "alice"]),
+        expect.any(Object),
+      );
+    });
+
+    it("respects custom limit", async () => {
+      mockGlab([]);
+      await tracker.listIssues!({ limit: 5 }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["-P", "5"]),
+        expect.any(Object),
+      );
+    });
+  });
+
+  // ---- updateIssue -------------------------------------------------------
+
+  describe("updateIssue", () => {
+    it("closes an issue", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await tracker.updateIssue!("123", { state: "closed" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["issue", "close", "123", "--repo", "acme/repo"],
+        expect.any(Object),
+      );
+    });
+
+    it("reopens an issue", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await tracker.updateIssue!("123", { state: "open" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["issue", "reopen", "123", "--repo", "acme/repo"],
+        expect.any(Object),
+      );
+    });
+
+    it("adds labels", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await tracker.updateIssue!("123", { labels: ["bug", "urgent"] }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["issue", "update", "123", "--repo", "acme/repo", "--label", "bug,urgent"],
+        expect.any(Object),
+      );
+    });
+
+    it("adds comment", async () => {
+      glabMock.mockResolvedValueOnce({ stdout: "" });
+      await tracker.updateIssue!("123", { comment: "Working on this" }, project);
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        ["issue", "note", "123", "--repo", "acme/repo", "-m", "Working on this"],
+        expect.any(Object),
+      );
+    });
+
+    it("handles multiple updates in one call", async () => {
+      glabMock.mockResolvedValue({ stdout: "" });
+      await tracker.updateIssue!(
+        "123",
+        { state: "closed", labels: ["done"], comment: "Done!" },
+        project,
+      );
+      expect(glabMock).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // ---- createIssue -------------------------------------------------------
+
+  describe("createIssue", () => {
+    it("creates an issue and fetches full details", async () => {
+      mockGlabRaw("https://gitlab.com/acme/repo/-/issues/999\n");
+      mockGlab({
+        iid: 999,
+        title: "New issue",
+        description: "Description",
+        web_url: "https://gitlab.com/acme/repo/-/issues/999",
+        state: "opened",
+        labels: [],
+        assignees: [],
+      });
+
+      const issue = await tracker.createIssue!(
+        { title: "New issue", description: "Description" },
+        project,
+      );
+      expect(issue).toMatchObject({ id: "999", title: "New issue", state: "open" });
+    });
+
+    it("passes labels and assignee to glab issue create", async () => {
+      mockGlabRaw("https://gitlab.com/acme/repo/-/issues/1000\n");
+      mockGlab({
+        iid: 1000,
+        title: "Bug",
+        description: "Crash",
+        web_url: "https://gitlab.com/acme/repo/-/issues/1000",
+        state: "opened",
+        labels: ["bug"],
+        assignees: [{ username: "alice" }],
+      });
+
+      await tracker.createIssue!(
+        { title: "Bug", description: "Crash", labels: ["bug"], assignee: "alice" },
+        project,
+      );
+      expect(glabMock).toHaveBeenCalledWith(
+        "glab",
+        expect.arrayContaining(["issue", "create", "--label", "bug", "--assignee", "alice"]),
+        expect.any(Object),
+      );
+    });
+
+    it("throws when URL cannot be parsed from glab output", async () => {
+      mockGlabRaw("unexpected output");
+      await expect(
+        tracker.createIssue!({ title: "Test", description: "" }, project),
+      ).rejects.toThrow("Failed to parse issue URL");
+    });
+  });
+});

--- a/packages/plugins/tracker-gitlab/tsconfig.json
+++ b/packages/plugins/tracker-gitlab/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/plugins/scm-gitlab:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
   packages/plugins/terminal-iterm2:
     dependencies:
       '@composio/ao-core':
@@ -426,6 +442,25 @@ importers:
       '@composio/ao-core':
         specifier: workspace:*
         version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/tracker-gitlab:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@composio/ao-plugin-scm-gitlab':
+        specifier: workspace:*
+        version: link:../scm-gitlab
     devDependencies:
       '@types/node':
         specifier: ^25.2.3


### PR DESCRIPTION
## Summary
- Closed MRs are now correctly reported as non-mergeable in `getMergeability`, returning a `"MR is closed"` blocker instead of falling through to produce an empty blockers list
- Extracted shared `glab`, `parseJSON`, `extractHost`, and `stripHost` helpers into `scm-gitlab/src/glab-utils.ts`; tracker-gitlab now imports from `@composio/ao-plugin-scm-gitlab/glab-utils` instead of maintaining duplicate copies

Addresses two unresolved Bugbot review comments from PR #191.

## Test plan
- [x] `pnpm lint` passes (warnings only, no errors)
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (all 200 tests)
- [ ] Verify closed MR state returns `mergeable: false` with `"MR is closed"` blocker
- [ ] Verify tracker-gitlab correctly resolves shared utils import at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)