### PR TITLE
fix: pass agentConfig.env to runtime environment

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -835,6 +835,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         launchCommand,
         environment: {
           ...environment,
+          ...(project.agentConfig?.env ?? {}), // Merge custom environment variables from config
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
           AO_SESSION_NAME: sessionId, // User-facing session name
@@ -1070,6 +1071,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       launchCommand,
       environment: {
         ...environment,
+        ...(project.agentConfig?.env ?? {}), // Merge custom environment variables from config
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,
@@ -1982,6 +1984,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       launchCommand,
       environment: {
         ...environment,
+        ...(project.agentConfig?.env ?? {}), // Merge custom environment variables from config
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,


### PR DESCRIPTION
## Problem

When using custom API endpoints (e.g., ANTHROPIC_API_KEY, ANTHROPIC_BASE_URL) configured in `agent-orchestrator.yaml` under `agentConfig.env`, these environment variables were not being passed to the tmux sessions where agents run.

This caused Claude Code to fail with "Not logged in" errors even though the config file had the correct API credentials.

## Solution

Modified `session-manager.ts` to merge `project.agentConfig.env` into the runtime environment in three places:
- Session spawn flow
- Orchestrator start flow  
- Session restore flow

## Testing

Verified that:
- Environment variables from config are now present in tmux sessions
- Claude Code can successfully connect using custom API endpoint
- Existing functionality remains unchanged

Fixes the issue where `agentConfig.env` was defined in config but ignored at runtime.