### PR TITLE
feat: add docker runtime and runtime selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ projects:
     path: ~/my-app
     defaultBranch: main
     sessionPrefix: app
+    # runtime: docker
+    # runtimeConfig:
+    #   image: ghcr.io/your-org/ao-agent:latest
+    #   passHostEnv: [OPENAI_API_KEY, ANTHROPIC_API_KEY, GITHUB_TOKEN]
 
 reactions:
   ci-failed:
@@ -135,6 +139,21 @@ reactions:
     action: notify
 ```
 
+Temporary runtime override for a single command:
+
+```bash
+ao spawn my-app --runtime docker
+ao start my-app --runtime docker
+```
+
+Permanent project runtime:
+
+```bash
+ao runtime show my-app
+ao runtime set my-app docker
+ao runtime clear my-app
+```
+
 CI fails → agent gets the logs and fixes it. Reviewer requests changes → agent addresses them. PR approved with green CI → you get a notification to merge.
 
 See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the full reference.
@@ -147,6 +166,7 @@ ao spawn <project> [issue]             # Spawn an agent
 ao send <session> "Fix the tests"      # Send instructions
 ao session ls                          # List sessions
 ao session kill <session>              # Kill a session
+ao runtime set <project> <runtime>     # Persist a project runtime
 ao session restore <session>           # Revive a crashed agent
 ao dashboard                           # Open web dashboard
 ao doctor [--fix]                      # Check install, runtime, and stale temp issues

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -17,14 +17,14 @@ port: 3000
 
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
-  runtime: tmux           # tmux | process | docker | kubernetes | ssh | e2b
-  agent: claude-code      # claude-code | codex | aider | goose | custom
+  runtime: tmux # tmux | process | docker | kubernetes | ssh | e2b
+  agent: claude-code # claude-code | codex | aider | goose | custom
   # orchestrator:
   #   agent: claude-code
   # worker:
   #   agent: codex
-  workspace: worktree     # worktree | clone | copy
-  notifiers: [desktop]    # desktop | slack | discord | webhook | email
+  workspace: worktree # worktree | clone | copy
+  notifiers: [desktop] # desktop | slack | discord | webhook | email
 
 # Projects — at minimum, specify repo and path
 projects:
@@ -62,6 +62,18 @@ projects:
     # agentConfig:
     #   permissions: skip    # --dangerously-skip-permissions
     #   model: opus
+
+    # Runtime-specific config (used by the selected runtime plugin)
+    # runtimeConfig:
+    #   image: ghcr.io/your-org/ao-agent:latest
+    #   mountHome: true
+    #   passHostEnv: [OPENAI_API_KEY, ANTHROPIC_API_KEY, GITHUB_TOKEN]
+    #   mounts:
+    #     - ~/.codex:~/.codex
+    #     - ~/.ao:~/.ao
+    #   extraArgs:
+    #     - --network
+    #     - host
 
     # Optional role-specific agent overrides
     # orchestrator:

--- a/packages/cli/__tests__/commands/open.test.ts
+++ b/packages/cli/__tests__/commands/open.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const { mockExec, mockConfigRef, mockTmux } = vi.hoisted(() => ({
+const { mockExec, mockConfigRef, mockTmux, mockSessionManager } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockTmux: vi.fn(),
   mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockSessionManager: {
+    list: vi.fn(),
+  },
 }));
 
 vi.mock("../../src/lib/shell.js", () => ({
@@ -24,11 +27,23 @@ vi.mock("@composio/ao-core", () => ({
   loadConfig: () => mockConfigRef.current,
 }));
 
+vi.mock("../../src/lib/create-session-manager.js", () => ({
+  getSessionManager: async () => mockSessionManager,
+}));
+
 import { Command } from "commander";
 import { registerOpen } from "../../src/commands/open.js";
 
 let program: Command;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+function makeSession(id: string, projectId: string) {
+  return {
+    id,
+    projectId,
+    runtimeHandle: { id, runtimeName: "tmux", data: {} },
+  };
+}
 
 beforeEach(() => {
   mockConfigRef.current = {
@@ -72,7 +87,13 @@ beforeEach(() => {
 
   mockExec.mockReset();
   mockTmux.mockReset();
+  mockSessionManager.list.mockReset();
   mockExec.mockResolvedValue({ stdout: "", stderr: "" });
+  mockSessionManager.list.mockResolvedValue([
+    makeSession("app-1", "my-app"),
+    makeSession("app-2", "my-app"),
+    makeSession("backend-1", "backend"),
+  ]);
 });
 
 afterEach(() => {
@@ -81,11 +102,6 @@ afterEach(() => {
 
 describe("open command", () => {
   it("opens all sessions when target is 'all'", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2\nbackend-1";
-      return null;
-    });
-
     await program.parseAsync(["node", "test", "open", "all"]);
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
@@ -96,10 +112,7 @@ describe("open command", () => {
   });
 
   it("opens all sessions when no target given", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession("app-1", "my-app")]);
 
     await program.parseAsync(["node", "test", "open"]);
 
@@ -108,11 +121,6 @@ describe("open command", () => {
   });
 
   it("opens sessions for a specific project", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2\nbackend-1";
-      return null;
-    });
-
     await program.parseAsync(["node", "test", "open", "my-app"]);
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
@@ -123,11 +131,6 @@ describe("open command", () => {
   });
 
   it("opens a single session by name", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1\napp-2";
-      return null;
-    });
-
     await program.parseAsync(["node", "test", "open", "app-1"]);
 
     const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
@@ -136,10 +139,7 @@ describe("open command", () => {
   });
 
   it("rejects unknown target", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession("app-1", "my-app")]);
 
     await expect(program.parseAsync(["node", "test", "open", "nonexistent"])).rejects.toThrow(
       "process.exit(1)",
@@ -147,10 +147,7 @@ describe("open command", () => {
   });
 
   it("passes --new-window flag to open-iterm-tab", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession("app-1", "my-app")]);
 
     await program.parseAsync(["node", "test", "open", "-w", "app-1"]);
 
@@ -158,10 +155,7 @@ describe("open command", () => {
   });
 
   it("falls back gracefully when open-iterm-tab fails", async () => {
-    mockTmux.mockImplementation(async (...args: string[]) => {
-      if (args[0] === "list-sessions") return "app-1";
-      return null;
-    });
+    mockSessionManager.list.mockResolvedValue([makeSession("app-1", "my-app")]);
     mockExec.mockRejectedValue(new Error("command not found"));
 
     await program.parseAsync(["node", "test", "open", "app-1"]);
@@ -171,7 +165,7 @@ describe("open command", () => {
   });
 
   it("shows 'No sessions to open' when none exist", async () => {
-    mockTmux.mockResolvedValue(null);
+    mockSessionManager.list.mockResolvedValue([]);
 
     await program.parseAsync(["node", "test", "open", "my-app"]);
 

--- a/packages/cli/__tests__/commands/runtime.test.ts
+++ b/packages/cli/__tests__/commands/runtime.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Command } from "commander";
+import { loadConfig } from "@composio/ao-core";
+import { registerRuntime } from "../../src/commands/runtime.js";
+
+let tmpDir: string;
+let configPath: string;
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ao-runtime-test-"));
+  mkdirSync(join(tmpDir, "my-app"), { recursive: true });
+  mkdirSync(join(tmpDir, "backend"), { recursive: true });
+  configPath = join(tmpDir, "agent-orchestrator.yaml");
+  writeFileSync(
+    configPath,
+    [
+      "defaults:",
+      "  runtime: tmux",
+      "  agent: claude-code",
+      "  workspace: worktree",
+      "  notifiers: [desktop]",
+      "projects:",
+      "  my-app:",
+      "    name: My App",
+      "    repo: org/my-app",
+      `    path: ${join(tmpDir, "my-app")}`,
+      "    defaultBranch: main",
+      "    sessionPrefix: app",
+      "  backend:",
+      "    name: Backend",
+      "    repo: org/backend",
+      `    path: ${join(tmpDir, "backend")}`,
+      "    defaultBranch: main",
+      "    sessionPrefix: api",
+      "    runtime: docker",
+      "    runtimeConfig:",
+      "      image: ghcr.io/example/ao-agent:latest",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+  process.env["AO_CONFIG_PATH"] = configPath;
+
+  program = new Command();
+  program.exitOverride();
+  registerRuntime(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation((code) => {
+    throw new Error(`process.exit(${code})`);
+  });
+});
+
+afterEach(() => {
+  delete process.env["AO_CONFIG_PATH"];
+  rmSync(tmpDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("runtime command", () => {
+  it("shows effective runtimes for all projects", async () => {
+    await program.parseAsync(["node", "test", "runtime", "show"]);
+
+    const output = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("my-app");
+    expect(output).toContain("tmux (defaults.runtime)");
+    expect(output).toContain("backend");
+    expect(output).toContain("docker (project config)");
+  });
+
+  it("persists a project runtime override", async () => {
+    await program.parseAsync(["node", "test", "runtime", "set", "my-app", "docker"]);
+
+    const config = loadConfig(configPath);
+    expect(config.projects["my-app"]?.runtime).toBe("docker");
+    expect(readFileSync(configPath, "utf-8")).toContain("runtime: docker");
+
+    const output = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Runtime for my-app set to docker");
+  });
+
+  it("clears a project runtime override", async () => {
+    await program.parseAsync(["node", "test", "runtime", "clear", "backend"]);
+
+    const config = loadConfig(configPath);
+    expect(config.projects["backend"]?.runtime).toBeUndefined();
+
+    const output = consoleLogSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(output).toContain("Runtime override cleared for backend");
+    expect(output).toContain("tmux (defaults.runtime)");
+  });
+
+  it("rejects unknown projects", async () => {
+    await expect(
+      program.parseAsync(["node", "test", "runtime", "set", "unknown", "docker"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const errors = consoleErrorSpy.mock.calls.map((call) => call.join(" ")).join("\n");
+    expect(errors).toContain("Unknown project: unknown");
+  });
+});

--- a/packages/cli/__tests__/commands/session.test.ts
+++ b/packages/cli/__tests__/commands/session.test.ts
@@ -410,17 +410,14 @@ describe("session attach", () => {
       metadata: {},
     } satisfies Session);
 
-    mockTmux.mockResolvedValue("");
-
     await program.parseAsync(["node", "test", "session", "attach", "app-1"]);
 
-    expect(mockTmux).toHaveBeenCalledWith("has-session", "-t", "tmux-target-1");
     expect(mockSpawn).toHaveBeenCalledWith("tmux", ["attach", "-t", "tmux-target-1"], {
       stdio: "inherit",
     });
   });
 
-  it("fails when tmux session does not exist", async () => {
+  it("fails when the session cannot be resolved", async () => {
     mockSessionManager.get.mockResolvedValue(null);
     mockTmux.mockResolvedValue(null);
 

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -312,6 +312,40 @@ describe("spawn command", () => {
     });
   });
 
+  it("passes --runtime flag to sessionManager.spawn()", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "docker-app-1", runtimeName: "docker", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+    mockExec
+      .mockResolvedValueOnce({ stdout: "Docker version 27.0", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "Server: Docker Engine", stderr: "" });
+
+    await program.parseAsync(["node", "test", "spawn", "my-app", "--runtime", "docker"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: undefined,
+      agent: undefined,
+      runtime: "docker",
+    });
+    expect(mockExec).toHaveBeenCalledWith("docker", ["--version"]);
+    expect(mockExec).toHaveBeenCalledWith("docker", ["info"]);
+  });
+
   it("rejects unknown project ID", async () => {
     await expect(program.parseAsync(["node", "test", "spawn", "nonexistent"])).rejects.toThrow(
       "process.exit(1)",
@@ -526,6 +560,34 @@ describe("spawn pre-flight checks", () => {
     await program.parseAsync(["node", "test", "spawn", "my-app"]);
 
     expect(mockSessionManager.spawn).toHaveBeenCalled();
+  });
+
+  it("uses runtime override for preflight even when project defaults to tmux", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "docker-app-1", runtimeName: "docker", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+    mockExec
+      .mockResolvedValueOnce({ stdout: "Docker version 27.0", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "Server: Docker Engine", stderr: "" });
+
+    await program.parseAsync(["node", "test", "spawn", "my-app", "--runtime", "docker"]);
+
+    expect(mockExec).not.toHaveBeenCalledWith("tmux", ["-V"]);
+    expect(mockExec).toHaveBeenCalledWith("docker", ["--version"]);
+    expect(mockExec).toHaveBeenCalledWith("docker", ["info"]);
   });
 
   it("checks gh auth when tracker is github", async () => {

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -24,6 +24,10 @@ const {
   mockSpawn,
   mockEnsureLifecycleWorker,
   mockStopLifecycleWorker,
+  mockCheckPort,
+  mockCheckBuilt,
+  mockCheckTmux,
+  mockCheckDocker,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockExecSilent: vi.fn(),
@@ -42,6 +46,10 @@ const {
   mockSpawn: vi.fn(),
   mockEnsureLifecycleWorker: vi.fn(),
   mockStopLifecycleWorker: vi.fn(),
+  mockCheckPort: vi.fn(),
+  mockCheckBuilt: vi.fn(),
+  mockCheckTmux: vi.fn(),
+  mockCheckDocker: vi.fn(),
 }));
 
 vi.mock("../../src/lib/shell.js", () => ({
@@ -111,8 +119,10 @@ vi.mock("../../src/lib/dashboard-rebuild.js", () => ({
 
 vi.mock("../../src/lib/preflight.js", () => ({
   preflight: {
-    checkPort: vi.fn(),
-    checkBuilt: vi.fn(),
+    checkPort: (...args: unknown[]) => mockCheckPort(...args),
+    checkBuilt: (...args: unknown[]) => mockCheckBuilt(...args),
+    checkTmux: (...args: unknown[]) => mockCheckTmux(...args),
+    checkDocker: (...args: unknown[]) => mockCheckDocker(...args),
   },
 }));
 
@@ -174,6 +184,14 @@ beforeEach(() => {
   });
   mockStopLifecycleWorker.mockReset();
   mockStopLifecycleWorker.mockResolvedValue(true);
+  mockCheckPort.mockReset();
+  mockCheckPort.mockResolvedValue(undefined);
+  mockCheckBuilt.mockReset();
+  mockCheckBuilt.mockResolvedValue(undefined);
+  mockCheckTmux.mockReset();
+  mockCheckTmux.mockResolvedValue(undefined);
+  mockCheckDocker.mockReset();
+  mockCheckDocker.mockResolvedValue(undefined);
   mockSpawn.mockClear();
 });
 
@@ -616,6 +634,34 @@ describe("start command — browser open waits for port", () => {
       expect.objectContaining({ configPath: expect.any(String) }),
       "my-app",
     );
+  });
+});
+
+describe("start command — runtime override", () => {
+  it("passes --runtime to orchestrator spawn and uses matching preflight", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({
+      id: "app-orchestrator",
+      runtimeHandle: { id: "docker-app-orchestrator", runtimeName: "docker", data: {} },
+      metadata: {},
+    });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard", "--runtime", "docker"]);
+
+    expect(mockCheckDocker).toHaveBeenCalledTimes(1);
+    expect(mockCheckTmux).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
+      projectId: "my-app",
+      systemPrompt: expect.any(String),
+      runtime: "docker",
+    });
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("docker (--runtime)");
+    expect(output).toContain("docker attach docker-app-orchestrator");
   });
 });
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -43,6 +43,7 @@
     "@composio/ao-plugin-notifier-openclaw": "workspace:*",
     "@composio/ao-plugin-notifier-slack": "workspace:*",
     "@composio/ao-plugin-notifier-webhook": "workspace:*",
+    "@composio/ao-plugin-runtime-docker": "workspace:*",
     "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",

--- a/packages/cli/src/commands/open.ts
+++ b/packages/cli/src/commands/open.ts
@@ -1,8 +1,9 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
-import { exec, getTmuxSessions } from "../lib/shell.js";
-import { matchesPrefix } from "../lib/session-utils.js";
+import { exec } from "../lib/shell.js";
+import { getSessionManager } from "../lib/create-session-manager.js";
+import { getAttachCommand } from "../lib/runtime.js";
 
 async function openInTerminal(sessionName: string, newWindow?: boolean): Promise<boolean> {
   try {
@@ -10,7 +11,7 @@ async function openInTerminal(sessionName: string, newWindow?: boolean): Promise
     await exec("open-iterm-tab", args);
     return true;
   } catch {
-    // Fall back to tmux attach hint
+    // Fall back to attach hint
     return false;
   }
 }
@@ -23,25 +24,16 @@ export function registerOpen(program: Command): void {
     .option("-w, --new-window", "Open in a new terminal window")
     .action(async (target: string | undefined, opts: { newWindow?: boolean }) => {
       const config = loadConfig();
-      const allTmux = await getTmuxSessions();
+      const sm = await getSessionManager(config);
+      const sessions = await sm.list();
 
-      let sessionsToOpen: string[] = [];
+      let sessionsToOpen = sessions;
 
       if (!target || target === "all") {
-        // Open all sessions across all projects
-        for (const [projectId, project] of Object.entries(config.projects)) {
-          const prefix = project.sessionPrefix || projectId;
-          const matching = allTmux.filter((s) => matchesPrefix(s, prefix));
-          sessionsToOpen.push(...matching);
-        }
       } else if (config.projects[target]) {
-        // Open all sessions for a specific project
-        const project = config.projects[target];
-        const prefix = project.sessionPrefix || target;
-        sessionsToOpen = allTmux.filter((s) => matchesPrefix(s, prefix));
-      } else if (allTmux.includes(target)) {
-        // Open a specific session
-        sessionsToOpen = [target];
+        sessionsToOpen = sessions.filter((session) => session.projectId === target);
+      } else if (sessions.some((session) => session.id === target)) {
+        sessionsToOpen = sessions.filter((session) => session.id === target);
       } else {
         console.error(
           chalk.red(`Unknown target: ${target}\nSpecify a session name, project ID, or "all".`),
@@ -60,13 +52,27 @@ export function registerOpen(program: Command): void {
         ),
       );
 
-      for (const session of sessionsToOpen.sort()) {
-        const opened = await openInTerminal(session, opts.newWindow);
-        if (opened) {
-          console.log(chalk.green(`  Opened: ${session}`));
+      for (const session of sessionsToOpen.sort((a, b) => a.id.localeCompare(b.id))) {
+        const runtimeName = session.runtimeHandle?.runtimeName ?? "tmux";
+        if (runtimeName === "tmux") {
+          const opened = await openInTerminal(
+            session.runtimeHandle?.id ?? session.id,
+            opts.newWindow,
+          );
+          if (opened) {
+            console.log(chalk.green(`  Opened: ${session.id}`));
+            continue;
+          }
+        }
+
+        console.log(
+          `  ${chalk.yellow(session.id)} — attach with: ${chalk.dim(getAttachCommand(session.runtimeHandle, session.id))}`,
+        );
+        if (runtimeName !== "tmux") {
+          console.log(chalk.dim(`    iTerm auto-open is only supported for tmux sessions.`));
         } else {
           console.log(
-            `  ${chalk.yellow(session)} — attach with: ${chalk.dim(`tmux attach -t ${session}`)}`,
+            chalk.dim(`    open-iterm-tab is unavailable; use the attach command above.`),
           );
         }
       }

--- a/packages/cli/src/commands/runtime.ts
+++ b/packages/cli/src/commands/runtime.ts
@@ -1,0 +1,112 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import chalk from "chalk";
+import type { Command } from "commander";
+import { loadConfig } from "@composio/ao-core";
+import { parseDocument } from "yaml";
+import { formatRuntimeSelection, getRuntimeSelection } from "../lib/runtime-selection.js";
+
+function requireProject(projectId: string) {
+  const config = loadConfig();
+  const project = config.projects[projectId];
+  if (!project) {
+    console.error(
+      chalk.red(
+        `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+      ),
+    );
+    process.exit(1);
+  }
+  return { config, project };
+}
+
+function parseConfigDocument(configPath: string) {
+  const doc = parseDocument(readFileSync(configPath, "utf-8"));
+  if (doc.errors.length > 0) {
+    throw new Error(doc.errors.map((error) => error.message).join("; "));
+  }
+  return doc;
+}
+
+function writeConfigDocument(
+  configPath: string,
+  doc: ReturnType<typeof parseConfigDocument>,
+): void {
+  writeFileSync(configPath, String(doc), "utf-8");
+}
+
+export function registerRuntime(program: Command): void {
+  const runtime = program
+    .command("runtime")
+    .description("Inspect or persist runtime selection for projects");
+
+  runtime
+    .command("show")
+    .description("Show the effective runtime for one project or all projects")
+    .argument("[project]", "Project ID from config")
+    .action((projectId?: string) => {
+      const config = loadConfig();
+      const projectIds = projectId ? [projectId] : Object.keys(config.projects);
+
+      if (projectId && !config.projects[projectId]) {
+        console.error(
+          chalk.red(
+            `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+          ),
+        );
+        process.exit(1);
+      }
+
+      for (const id of projectIds) {
+        const selection = getRuntimeSelection(config, id);
+        console.log(`${chalk.bold(id)}: ${chalk.dim(formatRuntimeSelection(selection))}`);
+      }
+      console.log(chalk.dim(`Config: ${config.configPath}`));
+    });
+
+  runtime
+    .command("set")
+    .description("Persist a runtime override for a project in agent-orchestrator.yaml")
+    .argument("<project>", "Project ID from config")
+    .argument("<runtime>", "Runtime plugin name to persist (e.g. tmux, docker)")
+    .action((projectId: string, runtimeName: string) => {
+      const normalizedRuntime = runtimeName.trim();
+      if (!normalizedRuntime) {
+        console.error(chalk.red("Runtime name cannot be empty."));
+        process.exit(1);
+      }
+
+      const { config, project } = requireProject(projectId);
+      const doc = parseConfigDocument(config.configPath);
+      doc.setIn(["projects", projectId, "runtime"], normalizedRuntime);
+      writeConfigDocument(config.configPath, doc);
+
+      console.log(chalk.green(`Runtime for ${projectId} set to ${normalizedRuntime}.`));
+      console.log(chalk.dim(`Config: ${config.configPath}`));
+      if (normalizedRuntime === "docker" && !project.runtimeConfig?.["image"]) {
+        console.log(
+          chalk.yellow(
+            "Docker runtime is now enabled for this project. Add projects." +
+              `${projectId}.runtimeConfig.image to run sessions successfully.`,
+          ),
+        );
+      }
+    });
+
+  runtime
+    .command("clear")
+    .description("Remove a project runtime override so it falls back to defaults.runtime")
+    .argument("<project>", "Project ID from config")
+    .action((projectId: string) => {
+      const { config } = requireProject(projectId);
+      const doc = parseConfigDocument(config.configPath);
+      doc.deleteIn(["projects", projectId, "runtime"]);
+      writeConfigDocument(config.configPath, doc);
+
+      console.log(
+        chalk.green(
+          `Runtime override cleared for ${projectId}. Now using ${config.defaults.runtime} (defaults.runtime).`,
+        ),
+      );
+      console.log(chalk.dim(`Config: ${config.configPath}`));
+    });
+}

--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -1,11 +1,10 @@
-import { spawn } from "node:child_process";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig, SessionNotRestorableError, WorkspaceMissingError } from "@composio/ao-core";
-import { git, getTmuxActivity, tmux } from "../lib/shell.js";
-import { formatAge } from "../lib/format.js";
+import { git } from "../lib/shell.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { isOrchestratorSessionName } from "../lib/session-utils.js";
+import { attachToRuntime, getAttachCommand, getLastActivityLabel } from "../lib/runtime.js";
 
 export function registerSession(program: Command): void {
   const session = program
@@ -59,10 +58,7 @@ export function registerSession(program: Command): void {
             if (liveBranch) branchStr = liveBranch;
           }
 
-          // Get tmux activity age
-          const tmuxTarget = s.runtimeHandle?.id ?? s.id;
-          const activityTs = await getTmuxActivity(tmuxTarget);
-          const age = activityTs ? formatAge(activityTs) : "-";
+          const age = await getLastActivityLabel(s);
 
           const parts = [chalk.green(s.id), chalk.dim(`(${age})`)];
           if (branchStr) parts.push(chalk.cyan(branchStr));
@@ -78,32 +74,22 @@ export function registerSession(program: Command): void {
 
   session
     .command("attach")
-    .description("Attach to a session's tmux window")
+    .description("Attach to a session")
     .argument("<session>", "Session name to attach")
     .action(async (sessionName: string) => {
       const config = loadConfig();
       const sm = await getSessionManager(config);
       const sessionInfo = await sm.get(sessionName);
-      const tmuxTarget = sessionInfo?.runtimeHandle?.id ?? sessionName;
-
-      const exists = await tmux("has-session", "-t", tmuxTarget);
-      if (exists === null) {
+      if (!sessionInfo) {
         console.error(chalk.red(`Session '${sessionName}' does not exist`));
         process.exit(1);
       }
 
-      await new Promise<void>((resolve, reject) => {
-        const child = spawn("tmux", ["attach", "-t", tmuxTarget], { stdio: "inherit" });
-        child.once("error", (err) => reject(err));
-        child.once("exit", (code) => {
-          if (code === 0 || code === null) {
-            resolve();
-            return;
-          }
-          reject(new Error(`tmux attach exited with code ${code}`));
-        });
-      }).catch((err) => {
+      await attachToRuntime(sessionInfo.runtimeHandle, sessionName).catch((err) => {
         console.error(chalk.red(`Failed to attach to session ${sessionName}: ${err}`));
+        console.error(
+          chalk.dim(`Attach command: ${getAttachCommand(sessionInfo.runtimeHandle, sessionName)}`),
+        );
         process.exit(1);
       });
     });
@@ -292,8 +278,9 @@ export function registerSession(program: Command): void {
         if (restored.branch) {
           console.log(chalk.dim(`  Branch:   ${restored.branch}`));
         }
-        const tmuxTarget = restored.runtimeHandle?.id ?? sessionName;
-        console.log(chalk.dim(`  Attach:   tmux attach -t ${tmuxTarget}`));
+        console.log(
+          chalk.dim(`  Attach:   ${getAttachCommand(restored.runtimeHandle, sessionName)}`),
+        );
       } catch (err) {
         if (err instanceof SessionNotRestorableError) {
           console.error(chalk.red(`Cannot restore: ${err.reason}`));

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -17,6 +17,8 @@ import { banner } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
+import { getAttachCommand } from "../lib/runtime.js";
+import { formatRuntimeSelection, getRuntimeSelection } from "../lib/runtime-selection.js";
 
 interface SpawnClaimOptions {
   claimPr?: string;
@@ -32,11 +34,14 @@ async function runSpawnPreflight(
   config: OrchestratorConfig,
   projectId: string,
   options?: SpawnClaimOptions,
+  runtimeOverride?: string,
 ): Promise<void> {
   const project = config.projects[projectId];
-  const runtime = project?.runtime ?? config.defaults.runtime;
+  const runtime = getRuntimeSelection(config, projectId, runtimeOverride).name;
   if (runtime === "tmux") {
     await preflight.checkTmux();
+  } else if (runtime === "docker") {
+    await preflight.checkDocker();
   }
   const needsGitHubAuth =
     project?.tracker?.plugin === "github" ||
@@ -53,6 +58,7 @@ async function spawnSession(
   openTab?: boolean,
   agent?: string,
   claimOptions?: SpawnClaimOptions,
+  runtime?: string,
 ): Promise<string> {
   const spinner = ora("Creating session").start();
 
@@ -64,10 +70,12 @@ async function spawnSession(
       projectId,
       issueId,
       agent,
+      runtime,
     });
 
     let branchStr = session.branch ?? "";
     let claimedPrUrl: string | null = null;
+    const runtimeSelection = getRuntimeSelection(config, projectId, runtime);
 
     if (claimOptions?.claimPr) {
       spinner.text = `Claiming PR ${claimOptions.claimPr}`;
@@ -94,16 +102,20 @@ async function spawnSession(
     console.log(`  Worktree: ${chalk.dim(session.workspacePath ?? "-")}`);
     if (branchStr) console.log(`  Branch:   ${chalk.dim(branchStr)}`);
     if (claimedPrUrl) console.log(`  PR:       ${chalk.dim(claimedPrUrl)}`);
+    console.log(`  Runtime:  ${chalk.dim(formatRuntimeSelection(runtimeSelection))}`);
+    if (runtimeSelection.source === "flag") {
+      console.log(chalk.dim(`  Persist:  ao runtime set ${projectId} ${runtimeSelection.name}`));
+    }
 
-    // Show the tmux name for attaching (stored in metadata or runtimeHandle)
-    const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-    console.log(`  Attach:   ${chalk.dim(`tmux attach -t ${tmuxTarget}`)}`);
+    console.log(`  Attach:   ${chalk.dim(getAttachCommand(session.runtimeHandle, session.id))}`);
     console.log();
 
     // Open terminal tab if requested
     if (openTab) {
       try {
-        await exec("open-iterm-tab", [tmuxTarget]);
+        if ((session.runtimeHandle?.runtimeName ?? "tmux") === "tmux") {
+          await exec("open-iterm-tab", [session.runtimeHandle?.id ?? session.id]);
+        }
       } catch {
         // Terminal plugin not available
       }
@@ -126,6 +138,7 @@ export function registerSpawn(program: Command): void {
     .argument("[issue]", "Issue identifier (e.g. INT-1234, #42) - must exist in tracker")
     .option("--open", "Open session in terminal tab")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
+    .option("--runtime <name>", "Temporarily override the runtime plugin (e.g. tmux, docker)")
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--decompose", "Decompose issue into subtasks before spawning")
@@ -137,6 +150,7 @@ export function registerSpawn(program: Command): void {
         opts: {
           open?: boolean;
           agent?: string;
+          runtime?: string;
           claimPr?: string;
           assignOnGithub?: boolean;
           decompose?: boolean;
@@ -164,7 +178,7 @@ export function registerSpawn(program: Command): void {
         };
 
         try {
-          await runSpawnPreflight(config, projectId, claimOptions);
+          await runSpawnPreflight(config, projectId, claimOptions, opts.runtime);
           await ensureLifecycleWorker(config, projectId);
 
           if (opts.decompose && issueId) {
@@ -191,7 +205,15 @@ export function registerSpawn(program: Command): void {
 
             if (leaves.length <= 1) {
               console.log(chalk.yellow("Task is atomic — spawning directly."));
-              await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+              await spawnSession(
+                config,
+                projectId,
+                issueId,
+                opts.open,
+                opts.agent,
+                claimOptions,
+                opts.runtime,
+              );
             } else {
               // Create child issues and spawn sessions with lineage context
               const sm = await getSessionManager(config);
@@ -207,6 +229,7 @@ export function registerSpawn(program: Command): void {
                     lineage: leaf.lineage,
                     siblings,
                     agent: opts.agent,
+                    runtime: opts.runtime,
                   });
                   console.log(`  ${chalk.green("✓")} ${session.id} — ${leaf.description}`);
                 } catch (err) {
@@ -218,7 +241,15 @@ export function registerSpawn(program: Command): void {
               }
             }
           } else {
-            await spawnSession(config, projectId, issueId, opts.open, opts.agent, claimOptions);
+            await spawnSession(
+              config,
+              projectId,
+              issueId,
+              opts.open,
+              opts.agent,
+              claimOptions,
+              opts.runtime,
+            );
           }
         } catch (err) {
           console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
@@ -235,102 +266,109 @@ export function registerBatchSpawn(program: Command): void {
     .argument("<project>", "Project ID from config")
     .argument("<issues...>", "Issue identifiers")
     .option("--open", "Open sessions in terminal tabs")
-    .action(async (projectId: string, issues: string[], opts: { open?: boolean }) => {
-      const config = loadConfig();
-      if (!config.projects[projectId]) {
-        console.error(
-          chalk.red(
-            `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
-          ),
-        );
-        process.exit(1);
-      }
-
-      console.log(banner("BATCH SESSION SPAWNER"));
-      console.log();
-      console.log(`  Project: ${chalk.bold(projectId)}`);
-      console.log(`  Issues:  ${issues.join(", ")}`);
-      console.log();
-
-      // Pre-flight once before the loop so a missing prerequisite fails fast
-      try {
-        await runSpawnPreflight(config, projectId);
-        await ensureLifecycleWorker(config, projectId);
-      } catch (err) {
-        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-        process.exit(1);
-      }
-
-      const sm = await getSessionManager(config);
-      const created: Array<{ session: string; issue: string }> = [];
-      const skipped: Array<{ issue: string; existing: string }> = [];
-      const failed: Array<{ issue: string; error: string }> = [];
-      const spawnedIssues = new Set<string>();
-
-      // Load existing sessions once before the loop to avoid repeated reads + enrichment.
-      // Exclude terminal sessions so completed/merged sessions don't block respawning
-      // (e.g. when an issue is reopened after its PR was merged).
-      const existingSessions = await sm.list(projectId);
-      const existingIssueMap = new Map(
-        existingSessions
-          .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
-          .map((s) => [s.issueId!.toLowerCase(), s.id]),
-      );
-
-      for (const issue of issues) {
-        // Duplicate detection — check both existing sessions and same-run duplicates
-        if (spawnedIssues.has(issue.toLowerCase())) {
-          console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
-          skipped.push({ issue, existing: "(this batch)" });
-          continue;
-        }
-
-        // Check existing sessions (pre-loaded before loop)
-        const existingSessionId = existingIssueMap.get(issue.toLowerCase());
-        if (existingSessionId) {
-          console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
-          skipped.push({ issue, existing: existingSessionId });
-          continue;
-        }
-
-        try {
-          const session = await sm.spawn({ projectId, issueId: issue });
-          created.push({ session: session.id, issue });
-          spawnedIssues.add(issue.toLowerCase());
-          console.log(chalk.green(`  Created ${session.id} for ${issue}`));
-
-          if (opts.open) {
-            try {
-              const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-              await exec("open-iterm-tab", [tmuxTarget]);
-            } catch {
-              // best effort
-            }
-          }
-        } catch (err) {
-          failed.push({
-            issue,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          console.log(
-            chalk.red(`  Failed ${issue} — ${err instanceof Error ? err.message : String(err)}`),
+    .option("--runtime <name>", "Temporarily override the runtime plugin (e.g. tmux, docker)")
+    .action(
+      async (projectId: string, issues: string[], opts: { open?: boolean; runtime?: string }) => {
+        const config = loadConfig();
+        if (!config.projects[projectId]) {
+          console.error(
+            chalk.red(
+              `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+            ),
           );
+          process.exit(1);
         }
-      }
 
-      console.log();
-      if (created.length > 0) {
-        console.log(chalk.green(`Created ${created.length} sessions:`));
-        for (const item of created) console.log(`  ${item.session} ← ${item.issue}`);
-      }
-      if (skipped.length > 0) {
-        console.log(chalk.yellow(`Skipped ${skipped.length} issues:`));
-        for (const item of skipped) console.log(`  ${item.issue} (existing: ${item.existing})`);
-      }
-      if (failed.length > 0) {
-        console.log(chalk.red(`Failed ${failed.length} issues:`));
-        for (const item of failed) console.log(`  ${item.issue}: ${item.error}`);
-      }
-      console.log();
-    });
+        console.log(banner("BATCH SESSION SPAWNER"));
+        console.log();
+        console.log(`  Project: ${chalk.bold(projectId)}`);
+        console.log(`  Issues:  ${issues.join(", ")}`);
+        console.log(
+          `  Runtime: ${chalk.dim(formatRuntimeSelection(getRuntimeSelection(config, projectId, opts.runtime)))}`,
+        );
+        console.log();
+
+        // Pre-flight once before the loop so a missing prerequisite fails fast
+        try {
+          await runSpawnPreflight(config, projectId, undefined, opts.runtime);
+          await ensureLifecycleWorker(config, projectId);
+        } catch (err) {
+          console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+          process.exit(1);
+        }
+
+        const sm = await getSessionManager(config);
+        const created: Array<{ session: string; issue: string }> = [];
+        const skipped: Array<{ issue: string; existing: string }> = [];
+        const failed: Array<{ issue: string; error: string }> = [];
+        const spawnedIssues = new Set<string>();
+
+        // Load existing sessions once before the loop to avoid repeated reads + enrichment.
+        // Exclude terminal sessions so completed/merged sessions don't block respawning
+        // (e.g. when an issue is reopened after its PR was merged).
+        const existingSessions = await sm.list(projectId);
+        const existingIssueMap = new Map(
+          existingSessions
+            .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
+            .map((s) => [s.issueId!.toLowerCase(), s.id]),
+        );
+
+        for (const issue of issues) {
+          // Duplicate detection — check both existing sessions and same-run duplicates
+          if (spawnedIssues.has(issue.toLowerCase())) {
+            console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
+            skipped.push({ issue, existing: "(this batch)" });
+            continue;
+          }
+
+          // Check existing sessions (pre-loaded before loop)
+          const existingSessionId = existingIssueMap.get(issue.toLowerCase());
+          if (existingSessionId) {
+            console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
+            skipped.push({ issue, existing: existingSessionId });
+            continue;
+          }
+
+          try {
+            const session = await sm.spawn({ projectId, issueId: issue, runtime: opts.runtime });
+            created.push({ session: session.id, issue });
+            spawnedIssues.add(issue.toLowerCase());
+            console.log(chalk.green(`  Created ${session.id} for ${issue}`));
+
+            if (opts.open) {
+              try {
+                if ((session.runtimeHandle?.runtimeName ?? "tmux") === "tmux") {
+                  await exec("open-iterm-tab", [session.runtimeHandle?.id ?? session.id]);
+                }
+              } catch {
+                // best effort
+              }
+            }
+          } catch (err) {
+            failed.push({
+              issue,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            console.log(
+              chalk.red(`  Failed ${issue} — ${err instanceof Error ? err.message : String(err)}`),
+            );
+          }
+        }
+
+        console.log();
+        if (created.length > 0) {
+          console.log(chalk.green(`Created ${created.length} sessions:`));
+          for (const item of created) console.log(`  ${item.session} ← ${item.issue}`);
+        }
+        if (skipped.length > 0) {
+          console.log(chalk.yellow(`Skipped ${skipped.length} issues:`));
+          for (const item of skipped) console.log(`  ${item.issue} (existing: ${item.existing})`);
+        }
+        if (failed.length > 0) {
+          console.log(chalk.red(`Failed ${failed.length} issues:`));
+          for (const item of failed) console.log(`  ${item.issue}: ${item.error}`);
+        }
+        console.log();
+      },
+    );
 }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -42,6 +42,8 @@ import {
 } from "../lib/web-dir.js";
 import { cleanNextCache } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
+import { getAttachCommand } from "../lib/runtime.js";
+import { formatRuntimeSelection, getRuntimeSelection } from "../lib/runtime-selection.js";
 
 const DEFAULT_PORT = 3000;
 
@@ -257,7 +259,13 @@ async function runStartup(
   config: OrchestratorConfig,
   projectId: string,
   project: ProjectConfig,
-  opts?: { dashboard?: boolean; orchestrator?: boolean; rebuild?: boolean; autoPort?: boolean },
+  opts?: {
+    dashboard?: boolean;
+    orchestrator?: boolean;
+    rebuild?: boolean;
+    autoPort?: boolean;
+    runtime?: string;
+  },
 ): Promise<void> {
   const sessionId = `${project.sessionPrefix}-orchestrator`;
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
@@ -266,12 +274,24 @@ async function runStartup(
   const orchestratorSessionStrategy = normalizeOrchestratorSessionStrategy(
     project.orchestratorSessionStrategy,
   );
+  const runtimeSelection = getRuntimeSelection(config, projectId, opts?.runtime);
+  const runtimeName = runtimeSelection.name;
 
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
+  console.log(chalk.dim(`Runtime: ${formatRuntimeSelection(runtimeSelection)}\n`));
+  if (runtimeSelection.source === "flag") {
+    console.log(chalk.dim(`Persist: ao runtime set ${projectId} ${runtimeSelection.name}\n`));
+  }
 
   const spinner = ora();
   let dashboardProcess: ChildProcess | null = null;
   let reused = false;
+
+  if (runtimeName === "tmux") {
+    await preflight.checkTmux();
+  } else if (runtimeName === "docker") {
+    await preflight.checkDocker();
+  }
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
@@ -334,17 +354,19 @@ async function runStartup(
   }
 
   // Create orchestrator session (unless --no-orchestrator or already exists)
-  let tmuxTarget = sessionId;
+  let attachCommand = getAttachCommand(null, sessionId);
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
 
     try {
       spinner.start("Creating orchestrator session");
       const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-      const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
-      if (session.runtimeHandle?.id) {
-        tmuxTarget = session.runtimeHandle.id;
-      }
+      const session = await sm.spawnOrchestrator({
+        projectId,
+        systemPrompt,
+        runtime: opts?.runtime,
+      });
+      attachCommand = getAttachCommand(session.runtimeHandle, sessionId);
       reused =
         orchestratorSessionStrategy === "reuse" &&
         session.metadata?.["orchestratorSessionReused"] === "true";
@@ -377,7 +399,7 @@ async function runStartup(
   }
 
   if (opts?.orchestrator !== false && !reused) {
-    console.log(chalk.cyan("Orchestrator:"), `tmux attach -t ${tmuxTarget}`);
+    console.log(chalk.cyan("Orchestrator:"), attachCommand);
   } else if (reused) {
     console.log(chalk.cyan("Orchestrator:"), `reused existing session (${sessionId})`);
   }
@@ -445,6 +467,7 @@ export function registerStart(program: Command): void {
     .option("--no-dashboard", "Skip starting the dashboard server")
     .option("--no-orchestrator", "Skip starting the orchestrator agent")
     .option("--rebuild", "Clean and rebuild dashboard before starting")
+    .option("--runtime <name>", "Temporarily override the runtime plugin (e.g. tmux, docker)")
     .action(
       async (
         projectArg?: string,
@@ -452,6 +475,7 @@ export function registerStart(program: Command): void {
           dashboard?: boolean;
           orchestrator?: boolean;
           rebuild?: boolean;
+          runtime?: string;
         },
       ) => {
         try {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -25,6 +25,7 @@ import {
 } from "../lib/format.js";
 import { getAgentByName, getSCM } from "../lib/plugins.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
+import { getLastActivityLabel } from "../lib/runtime.js";
 
 interface SessionInfo {
   name: string;
@@ -63,10 +64,7 @@ async function gatherSessionInfo(
     if (liveBranch) branch = liveBranch;
   }
 
-  // Get last activity time from tmux
-  const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-  const activityTs = await getTmuxActivity(tmuxTarget);
-  const lastActivity = activityTs ? formatAge(activityTs) : "-";
+  const lastActivity = await getLastActivityLabel(session);
 
   // Get agent's auto-generated summary via introspection
   let claudeSummary: string | null = null;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import { registerLifecycleWorker } from "./commands/lifecycle-worker.js";
 import { registerVerify } from "./commands/verify.js";
 import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
+import { registerRuntime } from "./commands/runtime.js";
 
 const program = new Command();
 
@@ -37,5 +38,6 @@ registerLifecycleWorker(program);
 registerVerify(program);
 registerDoctor(program);
 registerUpdate(program);
+registerRuntime(program);
 
 program.parse();

--- a/packages/cli/src/lib/preflight.ts
+++ b/packages/cli/src/lib/preflight.ts
@@ -55,6 +55,25 @@ async function checkTmux(): Promise<void> {
 }
 
 /**
+ * Check that Docker is installed and the daemon is reachable.
+ */
+async function checkDocker(): Promise<void> {
+  try {
+    await exec("docker", ["--version"]);
+  } catch {
+    throw new Error("Docker is not installed. Install Docker Desktop or docker-ce first.");
+  }
+
+  try {
+    await exec("docker", ["info"]);
+  } catch {
+    throw new Error(
+      "Docker is installed, but the daemon is not reachable. Start Docker and retry.",
+    );
+  }
+}
+
+/**
  * Check that the GitHub CLI is installed and authenticated.
  * Distinguishes between "not installed" and "not authenticated"
  * so the user gets the right troubleshooting guidance.
@@ -77,5 +96,6 @@ export const preflight = {
   checkPort,
   checkBuilt,
   checkTmux,
+  checkDocker,
   checkGhAuth,
 };

--- a/packages/cli/src/lib/runtime-selection.ts
+++ b/packages/cli/src/lib/runtime-selection.ts
@@ -1,0 +1,39 @@
+import type { OrchestratorConfig } from "@composio/ao-core";
+
+export type RuntimeSelectionSource = "flag" | "project" | "default";
+
+export interface RuntimeSelection {
+  name: string;
+  source: RuntimeSelectionSource;
+}
+
+export function getRuntimeSelection(
+  config: Pick<OrchestratorConfig, "defaults" | "projects">,
+  projectId: string,
+  runtimeOverride?: string,
+): RuntimeSelection {
+  const project = config.projects[projectId];
+  if (!project) {
+    throw new Error(`Unknown project: ${projectId}`);
+  }
+
+  if (runtimeOverride) {
+    return { name: runtimeOverride, source: "flag" };
+  }
+  if (project.runtime) {
+    return { name: project.runtime, source: "project" };
+  }
+  return { name: config.defaults.runtime, source: "default" };
+}
+
+export function formatRuntimeSelection(selection: RuntimeSelection): string {
+  switch (selection.source) {
+    case "flag":
+      return `${selection.name} (--runtime)`;
+    case "project":
+      return `${selection.name} (project config)`;
+    case "default":
+    default:
+      return `${selection.name} (defaults.runtime)`;
+  }
+}

--- a/packages/cli/src/lib/runtime.ts
+++ b/packages/cli/src/lib/runtime.ts
@@ -1,0 +1,67 @@
+import { spawn } from "node:child_process";
+import type { RuntimeHandle, Session } from "@composio/ao-core";
+import { formatAge } from "./format.js";
+import { getTmuxActivity } from "./shell.js";
+
+function defaultHandle(sessionId: string): RuntimeHandle {
+  return { id: sessionId, runtimeName: "tmux", data: {} };
+}
+
+export function getAttachCommand(
+  runtimeHandle: RuntimeHandle | null | undefined,
+  sessionId: string,
+): string {
+  const handle = runtimeHandle ?? defaultHandle(sessionId);
+  switch (handle.runtimeName) {
+    case "docker":
+      return `docker attach ${handle.id}`;
+    case "process":
+      return "(no interactive attach available for process runtime)";
+    case "tmux":
+    default:
+      return `tmux attach -t ${handle.id}`;
+  }
+}
+
+export async function attachToRuntime(
+  runtimeHandle: RuntimeHandle | null | undefined,
+  sessionId: string,
+): Promise<void> {
+  const handle = runtimeHandle ?? defaultHandle(sessionId);
+
+  const { cmd, args } =
+    handle.runtimeName === "docker"
+      ? { cmd: "docker", args: ["attach", handle.id] }
+      : handle.runtimeName === "tmux"
+        ? { cmd: "tmux", args: ["attach", "-t", handle.id] }
+        : { cmd: "", args: [] as string[] };
+
+  if (!cmd) {
+    throw new Error(`Runtime "${handle.runtimeName}" does not support interactive attach`);
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit" });
+    child.once("error", (err) => reject(err));
+    child.once("exit", (code) => {
+      if (code === 0 || code === null) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${cmd} attach exited with code ${code}`));
+    });
+  });
+}
+
+export async function getLastActivityLabel(
+  session: Pick<Session, "id" | "runtimeHandle" | "lastActivityAt">,
+): Promise<string> {
+  const runtimeHandle = session.runtimeHandle;
+  if (!runtimeHandle || runtimeHandle.runtimeName === "tmux") {
+    const target = runtimeHandle?.id ?? session.id;
+    const activityTs = await getTmuxActivity(target);
+    return activityTs ? formatAge(activityTs) : "-";
+  }
+
+  return session.lastActivityAt ? formatAge(session.lastActivityAt.getTime()) : "-";
+}

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -72,6 +72,33 @@ describe("Config Validation - Project Uniqueness", () => {
   });
 });
 
+describe("Config Validation - Runtime Config", () => {
+  it("accepts arbitrary runtimeConfig objects", () => {
+    const validated = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/integrator",
+          repo: "org/integrator",
+          defaultBranch: "main",
+          runtime: "docker",
+          runtimeConfig: {
+            image: "ghcr.io/example/ao-agent:latest",
+            mountHome: true,
+            mounts: ["~/cache:/cache:ro"],
+          },
+        },
+      },
+    });
+
+    expect(validated.projects.proj1.runtime).toBe("docker");
+    expect(validated.projects.proj1.runtimeConfig).toEqual({
+      image: "ghcr.io/example/ao-agent:latest",
+      mountHome: true,
+      mounts: ["~/cache:/cache:ro"],
+    });
+  });
+});
+
 describe("Config Validation - Session Prefix Uniqueness", () => {
   it("rejects duplicate explicit prefixes", () => {
     const config = {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -21,6 +21,7 @@ import {
   reserveSessionId,
   updateMetadata,
 } from "../metadata.js";
+import * as metadataModule from "../metadata.js";
 import { getSessionsDir, getProjectBaseDir, getWorktreesDir } from "../paths.js";
 import {
   SessionNotRestorableError,
@@ -3210,6 +3211,7 @@ describe("spawnOrchestrator", () => {
     const session = await sm.spawnOrchestrator({ projectId: "my-app" });
 
     expect(session.id).toBe("app-orchestrator");
+    expect(mockRuntime.destroy).toHaveBeenCalledTimes(1);
     expect(mockRuntime.destroy).toHaveBeenCalledWith(orphanedHandle);
     expect(mockRuntime.create).toHaveBeenCalled();
   });
@@ -3880,6 +3882,65 @@ describe("spawnOrchestrator", () => {
 
     expect(session.metadata["orchestratorSessionReused"]).toBe("true");
     expect(mockRuntime.create).not.toHaveBeenCalled();
+  });
+
+  it("replaces a concurrent orchestrator when reservation conflict finds a different runtime", async () => {
+    const dockerRuntimeHandle: RuntimeHandle = {
+      id: "rt-docker",
+      runtimeName: "docker",
+      data: {},
+    };
+    const dockerRuntime: Runtime = {
+      ...mockRuntime,
+      name: "docker",
+      destroy: vi.fn().mockResolvedValue(undefined),
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const registryWithDocker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime" && name === "docker") return dockerRuntime;
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const concurrentRaw = {
+      worktree: join(tmpDir, "my-app"),
+      branch: "main",
+      status: "working",
+      role: "orchestrator",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(dockerRuntimeHandle),
+      createdAt: new Date().toISOString(),
+    };
+
+    expect(reserveSessionId(sessionsDir, "app-orchestrator")).toBe(true);
+
+    const actualReadMetadataRaw = metadataModule.readMetadataRaw;
+    let readCount = 0;
+    const readMetadataRawSpy = vi
+      .spyOn(metadataModule, "readMetadataRaw")
+      .mockImplementation((...args) => {
+        readCount += 1;
+        if (readCount === 1) return {};
+        if (readCount === 2) return concurrentRaw;
+        return actualReadMetadataRaw(...args);
+      });
+
+    try {
+      const sm = createSessionManager({ config, registry: registryWithDocker });
+      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(session.runtimeHandle).toEqual(makeHandle("rt-1"));
+      expect(dockerRuntime.destroy).toHaveBeenCalledTimes(1);
+      expect(dockerRuntime.destroy).toHaveBeenCalledWith(dockerRuntimeHandle);
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+    } finally {
+      readMetadataRawSpy.mockRestore();
+    }
   });
 
   it("recovers reservation conflict when existing session is not usable", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -152,6 +152,7 @@ const ProjectConfigSchema = z.object({
     .regex(/^[a-zA-Z0-9_-]+$/, "sessionPrefix must match [a-zA-Z0-9_-]+")
     .optional(),
   runtime: z.string().optional(),
+  runtimeConfig: z.record(z.unknown()).optional(),
   agent: z.string().optional(),
   workspace: z.string().optional(),
   tracker: TrackerConfigSchema.optional(),

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -27,6 +27,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   // Runtimes
   { slot: "runtime", name: "tmux", pkg: "@composio/ao-plugin-runtime-tmux" },
   { slot: "runtime", name: "process", pkg: "@composio/ao-plugin-runtime-process" },
+  { slot: "runtime", name: "docker", pkg: "@composio/ao-plugin-runtime-docker" },
   // Agents
   { slot: "agent", name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@composio/ao-plugin-agent-codex" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1294,8 +1294,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ?.destroy(existingOrchestrator.runtimeHandle)
           .catch(() => undefined);
         deleteMetadata(sessionsDir, sessionId, false);
-      }
-      if (existingAlive) {
+      } else if (existingAlive) {
         await existingRuntimePlugin
           ?.destroy(existingOrchestrator.runtimeHandle)
           .catch(() => undefined);
@@ -1337,7 +1336,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           concurrentSession.metadata["orchestratorSessionReused"] = "true";
           return concurrentSession;
         }
-        if (!concurrentAlive) {
+        if (concurrentAlive) {
+          await concurrentRuntimePlugin
+            ?.destroy(concurrentSession.runtimeHandle)
+            .catch(() => undefined);
+          deleteMetadata(sessionsDir, sessionId, false);
+          reserved = reserveSessionId(sessionsDir, sessionId);
+        } else {
           deleteMetadata(sessionsDir, sessionId, orchestratorSessionStrategy === "reuse");
           reserved = reserveSessionId(sessionsDir, sessionId);
         }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -702,9 +702,20 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
   }
 
+  function resolveRuntimeName(project: ProjectConfig, runtimeNameOverride?: string): string {
+    return runtimeNameOverride ?? project.runtime ?? config.defaults.runtime;
+  }
+
   /** Resolve which plugins to use for a project. */
-  function resolvePlugins(project: ProjectConfig, agentName?: string) {
-    const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
+  function resolvePlugins(
+    project: ProjectConfig,
+    agentName?: string,
+    runtimeNameOverride?: string,
+  ) {
+    const runtime = registry.get<Runtime>(
+      "runtime",
+      resolveRuntimeName(project, runtimeNameOverride),
+    );
     const agent = registry.get<Agent>("agent", agentName ?? project.agent ?? config.defaults.agent);
     const workspace = registry.get<Workspace>(
       "workspace",
@@ -909,9 +920,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       defaults: config.defaults,
       spawnAgentOverride: spawnConfig.agent,
     });
-    const plugins = resolvePlugins(project, selection.agentName);
+    const runtimeName = resolveRuntimeName(project, spawnConfig.runtime);
+    const plugins = resolvePlugins(project, selection.agentName, spawnConfig.runtime);
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(`Runtime plugin '${runtimeName}' not found`);
     }
 
     if (!plugins.agent) {
@@ -1071,6 +1083,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_SESSION_NAME: sessionId, // User-facing session name
           ...(tmuxName && { AO_TMUX_NAME: tmuxName }), // Tmux session name if using new arch
         },
+        runtimeConfig: project.runtimeConfig,
       });
     } catch (err) {
       // Clean up workspace and reserved ID if agent config or runtime creation failed
@@ -1207,9 +1220,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       project,
       defaults: config.defaults,
     });
-    const plugins = resolvePlugins(project, selection.agentName);
+    const runtimeName = resolveRuntimeName(project, orchestratorConfig.runtime);
+    const plugins = resolvePlugins(project, selection.agentName, orchestratorConfig.runtime);
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(`Runtime plugin '${runtimeName}' not found`);
     }
     if (!plugins.agent) {
       throw new Error(`Agent plugin '${selection.agentName}' not found`);
@@ -1256,10 +1270,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       ? metadataToSession(sessionId, existingRaw, orchestratorConfig.projectId)
       : null;
     if (existingOrchestrator?.runtimeHandle) {
-      const existingAlive = await plugins.runtime
-        .isAlive(existingOrchestrator.runtimeHandle)
-        .catch(() => false);
-      if (existingAlive && orchestratorSessionStrategy === "reuse") {
+      const existingRuntimeName = existingOrchestrator.runtimeHandle.runtimeName ?? runtimeName;
+      const existingRuntimePlugin = registry.get<Runtime>("runtime", existingRuntimeName);
+      const existingAlive = existingRuntimePlugin
+        ? await existingRuntimePlugin.isAlive(existingOrchestrator.runtimeHandle).catch(() => false)
+        : false;
+      if (
+        existingAlive &&
+        existingRuntimeName === runtimeName &&
+        orchestratorSessionStrategy === "reuse"
+      ) {
         const persistedRaw = readMetadataRaw(sessionsDir, sessionId);
         if (persistedRaw?.["runtimeHandle"]) {
           const persisted = metadataToSession(
@@ -1270,11 +1290,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           persisted.metadata["orchestratorSessionReused"] = "true";
           return persisted;
         }
-        await plugins.runtime.destroy(existingOrchestrator.runtimeHandle).catch(() => undefined);
+        await existingRuntimePlugin
+          ?.destroy(existingOrchestrator.runtimeHandle)
+          .catch(() => undefined);
         deleteMetadata(sessionsDir, sessionId, false);
       }
-      if (existingAlive && orchestratorSessionStrategy !== "reuse") {
-        await plugins.runtime.destroy(existingOrchestrator.runtimeHandle).catch(() => undefined);
+      if (existingAlive) {
+        await existingRuntimePlugin
+          ?.destroy(existingOrchestrator.runtimeHandle)
+          .catch(() => undefined);
         // Destroy runtime and delete metadata without archive for ignore strategy
         deleteMetadata(sessionsDir, sessionId, false);
       }
@@ -1298,10 +1322,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         ? metadataToSession(sessionId, concurrentRaw, orchestratorConfig.projectId)
         : null;
       if (concurrentSession?.runtimeHandle) {
-        const concurrentAlive = await plugins.runtime
-          .isAlive(concurrentSession.runtimeHandle)
-          .catch(() => false);
-        if (concurrentAlive && orchestratorSessionStrategy === "reuse") {
+        const concurrentRuntimeName = concurrentSession.runtimeHandle.runtimeName ?? runtimeName;
+        const concurrentRuntimePlugin = registry.get<Runtime>("runtime", concurrentRuntimeName);
+        const concurrentAlive = concurrentRuntimePlugin
+          ? await concurrentRuntimePlugin
+              .isAlive(concurrentSession.runtimeHandle)
+              .catch(() => false)
+          : false;
+        if (
+          concurrentAlive &&
+          concurrentRuntimeName === runtimeName &&
+          orchestratorSessionStrategy === "reuse"
+        ) {
           concurrentSession.metadata["orchestratorSessionReused"] = "true";
           return concurrentSession;
         }
@@ -1366,6 +1398,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         AO_SESSION_NAME: sessionId,
         ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
       },
+      runtimeConfig: project.runtimeConfig,
     });
 
     // Write metadata and run post-launch setup
@@ -1471,7 +1504,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const session = metadataToSession(sessionName, raw, sessionProjectId, createdAt, modifiedAt);
       const selection = resolveSelectionForSession(project, sessionName, raw);
       const effectiveAgentName = selection.agentName;
-      const plugins = resolvePlugins(project, effectiveAgentName);
+      const plugins = resolvePlugins(
+        project,
+        effectiveAgentName,
+        session.runtimeHandle?.runtimeName,
+      );
       const sessionListPromise =
         effectiveAgentName === "opencode"
           ? (openCodeSessionListPromise ??= fetchOpenCodeSessionList())
@@ -1534,7 +1571,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       const selection = resolveSelectionForSession(project, sessionId, repaired.raw);
       const effectiveAgentName = selection.agentName;
-      const plugins = resolvePlugins(project, effectiveAgentName);
+      const plugins = resolvePlugins(
+        project,
+        effectiveAgentName,
+        session.runtimeHandle?.runtimeName,
+      );
       await ensureHandleAndEnrich(
         session,
         sessionId,
@@ -1666,7 +1707,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           continue;
         }
 
-        const plugins = resolvePlugins(project);
+        const plugins = resolvePlugins(project, undefined, session.runtimeHandle?.runtimeName);
         let shouldKill = false;
 
         // Check if PR is merged
@@ -2245,7 +2286,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     //    session (status "working", agent exited) would not be detected as terminal
     //    and isRestorable would reject it.
     const session = metadataToSession(sessionId, raw, projectId);
-    const plugins = resolvePlugins(project, selection.agentName);
+    const plugins = resolvePlugins(
+      project,
+      selection.agentName,
+      session.runtimeHandle?.runtimeName,
+    );
     await enrichSessionWithRuntimeState(session, plugins, true);
 
     // 3. Validate restorability
@@ -2278,7 +2323,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // 4. Validate required plugins (plugins already resolved above for enrichment)
     if (!plugins.runtime) {
-      throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
+      throw new Error(
+        `Runtime plugin '${session.runtimeHandle?.runtimeName ?? resolveRuntimeName(project)}' not found`,
+      );
     }
     if (!plugins.agent) {
       throw new Error(`Agent plugin '${selection.agentName}' not found`);
@@ -2372,6 +2419,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         AO_SESSION_NAME: sessionId,
         ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
       },
+      runtimeConfig: project.runtimeConfig,
     });
 
     // 9. Update metadata — merge updates, preserving existing fields

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -185,6 +185,8 @@ export interface SessionSpawnConfig {
   issueId?: string;
   branch?: string;
   prompt?: string;
+  /** Temporarily override the runtime plugin for this session (e.g. "docker", "tmux") */
+  runtime?: string;
   /** Override the agent plugin for this session (e.g. "codex", "claude-code") */
   agent?: string;
   /** Override the OpenCode subagent for this session (e.g. "sisyphus", "oracle") */
@@ -199,6 +201,8 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Temporarily override the runtime plugin for this orchestrator session */
+  runtime?: string;
 }
 
 // =============================================================================
@@ -239,6 +243,7 @@ export interface RuntimeCreateConfig {
   workspacePath: string;
   launchCommand: string;
   environment: Record<string, string>;
+  runtimeConfig?: Record<string, unknown>;
 }
 
 /** Opaque handle returned by runtime.create() */
@@ -950,6 +955,9 @@ export interface ProjectConfig {
 
   /** Override default runtime */
   runtime?: string;
+
+  /** Runtime-specific configuration passed to the selected runtime plugin */
+  runtimeConfig?: Record<string, unknown>;
 
   /** Override default agent */
   agent?: string;

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -15,6 +15,7 @@
     "@composio/ao-plugin-agent-codex": "workspace:*",
     "@composio/ao-plugin-agent-aider": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
+    "@composio/ao-plugin-runtime-docker": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-runtime-process": "workspace:*",
     "@composio/ao-plugin-workspace-worktree": "workspace:*",

--- a/packages/integration-tests/src/helpers/docker.ts
+++ b/packages/integration-tests/src/helpers/docker.ts
@@ -1,0 +1,37 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TIMEOUT = 30_000;
+
+export async function isDockerAvailable(): Promise<boolean> {
+  try {
+    await execFileAsync("docker", ["info"], { timeout: TIMEOUT });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function killContainersByPrefix(prefix: string): Promise<void> {
+  try {
+    const { stdout } = await execFileAsync("docker", ["ps", "-a", "--format", "{{.Names}}"], {
+      timeout: TIMEOUT,
+    });
+    const containers = stdout
+      .trim()
+      .split("\n")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0 && entry.startsWith(prefix));
+
+    for (const name of containers) {
+      try {
+        await execFileAsync("docker", ["rm", "-f", name], { timeout: TIMEOUT });
+      } catch {
+        // best effort
+      }
+    }
+  } catch {
+    // Docker unavailable or no containers
+  }
+}

--- a/packages/integration-tests/src/runtime-docker.integration.test.ts
+++ b/packages/integration-tests/src/runtime-docker.integration.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import dockerPlugin from "@composio/ao-plugin-runtime-docker";
+import type { RuntimeHandle } from "@composio/ao-core";
+import { sleep } from "./helpers/polling.js";
+import { isDockerAvailable, killContainersByPrefix } from "./helpers/docker.js";
+
+const dockerOk = await isDockerAvailable();
+const CONTAINER_PREFIX = "ao-inttest-docker-";
+const TEST_IMAGE = "busybox:1.36";
+
+describe.skipIf(!dockerOk)("runtime-docker (integration)", () => {
+  const runtime = dockerPlugin.create();
+  const sessionId = `${CONTAINER_PREFIX}${Date.now()}`;
+  let handle: RuntimeHandle;
+  let workspacePath: string;
+
+  beforeAll(async () => {
+    workspacePath = await mkdtemp(join(homedir(), ".ao-docker-runtime-"));
+    await killContainersByPrefix(CONTAINER_PREFIX);
+  }, 60_000);
+
+  afterAll(async () => {
+    try {
+      if (handle) {
+        await runtime.destroy(handle);
+      }
+    } catch {
+      /* best effort */
+    }
+    await killContainersByPrefix(CONTAINER_PREFIX);
+    if (workspacePath) {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  }, 60_000);
+
+  it("creates a Docker container", async () => {
+    handle = await runtime.create({
+      sessionId,
+      workspacePath,
+      launchCommand: "cat",
+      environment: { AO_TEST: "1" },
+      runtimeConfig: {
+        image: TEST_IMAGE,
+        mountHome: false,
+      },
+    });
+
+    expect(handle.id).toBe(sessionId);
+    expect(handle.runtimeName).toBe("docker");
+  }, 60_000);
+
+  it("isAlive returns true for a running container", async () => {
+    expect(await runtime.isAlive(handle)).toBe(true);
+  }, 30_000);
+
+  it("sendMessage writes to the container stdin and getOutput captures it", async () => {
+    await runtime.sendMessage(handle, "hello docker");
+    await sleep(1_000);
+    const output = await runtime.getOutput(handle);
+    expect(output).toContain("hello docker");
+  }, 30_000);
+
+  it("getMetrics returns uptime", async () => {
+    const metrics = await runtime.getMetrics!(handle);
+    expect(metrics.uptimeMs).toBeGreaterThan(0);
+  });
+
+  it("getAttachInfo returns a docker attach command", async () => {
+    const info = await runtime.getAttachInfo!(handle);
+    expect(info.type).toBe("docker");
+    expect(info.target).toBe(sessionId);
+    expect(info.command).toContain("docker attach");
+  });
+
+  it("destroy removes the container", async () => {
+    await runtime.destroy(handle);
+    expect(await runtime.isAlive(handle)).toBe(false);
+  }, 30_000);
+});

--- a/packages/plugins/runtime-docker/package.json
+++ b/packages/plugins/runtime-docker/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@composio/ao-plugin-runtime-docker",
+  "version": "0.1.0",
+  "description": "Runtime plugin: Docker containers",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/runtime-docker"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/runtime-docker/src/index.test.ts
+++ b/packages/plugins/runtime-docker/src/index.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { create, manifest, normalizeDockerRuntimeConfig } from "./index.js";
+
+describe("runtime-docker", () => {
+  it("exports the docker runtime manifest", () => {
+    expect(manifest).toMatchObject({
+      name: "docker",
+      slot: "runtime",
+    });
+  });
+
+  it("requires an image in runtimeConfig", () => {
+    expect(() => normalizeDockerRuntimeConfig()).toThrow(/runtimeConfig\.image/);
+  });
+
+  it("normalizes default Docker settings", () => {
+    const config = normalizeDockerRuntimeConfig({ image: "ghcr.io/example/ao:latest" });
+    expect(config.image).toBe("ghcr.io/example/ao:latest");
+    expect(config.shell).toBe("/bin/sh");
+    expect(config.mountHome).toBe(true);
+  });
+
+  it("passes through custom mounts and env settings", () => {
+    const config = normalizeDockerRuntimeConfig({
+      image: "ghcr.io/example/ao:latest",
+      shell: "/bin/bash",
+      mountHome: false,
+      mounts: ["~/cache:/cache:ro"],
+      env: { FOO: "bar" },
+      passHostEnv: ["OPENAI_API_KEY"],
+      extraArgs: ["--network", "host"],
+      user: "1000:1000",
+    });
+
+    expect(config).toMatchObject({
+      image: "ghcr.io/example/ao:latest",
+      shell: "/bin/bash",
+      mountHome: false,
+      env: { FOO: "bar" },
+      passHostEnv: ["OPENAI_API_KEY"],
+      extraArgs: ["--network", "host"],
+      user: "1000:1000",
+    });
+    expect(config.mounts[0]).toContain("/cache:ro");
+  });
+
+  it("creates a runtime instance", () => {
+    const runtime = create();
+    expect(runtime.name).toBe("docker");
+  });
+});

--- a/packages/plugins/runtime-docker/src/index.ts
+++ b/packages/plugins/runtime-docker/src/index.ts
@@ -1,0 +1,334 @@
+import { execFile, spawn } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import type {
+  AttachInfo,
+  PluginModule,
+  Runtime,
+  RuntimeCreateConfig,
+  RuntimeHandle,
+  RuntimeMetrics,
+} from "@composio/ao-core";
+
+const execFileAsync = promisify(execFile);
+const DOCKER_TIMEOUT_MS = 30_000;
+const SAFE_SESSION_ID = /^[a-zA-Z0-9_.-]+$/;
+const READ_ONLY_MODES = new Set(["ro"]);
+
+export interface DockerRuntimeConfig {
+  image: string;
+  shell: string;
+  mountHome: boolean;
+  mounts: string[];
+  env: Record<string, string>;
+  passHostEnv: string[];
+  extraArgs: string[];
+  user?: string;
+}
+
+export const manifest = {
+  name: "docker",
+  slot: "runtime" as const,
+  description: "Runtime plugin: Docker containers",
+  version: "0.1.0",
+};
+
+function assertValidSessionId(id: string): void {
+  if (!SAFE_SESSION_ID.test(id)) {
+    throw new Error(`Invalid session ID "${id}": must match ${SAFE_SESSION_ID}`);
+  }
+}
+
+function expandHomePath(value: string): string {
+  if (value === "~") return homedir();
+  if (value.startsWith("~/")) return join(homedir(), value.slice(2));
+  return value;
+}
+
+function normalizeEnvMap(input: unknown): Record<string, string> {
+  if (!input || typeof input !== "object") return {};
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (typeof value === "string") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function normalizeStringArray(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input.filter((value): value is string => typeof value === "string" && value.length > 0);
+}
+
+function detectHostUser(): string | undefined {
+  if (typeof process.getuid !== "function" || typeof process.getgid !== "function") {
+    return undefined;
+  }
+  return `${process.getuid()}:${process.getgid()}`;
+}
+
+export function normalizeDockerRuntimeConfig(
+  runtimeConfig?: Record<string, unknown>,
+): DockerRuntimeConfig {
+  const image = typeof runtimeConfig?.["image"] === "string" ? runtimeConfig["image"].trim() : "";
+  if (image.length === 0) {
+    throw new Error(
+      "Docker runtime requires project.runtimeConfig.image (for example, ghcr.io/your-org/ao-agent:latest)",
+    );
+  }
+
+  const shell =
+    typeof runtimeConfig?.["shell"] === "string" && runtimeConfig["shell"].trim().length > 0
+      ? runtimeConfig["shell"].trim()
+      : "/bin/sh";
+
+  const mountHome = runtimeConfig?.["mountHome"] !== false;
+  const env = normalizeEnvMap(runtimeConfig?.["env"]);
+  const passHostEnv = normalizeStringArray(runtimeConfig?.["passHostEnv"]);
+  const extraArgs = normalizeStringArray(runtimeConfig?.["extraArgs"]);
+  const mounts = normalizeStringArray(runtimeConfig?.["mounts"]).map((entry) =>
+    entry.replace(/^~(?=\/|$)/, homedir()),
+  );
+  const configuredUser =
+    typeof runtimeConfig?.["user"] === "string" && runtimeConfig["user"].trim().length > 0
+      ? runtimeConfig["user"].trim()
+      : undefined;
+
+  return {
+    image,
+    shell,
+    mountHome,
+    mounts,
+    env,
+    passHostEnv,
+    extraArgs,
+    user: configuredUser ?? detectHostUser(),
+  };
+}
+
+function toVolumeArg(spec: string): string {
+  const parts = spec.split(":");
+  if (parts.length < 2 || parts.length > 3) {
+    throw new Error(`Invalid Docker mount "${spec}". Expected SOURCE:TARGET[:ro|rw].`);
+  }
+
+  const source = expandHomePath(parts[0] ?? "");
+  const target = expandHomePath(parts[1] ?? "");
+  const mode = parts[2];
+
+  if (!source.startsWith("/")) {
+    throw new Error(`Docker mount source must be an absolute path: "${spec}"`);
+  }
+  if (!target.startsWith("/")) {
+    throw new Error(`Docker mount target must be an absolute path: "${spec}"`);
+  }
+  if (mode && mode !== "rw" && !READ_ONLY_MODES.has(mode)) {
+    throw new Error(`Unsupported Docker mount mode "${mode}" in "${spec}"`);
+  }
+
+  return mode ? `${source}:${target}:${mode}` : `${source}:${target}`;
+}
+
+async function docker(args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("docker", args, {
+    timeout: DOCKER_TIMEOUT_MS,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+  return stdout.trimEnd();
+}
+
+async function dockerExists(containerName: string): Promise<boolean> {
+  try {
+    await docker(["inspect", containerName]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function removeContainer(containerName: string): Promise<void> {
+  try {
+    await docker(["rm", "-f", containerName]);
+  } catch {
+    // Best effort cleanup
+  }
+}
+
+function buildContainerEnv(
+  launchConfig: RuntimeCreateConfig,
+  runtimeConfig: DockerRuntimeConfig,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    ...runtimeConfig.env,
+    ...launchConfig.environment,
+    TERM: process.env["TERM"] ?? "xterm-256color",
+  };
+
+  for (const key of runtimeConfig.passHostEnv) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      env[key] = value;
+    }
+  }
+
+  if (runtimeConfig.mountHome && !("HOME" in env)) {
+    env["HOME"] = homedir();
+  }
+
+  return env;
+}
+
+function createAttachCommand(handle: RuntimeHandle): string {
+  return `docker attach ${handle.id}`;
+}
+
+export function create(): Runtime {
+  return {
+    name: "docker",
+
+    async create(config: RuntimeCreateConfig): Promise<RuntimeHandle> {
+      assertValidSessionId(config.sessionId);
+
+      const runtimeConfig = normalizeDockerRuntimeConfig(config.runtimeConfig);
+      const containerName = config.sessionId;
+      const env = buildContainerEnv(config, runtimeConfig);
+      const workspacePath = expandHomePath(config.workspacePath);
+      const volumeArgs = ["-v", `${workspacePath}:${workspacePath}`];
+
+      if (runtimeConfig.mountHome) {
+        const home = homedir();
+        volumeArgs.push("-v", `${home}:${home}`);
+      }
+
+      for (const mount of runtimeConfig.mounts) {
+        volumeArgs.push("-v", toVolumeArg(mount));
+      }
+
+      if (await dockerExists(containerName)) {
+        await removeContainer(containerName);
+      }
+
+      const args = [
+        "run",
+        "--detach",
+        "--interactive",
+        "--tty",
+        "--name",
+        containerName,
+        "--workdir",
+        workspacePath,
+      ];
+
+      if (runtimeConfig.user) {
+        args.push("--user", runtimeConfig.user);
+      }
+
+      for (const [key, value] of Object.entries(env)) {
+        args.push("-e", `${key}=${value}`);
+      }
+
+      args.push(...volumeArgs);
+      args.push(...runtimeConfig.extraArgs);
+      args.push(runtimeConfig.image, runtimeConfig.shell, "-lc", config.launchCommand);
+
+      try {
+        await docker(args);
+      } catch (err) {
+        await removeContainer(containerName);
+        const message = err instanceof Error ? err.message : String(err);
+        throw new Error(`Failed to start Docker container "${containerName}": ${message}`, {
+          cause: err,
+        });
+      }
+
+      return {
+        id: containerName,
+        runtimeName: "docker",
+        data: {
+          createdAt: Date.now(),
+          image: runtimeConfig.image,
+          shell: runtimeConfig.shell,
+          workspacePath,
+        },
+      };
+    },
+
+    async destroy(handle: RuntimeHandle): Promise<void> {
+      await removeContainer(handle.id);
+    },
+
+    async sendMessage(handle: RuntimeHandle, message: string): Promise<void> {
+      const shell =
+        typeof handle.data["shell"] === "string" && handle.data["shell"].length > 0
+          ? String(handle.data["shell"])
+          : "/bin/sh";
+
+      const child = spawn("docker", ["exec", "-i", handle.id, shell, "-lc", "cat > /proc/1/fd/0"], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const finish = (err?: Error | null) => {
+          if (settled) return;
+          settled = true;
+          if (err) reject(err);
+          else resolve();
+        };
+
+        child.once("error", (err) => finish(err));
+        child.once("exit", (code) => {
+          if (code === 0 || code === null) {
+            finish();
+          } else {
+            finish(new Error(`docker exec exited with code ${code}`));
+          }
+        });
+
+        child.stdin?.write(message.endsWith("\n") ? message : `${message}\n`, (err) => {
+          if (err) {
+            finish(err);
+            return;
+          }
+          child.stdin?.end();
+        });
+      });
+    },
+
+    async getOutput(handle: RuntimeHandle, lines = 50): Promise<string> {
+      try {
+        return await docker(["logs", "--tail", String(lines), handle.id]);
+      } catch {
+        return "";
+      }
+    },
+
+    async isAlive(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        const output = await docker(["inspect", "-f", "{{.State.Running}}", handle.id]);
+        return output.trim() === "true";
+      } catch {
+        return false;
+      }
+    },
+
+    async getMetrics(handle: RuntimeHandle): Promise<RuntimeMetrics> {
+      const createdAt = (handle.data["createdAt"] as number) ?? Date.now();
+      return {
+        uptimeMs: Date.now() - createdAt,
+      };
+    },
+
+    async getAttachInfo(handle: RuntimeHandle): Promise<AttachInfo> {
+      return {
+        type: "docker",
+        target: handle.id,
+        command: createAttachCommand(handle),
+      };
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Runtime>;

--- a/packages/plugins/runtime-docker/tsconfig.json
+++ b/packages/plugins/runtime-docker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -22,6 +22,7 @@
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
+    "@composio/ao-plugin-runtime-docker": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",
     "@composio/ao-plugin-scm-github": "workspace:*",
     "@composio/ao-plugin-tracker-github": "workspace:*",

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -6,6 +6,7 @@ const {
   mockCreateSessionManager,
   mockRegistry,
   tmuxPlugin,
+  dockerPlugin,
   claudePlugin,
   opencodePlugin,
   worktreePlugin,
@@ -30,6 +31,7 @@ const {
     mockCreateSessionManager,
     mockRegistry,
     tmuxPlugin: { manifest: { name: "tmux" } },
+    dockerPlugin: { manifest: { name: "docker" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     opencodePlugin: { manifest: { name: "opencode" } },
     worktreePlugin: { manifest: { name: "worktree" } },
@@ -58,6 +60,7 @@ vi.mock("@composio/ao-core", () => ({
 }));
 
 vi.mock("@composio/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
+vi.mock("@composio/ao-plugin-runtime-docker", () => ({ default: dockerPlugin }));
 vi.mock("@composio/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
 vi.mock("@composio/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));
 vi.mock("@composio/ao-plugin-workspace-worktree", () => ({ default: worktreePlugin }));

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -36,6 +36,7 @@ import {
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
+import pluginRuntimeDocker from "@composio/ao-plugin-runtime-docker";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
@@ -78,6 +79,7 @@ async function initServices(): Promise<Services> {
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
+  registry.register(pluginRuntimeDocker);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@composio/ao-plugin-notifier-webhook':
         specifier: workspace:*
         version: link:../plugins/notifier-webhook
+      '@composio/ao-plugin-runtime-docker':
+        specifier: workspace:*
+        version: link:../plugins/runtime-docker
       '@composio/ao-plugin-runtime-process':
         specifier: workspace:*
         version: link:../plugins/runtime-process
@@ -169,6 +172,9 @@ importers:
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@composio/ao-plugin-runtime-docker':
+        specifier: workspace:*
+        version: link:../plugins/runtime-docker
       '@composio/ao-plugin-runtime-process':
         specifier: workspace:*
         version: link:../plugins/runtime-process
@@ -351,6 +357,22 @@ importers:
         version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/plugins/notifier-webhook:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/runtime-docker:
     dependencies:
       '@composio/ao-core':
         specifier: workspace:*
@@ -556,6 +578,9 @@ importers:
       '@composio/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@composio/ao-plugin-runtime-docker':
+        specifier: workspace:*
+        version: link:../plugins/runtime-docker
       '@composio/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux


### PR DESCRIPTION
```md
## Summary

This PR adds first-class Docker runtime support while keeping tmux as the default local runtime.

It also improves runtime selection UX by supporting:
- config-driven runtime selection per project
- temporary CLI overrides with `--runtime`
- permanent project runtime updates with `ao runtime set`

## Changes

- Added a new `runtime-docker` plugin for running agent sessions inside Docker containers
- Registered Docker as a built-in runtime in core, CLI, and web service wiring
- Added `runtimeConfig` support so Docker-specific settings can be passed per project
- Updated CLI commands (`start`, `spawn`, `open`, `session`, `status`) to be runtime-aware instead of assuming tmux
- Added runtime preflight checks for Docker
- Added `--runtime` overrides for `ao start`, `ao spawn`, and `ao batch-spawn`
- Added `ao runtime show|set|clear` to inspect and persist project runtime configuration
- Added tests for Docker runtime support and runtime selection behavior
- Updated docs and example config

## Example

Temporary override:

```bash
ao spawn my-app --runtime docker
ao start my-app --runtime docker
```

Permanent project setting:

```bash
ao runtime set my-app docker
ao runtime show my-app
ao runtime clear my-app
```

Example YAML:

```yaml
defaults:
  runtime: tmux

projects:
  my-app:
    path: ~/code/my-app
    repo: org/my-app
    defaultBranch: main
    sessionPrefix: app
    runtime: docker
    runtimeConfig:
      image: ghcr.io/your-org/ao-agent:latest
```

## Validation

- Built `@composio/ao-core`
- Ran targeted CLI tests for `open`, `session`, `spawn`, `start`, and `runtime`
- Ran CLI typecheck
- Ran targeted web services test and typecheck
- Ran targeted core config validation test
- Added Docker integration test coverage with clean skip behavior when Docker is unavailable

## Notes

- `--runtime` is a temporary override and does not rewrite project config
- `ao runtime set <project> <runtime>` is the explicit permanent path
- Docker runtime requires `projects.<id>.runtimeConfig.image` to be set