### PR TITLE
fix: suppress Next.js build warnings and clean fallback summaries

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -332,7 +332,11 @@ function extractSummary(
       line.message?.content &&
       typeof line.message.content === "string"
     ) {
-      const msg = line.message.content.trim();
+      // Strip XML-like system tags (e.g. <local-command-caveat>...</local-command-caveat>,
+      // <system-reminder>...</system-reminder>) that Claude Code injects into messages.
+      const msg = line.message.content
+        .replace(/<[a-zA-Z_-]+>[\s\S]*?<\/[a-zA-Z_-]+>/g, "")
+        .trim();
       if (msg.length > 0) {
         return {
           summary: msg.length > 120 ? msg.substring(0, 120) + "..." : msg,

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,6 +1,20 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   transpilePackages: ["@composio/ao-core"],
+
+  // @composio/core is an optional peer dep of tracker-linear (Composio SDK).
+  // Mark it as external so webpack doesn't fail when it's not installed.
+  serverExternalPackages: ["@composio/core"],
+
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      // Suppress "Critical dependency: the request of a dependency is an expression"
+      // from plugin-registry.ts's dynamic import(pkg). The web app uses explicit
+      // static imports in services.ts instead of loadBuiltins(), so this is safe.
+      config.module.exprContextCritical = false;
+    }
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Add `@composio/core` to `serverExternalPackages` in `next.config.js` to resolve the "Module not found" error from tracker-linear's optional Composio SDK import
- Set `exprContextCritical = false` for server webpack builds to suppress the "Critical dependency: the request of a dependency is an expression" warning from plugin-registry's dynamic `import(pkg)`
- Strip XML system tags (e.g. `<local-command-caveat>`, `<system-reminder>`) from fallback summaries in agent-claude-code so raw markup doesn't leak into the dashboard UI

## Test plan
- [x] `agent-claude-code` tests pass (110/110)
- [ ] Restart dashboard dev server and verify no build warnings
- [ ] Check orchestrator session card no longer shows raw XML tags