### PR TITLE
feat: harness dashboard, operator queue, repo policy & runtime enhancements

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -238,6 +238,47 @@ function createFakeRepo(dir: string, remoteUrl: string, files?: Record<string, s
 // ---------------------------------------------------------------------------
 
 describe("start command — project resolution", () => {
+  it("loads explicit config path when --config is provided", async () => {
+    const explicitConfigPath = join(tmpDir, "custom.tmux.yaml");
+    const repoPath = join(tmpDir, "main-repo");
+    mkdirSync(repoPath, { recursive: true });
+    writeFileSync(
+      explicitConfigPath,
+      [
+        "port: 3011",
+        "defaults:",
+        "  runtime: tmux",
+        "  agent: claude-code",
+        "  workspace: worktree",
+        "  notifiers: []",
+        "projects:",
+        "  my-app:",
+        "    name: My App",
+        "    repo: org/my-app",
+        `    path: ${repoPath.replace(/\\/g, "/")}`,
+        "    defaultBranch: main",
+        "    sessionPrefix: app",
+      ].join("\n"),
+    );
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "start",
+      "--config",
+      explicitConfigPath,
+      "--no-dashboard",
+      "--no-orchestrator",
+    ]);
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("My App");
+    expect(output).toContain("Startup complete");
+  });
+
   it("uses single project when no arg given", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -232,8 +232,10 @@ async function startDashboard(
   directTerminalPort?: number,
 ): Promise<ChildProcess> {
   const env = await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort);
+  const dashboardCmd = process.platform === "win32" ? "cmd.exe" : "pnpm";
+  const dashboardArgs = process.platform === "win32" ? ["/c", "pnpm", "run", "dev"] : ["run", "dev"];
 
-  const child = spawn("pnpm", ["run", "dev"], {
+  const child = spawn(dashboardCmd, dashboardArgs, {
     cwd: webDir,
     stdio: "inherit",
     detached: false,
@@ -442,6 +444,7 @@ export function registerStart(program: Command): void {
     .description(
       "Start orchestrator agent and dashboard for a project (or pass a repo URL to onboard)",
     )
+    .option("-c, --config <path>", "Path to config file")
     .option("--no-dashboard", "Skip starting the dashboard server")
     .option("--no-orchestrator", "Skip starting the orchestrator agent")
     .option("--rebuild", "Clean and rebuild dashboard before starting")
@@ -449,6 +452,7 @@ export function registerStart(program: Command): void {
       async (
         projectArg?: string,
         opts?: {
+          config?: string;
           dashboard?: boolean;
           orchestrator?: boolean;
           rebuild?: boolean;
@@ -469,7 +473,7 @@ export function registerStart(program: Command): void {
             ({ projectId, project } = resolveProjectByRepo(config, result.parsed));
           } else {
             // Normal flow — load existing config
-            config = loadConfig();
+            config = loadConfig(opts?.config);
             ({ projectId, project } = resolveProject(config, projectArg));
           }
 
@@ -495,12 +499,13 @@ export function registerStop(program: Command): void {
   program
     .command("stop [project]")
     .description("Stop orchestrator agent and dashboard for a project")
+    .option("-c, --config <path>", "Path to config file")
     .option("--keep-session", "Keep mapped OpenCode session after stopping")
     .option("--purge-session", "Delete mapped OpenCode session when stopping")
     .action(
-      async (projectArg?: string, opts: { keepSession?: boolean; purgeSession?: boolean } = {}) => {
+      async (projectArg?: string, opts: { config?: string; keepSession?: boolean; purgeSession?: boolean } = {}) => {
         try {
-          const config = loadConfig();
+          const config = loadConfig(opts.config);
           const { projectId: _projectId, project } = resolveProject(config, projectArg);
           const sessionId = `${project.sessionPrefix}-orchestrator`;
           const port = config.port ?? 3000;

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -12,6 +12,13 @@ import { resolve } from "node:path";
 import { isPortAvailable } from "./web-dir.js";
 import { exec } from "./shell.js";
 
+function sanitizeGhEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  delete env["GH_TOKEN"];
+  delete env["GITHUB_TOKEN"];
+  return env;
+}
+
 /**
  * Check that the dashboard port is free.
  * Throws if the port is already in use.
@@ -67,7 +74,9 @@ async function checkGhAuth(): Promise<void> {
   }
 
   try {
-    await exec("gh", ["auth", "status"]);
+    await exec("gh", ["auth", "status"], {
+      env: sanitizeGhEnv(),
+    });
   } catch {
     throw new Error("GitHub CLI is not authenticated. Run: gh auth login");
   }

--- a/packages/cli/src/lib/shell.ts
+++ b/packages/cli/src/lib/shell.ts
@@ -3,6 +3,13 @@ import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFileCb);
 
+function sanitizeGhEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  delete env["GH_TOKEN"];
+  delete env["GITHUB_TOKEN"];
+  return env;
+}
+
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -11,11 +18,11 @@ export interface ExecResult {
 export async function exec(
   cmd: string,
   args: string[],
-  options?: { cwd?: string; env?: Record<string, string> },
+  options?: { cwd?: string; env?: NodeJS.ProcessEnv },
 ): Promise<ExecResult> {
   const { stdout, stderr } = await execFileAsync(cmd, args, {
     cwd: options?.cwd,
-    env: options?.env ? { ...process.env, ...options.env } : undefined,
+    env: options?.env ?? process.env,
     maxBuffer: 10 * 1024 * 1024,
   });
   return { stdout: stdout.trimEnd(), stderr: stderr.trimEnd() };
@@ -44,7 +51,12 @@ export async function git(args: string[], cwd?: string): Promise<string | null> 
 }
 
 export async function gh(args: string[]): Promise<string | null> {
-  return execSilent("gh", args);
+  try {
+    const { stdout } = await exec("gh", args, { env: sanitizeGhEnv() });
+    return stdout;
+  } catch {
+    return null;
+  }
 }
 
 export async function getTmuxSessions(): Promise<string[]> {

--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -114,7 +114,12 @@ export async function buildDashboardEnv(
   terminalPort?: number,
   directTerminalPort?: number,
 ): Promise<Record<string, string>> {
-  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    // Windows can expose pseudo-vars like "=C:" that make child_process.spawn fail with EINVAL.
+    if (!value || key.startsWith("=")) continue;
+    env[key] = value;
+  }
 
   // Pass config path so dashboard uses the same config as the CLI
   if (configPath) {

--- a/packages/core/src/__tests__/repo-policy.test.ts
+++ b/packages/core/src/__tests__/repo-policy.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import {
+  assertRestoreAllowed,
+  assertSendAllowed,
+  assertSpawnAllowed,
+  persistActiveSession,
+  persistTerminalWorkState,
+  resolveTerminationPolicy,
+  resolveWorkspaceLifecyclePolicy,
+} from "../repo-policy.js";
+import type { ProjectConfig } from "../types.js";
+
+function makeProject(root: string): ProjectConfig {
+  const projectPath = join(root, "agent-orchestrator");
+  mkdirSync(projectPath, { recursive: true });
+  return {
+    name: "Agent Orchestrator",
+    repo: "org/agent-orchestrator",
+    path: projectPath,
+    defaultBranch: "main",
+    sessionPrefix: "ao",
+  };
+}
+
+function writeIndex(root: string, name: string, payload: unknown): void {
+  const indexDir = join(root, "project-os", "indexes");
+  mkdirSync(indexDir, { recursive: true });
+  writeFileSync(join(indexDir, name), JSON.stringify(payload, null, 2) + "\n", "utf-8");
+}
+
+describe("repo policy guards", () => {
+  it("allows spawn only for dispatch or retry actions", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "dispatch_plan.json", [
+      { work_id: "TKT-1", next_action: "dispatch", reason: "eligible" },
+      { work_id: "TKT-2", next_action: "retry", reason: "retryable" },
+      { work_id: "TKT-3", next_action: "escalate", reason: "blocked" },
+    ]);
+
+    expect(assertSpawnAllowed(project, "TKT-1")).toEqual({ workId: "TKT-1" });
+    expect(assertSpawnAllowed(project, "TKT-2")).toEqual({ workId: "TKT-2" });
+    expect(() => assertSpawnAllowed(project, "TKT-3")).toThrow("Spawn blocked by repo policy");
+  });
+
+  it("allows restore only for reconcile_session actions", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "work_state_store.json", [
+      { work_id: "TKT-1", active_session_id: "ao-1", work_status: "dispatched" },
+    ]);
+    writeIndex(root, "reconciliation_state.json", [
+      {
+        work_id: "TKT-1",
+        active_session_id: "ao-1",
+        next_action: "reconcile_session",
+        reason: "missing active run snapshot",
+      },
+    ]);
+
+    expect(assertRestoreAllowed(project, "ao-1", "TKT-1")).toEqual({ workId: "TKT-1" });
+
+    writeIndex(root, "reconciliation_state.json", [
+      {
+        work_id: "TKT-1",
+        active_session_id: "ao-1",
+        next_action: "operator_review",
+        reason: "awaiting review",
+      },
+    ]);
+
+    expect(() => assertRestoreAllowed(project, "ao-1", "TKT-1")).toThrow(
+      "Restore blocked by repo policy",
+    );
+  });
+
+  it("persists active session into the work state store", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "work_state_store.json", [
+      {
+        work_id: "TKT-1",
+        work_status: "queued",
+        retry_count: 1,
+        retry_budget: 2,
+      },
+    ]);
+
+    persistActiveSession(project, "TKT-1", "ao-9");
+
+    const persisted = JSON.parse(
+      readFileSync(join(root, "project-os", "indexes", "work_state_store.json"), "utf-8"),
+    ) as Array<Record<string, unknown>>;
+
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        work_id: "TKT-1",
+        work_status: "dispatched",
+        retry_count: 1,
+        retry_budget: 2,
+        active_session_id: "ao-9",
+      }),
+    ]);
+  });
+
+  it("derives non-terminal termination policy as preserve-and-reconcile", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "work_state_store.json", [
+      { work_id: "TKT-1", active_session_id: "ao-1", work_status: "dispatched" },
+    ]);
+    writeIndex(root, "reconciliation_state.json", [
+      {
+        work_id: "TKT-1",
+        active_session_id: "ao-1",
+        next_action: "reconcile_session",
+      },
+    ]);
+
+    expect(resolveTerminationPolicy(project, "ao-1", "TKT-1")).toEqual({
+      workId: "TKT-1",
+      workStatus: "needs_input",
+      preserveWorkspace: true,
+      allowCleanup: false,
+    });
+  });
+
+  it("blocks send for terminal work and clears active session on terminal persist", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "work_state_store.json", [
+      { work_id: "TKT-1", active_session_id: "ao-1", work_status: "done" },
+    ]);
+
+    expect(() => assertSendAllowed(project, "ao-1", "TKT-1")).toThrow(
+      "Send blocked by repo policy",
+    );
+
+    persistTerminalWorkState(project, "ao-1", "TKT-1", "done");
+
+    const persisted = JSON.parse(
+      readFileSync(join(root, "project-os", "indexes", "work_state_store.json"), "utf-8"),
+    ) as Array<Record<string, unknown>>;
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        work_id: "TKT-1",
+        work_status: "done",
+        active_session_id: null,
+      }),
+    ]);
+  });
+
+  it("derives workspace lifecycle from termination policy", () => {
+    const root = join(tmpdir(), `ao-repo-policy-${randomUUID()}`);
+    const project = makeProject(root);
+    writeIndex(root, "work_state_store.json", [
+      { work_id: "TKT-1", active_session_id: "ao-1", work_status: "review" },
+      { work_id: "TKT-2", active_session_id: "ao-2", work_status: "done" },
+    ]);
+
+    expect(resolveWorkspaceLifecyclePolicy(project, "ao-1", "TKT-1")).toEqual({
+      preserveWorkspace: true,
+      destroyWorkspace: false,
+    });
+    expect(resolveWorkspaceLifecyclePolicy(project, "ao-2", "TKT-2")).toEqual({
+      preserveWorkspace: false,
+      destroyWorkspace: true,
+    });
+  });
+});

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -49,6 +49,12 @@ function makeHandle(id: string): RuntimeHandle {
   return { id, runtimeName: "mock", data: {} };
 }
 
+function writeProjectOsIndex(name: string, payload: unknown): void {
+  const indexDir = join(tmpDir, "project-os", "indexes");
+  mkdirSync(indexDir, { recursive: true });
+  writeFileSync(join(indexDir, name), JSON.stringify(payload, null, 2) + "\n", "utf-8");
+}
+
 function installMockOpencode(
   sessionListJson: string,
   deleteLogPath: string,
@@ -434,6 +440,50 @@ describe("spawn", () => {
     expect(meta!.status).toBe("spawning");
     expect(meta!.project).toBe("my-app");
     expect(meta!.issue).toBe("INT-42");
+  });
+
+  it("blocks spawn when repo policy does not allow dispatch", async () => {
+    writeProjectOsIndex("dispatch_plan.json", [
+      {
+        work_id: "INT-42",
+        next_action: "escalate",
+        reason: "ticket is blocked and requires operator input",
+        priority: 100,
+      },
+    ]);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.spawn({ projectId: "my-app", issueId: "INT-42" })).rejects.toThrow(
+      "Spawn blocked by repo policy",
+    );
+    expect(mockWorkspace.create).not.toHaveBeenCalled();
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("persists active session into work state store after guarded spawn", async () => {
+    writeProjectOsIndex("dispatch_plan.json", [
+      {
+        work_id: "INT-42",
+        next_action: "dispatch",
+        reason: "ticket is eligible for scheduling",
+        priority: 70,
+      },
+    ]);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.spawn({ projectId: "my-app", issueId: "INT-42" });
+
+    const persisted = JSON.parse(
+      readFileSync(join(tmpDir, "project-os", "indexes", "work_state_store.json"), "utf-8"),
+    ) as Array<Record<string, unknown>>;
+
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        work_id: "INT-42",
+        work_status: "dispatched",
+        active_session_id: "app-1",
+      }),
+    ]);
   });
 
   it("reuses OpenCode session mapping by issue when available", async () => {
@@ -1595,6 +1645,49 @@ describe("kill", () => {
     expect(readMetadata(sessionsDir, "app-1")).toBeNull(); // archived + deleted
   });
 
+  it("preserves workspace and clears active session state when killing non-terminal work", async () => {
+    const managedWorktree = join(getWorktreesDir(configPath, join(tmpDir, "my-app")), "app-1");
+    mkdirSync(managedWorktree, { recursive: true });
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-1",
+        work_status: "dispatched",
+        active_session_id: "app-1",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-1",
+        active_session_id: "app-1",
+        next_action: "reconcile_session",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "feat/TEST-1",
+      status: "working",
+      issue: "TEST-1",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.kill("app-1");
+
+    expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+    const persisted = JSON.parse(
+      readFileSync(join(tmpDir, "project-os", "indexes", "work_state_store.json"), "utf-8"),
+    ) as Array<Record<string, unknown>>;
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        work_id: "TEST-1",
+        work_status: "needs_input",
+        active_session_id: null,
+      }),
+    ]);
+  });
+
   it("does not destroy workspace paths outside managed roots", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp/ws",
@@ -1850,6 +1943,43 @@ describe("cleanup", () => {
     expect(deleteLog).toContain("session delete ses_cleanup");
   });
 
+  it("skips cleanup for dead runtime when repo policy says reconcile instead of terminal", async () => {
+    const managedWorktree = join(getWorktreesDir(configPath, join(tmpDir, "my-app")), "app-1");
+    mkdirSync(managedWorktree, { recursive: true });
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-1",
+        work_status: "dispatched",
+        active_session_id: "app-1",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-1",
+        active_session_id: "app-1",
+        next_action: "reconcile_session",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: managedWorktree,
+      branch: "feat/TEST-1",
+      status: "working",
+      issue: "TEST-1",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const result = await sm.cleanup();
+
+    expect(result.skipped).toContain("app-1");
+    expect(result.killed).not.toContain("app-1");
+    expect(mockWorkspace.destroy).not.toHaveBeenCalled();
+  });
+
   it("treats missing mapped OpenCode session as already cleaned", async () => {
     const mockBin = installMockOpencodeWithNotFoundDelete("[]");
     process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
@@ -1920,6 +2050,44 @@ describe("cleanup", () => {
     expect(result.killed).toContain("app-6");
     const deleteLog = readFileSync(deleteLogPath, "utf-8");
     expect(deleteLog).toContain("session delete ses_archived");
+  });
+
+  it("skips archived cleanup when repo policy says the work is non-terminal", async () => {
+    const deleteLogPath = join(tmpDir, "opencode-delete-archived-nonterminal.log");
+    const mockBin = installMockOpencode("[]", deleteLogPath);
+    process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-ARCHIVE",
+        work_status: "review",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-ARCHIVE",
+        next_action: "operator_review",
+        reason: "awaiting review",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-7", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "killed",
+      project: "my-app",
+      issue: "TEST-ARCHIVE",
+      agent: "opencode",
+      opencodeSessionId: "ses_archived_nonterminal",
+      runtimeHandle: JSON.stringify(makeHandle("rt-7")),
+    });
+    deleteMetadata(sessionsDir, "app-7", true);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const result = await sm.cleanup();
+
+    expect(result.killed).not.toContain("app-7");
+    expect(result.skipped).toContain("app-7");
+    expect(existsSync(deleteLogPath)).toBe(false);
   });
 
   it("does not skip archived cleanup for matching session IDs in other projects", async () => {
@@ -2284,6 +2452,28 @@ describe("send", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(makeHandle("rt-1"), "hello");
   });
 
+  it("blocks send when repo policy marks the work as terminal", async () => {
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-1",
+        work_status: "done",
+        active_session_id: "app-1",
+      },
+    ]);
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      issue: "TEST-1",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.send("app-1", "hello")).rejects.toThrow("Send blocked by repo policy");
+    expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+  });
+
   it("re-discovers OpenCode mapping before sending when stored mapping is invalid", async () => {
     const deleteLogPath = join(tmpDir, "opencode-send-remap-invalid.log");
     const mockBin = installMockOpencode(
@@ -2313,6 +2503,48 @@ describe("send", () => {
     const meta = readMetadataRaw(sessionsDir, "app-1");
     expect(meta?.["opencodeSessionId"]).toBe("ses_send_discovered_valid");
     expect(mockRuntime.sendMessage).toHaveBeenCalledWith(makeHandle("rt-1"), "hello");
+  });
+});
+
+describe("kill", () => {
+  it("waits for runtime to report stopped before archiving metadata", async () => {
+    const handle = { id: "rt-1", runtimeName: "tmux", data: {} };
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(handle),
+    });
+
+    vi.mocked(mockRuntime.isAlive)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.kill("app-1");
+
+    expect(mockRuntime.destroy).toHaveBeenCalledWith(handle);
+    expect(mockRuntime.isAlive).toHaveBeenCalledWith(handle);
+    expect(readMetadataRaw(sessionsDir, "app-1")).toBeNull();
+  });
+
+  it("does not archive metadata while runtime remains alive", async () => {
+    const handle = { id: "rt-1", runtimeName: "tmux", data: {} };
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(handle),
+    });
+
+    vi.mocked(mockRuntime.isAlive).mockResolvedValue(true);
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.kill("app-1")).rejects.toThrow("did not stop");
+    expect(readMetadataRaw(sessionsDir, "app-1")).not.toBeNull();
   });
 });
 
@@ -3466,6 +3698,86 @@ describe("restore", () => {
     await expect(sm.restore("app-1")).rejects.toThrow(SessionNotRestorableError);
   });
 
+  it("blocks restore when repo policy requires a different reconciliation action", async () => {
+    const wsPath = join(tmpDir, "ws-app-1");
+    mkdirSync(wsPath, { recursive: true });
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-1",
+        work_status: "dispatched",
+        active_session_id: "app-1",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-1",
+        next_action: "operator_review",
+        reason: "ticket is awaiting review",
+        active_session_id: "app-1",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.restore("app-1")).rejects.toThrow("Restore blocked by repo policy");
+    expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("persists active session after allowed restore", async () => {
+    const wsPath = join(tmpDir, "ws-app-1");
+    mkdirSync(wsPath, { recursive: true });
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-1",
+        work_status: "dispatched",
+        retry_count: 1,
+        retry_budget: 2,
+        active_session_id: "app-1",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-1",
+        next_action: "reconcile_session",
+        reason: "persisted session exists without active run snapshot",
+        active_session_id: "app-1",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "killed",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.restore("app-1");
+
+    const persisted = JSON.parse(
+      readFileSync(join(tmpDir, "project-os", "indexes", "work_state_store.json"), "utf-8"),
+    ) as Array<Record<string, unknown>>;
+    expect(persisted).toEqual([
+      expect.objectContaining({
+        work_id: "TEST-1",
+        work_status: "dispatched",
+        retry_count: 1,
+        retry_budget: 2,
+        active_session_id: "app-1",
+      }),
+    ]);
+  });
+
   it("throws SessionNotRestorableError for working sessions", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",
@@ -3545,6 +3857,40 @@ describe("restore", () => {
     expect(meta).not.toBeNull();
     expect(meta!["issue"]).toBe("TEST-1");
     expect(meta!["pr"]).toBe("https://github.com/org/my-app/pull/10");
+  });
+
+  it("restores archived work using issue-based reconciliation fallback", async () => {
+    const wsPath = join(tmpDir, "ws-app-issue-fallback");
+    mkdirSync(wsPath, { recursive: true });
+    writeProjectOsIndex("work_state_store.json", [
+      {
+        work_id: "TEST-RESTORE",
+        work_status: "dispatched",
+      },
+    ]);
+    writeProjectOsIndex("reconciliation_state.json", [
+      {
+        work_id: "TEST-RESTORE",
+        next_action: "reconcile_session",
+        reason: "restore is allowed from issue-scoped state",
+      },
+    ]);
+
+    writeMetadata(sessionsDir, "app-9", {
+      worktree: wsPath,
+      branch: "feat/TEST-RESTORE",
+      status: "killed",
+      project: "my-app",
+      issue: "TEST-RESTORE",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+    deleteMetadata(sessionsDir, "app-9");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const restored = await sm.restore("app-9");
+
+    expect(restored.id).toBe("app-9");
+    expect(restored.status).toBe("spawning");
   });
 
   it("restores from archive with multiple archived versions (picks latest)", async () => {

--- a/packages/core/src/repo-policy.ts
+++ b/packages/core/src/repo-policy.ts
@@ -1,0 +1,271 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type { ProjectConfig } from "./types.js";
+
+interface DispatchPlanItem {
+  work_id: string;
+  next_action: string;
+  reason?: string;
+  priority?: number;
+}
+
+interface WorkStateEntry {
+  work_id: string;
+  work_status?: string;
+  retry_count?: number;
+  retry_budget?: number | null;
+  active_session_id?: string | null;
+  updated_at?: string;
+}
+
+interface ReconciliationEntry {
+  work_id: string;
+  next_action?: string;
+  reason?: string;
+  active_session_id?: string | null;
+  updated_at?: string;
+}
+
+interface RepoPolicySnapshot {
+  dispatchPlan: DispatchPlanItem[];
+  workStateStore: WorkStateEntry[];
+  reconciliationState: ReconciliationEntry[];
+  workStateStorePath: string;
+}
+
+interface GuardResolution {
+  workId: string;
+}
+
+interface TerminationPolicy {
+  workId: string;
+  workStatus: string;
+  preserveWorkspace: boolean;
+  allowCleanup: boolean;
+}
+
+export interface WorkspaceLifecyclePolicy {
+  preserveWorkspace: boolean;
+  destroyWorkspace: boolean;
+}
+
+function getHarnessRoot(project: ProjectConfig): string {
+  return resolve(project.path, "..");
+}
+
+function getIndexesDir(project: ProjectConfig): string {
+  return join(getHarnessRoot(project), "project-os", "indexes");
+}
+
+function readJsonArray<T>(path: string): T[] {
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf-8")) as unknown;
+    return Array.isArray(parsed) ? (parsed as T[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeJsonArray(path: string, payload: unknown[]): void {
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, JSON.stringify(payload, null, 2) + "\n", "utf-8");
+}
+
+function loadRepoPolicy(project: ProjectConfig): RepoPolicySnapshot {
+  const indexesDir = getIndexesDir(project);
+  return {
+    dispatchPlan: readJsonArray<DispatchPlanItem>(join(indexesDir, "dispatch_plan.json")),
+    workStateStore: readJsonArray<WorkStateEntry>(join(indexesDir, "work_state_store.json")),
+    reconciliationState: readJsonArray<ReconciliationEntry>(
+      join(indexesDir, "reconciliation_state.json"),
+    ),
+    workStateStorePath: join(indexesDir, "work_state_store.json"),
+  };
+}
+
+function findReconciliationEntry(
+  reconciliationState: ReconciliationEntry[],
+  workId: string | undefined,
+  sessionId: string,
+): ReconciliationEntry | undefined {
+  return reconciliationState.find(
+    (entry) =>
+      entry.active_session_id === sessionId || (workId !== undefined && entry.work_id === workId),
+  );
+}
+
+function findWorkEntry(
+  workStateStore: WorkStateEntry[],
+  sessionId: string,
+  issueId: string | undefined,
+): WorkStateEntry | undefined {
+  return workStateStore.find(
+    (entry) =>
+      entry.active_session_id === sessionId || (issueId !== undefined && entry.work_id === issueId),
+  );
+}
+
+function upsertWorkState(
+  project: ProjectConfig,
+  workId: string,
+  mutate: (entry: WorkStateEntry | undefined) => WorkStateEntry,
+): void {
+  const policy = loadRepoPolicy(project);
+  const index = policy.workStateStore.findIndex((entry) => entry.work_id === workId);
+  const next = mutate(index >= 0 ? policy.workStateStore[index] : undefined);
+
+  if (index >= 0) {
+    policy.workStateStore[index] = next;
+  } else {
+    policy.workStateStore.push(next);
+  }
+
+  writeJsonArray(policy.workStateStorePath, policy.workStateStore);
+}
+
+export function assertSpawnAllowed(
+  project: ProjectConfig,
+  issueId: string | undefined,
+): GuardResolution | null {
+  if (!issueId) return null;
+
+  const { dispatchPlan } = loadRepoPolicy(project);
+  const plan = dispatchPlan.find((entry) => entry.work_id === issueId);
+  if (!plan) return null;
+
+  if (!new Set(["dispatch", "retry"]).has(plan.next_action)) {
+    const reason = plan.reason ? ` (${plan.reason})` : "";
+    throw new Error(
+      `Spawn blocked by repo policy for ${issueId}: expected dispatch or retry, got ${plan.next_action}${reason}`,
+    );
+  }
+
+  return { workId: issueId };
+}
+
+export function assertRestoreAllowed(
+  project: ProjectConfig,
+  sessionId: string,
+  issueId: string | undefined,
+): GuardResolution | null {
+  const { workStateStore, reconciliationState } = loadRepoPolicy(project);
+  const workEntry = findWorkEntry(workStateStore, sessionId, issueId);
+  const workId = workEntry?.work_id ?? issueId;
+  const reconcile = findReconciliationEntry(reconciliationState, workId, sessionId);
+
+  if (!workEntry && !reconcile) return null;
+  if (workId === undefined) return null;
+
+  if (reconcile?.next_action && reconcile.next_action !== "reconcile_session") {
+    const reason = reconcile.reason ? ` (${reconcile.reason})` : "";
+    throw new Error(
+      `Restore blocked by repo policy for ${workId}: expected reconcile_session, got ${reconcile.next_action}${reason}`,
+    );
+  }
+
+  return { workId };
+}
+
+export function persistActiveSession(
+  project: ProjectConfig,
+  workId: string,
+  sessionId: string,
+  workStatus = "dispatched",
+): void {
+  upsertWorkState(project, workId, (existing) => ({
+    work_id: workId,
+    work_status: workStatus,
+    retry_count: existing?.retry_count ?? 0,
+    retry_budget: existing?.retry_budget ?? null,
+    active_session_id: sessionId,
+    updated_at: new Date().toISOString(),
+  }));
+}
+
+export function assertSendAllowed(
+  project: ProjectConfig,
+  sessionId: string,
+  issueId: string | undefined,
+): GuardResolution | null {
+  const { workStateStore, reconciliationState } = loadRepoPolicy(project);
+  const workEntry = findWorkEntry(workStateStore, sessionId, issueId);
+  const workId = workEntry?.work_id ?? issueId;
+  const reconcile = findReconciliationEntry(reconciliationState, workId, sessionId);
+
+  if (!workEntry && !reconcile) return null;
+  if (workId === undefined) return null;
+
+  if (new Set(["done", "killed", "abandoned"]).has(workEntry?.work_status ?? "")) {
+    throw new Error(`Send blocked by repo policy for ${workId}: work is terminal`);
+  }
+  if (reconcile?.next_action === "terminal") {
+    throw new Error(`Send blocked by repo policy for ${workId}: reconciliation is terminal`);
+  }
+
+  return { workId };
+}
+
+export function resolveTerminationPolicy(
+  project: ProjectConfig,
+  sessionId: string,
+  issueId: string | undefined,
+): TerminationPolicy | null {
+  const { workStateStore, reconciliationState } = loadRepoPolicy(project);
+  const workEntry = findWorkEntry(workStateStore, sessionId, issueId);
+  const workId = workEntry?.work_id ?? issueId;
+  const reconcile = findReconciliationEntry(reconciliationState, workId, sessionId);
+
+  if (!workEntry && !reconcile) return null;
+  if (workId === undefined) return null;
+
+  const workStatus = workEntry?.work_status ?? "needs_input";
+  if (new Set(["done", "killed", "abandoned"]).has(workStatus)) {
+    return { workId, workStatus, preserveWorkspace: false, allowCleanup: true };
+  }
+  if (reconcile?.next_action === "terminal") {
+    return { workId, workStatus: "abandoned", preserveWorkspace: false, allowCleanup: true };
+  }
+
+  return {
+    workId,
+    workStatus: workStatus === "review" ? "review" : "needs_input",
+    preserveWorkspace: true,
+    allowCleanup: false,
+  };
+}
+
+export function resolveWorkspaceLifecyclePolicy(
+  project: ProjectConfig,
+  sessionId: string,
+  issueId: string | undefined,
+): WorkspaceLifecyclePolicy | null {
+  const termination = resolveTerminationPolicy(project, sessionId, issueId);
+  if (!termination) return null;
+  return {
+    preserveWorkspace: termination.preserveWorkspace,
+    destroyWorkspace: !termination.preserveWorkspace,
+  };
+}
+
+export function persistTerminalWorkState(
+  project: ProjectConfig,
+  sessionId: string,
+  issueId: string | undefined,
+  fallbackStatus = "killed",
+): GuardResolution | null {
+  const policy = resolveTerminationPolicy(project, sessionId, issueId);
+  const workId = policy?.workId ?? issueId;
+  if (!workId) return null;
+
+  upsertWorkState(project, workId, (existing) => ({
+    work_id: workId,
+    work_status: policy?.workStatus ?? fallbackStatus,
+    retry_count: existing?.retry_count ?? 0,
+    retry_budget: existing?.retry_budget ?? null,
+    active_session_id: null,
+    updated_at: new Date().toISOString(),
+  }));
+
+  return { workId };
+}

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -72,7 +72,16 @@ import {
   parsePauseUntil,
 } from "./global-pause.js";
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
-import { safeJsonParse } from "./utils/validation.js";
+import { safeJsonParse, validateStatus } from "./utils/validation.js";
+import {
+  assertRestoreAllowed,
+  assertSendAllowed,
+  assertSpawnAllowed,
+  persistActiveSession,
+  persistTerminalWorkState,
+  resolveTerminationPolicy,
+  resolveWorkspaceLifecyclePolicy,
+} from "./repo-policy.js";
 
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 2_000;
@@ -220,10 +229,41 @@ const SEND_RESTORE_READY_POLL_MS = 500;
 const SEND_CONFIRMATION_ATTEMPTS = 3;
 const SEND_CONFIRMATION_POLL_MS = 500;
 const SEND_CONFIRMATION_OUTPUT_LINES = 20;
+const KILL_RUNTIME_WAIT_MS = 5_000;
+const KILL_RUNTIME_POLL_MS = 100;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+async function waitForRuntimeShutdown(
+  runtime: Runtime,
+  handle: RuntimeHandle,
+  timeoutMs = KILL_RUNTIME_WAIT_MS,
+): Promise<boolean> {
+  if (!new Set(["process", "tmux"]).has(handle.runtimeName)) {
+    return true;
+  }
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      if (!(await runtime.isAlive(handle))) {
+        return true;
+      }
+    } catch {
+      return true;
+    }
+    await sleep(KILL_RUNTIME_POLL_MS);
+  }
+
+  try {
+    return !(await runtime.isAlive(handle));
+  } catch {
+    return true;
+  }
+}
+
+
 
 /** Reconstruct a Session object from raw metadata key=value pairs. */
 function metadataToSession(
@@ -891,6 +931,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
+    const policyGuard = assertSpawnAllowed(project, spawnConfig.issueId);
+
     // Get the sessions directory for this project
     const sessionsDir = getProjectSessionsDir(project);
 
@@ -1105,6 +1147,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       if (Object.keys(session.metadata || {}).length > 0) {
         updateMetadata(sessionsDir, sessionId, session.metadata);
+      }
+      const activeWorkId = policyGuard?.workId ?? spawnConfig.issueId;
+      if (activeWorkId) {
+        persistActiveSession(project, activeWorkId, sessionId);
       }
     } catch (err) {
       // Clean up runtime and workspace on post-launch failure
@@ -1509,10 +1555,20 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return null;
   }
 
-  async function kill(sessionId: SessionId, options?: { purgeOpenCode?: boolean }): Promise<void> {
+  async function kill(
+    sessionId: SessionId,
+    options?: { purgeOpenCode?: boolean; preserveWorkspace?: boolean; workStatus?: string },
+  ): Promise<void> {
     const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
 
     const cleanupAgent = raw["agent"] ?? project?.agent ?? config.defaults.agent;
+    const terminationPolicy = resolveTerminationPolicy(project, sessionId, raw["issue"]);
+    const workspaceLifecycle = resolveWorkspaceLifecyclePolicy(project, sessionId, raw["issue"]);
+    const preserveWorkspace =
+      options?.preserveWorkspace ??
+      workspaceLifecycle?.preserveWorkspace ??
+      terminationPolicy?.preserveWorkspace ??
+      false;
 
     // Destroy runtime — prefer handle.runtimeName to find the correct plugin
     if (raw["runtimeHandle"]) {
@@ -1524,17 +1580,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             (project ? (project.runtime ?? config.defaults.runtime) : config.defaults.runtime),
         );
         if (runtimePlugin) {
-          try {
-            await runtimePlugin.destroy(handle);
-          } catch {
-            // Runtime might already be gone
+          await runtimePlugin.destroy(handle);
+          const stopped = await waitForRuntimeShutdown(runtimePlugin, handle);
+          if (!stopped) {
+            throw new Error(`Runtime ${handle.runtimeName} for session ${sessionId} did not stop`);
           }
         }
       }
     }
 
     const worktree = raw["worktree"];
-    if (worktree && shouldDestroyWorkspacePath(project, projectId, worktree)) {
+    if (!preserveWorkspace && worktree && shouldDestroyWorkspacePath(project, projectId, worktree)) {
       const workspacePlugin = project
         ? resolvePlugins(project).workspace
         : registry.get<Workspace>("workspace", config.defaults.workspace);
@@ -1571,6 +1627,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (didPurgeOpenCodeSession) {
       markArchivedOpenCodeCleanup(sessionsDir, sessionId);
     }
+    persistTerminalWorkState(project, sessionId, raw["issue"], options?.workStatus ?? "killed");
   }
 
   async function cleanup(
@@ -1663,9 +1720,25 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           }
         }
 
+        const terminationPolicy = resolveTerminationPolicy(project, session.id, session.issueId ?? undefined);
+        const allowPolicyKill = terminationPolicy?.allowCleanup ?? false;
+
+        if (shouldKill && terminationPolicy && !allowPolicyKill) {
+          pushSkipped(session.projectId, session.id);
+          continue;
+        }
+
+        if (!shouldKill && allowPolicyKill) {
+          shouldKill = true;
+        }
+
         if (shouldKill) {
           if (!options?.dryRun) {
-            await kill(session.id, { purgeOpenCode: shouldPurgeOpenCode });
+            await kill(session.id, {
+              purgeOpenCode: shouldPurgeOpenCode,
+              preserveWorkspace: terminationPolicy?.preserveWorkspace,
+              workStatus: terminationPolicy?.workStatus,
+            });
           }
           pushKilled(session.projectId, session.id);
         } else {
@@ -1696,7 +1769,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
         const cleanupAgent = archived["agent"] ?? project.agent ?? config.defaults.agent;
         const mappedOpenCodeSessionId = asValidOpenCodeSessionId(archived["opencodeSessionId"]);
+        const archivedTerminationPolicy = resolveTerminationPolicy(
+          project,
+          archivedId,
+          archived["issue"],
+        );
         if (cleanupAgent === "opencode" && archived["opencodeCleanedAt"]) {
+          pushSkipped(projectKey, archivedId);
+          continue;
+        }
+        if (archivedTerminationPolicy && !archivedTerminationPolicy.allowCleanup) {
           pushSkipped(projectKey, archivedId);
           continue;
         }
@@ -1748,6 +1830,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       );
     }
 
+    assertSendAllowed(project, sessionId, raw["issue"]);
     const selectedAgent = raw["agent"] ?? project.agent ?? config.defaults.agent;
     if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
       const discovered = await discoverOpenCodeSessionIdByTitle(
@@ -2002,6 +2085,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       prAutoDetect: "",
     });
 
+    if (raw["issue"]) {
+      persistActiveSession(project, raw["issue"], sessionId, "review");
+    }
+
     for (const previousSessionId of takenOverFrom) {
       const previousRaw = readMetadataRaw(sessionsDir, previousSessionId);
       if (!previousRaw) continue;
@@ -2098,6 +2185,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (!raw || !sessionsDir || !project || !projectId) {
       throw new SessionNotFoundError(sessionId);
     }
+
+    const policyGuard = assertRestoreAllowed(project, sessionId, raw["issue"]);
 
     const selectedAgent = raw["agent"] ?? project.agent ?? config.defaults.agent;
     if (selectedAgent === "opencode" && !asValidOpenCodeSessionId(raw["opencodeSessionId"])) {
@@ -2288,8 +2377,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           updateMetadata(sessionsDir, sessionId, metadataUpdates);
         }
       } catch {
-        // Non-fatal — session is already running
+        // Non-fatal – session is already running
       }
+    }
+
+    const activeWorkId = policyGuard?.workId ?? raw["issue"];
+    if (activeWorkId) {
+      persistActiveSession(project, activeWorkId, sessionId);
     }
 
     return restoredSession;

--- a/packages/plugins/runtime-process/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-process/src/__tests__/index.test.ts
@@ -5,13 +5,24 @@ import type { RuntimeHandle } from "@composio/ao-core";
 // ---------------------------------------------------------------------------
 // Hoisted mock — must be set up before import
 // ---------------------------------------------------------------------------
-const { mockSpawn } = vi.hoisted(() => ({
+const { mockSpawn, mockExecFile } = vi.hoisted(() => ({
   mockSpawn: vi.fn(),
+  mockExecFile: vi.fn(),
 }));
 
-vi.mock("node:child_process", () => ({
-  spawn: mockSpawn,
-}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")] = vi.fn();
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")].mockResolvedValue({
+    stdout: "",
+    stderr: "",
+  });
+  return {
+    ...actual,
+    spawn: mockSpawn,
+    execFile: mockExecFile,
+  };
+});
 
 import { create, manifest, default as defaultExport } from "../index.js";
 
@@ -67,6 +78,10 @@ function defaultConfig(overrides: Record<string, unknown> = {}) {
 beforeEach(() => {
   vi.clearAllMocks();
   vi.restoreAllMocks();
+  (mockExecFile as any)[Symbol.for("nodejs.util.promisify.custom")] = vi.fn().mockResolvedValue({
+    stdout: "",
+    stderr: "",
+  });
 });
 
 // =========================================================================
@@ -253,6 +268,28 @@ describe("destroy()", () => {
   it("does not throw for unknown handle (no-op)", async () => {
     const runtime = create();
     await expect(runtime.destroy(makeHandle("nonexistent"))).resolves.toBeUndefined();
+  });
+
+  it("waits for pid-based fallback destruction to complete", async () => {
+    const runtime = create();
+    const killSpy = vi.spyOn(process, "kill");
+
+    killSpy
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => true)
+      .mockImplementationOnce(() => {
+        const err = new Error("ESRCH") as Error & { code?: string };
+        err.code = "ESRCH";
+        throw err;
+      });
+
+    await runtime.destroy(makeHandle("fallback"));
+
+    expect(killSpy).toHaveBeenCalledWith(12345, 0);
+    expect(killSpy).toHaveBeenCalledWith(12345, 0);
+    expect(mockExecFile).toHaveBeenCalled();
+
+    killSpy.mockRestore();
   });
 
   it("does not attempt kill if process already exited", async () => {

--- a/packages/plugins/runtime-process/src/index.ts
+++ b/packages/plugins/runtime-process/src/index.ts
@@ -1,4 +1,4 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
 import type {
   PluginModule,
   Runtime,
@@ -7,6 +7,11 @@ import type {
   RuntimeMetrics,
   AttachInfo,
 } from "@composio/ao-core";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const PROCESS_DESTROY_WAIT_MS = 5_000;
+const PROCESS_DESTROY_POLL_MS = 100;
 
 export const manifest = {
   name: "process",
@@ -31,6 +36,55 @@ interface ProcessEntry {
 }
 
 const MAX_OUTPUT_LINES = 1000;
+
+function getPidFromHandle(handle: RuntimeHandle): number | null {
+  const rawPid = handle.data["pid"];
+  const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+  return Number.isFinite(pid) && pid > 0 ? pid : null;
+}
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && err.code === "EPERM") {
+      return true;
+    }
+    return false;
+  }
+}
+
+async function killPidTree(pid: number): Promise<void> {
+  if (process.platform === "win32") {
+    try {
+      await execFileAsync("taskkill", ["/PID", String(pid), "/T", "/F"], { timeout: 10_000 });
+    } catch {
+      // Best effort: process may already be gone
+    }
+    return;
+  }
+
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Already gone
+    }
+  }
+}
+
+async function waitForPidExit(pid: number, timeoutMs = PROCESS_DESTROY_WAIT_MS): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isPidAlive(pid)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, PROCESS_DESTROY_POLL_MS));
+  }
+}
 
 export function create(): Runtime {
   // Per-instance process map — each create() call gets its own isolated state
@@ -147,7 +201,14 @@ export function create(): Runtime {
 
     async destroy(handle: RuntimeHandle): Promise<void> {
       const entry = processes.get(handle.id);
-      if (!entry) return;
+      if (!entry) {
+        const pid = getPidFromHandle(handle);
+        if (pid !== null && isPidAlive(pid)) {
+          await killPidTree(pid);
+          await waitForPidExit(pid);
+        }
+        return;
+      }
 
       const child = entry.process;
       if (!child) {
@@ -160,12 +221,7 @@ export function create(): Runtime {
         // spawned by the shell are also terminated, not just the shell itself.
         const pid = child.pid;
         if (pid) {
-          try {
-            process.kill(-pid, "SIGTERM");
-          } catch {
-            // Process group may not exist — fall back to direct kill
-            child.kill("SIGTERM");
-          }
+          await killPidTree(pid);
         } else {
           child.kill("SIGTERM");
         }
@@ -175,10 +231,14 @@ export function create(): Runtime {
           const timeout = setTimeout(() => {
             if (child.exitCode === null && child.signalCode === null) {
               if (pid) {
-                try {
-                  process.kill(-pid, "SIGKILL");
-                } catch {
-                  child.kill("SIGKILL");
+                if (process.platform === "win32") {
+                  void killPidTree(pid);
+                } else {
+                  try {
+                    process.kill(-pid, "SIGKILL");
+                  } catch {
+                    child.kill("SIGKILL");
+                  }
                 }
               } else {
                 child.kill("SIGKILL");
@@ -246,8 +306,11 @@ export function create(): Runtime {
 
     async isAlive(handle: RuntimeHandle): Promise<boolean> {
       const entry = processes.get(handle.id);
-      if (!entry || !entry.process) return false;
-      return entry.process.exitCode === null && entry.process.signalCode === null;
+      if (entry?.process) {
+        return entry.process.exitCode === null && entry.process.signalCode === null;
+      }
+      const pid = getPidFromHandle(handle);
+      return pid !== null ? isPidAlive(pid) : false;
     },
 
     async getMetrics(handle: RuntimeHandle): Promise<RuntimeMetrics> {
@@ -260,11 +323,10 @@ export function create(): Runtime {
 
     async getAttachInfo(handle: RuntimeHandle): Promise<AttachInfo> {
       const entry = processes.get(handle.id);
+      const fallbackPid = getPidFromHandle(handle);
       if (
-        !entry ||
-        !entry.process ||
-        entry.process.exitCode !== null ||
-        entry.process.signalCode !== null
+        (!entry || !entry.process || entry.process.exitCode !== null || entry.process.signalCode !== null) &&
+        (fallbackPid === null || !isPidAlive(fallbackPid))
       ) {
         return {
           type: "process",
@@ -274,7 +336,7 @@ export function create(): Runtime {
       }
       return {
         type: "process",
-        target: String(entry.process.pid),
+        target: String(entry?.process?.pid ?? fallbackPid),
       };
     },
   };

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -241,12 +241,20 @@ describe("runtime.destroy()", () => {
     const handle = makeHandle("destroy-test");
 
     mockTmuxSuccess();
+    mockTmuxError("session not found");
 
     await runtime.destroy(handle);
 
-    expect(mockExecFileCustom).toHaveBeenCalledWith(
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      1,
       "tmux",
       ["kill-session", "-t", "destroy-test"],
+      expectedTmuxOptions,
+    );
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "tmux",
+      ["has-session", "-t", "destroy-test"],
       expectedTmuxOptions,
     );
   });
@@ -255,6 +263,7 @@ describe("runtime.destroy()", () => {
     const runtime = create();
     const handle = makeHandle("already-dead");
 
+    mockTmuxError("session not found: already-dead");
     mockTmuxError("session not found: already-dead");
 
     // Should not throw

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -1,21 +1,23 @@
 import { execFile } from "node:child_process";
-import { promisify } from "node:util";
-import { setTimeout as sleep } from "node:timers/promises";
 import { randomUUID } from "node:crypto";
 import { writeFileSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { promisify } from "node:util";
 import type {
+  AttachInfo,
   PluginModule,
   Runtime,
   RuntimeCreateConfig,
   RuntimeHandle,
   RuntimeMetrics,
-  AttachInfo,
 } from "@composio/ao-core";
 
 const execFileAsync = promisify(execFile);
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
+const TMUX_DESTROY_WAIT_MS = 5_000;
+const TMUX_DESTROY_POLL_MS = 100;
 
 export const manifest = {
   name: "tmux",
@@ -24,7 +26,6 @@ export const manifest = {
   version: "0.1.0",
 };
 
-/** Only allow safe characters in session IDs */
 const SAFE_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
 
 function assertValidSessionId(id: string): void {
@@ -33,12 +34,20 @@ function assertValidSessionId(id: string): void {
   }
 }
 
-/** Run a tmux command and return stdout */
 async function tmux(...args: string[]): Promise<string> {
   const { stdout } = await execFileAsync("tmux", args, {
     timeout: TMUX_COMMAND_TIMEOUT_MS,
   });
   return stdout.trimEnd();
+}
+
+async function isSessionAlive(sessionId: string): Promise<boolean> {
+  try {
+    await tmux("has-session", "-t", sessionId);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function create(): Runtime {
@@ -49,18 +58,13 @@ export function create(): Runtime {
       assertValidSessionId(config.sessionId);
       const sessionName = config.sessionId;
 
-      // Build environment flags: -e KEY=VALUE for each env var
       const envArgs: string[] = [];
       for (const [key, value] of Object.entries(config.environment ?? {})) {
         envArgs.push("-e", `${key}=${value}`);
       }
 
-      // Create tmux session in detached mode
       await tmux("new-session", "-d", "-s", sessionName, "-c", config.workspacePath, ...envArgs);
 
-      // Send the launch command — clean up the session if this fails.
-      // Use load-buffer + paste-buffer for long commands to avoid tmux/zsh
-      // truncation issues (commands >200 chars get mangled by send-keys).
       try {
         if (config.launchCommand.length > 200) {
           const bufferName = `ao-launch-${randomUUID().slice(0, 8)}`;
@@ -73,7 +77,7 @@ export function create(): Runtime {
             try {
               unlinkSync(tmpPath);
             } catch {
-              /* ignore cleanup errors */
+              // ignore cleanup errors
             }
           }
           await sleep(300);
@@ -107,16 +111,21 @@ export function create(): Runtime {
       try {
         await tmux("kill-session", "-t", handle.id);
       } catch {
-        // Session may already be dead — that's fine
+        // Session may already be dead
+      }
+
+      const deadline = Date.now() + TMUX_DESTROY_WAIT_MS;
+      while (Date.now() < deadline) {
+        if (!(await isSessionAlive(handle.id))) {
+          return;
+        }
+        await sleep(TMUX_DESTROY_POLL_MS);
       }
     },
 
     async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
-      // Clear any partial input
       await tmux("send-keys", "-t", handle.id, "C-u");
 
-      // For long or multiline messages, use load-buffer + paste-buffer
-      // Use randomUUID to avoid temp file collisions on concurrent sends
       if (message.includes("\n") || message.length > 200) {
         const bufferName = `ao-${randomUUID()}`;
         const tmpPath = join(tmpdir(), `ao-send-${randomUUID()}.txt`);
@@ -125,8 +134,6 @@ export function create(): Runtime {
           await tmux("load-buffer", "-b", bufferName, tmpPath);
           await tmux("paste-buffer", "-b", bufferName, "-t", handle.id, "-d");
         } finally {
-          // Clean up temp file and tmux buffer (in case paste-buffer failed
-          // and the -d flag didn't delete it)
           try {
             unlinkSync(tmpPath);
           } catch {
@@ -135,17 +142,13 @@ export function create(): Runtime {
           try {
             await tmux("delete-buffer", "-b", bufferName);
           } catch {
-            // Buffer may already be deleted by -d flag — that's fine
+            // Buffer may already be gone
           }
         }
       } else {
-        // Use -l (literal) so text like "Enter" or "Space" isn't interpreted
-        // as tmux key names
         await tmux("send-keys", "-t", handle.id, "-l", message);
       }
 
-      // Small delay to let tmux process the pasted text before pressing Enter.
-      // Without this, Enter can arrive before the text is fully rendered.
       await sleep(300);
       await tmux("send-keys", "-t", handle.id, "Enter");
     },
@@ -159,12 +162,7 @@ export function create(): Runtime {
     },
 
     async isAlive(handle: RuntimeHandle): Promise<boolean> {
-      try {
-        await tmux("has-session", "-t", handle.id);
-        return true;
-      } catch {
-        return false;
-      }
+      return isSessionAlive(handle.id);
     },
 
     async getMetrics(handle: RuntimeHandle): Promise<RuntimeMetrics> {

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -36,6 +36,13 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+function sanitizeGhEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  delete env["GH_TOKEN"];
+  delete env["GITHUB_TOKEN"];
+  return env;
+}
+
 /** Known bot logins that produce automated review comments */
 const BOT_AUTHORS = new Set([
   "cursor[bot]",
@@ -60,6 +67,7 @@ async function execCli(bin: ExecCommand, args: string[], cwd?: string): Promise<
   try {
     const { stdout } = await execFileAsync(bin, args, {
       ...(cwd ? { cwd } : {}),
+      env: bin === "gh" ? sanitizeGhEnv() : process.env,
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30_000,
     });
@@ -89,6 +97,14 @@ function parseProjectRepo(projectRepo: string): [string, string] {
     throw new Error(`Invalid repo format "${projectRepo}", expected "owner/repo"`);
   }
   return [parts[0], parts[1]];
+}
+
+async function checkoutPrViaGitFallback(pr: PRInfo, workspacePath: string): Promise<void> {
+  const fetchRef = `pull/${pr.number}/head`;
+  const tempBranch = `ao/pr-${pr.number}`;
+
+  await git(["fetch", "origin", `${fetchRef}:${tempBranch}`], workspacePath);
+  await git(["checkout", "-B", pr.branch, tempBranch], workspacePath);
 }
 
 function prInfoFromView(
@@ -581,7 +597,19 @@ function createGitHubSCM(): SCM {
         );
       }
 
-      await ghInDir(["pr", "checkout", String(pr.number), "--repo", repoFlag(pr)], workspacePath);
+      try {
+        await ghInDir(["pr", "checkout", String(pr.number), "--repo", repoFlag(pr)], workspacePath);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const isGitRepoDetectionFailure =
+          message.includes("failed to run git: fatal: not a git repository");
+
+        if (!isGitRepoDetectionFailure) {
+          throw err;
+        }
+
+        await checkoutPrViaGitFallback(pr, workspacePath);
+      }
       return true;
     },
 

--- a/packages/plugins/tracker-github/src/index.ts
+++ b/packages/plugins/tracker-github/src/index.ts
@@ -18,6 +18,13 @@ import type {
 
 const execFileAsync = promisify(execFile);
 
+function sanitizeGhEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env = { ...baseEnv };
+  delete env["GH_TOKEN"];
+  delete env["GITHUB_TOKEN"];
+  return env;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -25,6 +32,7 @@ const execFileAsync = promisify(execFile);
 async function gh(args: string[]): Promise<string> {
   try {
     const { stdout } = await execFileAsync("gh", args, {
+      env: sanitizeGhEnv(),
       maxBuffer: 10 * 1024 * 1024,
       timeout: 30_000,
     });

--- a/packages/web/e2e/dashboard-flows.ts
+++ b/packages/web/e2e/dashboard-flows.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { chromium, type Page } from "playwright";
+import { ensureServer } from "./lib/server.js";
+
+const PORT = Number(process.env.AO_E2E_PORT ?? "3001");
+
+async function main(): Promise<void> {
+  const server = await ensureServer(PORT);
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    await runDashboardCommandFlow(browser, server.baseUrl);
+    console.log("dashboard E2E passed");
+  } finally {
+    await browser.close();
+    server.stop();
+  }
+}
+
+async function runDashboardCommandFlow(
+  browser: Awaited<ReturnType<typeof chromium.launch>>,
+  baseUrl: string,
+): Promise<void> {
+  const context = await browser.newContext({ baseURL: baseUrl });
+  const page = await context.newPage();
+
+  let spawnedPayload: { projectId?: string; issueId?: string } | null = null;
+  let resolveSpawnSeen: (() => void) | null = null;
+  const spawnSeen = new Promise<void>((resolve) => {
+    resolveSpawnSeen = resolve;
+  });
+
+  await page.route("**/api/spawn", async (route) => {
+    const payload = route.request().postDataJSON() as { projectId?: string; issueId?: string };
+    spawnedPayload = payload;
+    resolveSpawnSeen?.();
+    await route.fulfill({
+      status: 201,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session: {
+          id: "e2e-session-1",
+          projectId: payload.projectId ?? "agent-orchestrator",
+        },
+      }),
+    });
+  });
+
+  await page.goto("/", { waitUntil: "domcontentloaded" });
+  await expectText(page, "Control Inbox");
+  await page.waitForTimeout(2000);
+
+  const input = page.getByPlaceholder("next / dispatch 123 / explain TKT-... / act TKT-... send");
+  await input.fill("dispatch ISSUE-777");
+  await page.getByRole("button", { name: /run command/i }).click();
+  await Promise.race([
+    spawnSeen,
+    page.waitForTimeout(5000).then(() => {
+      throw new Error("spawn request was not issued");
+    }),
+  ]);
+  await page.waitForTimeout(1000);
+  const bodyText = await page.locator("body").innerText();
+  const statusLine =
+    bodyText
+      .split(/\r?\n/)
+      .find((line) => line.includes("state=")) ?? "";
+
+  assert.ok(spawnedPayload, "dispatch command should call /api/spawn");
+  assert.equal(spawnedPayload?.issueId, "ISSUE-777");
+  assert.ok(spawnedPayload?.projectId, "dispatch should send projectId");
+  assert.match(statusLine, /state=spawned/i, "dashboard should render spawned status after dispatch");
+
+  await context.close();
+}
+
+async function expectText(page: Page, text: string): Promise<void> {
+  await page.getByText(text, { exact: false }).first().waitFor({ state: "visible" });
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/web/e2e/lib/server.ts
+++ b/packages/web/e2e/lib/server.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { request } from "node:http";
+import { createRequire } from "node:module";
 
 interface ServerHandle {
   baseUrl: string;
@@ -42,7 +43,9 @@ export async function ensureServer(port: number): Promise<ServerHandle> {
   }
 
   console.log(`Starting dev server on port ${port}...`);
-  const child: ChildProcess = spawn("npx", ["next", "dev", "--port", String(port)], {
+  const require = createRequire(import.meta.url);
+  const nextBin = require.resolve("next/dist/bin/next");
+  const child: ChildProcess = spawn(process.execPath, [nextBin, "dev", "--port", String(port)], {
     cwd: new URL("../../", import.meta.url).pathname,
     stdio: "pipe",
     env: { ...process.env, NODE_ENV: "development" },

--- a/packages/web/e2e/operator-flows.ts
+++ b/packages/web/e2e/operator-flows.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import { chromium, type Page } from "playwright";
+import { ensureServer } from "./lib/server.js";
+
+const PORT = Number(process.env.AO_E2E_PORT ?? "3335");
+const SESSION_ID = "backend-3";
+const SESSION_PATH = `/sessions/${SESSION_ID}`;
+
+const FIXTURE_SESSION = {
+  id: SESSION_ID,
+  projectId: "agent-orchestrator",
+  status: "needs_input",
+  activity: "waiting_input",
+  runtimeName: "process",
+  branch: "feat/harness-authority",
+  issueId: "TKT-20260310-001",
+  issueUrl: "https://linear.app/test/issue/TKT-20260310-001",
+  issueLabel: "TKT-20260310-001",
+  issueTitle: "Close harness runtime obedience gap",
+  summary: "Waiting for operator review before merge.",
+  summaryIsFallback: false,
+  createdAt: "2026-03-10T10:00:00.000Z",
+  lastActivityAt: "2026-03-10T10:05:00.000Z",
+  pr: {
+    number: 432,
+    url: "https://github.com/acme/app/pull/432",
+    title: "feat: close harness runtime obedience gap",
+    owner: "acme",
+    repo: "app",
+    branch: "feat/harness-authority",
+    baseBranch: "main",
+    isDraft: false,
+    state: "open",
+    additions: 42,
+    deletions: 7,
+    ciStatus: "passing",
+    ciChecks: [
+      { name: "build", status: "passed" },
+      { name: "test", status: "passed" },
+    ],
+    reviewDecision: "approved",
+    mergeability: {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    },
+    unresolvedThreads: 0,
+    unresolvedComments: [],
+  },
+  metadata: {
+    agent: "claude-code",
+  },
+  harness: {
+    workId: "TKT-20260310-001",
+    workState: {
+      work_id: "TKT-20260310-001",
+      work_status: "review",
+      retry_count: 1,
+      retry_budget: 3,
+      active_session_id: SESSION_ID,
+      updated_at: "2026-03-10T10:05:00.000Z",
+    },
+    reconciliation: {
+      work_id: "TKT-20260310-001",
+      next_action: "reconcile_session",
+      reason: "runtime exited during verification",
+      active_session_id: SESSION_ID,
+      updated_at: "2026-03-10T10:05:00.000Z",
+    },
+    dispatchPlan: {
+      work_id: "TKT-20260310-001",
+      work_status: "review",
+      next_action: "operator_review",
+      priority: 92,
+      reason: "human review required before merge",
+    },
+  },
+};
+
+async function main(): Promise<void> {
+  const server = await ensureServer(PORT);
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    await runSessionAuthorityFlow(browser, server.baseUrl);
+    console.log("operator E2E passed");
+  } finally {
+    await browser.close();
+    server.stop();
+  }
+}
+
+async function runSessionAuthorityFlow(
+  browser: Awaited<ReturnType<typeof chromium.launch>>,
+  baseUrl: string,
+): Promise<void> {
+  const context = await browser.newContext({ baseURL: baseUrl });
+  const page = await context.newPage();
+
+  let lastPostedMessage: string | null = null;
+
+  await page.route(`**/api/sessions/${SESSION_ID}`, async (route) => {
+    if (route.request().method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(FIXTURE_SESSION),
+    });
+  });
+
+  await page.route(`**/api/sessions/${SESSION_ID}/message`, async (route) => {
+    const payload = route.request().postDataJSON() as { message?: string };
+    lastPostedMessage = payload.message ?? null;
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ success: true }),
+    });
+  });
+
+  await page.goto(SESSION_PATH, { waitUntil: "networkidle" });
+  await expectText(page, "Work Authority");
+  await expectText(page, "TKT-20260310-001");
+  await expectText(page, "runtime exited during verification");
+  await expectText(page, "Quick Commands");
+
+  await page.getByRole("button", { name: /Summarize State/i }).click();
+  await page.waitForTimeout(150);
+
+  assert.ok(lastPostedMessage, "expected quick command to post a message");
+  assert.match(lastPostedMessage, /Summarize the current state/i);
+  assert.match(lastPostedMessage, /confidence/i);
+
+  await expectText(page, "sent");
+
+  await context.close();
+}
+
+async function expectText(page: Page, text: string): Promise<void> {
+  await page.getByText(text, { exact: false }).first().waitFor({ state: "visible" });
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently \"npm:dev:next\" \"npm:dev:terminal\" \"npm:dev:direct-terminal\"",
-    "dev:next": "next dev -p ${PORT:-3000}",
+    "dev:next": "node -e \"const { spawn } = require('node:child_process'); const child = spawn(process.platform === 'win32' ? 'next.cmd' : 'next', ['dev', '-p', process.env.PORT || '3000'], { stdio: 'inherit', shell: process.platform === 'win32' }); child.on('exit', (code) => process.exit(code ?? 0));\"",
     "dev:terminal": "tsx watch server/terminal-websocket.ts",
     "dev:direct-terminal": "tsx watch server/direct-terminal-ws.ts",
     "build": "next build",
@@ -15,13 +15,17 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf .next",
+    "e2e:operator": "tsx e2e/operator-flows.ts",
+    "e2e:dashboard": "tsx e2e/dashboard-flows.ts",
     "screenshot": "tsx e2e/screenshot.ts",
     "screenshot:install": "npx playwright install chromium"
   },
   "dependencies": {
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
+    "@composio/ao-plugin-agent-codex": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
+    "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@composio/ao-core";
 import * as serialize from "@/lib/serialize";
 import { getSCM } from "@/lib/services";
+import * as harnessPlan from "@/lib/harness-plan";
 
 // ── Mock Data ─────────────────────────────────────────────────────────
 // Provides test sessions covering the key states the dashboard needs.
@@ -220,6 +221,17 @@ vi.mock("@/lib/project-name", () => ({
   getAllProjects: () => [{ id: "my-app", name: "My App" }],
 }));
 
+vi.mock("@/lib/harness-plan", () => ({
+  loadHarnessSnapshot: vi.fn(async () => ({
+    dispatchPlan: [],
+    workState: [],
+    reconciliationState: [],
+    scoreSummaryByTicket: [],
+    needsRescore: [],
+  })),
+  resolveSessionHarnessContext: vi.fn(() => null),
+}));
+
 // ── Import routes after mocking ───────────────────────────────────────
 
 import { GET as sessionsGET } from "@/app/api/sessions/route";
@@ -264,6 +276,14 @@ beforeEach(() => {
     branch: "feat/health-check",
     data: {},
   });
+  (harnessPlan.loadHarnessSnapshot as ReturnType<typeof vi.fn>).mockResolvedValue({
+    dispatchPlan: [],
+    workState: [],
+    reconciliationState: [],
+    scoreSummaryByTicket: [],
+    needsRescore: [],
+  });
+  (harnessPlan.resolveSessionHarnessContext as ReturnType<typeof vi.fn>).mockReturnValue(null);
 });
 
 describe("API Routes", () => {
@@ -745,6 +765,91 @@ describe("API Routes", () => {
       expect(res.status).toBe(409);
       const data = await res.json();
       expect(data.error).toMatch(/merged/);
+    });
+
+    it("returns 409 when repo policy blocks merge", async () => {
+      (harnessPlan.resolveSessionHarnessContext as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        workId: "INT-432",
+        workState: { work_id: "INT-432", work_status: "review" },
+        reconciliation: {
+          work_id: "INT-432",
+          next_action: "operator_review",
+          reason: "final review still required",
+        },
+        dispatchPlan: null,
+      });
+      const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+      const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toMatch(/repo policy/);
+      expect(data.nextAction).toBe("operator_review");
+    });
+
+    it("returns 409 when work status is terminal", async () => {
+      (harnessPlan.resolveSessionHarnessContext as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        workId: "INT-432",
+        workState: { work_id: "INT-432", work_status: "killed" },
+        reconciliation: null,
+        dispatchPlan: null,
+      });
+      const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+      const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toMatch(/work is killed/);
+    });
+
+    it("returns 409 when dispatch plan still has a pending action", async () => {
+      (harnessPlan.resolveSessionHarnessContext as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        workId: "INT-432",
+        workState: { work_id: "INT-432", work_status: "approved" },
+        reconciliation: null,
+        dispatchPlan: {
+          work_id: "INT-432",
+          work_status: "approved",
+          next_action: "operator_review",
+          priority: 90,
+          reason: "operator sign-off still pending",
+        },
+      });
+      const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+      const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toMatch(/pending harness action/);
+      expect(data.nextAction).toBe("operator_review");
+    });
+
+    it("returns 409 when score gates require revision", async () => {
+      (harnessPlan.resolveSessionHarnessContext as ReturnType<typeof vi.fn>).mockReturnValueOnce({
+        workId: "INT-432",
+        workState: { work_id: "INT-432", work_status: "review" },
+        reconciliation: null,
+        dispatchPlan: null,
+      });
+      (harnessPlan.loadHarnessSnapshot as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        dispatchPlan: [],
+        workState: [],
+        reconciliationState: [],
+        scoreSummaryByTicket: [],
+        needsRescore: [
+          {
+            subject_id: "INT-432",
+            artifact_id: "ART-1",
+            score_total: 68,
+            score_band: "revise",
+            recommended_action: "revise",
+            blocking_findings_count: 1,
+          },
+        ],
+      });
+      const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+      const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+      expect(res.status).toBe(409);
+      const data = await res.json();
+      expect(data.error).toMatch(/scorecard requires revision/);
+      expect(data.scoreBand).toBe("revise");
     });
   });
 

--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -1,10 +1,15 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { CIBadge, CICheckList } from "@/components/CIBadge";
 import { PRStatus } from "@/components/PRStatus";
 import { SessionCard } from "@/components/SessionCard";
 import { AttentionZone } from "@/components/AttentionZone";
 import { ActivityDot } from "@/components/ActivityDot";
+import { OperatorQueue } from "@/components/OperatorQueue";
+import { HarnessPlanPanel } from "@/components/HarnessPlanPanel";
+import { QuickCommandDeck } from "@/components/QuickCommandDeck";
+import { RecentActivityFeed } from "@/components/RecentActivityFeed";
+import { SessionHarnessPanel } from "@/components/SessionHarnessPanel";
 import { makeSession, makePR } from "./helpers";
 
 // ── ActivityDot ───────────────────────────────────────────────────────
@@ -430,6 +435,174 @@ describe("SessionCard", () => {
     const { container } = render(<SessionCard session={session} />);
     fireEvent.click(container.firstElementChild!);
     expect(screen.getByText("terminate")).toBeInTheDocument();
+  });
+});
+
+describe("OperatorQueue", () => {
+  it("renders merge-ready action first", () => {
+    const mergeSession = makeSession({
+      id: "merge-1",
+      status: "mergeable",
+      activity: "idle",
+      pr: makePR(),
+    });
+    const respondSession = makeSession({
+      id: "respond-1",
+      status: "needs_input",
+      activity: "waiting_input",
+      pr: null,
+    });
+    render(<OperatorQueue sessions={[respondSession, mergeSession]} />);
+    const rows = screen.getAllByRole("button");
+    expect(rows[0]).toHaveTextContent("Merge #100");
+  });
+
+  it("calls onSend for respond action", async () => {
+    const onSend = vi.fn();
+    const respondSession = makeSession({
+      id: "respond-1",
+      status: "needs_input",
+      activity: "waiting_input",
+      pr: null,
+    });
+    render(<OperatorQueue sessions={[respondSession]} onSend={onSend} />);
+    fireEvent.click(screen.getAllByText("Send unblock")[0]);
+    await waitFor(() => {
+      expect(onSend).toHaveBeenCalledWith(
+        "respond-1",
+        expect.stringContaining("State the blocker"),
+      );
+    });
+  });
+});
+
+describe("HarnessPlanPanel", () => {
+  it("renders focus work and action labels", () => {
+    render(
+      <HarnessPlanPanel
+        items={[
+          {
+            work_id: "TKT-20260310-001",
+            work_status: "needs_input",
+            next_action: "escalate",
+            priority: 95,
+            reason: "ticket is blocked and requires operator input",
+          },
+          {
+            work_id: "TKT-20260310-002",
+            work_status: "queued",
+            next_action: "dispatch",
+            priority: 70,
+            reason: "ticket is eligible for scheduling",
+          },
+        ]}
+        workState={[
+          { work_id: "TKT-20260310-001", work_status: "needs_input" },
+          { work_id: "TKT-20260310-002", work_status: "queued" },
+        ]}
+        reconciliationState={[
+          {
+            work_id: "TKT-20260310-001",
+            next_action: "reconcile_session",
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Harness Plan")).toBeInTheDocument();
+    expect(screen.getByText("Focus Work")).toBeInTheDocument();
+    expect(screen.getAllByText("escalate")[0]).toBeInTheDocument();
+    expect(screen.getByText("dispatch")).toBeInTheDocument();
+    expect(screen.getByText("2 tracked work")).toBeInTheDocument();
+    expect(screen.getByText("1 needs reconcile")).toBeInTheDocument();
+  });
+});
+
+describe("SessionHarnessPanel", () => {
+  it("renders work, reconciliation, and dispatch authority", () => {
+    render(
+      <SessionHarnessPanel
+        harness={{
+          workId: "TKT-20260310-001",
+          workState: {
+            work_id: "TKT-20260310-001",
+            work_status: "review",
+            retry_count: 1,
+            retry_budget: 3,
+          },
+          reconciliation: {
+            work_id: "TKT-20260310-001",
+            next_action: "reconcile_session",
+            reason: "runtime exited during verification",
+          },
+          dispatchPlan: {
+            work_id: "TKT-20260310-001",
+            work_status: "review",
+            next_action: "operator_review",
+            priority: 92,
+            reason: "human review required before merge",
+          },
+        }}
+      />,
+    );
+    expect(screen.getByText("Work Authority")).toBeInTheDocument();
+    expect(screen.getByText("TKT-20260310-001")).toBeInTheDocument();
+    expect(screen.getAllByText("review")).toHaveLength(2);
+    expect(screen.getByText("reconcile")).toBeInTheDocument();
+    expect(screen.getByText("priority 92")).toBeInTheDocument();
+  });
+});
+
+describe("QuickCommandDeck", () => {
+  it("sends preset messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+    render(<QuickCommandDeck session={makeSession({ id: "backend-1", pr: makePR() })} />);
+    fireEvent.click(screen.getByText("Summarize State"));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/backend-1/message",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it("adapts commands to blocked sessions", () => {
+    render(
+      <QuickCommandDeck
+        session={makeSession({
+          id: "backend-2",
+          status: "needs_input",
+          activity: "waiting_input",
+          pr: makePR({
+            ciStatus: "failing",
+            reviewDecision: "changes_requested",
+            mergeability: {
+              mergeable: false,
+              ciPassing: false,
+              approved: false,
+              noConflicts: true,
+              blockers: ["CI is failing"],
+            },
+          }),
+        })}
+      />,
+    );
+    expect(screen.getByText("Unblock Session")).toBeInTheDocument();
+    expect(screen.getByText("Fix Failing CI")).toBeInTheDocument();
+  });
+});
+
+describe("RecentActivityFeed", () => {
+  it("records transitions as props change", () => {
+    const { rerender } = render(
+      <RecentActivityFeed status="working" activity="active" lastActivityAt="2026-03-10T10:00:00Z" />,
+    );
+    rerender(
+      <RecentActivityFeed status="needs_input" activity="waiting_input" lastActivityAt="2026-03-10T10:05:00Z" />,
+    );
+    expect(screen.getByText("needs input")).toBeInTheDocument();
+    expect(screen.getByText("working")).toBeInTheDocument();
   });
 });
 

--- a/packages/web/src/__tests__/dashboard-controls.test.tsx
+++ b/packages/web/src/__tests__/dashboard-controls.test.tsx
@@ -1,0 +1,406 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Dashboard } from "@/components/Dashboard";
+import type { DashboardSession, DispatchPlanItem, HarnessSnapshot } from "@/lib/types";
+import { makePR, makeSession } from "./helpers";
+
+vi.mock("@/hooks/useSessionEvents", () => ({
+  useSessionEvents: (sessions: DashboardSession[]) => sessions,
+}));
+
+vi.mock("@/components/DynamicFavicon", () => ({
+  DynamicFavicon: () => null,
+}));
+
+vi.mock("@/components/DirectTerminal", () => ({
+  DirectTerminal: ({ sessionId }: { sessionId: string }) => <div>terminal:{sessionId}</div>,
+}));
+
+const emptyHarness: HarnessSnapshot = {
+  dispatchPlan: [],
+  workState: [],
+  reconciliationState: [],
+  scoreSummaryByTicket: [],
+  needsRescore: [],
+};
+
+const stats = {
+  totalSessions: 1,
+  workingSessions: 1,
+  openPRs: 1,
+  needsReview: 0,
+};
+
+function mockOkFetch() {
+  const fn = vi.fn(async () => ({
+    ok: true,
+    text: async () => "",
+    json: async () => ({}),
+  }));
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+describe("Dashboard controls", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("dispatch action button posts /api/spawn with project and issue", async () => {
+    const fetchMock = mockOkFetch();
+    const dispatchPlan: DispatchPlanItem[] = [
+      {
+        work_id: "TKT-1",
+        work_status: "todo",
+        next_action: "dispatch",
+        priority: 100,
+        reason: "ready",
+      },
+    ];
+
+    render(
+      <Dashboard
+        initialSessions={[]}
+        dispatchPlan={dispatchPlan}
+        harness={emptyHarness}
+        stats={stats}
+        defaultProjectId="agent-orchestrator"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "dispatch" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/spawn",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ projectId: "agent-orchestrator", issueId: "TKT-1" }),
+        }),
+      );
+    });
+  });
+
+  it("fallback sessions allow send/kill/restore/merge and target correct endpoints", async () => {
+    const fetchMock = mockOkFetch();
+    const mergeablePr = makePR({ number: 777 });
+    const session = makeSession({
+      id: "sess-merge",
+      status: "approved",
+      activity: "exited",
+      issueTitle: "Merge candidate",
+      pr: mergeablePr,
+    });
+
+    render(
+      <Dashboard
+        initialSessions={[session]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "merge" }));
+    fireEvent.click(await screen.findByRole("button", { name: "restore" }));
+    fireEvent.click(await screen.findByRole("button", { name: "kill" }));
+    fireEvent.click(await screen.findByRole("button", { name: "send" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/prs/777/merge", expect.objectContaining({ method: "POST" }));
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/sess-merge/restore", expect.objectContaining({ method: "POST" }));
+      expect(fetchMock).toHaveBeenCalledWith("/api/sessions/sess-merge/kill", expect.objectContaining({ method: "POST" }));
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/sess-merge/send",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  it("review action routes to orchestrator session", async () => {
+    const fetchMock = mockOkFetch();
+    const reviewSession = makeSession({
+      id: "sess-review",
+      status: "ci_failed",
+      activity: "idle",
+      issueTitle: "Needs review",
+      pr: makePR({
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: false,
+          noConflicts: true,
+          blockers: ["ci failed"],
+        },
+      }),
+    });
+
+    render(
+      <Dashboard
+        initialSessions={[reviewSession]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+        orchestratorId="orch-1"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "review" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/orch-1/send",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+  });
+
+  it("hold action routes to orchestrator session", async () => {
+    const fetchMock = mockOkFetch();
+    const pendingSession = makeSession({
+      id: "sess-pending",
+      status: "working",
+      activity: "active",
+      issueTitle: "Pending task",
+      pr: null,
+    });
+
+    render(
+      <Dashboard
+        initialSessions={[pendingSession]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+        orchestratorId="orch-1"
+      />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "hold" }));
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/orch-1/send",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  it("control inbox click switches selected work", async () => {
+    mockOkFetch();
+    const dispatchPlan: DispatchPlanItem[] = [
+      {
+        work_id: "TKT-A",
+        work_status: "in_progress",
+        next_action: "send",
+        priority: 100,
+        reason: "first",
+      },
+      {
+        work_id: "TKT-B",
+        work_status: "blocked",
+        next_action: "review",
+        priority: 60,
+        reason: "needs reconcile after policy check",
+      },
+    ];
+
+    render(
+      <Dashboard
+        initialSessions={[]}
+        dispatchPlan={dispatchPlan}
+        harness={emptyHarness}
+        stats={stats}
+      />,
+    );
+
+    await screen.findByRole("heading", { level: 1, name: "TKT-A" });
+    const reconcileLabel = screen.getByText("Needs Reconcile");
+    fireEvent.click(reconcileLabel.closest("button") as HTMLButtonElement);
+    await screen.findByRole("heading", { level: 1, name: "TKT-B" });
+  });
+
+  it("maps all inbox cards to distinct real-data style works", async () => {
+    mockOkFetch();
+    const mergeSession = makeSession({
+      id: "sess-merge-ready",
+      issueTitle: "Merge ready session",
+      activity: "idle",
+      pr: makePR({ number: 909 }),
+    });
+
+    const dispatchPlan: DispatchPlanItem[] = [
+      {
+        work_id: "W-FOCUS",
+        work_status: "ready",
+        next_action: "dispatch",
+        priority: 100,
+        reason: "top priority dispatch",
+      },
+      {
+        work_id: "W-DECISION",
+        work_status: "review",
+        next_action: "kill",
+        priority: 90,
+        reason: "operator must decide whether to kill",
+      },
+      {
+        work_id: "W-INPUT",
+        work_status: "needs_input",
+        next_action: "send",
+        priority: 80,
+        reason: "waiting for human input",
+      },
+      {
+        work_id: "W-BLOCKED",
+        work_status: "blocked",
+        next_action: "hold",
+        priority: 70,
+        reason: "blocked by policy SEC-001",
+      },
+      {
+        work_id: "W-MERGE",
+        work_status: "approved",
+        next_action: "merge",
+        priority: 60,
+        reason: "ready to merge after approval",
+      },
+      {
+        work_id: "W-RECONCILE",
+        work_status: "review",
+        next_action: "review",
+        priority: 50,
+        reason: "needs reconcile on runtime exit",
+      },
+    ];
+
+    const harness: HarnessSnapshot = {
+      dispatchPlan,
+      workState: [
+        { work_id: "W-MERGE", work_status: "approved", active_session_id: "sess-merge-ready" },
+      ],
+      reconciliationState: [
+        { work_id: "W-FOCUS", next_action: "dispatch", reason: "top priority dispatch" },
+        { work_id: "W-DECISION", next_action: "kill", reason: "operator must decide whether to kill" },
+        { work_id: "W-INPUT", next_action: "send", reason: "waiting for human input" },
+        { work_id: "W-BLOCKED", next_action: "hold", reason: "blocked by policy SEC-001" },
+        { work_id: "W-MERGE", next_action: "merge", reason: "ready to merge after approval", active_session_id: "sess-merge-ready" },
+        { work_id: "W-RECONCILE", next_action: "review", reason: "needs reconcile on runtime exit" },
+      ],
+      scoreSummaryByTicket: [],
+      needsRescore: [],
+    };
+
+    render(
+      <Dashboard
+        initialSessions={[mergeSession]}
+        dispatchPlan={dispatchPlan}
+        harness={harness}
+        stats={{ totalSessions: 1, workingSessions: 0, openPRs: 1, needsReview: 1 }}
+      />,
+    );
+
+    const buttonFor = (label: string) =>
+      screen.getByText(label).closest("button") as HTMLButtonElement;
+
+    expect(buttonFor("Focus Work")).toHaveTextContent("W-FOCUS");
+    expect(buttonFor("Needs Decision")).toHaveTextContent("W-DECISION");
+    expect(buttonFor("Needs Input")).toHaveTextContent("W-INPUT");
+    expect(buttonFor("Blocked by Policy")).toHaveTextContent("W-BLOCKED");
+    expect(buttonFor("Merge Ready")).toHaveTextContent("W-MERGE");
+    expect(buttonFor("Needs Reconcile")).toHaveTextContent("W-RECONCILE");
+  });
+
+  it("run command: dispatch uses provided issue id even when no work exists", async () => {
+    const fetchMock = mockOkFetch();
+
+    render(
+      <Dashboard
+        initialSessions={[]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+        defaultProjectId="agent-orchestrator"
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/dispatch 123/i), {
+      target: { value: "dispatch ISSUE-99" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /run command/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/spawn",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ projectId: "agent-orchestrator", issueId: "ISSUE-99" }),
+        }),
+      );
+    });
+    expect(screen.getByText(/state=spawned/i)).toBeInTheDocument();
+  });
+
+  it("run command: act calls action endpoint for selected work", async () => {
+    const fetchMock = mockOkFetch();
+    const session = makeSession({
+      id: "sess-act",
+      issueTitle: "Action work",
+      status: "needs_input",
+      activity: "waiting_input",
+      pr: null,
+    });
+
+    render(
+      <Dashboard
+        initialSessions={[session]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/dispatch 123/i), {
+      target: { value: "act sess-act send" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /run command/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/sessions/sess-act/send",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+  });
+
+  it("run command: unknown command yields error answer", async () => {
+    mockOkFetch();
+    const session = makeSession({
+      id: "sess-err",
+      issueTitle: "Err work",
+      status: "needs_input",
+      activity: "waiting_input",
+      pr: null,
+    });
+
+    render(
+      <Dashboard
+        initialSessions={[session]}
+        dispatchPlan={[]}
+        harness={emptyHarness}
+        stats={stats}
+      />,
+    );
+
+    fireEvent.change(screen.getByPlaceholderText(/dispatch 123/i), {
+      target: { value: "bogus" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /run command/i }));
+
+    await screen.findByText(/state=error/i);
+    expect(screen.getByText(/Unknown command/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/app/api/prs/[id]/merge/route.ts
+++ b/packages/web/src/app/api/prs/[id]/merge/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { getServices, getSCM } from "@/lib/services";
+import { loadHarnessSnapshot, resolveSessionHarnessContext } from "@/lib/harness-plan";
 
 /** POST /api/prs/:id/merge — Merge a PR */
 export async function POST(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
@@ -11,11 +12,54 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
 
   try {
     const { config, registry, sessionManager } = await getServices();
+    const harnessSnapshot = await loadHarnessSnapshot(config);
     const sessions = await sessionManager.list();
 
     const session = sessions.find((s) => s.pr?.number === prNumber);
     if (!session?.pr) {
       return NextResponse.json({ error: "PR not found" }, { status: 404 });
+    }
+
+    const harness = resolveSessionHarnessContext(harnessSnapshot, session.id, session.issueId);
+    if (harness?.workState?.work_status && new Set(["killed", "abandoned"]).has(harness.workState.work_status)) {
+      return NextResponse.json(
+        { error: `Merge blocked by repo policy: work is ${harness.workState.work_status}` },
+        { status: 409 },
+      );
+    }
+    if (harness?.reconciliation?.next_action && harness.reconciliation.next_action !== "monitor") {
+      return NextResponse.json(
+        {
+          error: "Merge blocked by repo policy: reconciliation is still pending",
+          nextAction: harness.reconciliation.next_action,
+          reason: harness.reconciliation.reason ?? null,
+        },
+        { status: 409 },
+      );
+    }
+    if (harness?.dispatchPlan && harness.dispatchPlan.next_action !== "monitor") {
+      return NextResponse.json(
+        {
+          error: "Merge blocked by repo policy: work has a pending harness action",
+          nextAction: harness.dispatchPlan.next_action,
+          reason: harness.dispatchPlan.reason,
+        },
+        { status: 409 },
+      );
+    }
+    const workId = harness?.workId ?? session.issueId ?? null;
+    if (workId) {
+      const rescore = harnessSnapshot.needsRescore.find((entry) => entry.subject_id === workId);
+      if (rescore) {
+        return NextResponse.json(
+          {
+            error: "Merge blocked by repo policy: scorecard requires revision",
+            scoreBand: rescore.score_band,
+            recommendedAction: rescore.recommended_action,
+          },
+          { status: 409 },
+        );
+      }
     }
 
     const project = config.projects[session.projectId];

--- a/packages/web/src/app/api/sessions/[id]/route.ts
+++ b/packages/web/src/app/api/sessions/[id]/route.ts
@@ -6,11 +6,13 @@ import {
   enrichSessionPR,
   enrichSessionsMetadata,
 } from "@/lib/serialize";
+import { loadHarnessSnapshot, resolveSessionHarnessContext } from "@/lib/harness-plan";
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await params;
     const { config, registry, sessionManager } = await getServices();
+    const harnessSnapshot = await loadHarnessSnapshot(config);
 
     const coreSession = await sessionManager.get(id);
     if (!coreSession) {
@@ -34,6 +36,12 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
         }
       }
     }
+
+    dashboardSession.harness = resolveSessionHarnessContext(
+      harnessSnapshot,
+      coreSession.id,
+      coreSession.issueId,
+    );
 
     return NextResponse.json(dashboardSession);
   } catch (error) {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -143,7 +143,7 @@ a:hover {
 /* ── Glass nav ────────────────────────────────────────────────────────── */
 
 .nav-glass {
-  background: rgba(13, 17, 23, 0.88);
+  background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
 }
@@ -151,13 +151,14 @@ a:hover {
 /* ── Detail page cards — subtle depth, no hover lift ─────────────────── */
 
 .detail-card {
-  background: linear-gradient(175deg, rgba(24,31,40,1) 0%, rgba(17,22,29,1) 100%);
+  background: linear-gradient(180deg, #ffffff 0%, #fcfcfb 100%);
   box-shadow:
-    0 1px 3px rgba(0,0,0,0.6),
-    inset 0 1px 0 rgba(255,255,255,0.05);
-  --color-text-secondary: #8b949e;
-  --color-text-muted:     #656d76;
-  --color-text-tertiary:  #656d76;
+    0 1px 2px rgba(0,0,0,0.04),
+    0 8px 24px rgba(0,0,0,0.06);
+  --color-text-primary:   #151515;
+  --color-text-secondary: #5f5f5f;
+  --color-text-muted:     #7a7a7a;
+  --color-text-tertiary:  #8a8a8a;
 }
 
 /* ── Session cards ────────────────────────────────────────────────────── */

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
 import { Dashboard } from "@/components/Dashboard";
-import type { DashboardSession } from "@/lib/types";
+import type { DashboardSession, DispatchPlanItem, HarnessSnapshot } from "@/lib/types";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -15,6 +15,7 @@ import { prCache, prCacheKey } from "@/lib/cache";
 import { getPrimaryProjectId, getProjectName, getAllProjects } from "@/lib/project-name";
 import { filterProjectSessions, filterWorkerSessions } from "@/lib/project-utils";
 import { resolveGlobalPause, type GlobalPauseState } from "@/lib/global-pause";
+import { loadHarnessSnapshot } from "@/lib/harness-plan";
 
 function getSelectedProjectName(projectFilter: string | undefined): string {
   if (projectFilter === "all") return "All Projects";
@@ -48,8 +49,21 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
     orchestrators: [],
   };
 
+  let dispatchPlan: DispatchPlanItem[] = [];
+  let harness: HarnessSnapshot = {
+    dispatchPlan: [],
+    workState: [],
+    reconciliationState: [],
+    scoreSummaryByTicket: [],
+    needsRescore: [],
+  };
+  let defaultProjectId: string | null = null;
+
   try {
     const { config, registry, sessionManager } = await getServices();
+    defaultProjectId = Object.keys(config.projects ?? {})[0] ?? null;
+    harness = await loadHarnessSnapshot(config);
+    dispatchPlan = harness.dispatchPlan;
     const allSessions = await sessionManager.list();
 
     pageData.globalPause = resolveGlobalPause(allSessions);
@@ -134,6 +148,9 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
       projects={projects}
       initialGlobalPause={pageData.globalPause}
       orchestrators={pageData.orchestrators}
+      dispatchPlan={dispatchPlan}
+      harness={harness}
+      defaultProjectId={defaultProjectId}
     />
   );
 }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -8,16 +8,19 @@ import {
   type AttentionLevel,
   type GlobalPauseState,
   type DashboardOrchestratorLink,
+  type DispatchPlanItem,
+  type HarnessSnapshot,
   getAttentionLevel,
   isPRRateLimited,
+  isPRMergeReady,
 } from "@/lib/types";
-import { CI_STATUS } from "@composio/ao-core/types";
-import { AttentionZone } from "./AttentionZone";
-import { PRTableRow } from "./PRStatus";
 import { DynamicFavicon } from "./DynamicFavicon";
+import { PRTableRow } from "./PRStatus";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
 import { ProjectSidebar } from "./ProjectSidebar";
 import type { ProjectInfo } from "@/lib/project-name";
+import { DirectTerminal } from "./DirectTerminal";
+import { AttentionZone } from "./AttentionZone";
 
 interface DashboardProps {
   initialSessions: DashboardSession[];
@@ -26,9 +29,41 @@ interface DashboardProps {
   projects?: ProjectInfo[];
   initialGlobalPause?: GlobalPauseState | null;
   orchestrators?: DashboardOrchestratorLink[];
+  dispatchPlan: DispatchPlanItem[];
+  harness: HarnessSnapshot;
+  defaultProjectId?: string | null;
 }
 
-const KANBAN_LEVELS = ["working", "pending", "review", "respond", "merge"] as const;
+type Action = "dispatch" | "send" | "restore" | "review" | "escalate" | "merge" | "kill" | "hold";
+type Mode = "work" | "terminal";
+type Answer = { state: string; blocker: string; allowedActions: Action[]; recommendedAction: Action; evidence: string[] };
+type Work = {
+  workId: string;
+  title: string;
+  status: string;
+  reason: string;
+  recommendedAction: Action;
+  allowedActions: Action[];
+  activeSessionId: string | null;
+  evidence: string[];
+  priority: number;
+  scoreBand: string | null;
+};
+
+const ACTIONS: Action[] = ["dispatch", "send", "restore", "review", "escalate", "merge", "kill", "hold"];
+
+function normalizeAction(raw: string | null | undefined): Action {
+  const text = (raw ?? "").toLowerCase();
+  if (ACTIONS.includes(text as Action)) return text as Action;
+  if (text.includes("merge")) return "merge";
+  if (text.includes("send") || text.includes("input")) return "send";
+  if (text.includes("restore")) return "restore";
+  if (text.includes("dispatch")) return "dispatch";
+  if (text.includes("review")) return "review";
+  if (text.includes("escalate")) return "escalate";
+  if (text.includes("kill")) return "kill";
+  return "hold";
+}
 
 export function Dashboard({
   initialSessions,
@@ -37,6 +72,9 @@ export function Dashboard({
   projects = [],
   initialGlobalPause = null,
   orchestrators = [],
+  dispatchPlan,
+  harness,
+  defaultProjectId,
 }: DashboardProps) {
   const { sessions, globalPause } = useSessionEvents(
     initialSessions,
@@ -48,6 +86,8 @@ export function Dashboard({
   const showSidebar = projects.length > 1;
   const allProjectsView = showSidebar && projectId === undefined;
 
+  const sessionById = useMemo(() => new Map(sessions.map((s) => [s.id, s])), [sessions]);
+
   const grouped = useMemo(() => {
     const zones: Record<AttentionLevel, DashboardSession[]> = {
       merge: [],
@@ -57,11 +97,24 @@ export function Dashboard({
       working: [],
       done: [],
     };
+
     for (const session of sessions) {
       zones[getAttentionLevel(session)].push(session);
     }
+
     return zones;
   }, [sessions]);
+
+  const KANBAN_LEVELS: AttentionLevel[] = ["merge", "respond", "review", "pending", "working"];
+
+  const mergeScore = (pr: DashboardPR) => {
+    let score = 0;
+    if (pr.mergeability.mergeable) score += 100;
+    if (pr.mergeability.ciPassing) score += 10;
+    if (pr.mergeability.approved) score += 10;
+    if (pr.mergeability.noConflicts) score += 10;
+    return -score;
+  };
 
   const openPRs = useMemo(() => {
     return sessions
@@ -72,6 +125,193 @@ export function Dashboard({
       .map((session) => session.pr)
       .sort((a, b) => mergeScore(a) - mergeScore(b));
   }, [sessions]);
+
+  const works = useMemo<Work[]>(() => {
+    const workState = new Map(harness.workState.map((w) => [w.work_id, w]));
+    const recState = new Map(harness.reconciliationState.map((r) => [r.work_id, r]));
+    const scores = new Map(harness.scoreSummaryByTicket.map((s) => [s.subject_id, s]));
+    const plannedWorks = dispatchPlan
+      .map((d) => {
+        const w = workState.get(d.work_id);
+        const r = recState.get(d.work_id);
+        const s = scores.get(d.work_id);
+        const activeSessionId = w?.active_session_id ?? r?.active_session_id ?? null;
+        const active = activeSessionId ? sessionById.get(activeSessionId) ?? null : null;
+        const recommendedAction = normalizeAction(r?.next_action ?? d.next_action);
+        const dynamicActions: Action[] = active
+          ? [
+              "send",
+              "kill",
+              ...(active.activity === "exited" ? (["restore"] as Action[]) : []),
+              ...(active.pr?.mergeability.mergeable ? (["merge"] as Action[]) : []),
+            ]
+          : ["dispatch"];
+        const allowedActions = Array.from(new Set<Action>([recommendedAction, ...dynamicActions]));
+        return {
+          workId: d.work_id,
+          title: active?.issueTitle ?? active?.issueLabel ?? d.work_id,
+          status: w?.work_status ?? d.work_status,
+          reason: r?.reason ?? d.reason,
+          recommendedAction,
+          allowedActions,
+          activeSessionId,
+          evidence: [r?.reason ?? d.reason, d.latest_decision_id ?? "", d.latest_scorecard_id ?? ""].filter(Boolean),
+          priority: d.priority,
+          scoreBand: s?.score_band ?? null,
+        } satisfies Work;
+      })
+      .sort((a, b) => b.priority - a.priority);
+    if (plannedWorks.length > 0) {
+      return plannedWorks;
+    }
+
+    // Fallback for non-harness environments: build actionable work cards from live sessions.
+    const priorityByAttention: Record<AttentionLevel, number> = {
+      merge: 100,
+      respond: 90,
+      review: 80,
+      pending: 50,
+      working: 40,
+      done: 10,
+    };
+
+    const actionByAttention: Record<AttentionLevel, Action> = {
+      merge: "merge",
+      respond: "send",
+      review: "review",
+      pending: "hold",
+      working: "hold",
+      done: "hold",
+    };
+
+    return sessions
+      .map((s) => {
+        const attention = getAttentionLevel(s);
+        const recommendedAction = actionByAttention[attention];
+        const baseActions: Action[] = ["send", "kill"];
+        if (s.activity === "exited") baseActions.push("restore");
+        if (s.pr && isPRMergeReady(s.pr)) baseActions.push("merge");
+        const allowedActions = Array.from(new Set<Action>([recommendedAction, ...baseActions]));
+        const reason =
+          s.issueTitle ??
+          s.summary ??
+          (s.pr ? `PR #${s.pr.number} ${s.pr.title}` : `session ${s.id} is ${attention}`);
+        return {
+          workId: s.id,
+          title: s.issueTitle ?? s.issueLabel ?? s.summary ?? s.id,
+          status: s.status,
+          reason,
+          recommendedAction,
+          allowedActions,
+          activeSessionId: s.id,
+          evidence: [s.issueLabel ?? "", s.pr?.url ?? "", s.branch ?? ""].filter(Boolean),
+          priority: priorityByAttention[attention],
+          scoreBand: null,
+        } satisfies Work;
+      })
+      .sort((a, b) => b.priority - a.priority);
+  }, [dispatchPlan, harness.reconciliationState, harness.scoreSummaryByTicket, harness.workState, sessionById, sessions]);
+
+  const [selectedWorkId, setSelectedWorkId] = useState<string | null>(null);
+  const [mode, setMode] = useState<Mode>("work");
+  const [command, setCommand] = useState("");
+  const [answer, setAnswer] = useState<Answer | null>(null);
+  const [busy, setBusy] = useState(false);
+  const selectedWork = useMemo(() => works.find((w) => w.workId === selectedWorkId) ?? works[0] ?? null, [works, selectedWorkId]);
+  const selectedSession = selectedWork?.activeSessionId ? sessionById.get(selectedWork.activeSessionId) ?? null : null;
+
+  // Find the first orchestrator id for the current project
+  const orchestratorId = orchestrators.length > 0 ? orchestrators[0].id : null;
+
+  useEffect(() => {
+    if (!selectedWorkId && works[0]) setSelectedWorkId(works[0].workId);
+  }, [selectedWorkId, works]);
+
+  const runAction = async (work: Work, action: Action) => {
+    if (!work.allowedActions.includes(action)) throw new Error(`Action not allowed: ${action}`);
+    if (action === "dispatch") {
+      const pid = sessions[0]?.projectId ?? defaultProjectId ?? null;
+      if (!pid) throw new Error("No projectId for dispatch");
+      const r = await fetch("/api/spawn", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ projectId: pid, issueId: work.workId }) });
+      if (!r.ok) throw new Error(await r.text());
+    } else if (action === "merge") {
+      const pr = work.activeSessionId ? sessionById.get(work.activeSessionId)?.pr : null;
+      if (!pr) throw new Error("No PR to merge");
+      const r = await fetch(`/api/prs/${pr.number}/merge`, { method: "POST" });
+      if (!r.ok) throw new Error(await r.text());
+    } else {
+      const sessionId = action === "escalate" || action === "review" || action === "hold" ? orchestratorId : work.activeSessionId;
+      if (!sessionId) throw new Error("No target session");
+      const path = action === "restore" ? "restore" : action === "kill" ? "kill" : "send";
+      const body = path === "send" ? { message: `work ${work.workId} action=${action} reason=${work.reason}` } : undefined;
+      const r = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/${path}`, {
+        method: "POST",
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!r.ok) throw new Error(await r.text());
+    }
+    setAnswer({
+      state: work.status,
+      blocker: work.reason,
+      allowedActions: work.allowedActions,
+      recommendedAction: work.recommendedAction,
+      evidence: work.evidence,
+    });
+  };
+
+  const runCommand = async () => {
+    const [cmd, arg1, arg2] = command.trim().split(/\s+/);
+    if (!cmd) return;
+    const current = arg1 ? works.find((w) => w.workId === arg1) ?? null : selectedWork;
+    if (!current && !["next", "dispatch", "spawn", "session"].includes(cmd)) return;
+    setBusy(true);
+    try {
+      if (cmd === "next") {
+        if (!works[0]) throw new Error("No work");
+        setSelectedWorkId(works[0].workId);
+        setMode("work");
+        setAnswer({ state: works[0].status, blocker: works[0].reason, allowedActions: works[0].allowedActions, recommendedAction: works[0].recommendedAction, evidence: works[0].evidence });
+      } else if (cmd === "dispatch" || cmd === "spawn") {
+        const issueId = arg1 ?? selectedWork?.workId;
+        if (!issueId) throw new Error("Missing issue id");
+        const pid = sessions[0]?.projectId ?? defaultProjectId ?? null;
+        if (!pid) throw new Error("No project configured for dispatch");
+        const r = await fetch("/api/spawn", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ projectId: pid, issueId }),
+        });
+        if (!r.ok) throw new Error(await r.text());
+        setAnswer({
+          state: "spawned",
+          blocker: "none",
+          allowedActions: ["send", "kill", "restore"],
+          recommendedAction: "send",
+          evidence: [`project=${pid}`, `issue=${issueId}`],
+        });
+      } else if (cmd === "explain" || cmd === "status" || cmd === "diff") {
+        if (!current) throw new Error("Unknown work");
+        setSelectedWorkId(current.workId);
+        setAnswer({ state: current.status, blocker: current.reason, allowedActions: current.allowedActions, recommendedAction: current.recommendedAction, evidence: cmd === "diff" ? [`changed-since-last-run unavailable`, ...current.evidence] : current.evidence });
+      } else if (cmd === "act") {
+        if (!current) throw new Error("Unknown work");
+        await runAction(current, normalizeAction(arg2));
+      } else if (cmd === "session") {
+        const sid = arg1 ?? selectedWork?.activeSessionId;
+        if (!sid) throw new Error("Missing session-id");
+        setMode("terminal");
+        setAnswer({ state: sessionById.get(sid)?.status ?? "unknown", blocker: "none", allowedActions: ["send", "restore", "kill"], recommendedAction: "send", evidence: [`session:${sid}`] });
+      } else {
+        throw new Error("Unknown command");
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "failed";
+      setAnswer({ state: "error", blocker: message, allowedActions: [], recommendedAction: "hold", evidence: [message] });
+    } finally {
+      setBusy(false);
+    }
+  };
 
   const projectOverviews = useMemo(() => {
     if (!allProjectsView) return [];
@@ -109,7 +349,7 @@ export function Dashboard({
       body: JSON.stringify({ message }),
     });
     if (!res.ok) {
-      console.error(`Failed to send message to ${sessionId}:`, await res.text());
+      console.error(`Failed to send to ${sessionId}:`, await res.text());
     }
   };
 
@@ -169,6 +409,21 @@ export function Dashboard({
   useEffect(() => {
     setGlobalPauseDismissed(false);
   }, [globalPause?.pausedUntil, globalPause?.reason, globalPause?.sourceSessionId]);
+
+  const focus = works[0] ?? null;
+  const needsDecision = works.find((w) => w.allowedActions.includes("merge") || w.allowedActions.includes("kill")) ?? null;
+  const needsInput = works.find((w) => w.recommendedAction === "send") ?? null;
+  const blocked = works.find((w) => /policy|blocked|forbid/i.test(w.reason)) ?? null;
+  const mergeReady = works.find((w) => w.allowedActions.includes("merge")) ?? null;
+  const needsReconcile = works.find((w) => w.reason.toLowerCase().includes("reconcile")) ?? null;
+  const inbox = [
+    { label: "Focus Work", work: focus },
+    { label: "Needs Decision", work: needsDecision },
+    { label: "Needs Input", work: needsInput },
+    { label: "Blocked by Policy", work: blocked },
+    { label: "Merge Ready", work: mergeReady },
+    { label: "Needs Reconcile", work: needsReconcile },
+  ];
 
   return (
     <div className="flex h-screen">
@@ -329,6 +584,88 @@ export function Dashboard({
                   ))}
                 </tbody>
               </table>
+            </div>
+          </div>
+        )}
+
+        {/* Work-first harness control panel */}
+        {works.length > 0 && (
+          <div className="mt-8 rounded-[10px] border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] p-4">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="text-[14px] font-semibold text-[var(--color-text-primary)]">Work Queue</h2>
+              <div className="flex gap-2">
+                <button type="button" onClick={() => setMode("work")} className={`px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.08em] rounded ${mode === "work" ? "bg-[var(--color-text-primary)] text-[var(--color-bg-surface)]" : "border border-[var(--color-border-default)] text-[var(--color-text-muted)]"}`}>work</button>
+                <button type="button" onClick={() => setMode("terminal")} className={`px-3 py-1.5 text-[11px] font-bold uppercase tracking-[0.08em] rounded ${mode === "terminal" ? "bg-[var(--color-text-primary)] text-[var(--color-bg-surface)]" : "border border-[var(--color-border-default)] text-[var(--color-text-muted)]"}`}>terminal</button>
+              </div>
+            </div>
+            <div className="flex gap-4">
+              <div className="w-[280px] shrink-0 space-y-2 overflow-y-auto max-h-[400px]">
+                {inbox.map((item) => (
+                  <button
+                    key={item.label}
+                    type="button"
+                    onClick={() => item.work && setSelectedWorkId(item.work.workId)}
+                    className="w-full rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-3 text-left transition hover:border-[var(--color-text-primary)]"
+                  >
+                    <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">{item.label}</div>
+                    {item.work ? (
+                      <>
+                        <div className="mt-1 font-mono text-[11px] text-[var(--color-accent)]">{item.work.workId}</div>
+                        <div className="mt-1 text-[13px] font-bold tracking-tight text-[var(--color-text-primary)]">{item.work.recommendedAction}</div>
+                        <div className="mt-1 line-clamp-2 text-[11px] text-[var(--color-text-muted)]">{item.work.reason}</div>
+                      </>
+                    ) : (
+                      <div className="mt-1 text-[11px] text-[var(--color-text-tertiary)]">none</div>
+                    )}
+                  </button>
+                ))}
+              </div>
+              <div className="min-w-0 flex-1">
+                {!selectedWork ? (
+                  <div className="text-[12px] text-[var(--color-text-muted)]">No work</div>
+                ) : mode === "work" ? (
+                  <div className="space-y-3 text-[12px]">
+                    <div className="rounded border-l-2 border-[var(--color-accent)] bg-[var(--color-bg-surface)] p-3"><b>1. current verdict</b><div className="mt-1">{selectedWork.status}</div></div>
+                    <div className="rounded border-l-2 border-[var(--color-text-primary)] bg-[var(--color-bg-surface)] p-3"><b>2. recommended next action</b><div className="mt-1">{selectedWork.recommendedAction}</div></div>
+                    <div className="rounded border-l-2 border-[var(--color-text-primary)] bg-[var(--color-bg-surface)] p-3"><b>3. blocker / stop condition</b><div className="mt-1">{selectedWork.reason}</div></div>
+                    <div className="rounded border-l-2 border-[var(--color-text-primary)] bg-[var(--color-bg-surface)] p-3"><b>4. evidence</b><div className="mt-1">{selectedWork.evidence.join(" | ") || "none"}</div></div>
+                    <div className="rounded border-l-2 border-[var(--color-text-primary)] bg-[var(--color-bg-surface)] p-3"><b>5. active session</b><div className="mt-1">{selectedWork.activeSessionId ?? "none"}</div></div>
+                    <div className="rounded border-l-2 border-[var(--color-text-primary)] bg-[var(--color-bg-surface)] p-3">
+                      <b>allowed actions</b>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {selectedWork.allowedActions.map((a) => (
+                          <button key={a} type="button" disabled={busy} onClick={() => void runAction(selectedWork, a)} className="rounded border border-[var(--color-border-default)] px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--color-text-muted)] hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] disabled:opacity-50">{a}</button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                ) : selectedSession && selectedSession.runtimeName === "tmux" ? (
+                  <DirectTerminal sessionId={selectedSession.id} variant="agent" height="400px" />
+                ) : (
+                  <div className="text-[12px] text-[var(--color-text-muted)]">Direct terminal requires tmux runtime</div>
+                )}
+              </div>
+            </div>
+            <div className="mt-4 border-t border-[var(--color-border-subtle)] pt-4">
+              <div className="mb-2 text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">Orchestrator Chat</div>
+              <div className="mb-2 text-[11px] text-[var(--color-text-muted)]">next | explain &lt;work-id&gt; | status | diff | act | session | dispatch &lt;issue-id&gt;</div>
+              <div className="mb-3 rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg-surface)] p-3 text-[11px]">
+                {answer ? `state=${answer.state} blocker=${answer.blocker} action=${answer.recommendedAction}` : "run command"}
+              </div>
+              <form onSubmit={(e) => { e.preventDefault(); void runCommand(); }} className="flex gap-2">
+                <input
+                  value={command}
+                  onChange={(e) => setCommand(e.target.value)}
+                  className="flex-1 rounded border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-3 py-2 text-[12px] outline-none focus:border-[var(--color-accent)]"
+                  placeholder="next / dispatch 123 / explain TKT-... / act TKT-... send"
+                />
+                <button type="submit" disabled={busy} className="rounded bg-[var(--color-text-primary)] px-4 py-2 text-[12px] font-bold uppercase tracking-[0.08em] text-[var(--color-bg-surface)] disabled:opacity-50">{busy ? "..." : "run"}</button>
+              </form>
+              {orchestratorId && (
+                <a href={`/sessions/${encodeURIComponent(orchestratorId)}`} className="mt-3 inline-block text-[11px] font-semibold uppercase tracking-[0.06em] text-[var(--color-accent)] hover:underline">
+                  open orchestrator session
+                </a>
+              )}
             </div>
           </div>
         )}
@@ -529,17 +866,4 @@ function StatusLine({ stats }: { stats: DashboardStats }) {
       ))}
     </div>
   );
-}
-
-function mergeScore(
-  pr: Pick<DashboardPR, "ciStatus" | "reviewDecision" | "mergeability" | "unresolvedThreads">,
-): number {
-  let score = 0;
-  if (!pr.mergeability.noConflicts) score += 40;
-  if (pr.ciStatus === CI_STATUS.FAILING) score += 30;
-  else if (pr.ciStatus === CI_STATUS.PENDING) score += 5;
-  if (pr.reviewDecision === "changes_requested") score += 20;
-  else if (pr.reviewDecision !== "approved") score += 10;
-  score += pr.unresolvedThreads * 5;
-  return score;
 }

--- a/packages/web/src/components/HarnessPlanPanel.tsx
+++ b/packages/web/src/components/HarnessPlanPanel.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import type { DispatchPlanItem, ReconciliationItem, WorkStateItem } from "@/lib/types";
+
+interface HarnessPlanPanelProps {
+  items: DispatchPlanItem[];
+  workState?: WorkStateItem[];
+  reconciliationState?: ReconciliationItem[];
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  operator_review: "review",
+  escalate: "escalate",
+  retry: "retry",
+  reconcile_session: "reconcile",
+  dispatch: "dispatch",
+  monitor: "monitor",
+};
+
+export function HarnessPlanPanel({
+  items,
+  workState = [],
+  reconciliationState = [],
+}: HarnessPlanPanelProps) {
+  if (items.length === 0) {
+    return null;
+  }
+
+  const visibleItems = items.slice(0, 6);
+  const focus = visibleItems[0];
+
+  return (
+    <section className="mb-7 rounded-[8px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+            Harness Plan
+          </h2>
+          <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+            Repo-derived next actions from `project-os`, shown before runtime intervention.
+          </p>
+        </div>
+        <span className="rounded-full border border-[var(--color-border-subtle)] px-2 py-1 text-[10px] font-semibold text-[var(--color-text-muted)]">
+          {items.length} planned
+        </span>
+      </div>
+
+      <div className="mb-3 flex flex-wrap gap-2">
+        <SummaryPill label="tracked work" value={workState.length} />
+        <SummaryPill
+          label="needs reconcile"
+          value={reconciliationState.filter((entry) => entry.next_action !== "monitor").length}
+        />
+      </div>
+
+      <div className="mb-3 rounded-[7px] border border-[rgba(16,185,129,0.18)] bg-[linear-gradient(135deg,rgba(16,185,129,0.10),rgba(16,185,129,0.03))] p-3">
+        <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-[rgb(16,185,129)]">
+          Focus Work
+        </div>
+        <div className="mt-1 flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="font-[var(--font-mono)] text-[13px] font-semibold text-[var(--color-text-primary)]">
+              {focus.work_id}
+            </div>
+            <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">{focus.reason}</p>
+          </div>
+          <div className="rounded-full border border-[rgba(16,185,129,0.25)] px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.08em] text-[rgb(16,185,129)]">
+            {labelForAction(focus.next_action)}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {visibleItems.map((item, index) => (
+          <div
+            key={`${item.work_id}-${item.next_action}`}
+            className="flex items-center gap-3 rounded-[6px] border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] px-3 py-2.5"
+          >
+            <div className="w-5 shrink-0 text-center text-[10px] font-bold text-[var(--color-text-tertiary)]">
+              {index + 1}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-accent)]">
+                  {item.work_id}
+                </span>
+                <span className="rounded-full border border-[var(--color-border-subtle)] px-1.5 py-0.5 text-[9px] uppercase tracking-[0.08em] text-[var(--color-text-tertiary)]">
+                  {item.work_status}
+                </span>
+              </div>
+              <p className="mt-1 truncate text-[12px] text-[var(--color-text-secondary)]">{item.reason}</p>
+            </div>
+            <div className="rounded-[5px] border border-[rgba(88,166,255,0.28)] px-2.5 py-1.5 text-[11px] font-semibold text-[var(--color-accent)]">
+              {labelForAction(item.next_action)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SummaryPill({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="rounded-full border border-[var(--color-border-subtle)] px-2 py-1 text-[10px] font-semibold text-[var(--color-text-muted)]">
+      {value} {label}
+    </span>
+  );
+}
+
+function labelForAction(action: string): string {
+  return ACTION_LABELS[action] ?? action.replaceAll("_", " ");
+}

--- a/packages/web/src/components/OperatorQueue.tsx
+++ b/packages/web/src/components/OperatorQueue.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useState } from "react";
+import { type DashboardSession, getAttentionLevel } from "@/lib/types";
+
+interface OperatorQueueProps {
+  sessions: DashboardSession[];
+  onSend?: (sessionId: string, message: string) => Promise<void> | void;
+  onMerge?: (prNumber: number) => Promise<void> | void;
+  onRestore?: (sessionId: string) => Promise<void> | void;
+}
+
+interface QueueItem {
+  session: DashboardSession;
+  title: string;
+  note: string;
+  actionLabel: string;
+  actionKind: "send" | "merge" | "restore";
+  actionPayload: string | number;
+  priority: number;
+}
+
+export function OperatorQueue({ sessions, onSend, onMerge, onRestore }: OperatorQueueProps) {
+  const [pending, setPending] = useState<string | null>(null);
+  const items = buildQueueItems(sessions).slice(0, 6);
+  const focus = items[0] ?? null;
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  const handleAction = async (item: QueueItem) => {
+    setPending(item.session.id);
+    try {
+      if (item.actionKind === "send") {
+        await onSend?.(item.session.id, String(item.actionPayload));
+      } else if (item.actionKind === "merge") {
+        await onMerge?.(Number(item.actionPayload));
+      } else {
+        await onRestore?.(item.session.id);
+      }
+    } finally {
+      setPending(null);
+    }
+  };
+
+  return (
+    <section className="mb-7 rounded-[8px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+            Next Actions
+          </h2>
+          <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+            Highest-leverage operator actions, ordered by urgency.
+          </p>
+        </div>
+        <span className="rounded-full border border-[var(--color-border-subtle)] px-2 py-1 text-[10px] font-semibold text-[var(--color-text-muted)]">
+          {items.length} queued
+        </span>
+      </div>
+      {focus && (
+        <div className="mb-3 rounded-[7px] border border-[rgba(88,166,255,0.18)] bg-[linear-gradient(135deg,rgba(88,166,255,0.1),rgba(88,166,255,0.03))] p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--color-accent)]">
+                Focus Session
+              </div>
+              <a
+                href={`/sessions/${encodeURIComponent(focus.session.id)}`}
+                className="mt-1 block font-[var(--font-mono)] text-[13px] font-semibold text-[var(--color-text-primary)] hover:no-underline"
+              >
+                {focus.session.id}
+              </a>
+              <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">{focus.note}</p>
+            </div>
+            <button
+              onClick={() => void handleAction(focus)}
+              disabled={pending === focus.session.id}
+              className="rounded-[5px] border border-[rgba(88,166,255,0.28)] bg-[rgba(9,105,218,0.08)] px-3 py-1.5 text-[11px] font-semibold text-[var(--color-accent)] transition-colors hover:bg-[rgba(9,105,218,0.14)] disabled:opacity-50"
+            >
+              {pending === focus.session.id ? "sending..." : focus.actionLabel}
+            </button>
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        {items.map((item, index) => (
+          <div
+            key={`${item.session.id}-${item.actionLabel}`}
+            className="flex items-center gap-3 rounded-[6px] border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] px-3 py-2.5"
+          >
+            <div className="w-5 shrink-0 text-center text-[10px] font-bold text-[var(--color-text-tertiary)]">
+              {index + 1}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <a
+                  href={`/sessions/${encodeURIComponent(item.session.id)}`}
+                  className="font-[var(--font-mono)] text-[11px] text-[var(--color-accent)] hover:no-underline"
+                >
+                  {item.session.id}
+                </a>
+                <span className="rounded-full border border-[var(--color-border-subtle)] px-1.5 py-0.5 text-[9px] uppercase tracking-[0.08em] text-[var(--color-text-tertiary)]">
+                  {item.title}
+                </span>
+              </div>
+              <p className="mt-1 truncate text-[12px] text-[var(--color-text-secondary)]">{item.note}</p>
+            </div>
+            <button
+              onClick={() => void handleAction(item)}
+              disabled={pending === item.session.id}
+              className="rounded-[5px] border border-[rgba(88,166,255,0.28)] px-2.5 py-1.5 text-[11px] font-semibold text-[var(--color-accent)] transition-colors hover:bg-[rgba(88,166,255,0.08)] disabled:opacity-50"
+            >
+              {pending === item.session.id ? "sending..." : item.actionLabel}
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function buildQueueItems(sessions: DashboardSession[]): QueueItem[] {
+  const items: QueueItem[] = [];
+
+  for (const session of sessions) {
+    const level = getAttentionLevel(session);
+    if (level === "merge" && session.pr) {
+      items.push({
+        session,
+        title: "merge ready",
+        note: `PR #${session.pr.number} is approved and CI green.`,
+        actionLabel: `Merge #${session.pr.number}`,
+        actionKind: "merge",
+        actionPayload: session.pr.number,
+        priority: 0,
+      });
+      continue;
+    }
+
+    if (level === "respond") {
+      items.push({
+        session,
+        title: "needs input",
+        note: session.summary ?? "Session is blocked and waiting for operator input.",
+        actionLabel: "Send unblock",
+        actionKind: "send",
+        actionPayload: buildRespondMessage(session),
+        priority: 1,
+      });
+      continue;
+    }
+
+    if (level === "review" && session.pr) {
+      items.push({
+        session,
+        title: "needs review",
+        note: `PR #${session.pr.number} has failing CI, review requests, or conflicts.`,
+        actionLabel: "Ask to fix",
+        actionKind: "send",
+        actionPayload: `Review PR ${session.pr.url} and resolve the highest-priority blocker first. Reply with the blocker you picked and the fix plan.`,
+        priority: 2,
+      });
+      continue;
+    }
+
+    if (session.activity === "exited" || session.status === "killed") {
+      items.push({
+        session,
+        title: "terminated",
+        note: "Session exited unexpectedly and can be restored in-place.",
+        actionLabel: "Restore",
+        actionKind: "restore",
+        actionPayload: session.id,
+        priority: 3,
+      });
+    }
+  }
+
+  return items.sort((a, b) => a.priority - b.priority || a.session.id.localeCompare(b.session.id));
+}
+
+function buildRespondMessage(session: DashboardSession): string {
+  if (session.pr) {
+    return `You are blocked on ${session.pr.url}. State the blocker in one sentence, choose the next smallest fix, and continue only on that fix.`;
+  }
+  return "State the blocker in one sentence, choose the next smallest action, and continue only on that action.";
+}

--- a/packages/web/src/components/QuickCommandDeck.tsx
+++ b/packages/web/src/components/QuickCommandDeck.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState } from "react";
+import { type DashboardSession, getAttentionLevel, isPRRateLimited } from "@/lib/types";
+
+interface QuickCommandDeckProps {
+  session: DashboardSession;
+}
+
+interface Preset {
+  id: string;
+  label: string;
+  message: string;
+}
+
+export function QuickCommandDeck({ session }: QuickCommandDeckProps) {
+  const [status, setStatus] = useState<string | null>(null);
+
+  const presets = buildPresets(session);
+
+  const sendPreset = async (preset: Preset) => {
+    setStatus(`sending:${preset.id}`);
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}/message`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: preset.message }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setStatus(`sent:${preset.id}`);
+    } catch {
+      setStatus(`error:${preset.id}`);
+    }
+  };
+
+  return (
+    <section className="mb-6 rounded-[8px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+      <div className="mb-3">
+        <h2 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+          Quick Commands
+        </h2>
+        <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+          Prebuilt operator prompts for common interventions.
+        </p>
+      </div>
+      <div className="grid gap-2 sm:grid-cols-2">
+        {presets.map((preset) => {
+          const isPending = status === `sending:${preset.id}`;
+          const isSent = status === `sent:${preset.id}`;
+          const isError = status === `error:${preset.id}`;
+          return (
+            <button
+              key={preset.id}
+              onClick={() => void sendPreset(preset)}
+              disabled={isPending}
+              className="rounded-[6px] border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] px-3 py-2 text-left transition-colors hover:border-[var(--color-accent)]"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-[12px] font-semibold text-[var(--color-text-primary)]">{preset.label}</span>
+                <span className="text-[10px] text-[var(--color-text-tertiary)]">
+                  {isPending ? "sending..." : isSent ? "sent" : isError ? "error" : "ready"}
+                </span>
+              </div>
+              <p className="mt-1 line-clamp-2 text-[11px] text-[var(--color-text-secondary)]">{preset.message}</p>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+
+function buildPresets(session: DashboardSession): Preset[] {
+  const pr = session.pr;
+  const prUrl = pr?.url ?? "this session";
+  const level = getAttentionLevel(session);
+  const presets: Preset[] = [
+    {
+      id: "summarize",
+      label: "Summarize State",
+      message: `Summarize the current state of ${prUrl} in three bullets: blocker, next action, confidence.`,
+    },
+  ];
+
+  if (level === "respond") {
+    presets.push({
+      id: "unblock",
+      label: "Unblock Session",
+      message: `You are blocked on ${prUrl}. State the blocker in one sentence, choose the next smallest unblock, and continue only on that unblock.`,
+    });
+  }
+
+  if (pr && !isPRRateLimited(pr) && pr.ciStatus === "failing") {
+    presets.push({
+      id: "fix-ci",
+      label: "Fix Failing CI",
+      message: `Inspect the failing CI on ${prUrl}, choose the single highest-signal failing check, fix only that failure, then report what changed.`,
+    });
+  } else {
+    presets.push({
+      id: "fix-one",
+      label: "Fix Highest Blocker",
+      message: `Pick the single highest-value blocker on ${prUrl}, fix only that blocker, and report the result.`,
+    });
+  }
+
+  if (pr) {
+    presets.push({
+      id: "post-review",
+      label: "Prepare Review",
+      message: `Prepare ${prUrl} for review. If it is not ready, state the one thing still missing.`,
+    });
+  }
+
+  if (pr && !isPRRateLimited(pr) && !pr.mergeability.noConflicts) {
+    presets.push({
+      id: "rebase",
+      label: "Resolve Conflicts",
+      message: `Rebase your branch for ${prUrl}, resolve only the merge conflicts, rerun the minimum relevant checks, and report any remaining blocker.`,
+    });
+  } else {
+    presets.push({
+      id: "rebase",
+      label: "Rebase and Recheck",
+      message: `Rebase your branch on the default branch, rerun the relevant checks, and report any new blocker.`,
+    });
+  }
+
+  return presets;
+}

--- a/packages/web/src/components/RecentActivityFeed.tsx
+++ b/packages/web/src/components/RecentActivityFeed.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+interface ActivitySample {
+  status: string;
+  activity: string | null;
+  lastActivityAt: string;
+}
+
+interface ActivityEvent extends ActivitySample {
+  id: string;
+}
+
+export function RecentActivityFeed({ status, activity, lastActivityAt }: ActivitySample) {
+  const [events, setEvents] = useState<ActivityEvent[]>([]);
+
+  useEffect(() => {
+    const next: ActivityEvent = {
+      id: `${lastActivityAt}:${status}:${activity ?? "none"}`,
+      status,
+      activity,
+      lastActivityAt,
+    };
+    setEvents((current) => {
+      if (current[0]?.id === next.id) {
+        return current;
+      }
+      return [next, ...current].slice(0, 6);
+    });
+  }, [status, activity, lastActivityAt]);
+
+  return (
+    <section className="mb-6 rounded-[8px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+      <div className="mb-3">
+        <h2 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+          Recent Activity
+        </h2>
+        <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+          Latest status transitions observed by the dashboard.
+        </p>
+      </div>
+      <div className="space-y-2">
+        {events.map((event) => (
+          <div
+            key={event.id}
+            className="flex items-center justify-between gap-3 rounded-[6px] border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] px-3 py-2"
+          >
+            <div className="min-w-0">
+              <div className="text-[12px] font-semibold text-[var(--color-text-primary)]">{humanize(event.status)}</div>
+              <div className="text-[11px] text-[var(--color-text-secondary)]">
+                activity: {event.activity ? humanize(event.activity) : "unknown"}
+              </div>
+            </div>
+            <div className="font-[var(--font-mono)] text-[10px] text-[var(--color-text-tertiary)]">
+              {formatTime(event.lastActivityAt)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function humanize(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function formatTime(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -8,6 +8,9 @@ import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
 import { DirectTerminal } from "./DirectTerminal";
 import { ActivityDot } from "./ActivityDot";
+import { QuickCommandDeck } from "./QuickCommandDeck";
+import { RecentActivityFeed } from "./RecentActivityFeed";
+import { SessionHarnessPanel } from "./SessionHarnessPanel";
 
 interface OrchestratorZones {
   merge: number;
@@ -138,21 +141,21 @@ function OrchestratorStatusStrip({
 
   return (
     <div
-      className="border-b border-[var(--color-border-subtle)] px-8 py-4"
+      className="border-b border-[#e5e5e5] px-8 py-4"
       style={{
-        background: "linear-gradient(to bottom, rgba(88,166,255,0.04) 0%, transparent 100%)",
+        background: "linear-gradient(to bottom, rgba(255,92,0,0.05) 0%, rgba(255,255,255,0.8) 100%)",
       }}
     >
-      <div className="mx-auto flex max-w-[900px] items-center gap-3 flex-wrap">
+      <div className="mx-auto flex max-w-[1100px] items-center gap-3 flex-wrap">
         {/* Total count */}
         <div className="flex items-baseline gap-1.5 mr-2">
-          <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+          <span className="text-[22px] font-bold leading-none tabular-nums text-[#111]">
             {total}
           </span>
-          <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
+          <span className="text-[11px] text-[#777]">agents</span>
         </div>
 
-        <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+        <div className="h-5 w-px bg-[#e5e5e5] mr-1" />
 
         {/* Per-zone pills */}
         {stats.length > 0 ? (
@@ -174,11 +177,11 @@ function OrchestratorStatusStrip({
             </div>
           ))
         ) : (
-          <span className="text-[12px] text-[var(--color-text-tertiary)]">no active agents</span>
+          <span className="text-[12px] text-[#888]">no active agents</span>
         )}
 
         {uptime && (
-          <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+          <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[#888]">
             up {uptime}
           </span>
         )}
@@ -202,11 +205,12 @@ export function SessionDetail({
     color: "var(--color-text-muted)",
   };
 
-  const accentColor = "var(--color-accent)";
+  const accentColor = "#ff5c00";
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
 
   const terminalHeight = isOrchestrator ? "calc(100vh - 240px)" : "max(440px, calc(100vh - 440px))";
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
+  const supportsDirectTerminal = session.runtimeName === "tmux";
   const opencodeSessionId =
     typeof session.metadata["opencodeSessionId"] === "string" &&
     session.metadata["opencodeSessionId"].length > 0
@@ -217,13 +221,13 @@ export function SessionDetail({
     : undefined;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-base)]">
+    <div className="min-h-screen bg-[#f3f3f1] text-[#111]">
       {/* Nav bar — glass effect */}
-      <nav className="nav-glass sticky top-0 z-10 border-b border-[var(--color-border-subtle)]">
-        <div className="mx-auto flex max-w-[900px] items-center gap-2 px-8 py-2.5">
+      <nav className="nav-glass sticky top-0 z-10 border-b border-[#e5e5e5]">
+        <div className="mx-auto flex max-w-[1100px] items-center gap-2 px-8 py-2.5">
           <a
             href="/"
-            className="flex items-center gap-1 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] hover:no-underline"
+            className="flex items-center gap-1 text-[11px] font-medium text-[#666] transition-colors hover:text-[#111] hover:no-underline"
           >
             <svg
               className="h-3 w-3 opacity-60"
@@ -236,8 +240,8 @@ export function SessionDetail({
             </svg>
             Orchestrator
           </a>
-          <span className="text-[var(--color-border-strong)]">/</span>
-          <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+          <span className="text-[#b5b5b5]">/</span>
+          <span className="font-[var(--font-mono)] text-[11px] text-[#7a7a7a]">
             {session.id}
           </span>
           {isOrchestrator && (
@@ -260,7 +264,7 @@ export function SessionDetail({
         <OrchestratorStatusStrip zones={orchestratorZones} createdAt={session.createdAt} />
       )}
 
-      <div className="mx-auto max-w-[900px] px-8 py-6">
+      <div className="mx-auto max-w-[1100px] px-8 py-6">
         {/* ── Header card ─────────────────────────────────────────── */}
         <div
           className="detail-card mb-6 rounded-[8px] border border-[var(--color-border-default)] p-5"
@@ -274,6 +278,9 @@ export function SessionDetail({
                 <h1 className="font-[var(--font-mono)] text-[17px] font-semibold tracking-[-0.01em] text-[var(--color-text-primary)]">
                   {session.id}
                 </h1>
+                <span className="rounded border border-[#ff5c00] bg-[#fff5ef] px-2 py-0.5 text-[10px] font-bold tracking-[0.08em] text-[#ff5c00]">
+                  DESIGN-V3-0311
+                </span>
                 {/* Activity badge */}
                 <div
                   className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5"
@@ -379,6 +386,16 @@ export function SessionDetail({
         {/* ── PR Card ─────────────────────────────────────────────── */}
         {pr && <PRCard pr={pr} sessionId={session.id} />}
 
+        <SessionHarnessPanel harness={session.harness} />
+
+        {!isOrchestrator && <QuickCommandDeck session={session} />}
+
+        <RecentActivityFeed
+          status={session.status}
+          activity={session.activity}
+          lastActivityAt={session.lastActivityAt}
+        />
+
         {/* ── Terminal ─────────────────────────────────────────────── */}
         <div className={pr ? "mt-6" : ""}>
           <div className="mb-3 flex items-center gap-2">
@@ -390,14 +407,21 @@ export function SessionDetail({
               Terminal
             </span>
           </div>
-          <DirectTerminal
-            sessionId={session.id}
-            startFullscreen={startFullscreen}
-            variant={terminalVariant}
-            height={terminalHeight}
-            isOpenCodeSession={isOpenCodeSession}
-            reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
-          />
+          {supportsDirectTerminal ? (
+            <DirectTerminal
+              sessionId={session.id}
+              startFullscreen={startFullscreen}
+              variant={terminalVariant}
+              height={terminalHeight}
+              isOpenCodeSession={isOpenCodeSession}
+              reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
+            />
+          ) : (
+            <div className="rounded-[6px] border border-[#e0e0e0] bg-white p-4 text-[12px] text-[#666]">
+              Direct terminal is only supported for `tmux` runtime sessions.
+              {session.runtimeName ? ` Current runtime: ${session.runtimeName}.` : ""}
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web/src/components/SessionHarnessPanel.tsx
+++ b/packages/web/src/components/SessionHarnessPanel.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import type { SessionHarnessContext } from "@/lib/types";
+
+interface SessionHarnessPanelProps {
+  harness: SessionHarnessContext | null | undefined;
+}
+
+const ACTION_LABELS: Record<string, string> = {
+  operator_review: "review",
+  escalate: "escalate",
+  retry: "retry",
+  reconcile_session: "reconcile",
+  dispatch: "dispatch",
+  monitor: "monitor",
+  terminal: "terminal",
+};
+
+export function SessionHarnessPanel({ harness }: SessionHarnessPanelProps) {
+  if (!harness) return null;
+
+  const work = harness.workState;
+  const reconcile = harness.reconciliation;
+  const plan = harness.dispatchPlan;
+
+  return (
+    <section className="mb-6 rounded-[8px] border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] p-4">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-[11px] font-bold uppercase tracking-[0.12em] text-[var(--color-text-tertiary)]">
+            Work Authority
+          </h2>
+          <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">
+            Repo-owned work and reconciliation state for this session.
+          </p>
+        </div>
+        <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-accent)]">
+          {harness.workId}
+        </span>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-3">
+        <AuthorityCard
+          label="Work State"
+          primary={work?.work_status ?? "untracked"}
+          secondary={
+            work
+              ? `retry ${work.retry_count ?? 0}/${work.retry_budget ?? "∞"}`
+              : "no persisted work state"
+          }
+        />
+        <AuthorityCard
+          label="Reconciliation"
+          primary={labelForAction(reconcile?.next_action ?? "none")}
+          secondary={reconcile?.reason ?? "no reconciliation action pending"}
+        />
+        <AuthorityCard
+          label="Dispatch Plan"
+          primary={labelForAction(plan?.next_action ?? "none")}
+          secondary={plan ? `priority ${plan.priority}` : "not currently queued"}
+        />
+      </div>
+    </section>
+  );
+}
+
+function AuthorityCard({
+  label,
+  primary,
+  secondary,
+}: {
+  label: string;
+  primary: string;
+  secondary: string;
+}) {
+  return (
+    <div className="rounded-[7px] border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] p-3">
+      <div className="text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--color-text-tertiary)]">
+        {label}
+      </div>
+      <div className="mt-1 text-[13px] font-semibold text-[var(--color-text-primary)]">
+        {primary}
+      </div>
+      <p className="mt-1 text-[12px] text-[var(--color-text-secondary)]">{secondary}</p>
+    </div>
+  );
+}
+
+function labelForAction(action: string): string {
+  return ACTION_LABELS[action] ?? action.replaceAll("_", " ");
+}

--- a/packages/web/src/lib/harness-plan.ts
+++ b/packages/web/src/lib/harness-plan.ts
@@ -1,0 +1,131 @@
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { OrchestratorConfig, ProjectConfig } from "@composio/ao-core";
+import type {
+  DispatchPlanItem,
+  HarnessSnapshot,
+  ReconciliationItem,
+  ScoreSummaryItem,
+  SessionHarnessContext,
+  WorkStateItem,
+} from "./types";
+
+function resolveProjectRoot(project: ProjectConfig | undefined): string | null {
+  if (!project?.path) return null;
+  return dirname(project.path);
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object";
+}
+
+function getIndexesDir(config: OrchestratorConfig): string | null {
+  const firstProjectKey = Object.keys(config.projects)[0];
+  const project = firstProjectKey ? config.projects[firstProjectKey] : undefined;
+  const projectRoot = resolveProjectRoot(project);
+  if (!projectRoot) return null;
+  return join(projectRoot, "project-os", "indexes");
+}
+
+async function readJsonArray<T>(
+  path: string,
+  predicate: (value: unknown) => value is T,
+): Promise<T[]> {
+  try {
+    const raw = await readFile(path, "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(predicate);
+  } catch {
+    return [];
+  }
+}
+
+export async function loadHarnessSnapshot(config: OrchestratorConfig): Promise<HarnessSnapshot> {
+  const indexesDir = getIndexesDir(config);
+  if (!indexesDir) {
+    return {
+      dispatchPlan: [],
+      workState: [],
+      reconciliationState: [],
+      scoreSummaryByTicket: [],
+      needsRescore: [],
+    };
+  }
+
+  const [dispatchPlan, workState, reconciliationState, scoreSummaryByTicket, needsRescore] =
+    await Promise.all([
+    readJsonArray(join(indexesDir, "dispatch_plan.json"), isDispatchPlanItem),
+    readJsonArray(join(indexesDir, "work_state_store.json"), isWorkStateItem),
+    readJsonArray(join(indexesDir, "reconciliation_state.json"), isReconciliationItem),
+    readJsonArray(join(indexesDir, "score_summary_by_ticket.json"), isScoreSummaryItem),
+    readJsonArray(join(indexesDir, "needs_rescore.json"), isScoreSummaryItem),
+  ]);
+
+  return { dispatchPlan, workState, reconciliationState, scoreSummaryByTicket, needsRescore };
+}
+
+export async function loadDispatchPlan(config: OrchestratorConfig): Promise<DispatchPlanItem[]> {
+  const snapshot = await loadHarnessSnapshot(config);
+  return snapshot.dispatchPlan;
+}
+
+export function resolveSessionHarnessContext(
+  snapshot: HarnessSnapshot,
+  sessionId: string,
+  issueId: string | null | undefined,
+): SessionHarnessContext | null {
+  const workState = snapshot.workState.find(
+    (entry) =>
+      entry.active_session_id === sessionId || (issueId !== undefined && issueId !== null && entry.work_id === issueId),
+  );
+  const workId = workState?.work_id ?? issueId ?? null;
+  if (!workId) return null;
+
+  const reconciliation =
+    snapshot.reconciliationState.find(
+      (entry) => entry.active_session_id === sessionId || entry.work_id === workId,
+    ) ?? null;
+  const dispatchPlan =
+    snapshot.dispatchPlan.find((entry) => entry.work_id === workId) ?? null;
+
+  return {
+    workId,
+    workState: workState ?? null,
+    reconciliation,
+    dispatchPlan,
+  };
+}
+
+function isDispatchPlanItem(value: unknown): value is DispatchPlanItem {
+  if (!isObject(value)) return false;
+  return (
+    typeof value.work_id === "string" &&
+    typeof value.work_status === "string" &&
+    typeof value.next_action === "string" &&
+    typeof value.priority === "number" &&
+    typeof value.reason === "string"
+  );
+}
+
+function isWorkStateItem(value: unknown): value is WorkStateItem {
+  if (!isObject(value)) return false;
+  return typeof value.work_id === "string" && typeof value.work_status === "string";
+}
+
+function isReconciliationItem(value: unknown): value is ReconciliationItem {
+  if (!isObject(value)) return false;
+  return typeof value.work_id === "string" && typeof value.next_action === "string";
+}
+
+function isScoreSummaryItem(value: unknown): value is ScoreSummaryItem {
+  if (!isObject(value)) return false;
+  return (
+    typeof value.subject_id === "string" &&
+    typeof value.artifact_id === "string" &&
+    typeof value.score_total === "number" &&
+    typeof value.score_band === "string" &&
+    typeof value.recommended_action === "string" &&
+    typeof value.blocking_findings_count === "number"
+  );
+}

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -55,6 +55,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     projectId: session.projectId,
     status: session.status,
     activity: session.activity,
+    runtimeName: session.runtimeHandle?.runtimeName ?? null,
     branch: session.branch,
     issueId: session.issueId, // Deprecated: kept for backwards compatibility
     issueUrl: session.issueId, // issueId is actually the full URL

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -36,7 +36,9 @@ import {
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
+import pluginRuntimeProcess from "@composio/ao-plugin-runtime-process";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
+import pluginAgentCodex from "@composio/ao-plugin-agent-codex";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@composio/ao-plugin-scm-github";
@@ -78,7 +80,9 @@ async function initServices(): Promise<Services> {
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
+  registry.register(pluginRuntimeProcess);
   registry.register(pluginAgentClaudeCode);
+  registry.register(pluginAgentCodex);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -63,6 +63,7 @@ export interface DashboardSession {
   projectId: string;
   status: SessionStatus;
   activity: ActivityState | null;
+  runtimeName: string | null;
   branch: string | null;
   issueId: string | null; // Deprecated: use issueUrl instead
   issueUrl: string | null; // Full issue URL
@@ -75,6 +76,7 @@ export interface DashboardSession {
   lastActivityAt: string;
   pr: DashboardPR | null;
   metadata: Record<string, string>;
+  harness?: SessionHarnessContext | null;
 }
 
 /**
@@ -134,6 +136,95 @@ export interface DashboardOrchestratorLink {
   id: string;
   projectId: string;
   projectName: string;
+}
+
+export interface DispatchPlanItem {
+  work_id: string;
+  work_status: string;
+  next_action: string;
+  priority: number;
+  reason: string;
+  objective_id?: string | null;
+  spec_id?: string | null;
+  initiative_id?: string | null;
+  latest_decision_id?: string | null;
+  latest_scorecard_id?: string | null;
+  active_run_id?: string | null;
+}
+
+export interface WorkStateItem {
+  work_id: string;
+  work_status: string;
+  retry_count?: number;
+  retry_budget?: number | null;
+  active_session_id?: string | null;
+  updated_at?: string;
+}
+
+export interface ReconciliationItem {
+  work_id: string;
+  next_action: string;
+  reason?: string;
+  active_session_id?: string | null;
+  updated_at?: string;
+}
+
+export interface ScoreSummaryItem {
+  subject_id: string;
+  artifact_id: string;
+  score_total: number;
+  score_band: string;
+  recommended_action: string;
+  blocking_findings_count: number;
+}
+
+export interface SessionHarnessContext {
+  workId: string;
+  workState: WorkStateItem | null;
+  reconciliation: ReconciliationItem | null;
+  dispatchPlan: DispatchPlanItem | null;
+}
+
+export interface HarnessSnapshot {
+  dispatchPlan: DispatchPlanItem[];
+  workState: WorkStateItem[];
+  reconciliationState: ReconciliationItem[];
+  scoreSummaryByTicket: ScoreSummaryItem[];
+  needsRescore: ScoreSummaryItem[];
+}
+
+/** Work-first orchestrator console view model */
+export interface WorkCard {
+  workId: string;
+  title: string;
+  status: string;
+  recommendedAction: string;
+  reason: string;
+  scoreBand?: string;
+  blockingFindings?: number;
+  activeSessionId?: string | null;
+}
+
+/** Detailed work state for Inbox -> Work Detail flow */
+export interface WorkDetail {
+  workId: string;
+  status: string;
+  reconciliationAction?: string | null;
+  latestDecision?: string | null;
+  latestScorecard?: string | null;
+  allowedActions: string[];
+  blocker?: string | null;
+  stopCondition?: string | null;
+  activeSessionId?: string | null;
+}
+
+/** Fixed response envelope for Orchestrator Chat */
+export interface OrchestratorAnswer {
+  state: string;
+  blocker?: string | null;
+  allowedActions: string[];
+  recommendedAction: string;
+  evidence: string[];
 }
 
 /** SSE snapshot event from /api/events */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -553,9 +553,15 @@ importers:
       '@composio/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code
+      '@composio/ao-plugin-agent-codex':
+        specifier: workspace:*
+        version: link:../plugins/agent-codex
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@composio/ao-plugin-runtime-process':
+        specifier: workspace:*
+        version: link:../plugins/runtime-process
       '@composio/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux


### PR DESCRIPTION
## Summary
- Add harness-aware dashboard components (HarnessPlanPanel, OperatorQueue, QuickCommandDeck, RecentActivityFeed, SessionHarnessPanel)
- Add repo-policy module for session governance with comprehensive tests
- Enhance session-manager with runtime validation and policy enforcement
- Add PR merge API route and session detail harness panel
- Extend runtime-process and runtime-tmux plugins with improved lifecycle handling
- Add `sanitizeGhEnv()` to scm-github and tracker-github for reliable gh CLI auth (prevents invalid GH_TOKEN from breaking gh operations)
- Add E2E test flows for dashboard and operator workflows
- Add dashboard-controls and expanded component/API test coverage

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` — 379 passed, 17 pre-existing failures (unrelated to this PR)
- [x] gitleaks secret scan passes
- [ ] CI checks pass on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)