### PR TITLE
fix: use terminal-notifier for clickable macOS notifications

### DIFF
--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -69,7 +69,7 @@ function extractPluginConfig(
       const matches = hasExplicitPlugin ? configuredPlugin === name : notifierName === name;
       if (matches) {
         const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
-        return { port: config.port, ...rest };
+        return { ...rest, port: config.port };
       }
     }
     // Notifier listed as a plain string (no config object) — still pass port

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -69,8 +69,12 @@ function extractPluginConfig(
       const matches = hasExplicitPlugin ? configuredPlugin === name : notifierName === name;
       if (matches) {
         const { plugin: _plugin, ...rest } = notifierConfig as Record<string, unknown>;
-        return rest;
+        return { port: config.port, ...rest };
       }
+    }
+    // Notifier listed as a plain string (no config object) — still pass port
+    if (Array.isArray(config.notifiers) && config.notifiers.includes(name)) {
+      return { port: config.port };
     }
   }
 

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -72,8 +72,8 @@ function extractPluginConfig(
         return { ...rest, port: config.port };
       }
     }
-    // Notifier listed as a plain string (no config object) — still pass port
-    if (Array.isArray(config.notifiers) && config.notifiers.includes(name)) {
+    // Notifier listed in defaults.notifiers without explicit config — still pass port
+    if (config.defaults?.notifiers?.includes(name)) {
       return { port: config.port };
     }
   }

--- a/packages/plugins/notifier-desktop/src/index.test.ts
+++ b/packages/plugins/notifier-desktop/src/index.test.ts
@@ -36,6 +36,7 @@ describe("notifier-desktop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPlatform.mockReturnValue("darwin");
+    // By default terminal-notifier succeeds
     mockExecFile.mockImplementation(
       (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
         cb(null);
@@ -83,98 +84,122 @@ describe("notifier-desktop", () => {
   });
 
   describe("notify", () => {
-    it("calls osascript on macOS", async () => {
+    it("calls terminal-notifier on macOS", async () => {
       const notifier = create();
       await notifier.notify(makeEvent());
 
       expect(mockExecFile).toHaveBeenCalledOnce();
-      expect(mockExecFile.mock.calls[0][0]).toBe("osascript");
-      expect(mockExecFile.mock.calls[0][1][0]).toBe("-e");
+      expect(mockExecFile.mock.calls[0][0]).toBe("terminal-notifier");
     });
 
     it("includes session ID in title", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ sessionId: "backend-5" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("backend-5");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const titleIdx = args.indexOf("-title");
+      expect(args[titleIdx + 1]).toContain("backend-5");
     });
 
     it("includes event message in notification body", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ message: "CI is failing" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("CI is failing");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const msgIdx = args.indexOf("-message");
+      expect(args[msgIdx + 1]).toContain("CI is failing");
     });
 
     it("uses URGENT prefix for urgent priority", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "urgent" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("URGENT");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const titleIdx = args.indexOf("-title");
+      expect(args[titleIdx + 1]).toContain("URGENT");
     });
 
     it("uses 'Agent Orchestrator' prefix for non-urgent priority", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "action" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("Agent Orchestrator");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const titleIdx = args.indexOf("-title");
+      expect(args[titleIdx + 1]).toContain("Agent Orchestrator");
     });
 
     it("includes sound for urgent notifications", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "urgent" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain('sound name "default"');
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).toContain("-sound");
     });
 
     it("does not include sound for info notifications", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "info" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).not.toContain("sound name");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).not.toContain("-sound");
     });
 
     it("does not include sound for action notifications", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "action" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).not.toContain("sound name");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).not.toContain("-sound");
     });
 
     it("does not include sound for warning notifications", async () => {
       const notifier = create();
       await notifier.notify(makeEvent({ priority: "warning" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).not.toContain("sound name");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).not.toContain("-sound");
     });
 
     it("respects sound=false config even for urgent", async () => {
       const notifier = create({ sound: false });
       await notifier.notify(makeEvent({ priority: "urgent" }));
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).not.toContain("sound name");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).not.toContain("-sound");
     });
 
-    it("escapes special characters in title and message", async () => {
-      const notifier = create();
-      await notifier.notify(
-        makeEvent({ sessionId: 'test"inject', message: 'msg with "quotes" and \\backslash' }),
-      );
+    it("includes dashboard URL as open action", async () => {
+      const notifier = create({ port: 4000 });
+      await notifier.notify(makeEvent());
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      // Should not contain unescaped quotes (other than the AppleScript string delimiters)
-      expect(script).toContain('test\\"inject');
-      expect(script).toContain('\\"quotes\\"');
-      expect(script).toContain("\\\\backslash");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const openIdx = args.indexOf("-open");
+      expect(args[openIdx + 1]).toBe("http://localhost:4000");
+    });
+
+    it("defaults to port 3000 for dashboard URL", async () => {
+      const notifier = create();
+      await notifier.notify(makeEvent());
+
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const openIdx = args.indexOf("-open");
+      expect(args[openIdx + 1]).toBe("http://localhost:3000");
+    });
+
+    it("falls back to osascript when terminal-notifier fails", async () => {
+      mockExecFile
+        .mockImplementationOnce((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+          cb(new Error("terminal-notifier not found"));
+        })
+        .mockImplementationOnce((_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
+          cb(null);
+        });
+
+      const notifier = create();
+      await expect(notifier.notify(makeEvent())).resolves.toBeUndefined();
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+      expect(mockExecFile.mock.calls[0][0]).toBe("terminal-notifier");
+      expect(mockExecFile.mock.calls[1][0]).toBe("osascript");
     });
   });
 
@@ -241,9 +266,11 @@ describe("notifier-desktop", () => {
       ];
       await notifier.notifyWithActions!(makeEvent(), actions);
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain("Merge");
-      expect(script).toContain("Kill");
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      const msgIdx = args.indexOf("-message");
+      const messageArg = args[msgIdx + 1];
+      expect(messageArg).toContain("Merge");
+      expect(messageArg).toContain("Kill");
     });
 
     it("includes sound for urgent with actions", async () => {
@@ -251,20 +278,20 @@ describe("notifier-desktop", () => {
       const actions: NotifyAction[] = [{ label: "Fix", url: "https://example.com" }];
       await notifier.notifyWithActions!(makeEvent({ priority: "urgent" }), actions);
 
-      const script = mockExecFile.mock.calls[0][1][1] as string;
-      expect(script).toContain('sound name "default"');
+      const args = mockExecFile.mock.calls[0][1] as string[];
+      expect(args).toContain("-sound");
     });
   });
 
   describe("error handling", () => {
-    it("rejects when execFile fails", async () => {
+    it("rejects when both terminal-notifier and osascript fail", async () => {
       mockExecFile.mockImplementation(
         (_cmd: string, _args: string[], cb: (err: Error | null) => void) => {
-          cb(new Error("osascript not found"));
+          cb(new Error("command not found"));
         },
       );
       const notifier = create();
-      await expect(notifier.notify(makeEvent())).rejects.toThrow("osascript not found");
+      await expect(notifier.notify(makeEvent())).rejects.toThrow("command not found");
     });
   });
 });

--- a/packages/plugins/notifier-desktop/src/index.ts
+++ b/packages/plugins/notifier-desktop/src/index.ts
@@ -48,27 +48,42 @@ function formatActionsMessage(event: OrchestratorEvent, actions: NotifyAction[])
  * Send a desktop notification using osascript (macOS) or notify-send (Linux).
  * Falls back gracefully if neither is available.
  *
- * Note: Desktop notifications do not support click-through URLs natively.
- * On macOS, osascript's `display notification` lacks URL support.
- * Consider `terminal-notifier` for click-to-open if needed in the future.
+ * On macOS, prefers terminal-notifier (click-to-open dashboard URL) over osascript.
+ * Falls back to osascript's `display notification` if terminal-notifier is not installed.
  */
 function sendNotification(
   title: string,
   message: string,
-  options: { sound: boolean; isUrgent: boolean },
+  options: { sound: boolean; isUrgent: boolean; openUrl?: string },
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const os = platform();
 
     if (os === "darwin") {
-      const safeTitle = escapeAppleScript(title);
-      const safeMessage = escapeAppleScript(message);
-      const soundClause = options.sound ? ' sound name "default"' : "";
-      const script = `display notification "${safeMessage}" with title "${safeTitle}"${soundClause}`;
-      execFile("osascript", ["-e", script], (err) => {
-        if (err) reject(err);
-        else resolve();
-      });
+      // Prefer terminal-notifier: supports click-to-open URL and shows under Terminal
+      // Falls back to osascript if terminal-notifier is not available
+      const tryTerminalNotifier = () => {
+        const args = ["-title", title, "-message", message, "-group", "ao-orchestrator"];
+        if (options.openUrl) args.push("-open", options.openUrl);
+        if (options.sound) args.push("-sound", "default");
+        execFile("terminal-notifier", args, (err) => {
+          if (err) fallbackOsascript();
+          else resolve();
+        });
+      };
+
+      const fallbackOsascript = () => {
+        const safeTitle = escapeAppleScript(title);
+        const safeMessage = escapeAppleScript(message);
+        const soundClause = options.sound ? ' sound name "default"' : "";
+        const script = `display notification "${safeMessage}" with title "${safeTitle}"${soundClause}`;
+        execFile("osascript", ["-e", script], (err) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      };
+
+      tryTerminalNotifier();
     } else if (os === "linux") {
       // Linux urgency is driven by event priority, not the macOS sound config
       const args: string[] = [];
@@ -89,6 +104,8 @@ function sendNotification(
 
 export function create(config?: Record<string, unknown>): Notifier {
   const soundEnabled = typeof config?.sound === "boolean" ? config.sound : true;
+  const port = typeof config?.port === "number" ? config.port : 3000;
+  const dashboardUrl = `http://localhost:${port}`;
 
   return {
     name: "desktop",
@@ -98,7 +115,7 @@ export function create(config?: Record<string, unknown>): Notifier {
       const message = formatMessage(event);
       const sound = shouldPlaySound(event.priority, soundEnabled);
       const isUrgent = event.priority === "urgent";
-      await sendNotification(title, message, { sound, isUrgent });
+      await sendNotification(title, message, { sound, isUrgent, openUrl: dashboardUrl });
     },
 
     async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
@@ -108,7 +125,7 @@ export function create(config?: Record<string, unknown>): Notifier {
       const message = formatActionsMessage(event, actions);
       const sound = shouldPlaySound(event.priority, soundEnabled);
       const isUrgent = event.priority === "urgent";
-      await sendNotification(title, message, { sound, isUrgent });
+      await sendNotification(title, message, { sound, isUrgent, openUrl: dashboardUrl });
     },
   };
 }


### PR DESCRIPTION
## Summary
- Fixes #534 — macOS desktop notifications showed as "Script Editor" and clicking them opened an empty Finder window
- Prefer `terminal-notifier` on macOS with `-open` flag so clicking a notification opens the web dashboard
- Falls back to `osascript` if `terminal-notifier` is not installed
- Passes `port` from orchestrator config to the notifier plugin so it builds the correct dashboard URL

## Test plan
- [x] All 28 notifier-desktop tests pass (updated for new terminal-notifier args)
- [ ] Verify on macOS: notification shows under "Terminal" instead of "Script Editor"
- [ ] Verify on macOS: clicking notification opens `http://localhost:<port>` in browser
- [ ] Verify fallback: uninstall terminal-notifier and confirm osascript still fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)