### PR TITLE
fix(opencode): use post-launch prompt delivery for spawned agents

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -12,6 +12,7 @@
  */
 
 import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
+import { readFile } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -1435,6 +1436,17 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         /* best effort */
       }
       throw err;
+    }
+
+    // Send system prompt post-launch for orchestrators
+    if (plugins.agent.promptDelivery === "post-launch" && systemPromptFile) {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+        const systemPromptContent = await readFile(systemPromptFile, "utf-8");
+        await plugins.runtime.sendMessage(handle, systemPromptContent);
+      } catch {
+        // Non-fatal: agent is running but didn't receive the system prompt.
+      }
     }
 
     return session;

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -211,29 +211,29 @@ describe("getLaunchCommand (integration)", () => {
     expect(cmd).not.toContain("--prompt");
   });
 
-  it("generates correct command with systemPrompt (only system prompt inlined)", () => {
+  it("generates correct command with systemPrompt (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       systemPrompt: "You are an orchestrator",
       prompt: "do the task",
     });
     expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    // Only system prompt is inlined, task prompt is post-launch
-    expect(cmd).toContain(`exec opencode --session "$SES_ID" --prompt 'You are an orchestrator'`);
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("You are an orchestrator");
     expect(cmd).not.toContain("do the task");
   });
 
-  it("generates correct command with systemPromptFile (only system prompt inlined)", () => {
+  it("generates correct command with systemPromptFile (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       systemPromptFile: "/tmp/orchestrator-prompt.md",
       prompt: "do the task",
     });
     expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
-    // Only system prompt file is inlined, task prompt is post-launch
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/orchestrator-prompt.md\')"',
-    );
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("/tmp/orchestrator-prompt.md");
     expect(cmd).not.toContain("do the task");
   });
 
@@ -248,7 +248,7 @@ describe("getLaunchCommand (integration)", () => {
     expect(cmd).not.toContain("do the task");
   });
 
-  it("combines subagent + systemPrompt + model (task prompt not inlined)", () => {
+  it("combines subagent + systemPrompt + model (all prompts delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       subagent: "oracle",
@@ -260,24 +260,26 @@ describe("getLaunchCommand (integration)", () => {
     expect(cmd).toContain(
       "opencode run --format json --title 'AO:test-1' --agent 'oracle' --model 'gpt-5.2' --command true",
     );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt 'You are an expert' --agent 'oracle' --model 'gpt-5.2'",
-    );
+    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --agent 'oracle' --model 'gpt-5.2'");
     expect(cmd).toContain("--model 'gpt-5.2'");
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("You are an expert");
     expect(cmd).not.toContain("review this code");
   });
 
-  it("systemPromptFile takes precedence over systemPrompt", () => {
+  it("systemPromptFile not inlined (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       systemPrompt: "direct prompt",
       systemPromptFile: "/tmp/file-prompt.md",
     });
-    expect(cmd).toContain("\"$(cat '/tmp/file-prompt.md')\"");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
     expect(cmd).not.toContain("direct prompt");
+    expect(cmd).not.toContain("/tmp/file-prompt.md");
   });
 
-  it("uses prompt with systemPromptFile for orchestrator-style launch", () => {
+  it("orchestrator-style launch without prompt inlining", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       sessionId: "test-orchestrator",
@@ -287,25 +289,31 @@ describe("getLaunchCommand (integration)", () => {
     expect(cmd).toContain(
       "opencode run --format json --title 'AO:test-orchestrator' --command true",
     );
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/orchestrator-prompt.md\')"',
-    );
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("/tmp/orchestrator-prompt.md");
   });
 
-  it("escapes single quotes in systemPrompt", () => {
+  it("handles systemPrompt with special chars (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       systemPrompt: "it's important",
     });
-    expect(cmd).toContain("'it'\\''s important'");
+    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("it's important");
   });
 
-  it("escapes path with single quotes in systemPromptFile", () => {
+  it("handles systemPromptFile with special path (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand({
       ...baseConfig,
       systemPromptFile: "/tmp/it's-prompt.md",
     });
-    expect(cmd).toContain("\"$(cat '/tmp/it'\\''s-prompt.md')\"");
+    expect(cmd).toContain("opencode run --format json --title 'AO:test-1' --command true");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("/tmp/it's-prompt.md");
   });
 
   it("handles prompt with special shell characters (task prompt not inlined)", () => {

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -239,53 +239,57 @@ describe("getLaunchCommand", () => {
     expect(cmd).not.toContain("--prompt");
   });
 
-  it("system prompt inlined for orchestrators", () => {
+  it("system prompt not inlined (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPrompt: "You are an orchestrator" }),
     );
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'You are an orchestrator'");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
   });
 
-  it("system prompt inlined, task prompt post-launch", () => {
+  it("system prompt and task prompt both delivered post-launch", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPrompt: "You are an orchestrator", prompt: "do the task" }),
     );
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'You are an orchestrator'");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
     expect(cmd).not.toContain("do the task");
   });
 
-  it("escapes single quotes in systemPrompt", () => {
+  it("handles systemPrompt with special chars (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPrompt: "it's important" }));
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --prompt 'it'\\''s important'");
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
   });
 
-  it("handles very long systemPrompt", () => {
+  it("handles very long systemPrompt (delivered post-launch)", () => {
     const longPrompt = "A".repeat(500);
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPrompt: longPrompt }));
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd.length).toBeGreaterThan(500);
+    expect(cmd).not.toContain("--prompt");
   });
 
-  it("systemPromptFile inlined via shell substitution", () => {
+  it("systemPromptFile not inlined (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPromptFile: "/tmp/prompt.md" }));
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain('exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/prompt.md\')"');
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
+    expect(cmd).not.toContain("/tmp/prompt.md");
   });
 
-  it("escapes path in systemPromptFile", () => {
+  it("handles systemPromptFile with special path (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ systemPromptFile: "/tmp/it's-prompt.md" }),
     );
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/it'\\''s-prompt.md')\"",
-    );
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
   });
 
-  it("systemPromptFile takes precedence over systemPrompt", () => {
+  it("systemPromptFile ignored in launch command (delivered post-launch)", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         systemPrompt: "direct prompt",
@@ -293,13 +297,13 @@ describe("getLaunchCommand", () => {
       }),
     );
     expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --command true");
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/file-prompt.md\')"',
-    );
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
     expect(cmd).not.toContain("direct prompt");
+    expect(cmd).not.toContain("/tmp/file-prompt.md");
   });
 
-  it("combines systemPromptFile with subagent, task prompt post-launch", () => {
+  it("systemPromptFile with subagent, all prompts delivered post-launch", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         systemPromptFile: "/tmp/orchestrator.md",
@@ -310,14 +314,14 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain(
       "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus' --command true",
     );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/orchestrator.md')\" --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --agent 'sisyphus'");
     expect(cmd).toContain("--agent 'sisyphus");
+    expect(cmd).not.toContain("--prompt");
     expect(cmd).not.toContain("fix the bug");
+    expect(cmd).not.toContain("/tmp/orchestrator.md");
   });
 
-  it("generates orchestrator-style systemPromptFile launch", () => {
+  it("generates orchestrator-style launch without prompt inlining", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         sessionId: "my-orchestrator",
@@ -326,12 +330,11 @@ describe("getLaunchCommand", () => {
       }),
     );
     expect(cmd).toContain("opencode run --format json --title 'AO:my-orchestrator' --command true");
-    expect(cmd).toContain(
-      'exec opencode --session "$SES_ID" --prompt "$(cat \'/tmp/orchestrator.md\')"',
-    );
+    expect(cmd).toContain('exec opencode --session "$SES_ID"');
+    expect(cmd).not.toContain("--prompt");
   });
 
-  it("combines systemPromptFile with subagent and task prompt post-launch", () => {
+  it("systemPromptFile with subagent, prompts delivered post-launch", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({
         systemPromptFile: "/tmp/orchestrator.md",
@@ -342,10 +345,10 @@ describe("getLaunchCommand", () => {
     expect(cmd).toContain(
       "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus' --command true",
     );
-    expect(cmd).toContain(
-      "exec opencode --session \"$SES_ID\" --prompt \"$(cat '/tmp/orchestrator.md')\" --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("exec opencode --session \"$SES_ID\" --agent 'sisyphus'");
+    expect(cmd).not.toContain("--prompt");
     expect(cmd).not.toContain("fix the bug");
+    expect(cmd).not.toContain("/tmp/orchestrator.md");
   });
 
   it("prompt with special characters not inlined (post-launch delivery)", () => {

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -180,15 +180,6 @@ function createOpenCodeAgent(): Agent {
         sharedOptions.push("--model", shellEscape(config.model));
       }
 
-      // Build system prompt value for orchestrators (still inlined in launch command)
-      // Task prompt (config.prompt) is delivered post-launch via runtime.sendMessage()
-      let systemPromptValue: string | undefined;
-      if (config.systemPromptFile) {
-        systemPromptValue = `"$(cat ${shellEscape(config.systemPromptFile)})"`;
-      } else if (config.systemPrompt) {
-        systemPromptValue = shellEscape(config.systemPrompt);
-      }
-
       if (!existingSessionId) {
         const runOptions = [
           "--format",
@@ -200,11 +191,7 @@ function createOpenCodeAgent(): Agent {
         const captureScript = buildSessionIdCaptureScript();
         const fallbackScript = buildSessionLookupScript();
         const runCommand = ["opencode", "run", ...runOptions, "--command", "true"].join(" ");
-        const resumeOptions = [
-          ...(systemPromptValue ? ["--prompt", systemPromptValue] : []),
-          ...sharedOptions,
-        ];
-        const resumeOptionsSuffix = resumeOptions.length > 0 ? ` ${resumeOptions.join(" ")}` : "";
+        const resumeOptionsSuffix = sharedOptions.length > 0 ? ` ${sharedOptions.join(" ")}` : "";
         const missingSessionError = shellEscape(
           `failed to discover OpenCode session ID for AO:${config.sessionId}`,
         );
@@ -213,10 +200,6 @@ function createOpenCodeAgent(): Agent {
           `if [ -z "$SES_ID" ]; then SES_ID=$(opencode session list --format json | node -e ${shellEscape(fallbackScript)} ${shellEscape(`AO:${config.sessionId}`)}); fi`,
           `[ -n "$SES_ID" ] && exec opencode --session "$SES_ID"${resumeOptionsSuffix}; echo ${missingSessionError} >&2; exit 1`,
         ].join("; ");
-      }
-
-      if (systemPromptValue) {
-        options.push("--prompt", systemPromptValue);
       }
 
       options.push(...sharedOptions);


### PR DESCRIPTION
## Summary
- Fixed bug where newly spawned OpenCode agents didn't receive their initial prompt
- Added `promptDelivery: "post-launch"` to the OpenCode agent plugin
- Removed prompt inlining from `getLaunchCommand()` - prompts are now delivered via `runtime.sendMessage()` after a 5s delay
- Updated tests to verify the post-launch delivery pattern

## Root Cause
The OpenCode agent plugin was missing the `promptDelivery: "post-launch"` property. Without this, the session manager inlined prompts in the launch command via `--prompt` flag, which created race conditions where the session wasn't ready to receive input, leaving spawned agents idle.

## Fix
Matches the pattern used by `agent-claude-code`: agent starts in interactive mode, then prompt is delivered via `runtime.sendMessage()` after initialization.

## Test plan
- [ ] All existing tests pass with updated expectations
- [ ] Spawn a new OpenCode agent and verify it receives the prompt and begins working