### PR TITLE
Fix orchestrator startup kickoff prompt

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -644,6 +644,30 @@ describe("start command — browser open waits for port", () => {
       "my-app",
     );
   });
+
+  it("passes an initial orchestration prompt into spawnOrchestrator", async () => {
+    mockConfigRef.current = makeConfig({
+      "my-app": makeProject({
+        tracker: { plugin: "github", issueFilters: { labels: ["ready"] } },
+      }),
+    });
+
+    mockSessionManager.get.mockResolvedValue(null);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        systemPrompt: expect.stringContaining("You are the **orchestrator agent**"),
+        prompt: expect.stringContaining("initial orchestration pass"),
+      }),
+    );
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining("labels=ready") }),
+    );
+  });
 });
 
 describe("start command — orchestrator session strategy display", () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -19,6 +19,7 @@ import type { Command } from "commander";
 import {
   loadConfig,
   generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
   generateSessionPrefix,
   findConfigFile,
   isRepoUrl,
@@ -565,7 +566,8 @@ async function runStartup(
     try {
       spinner.start("Creating orchestrator session");
       const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-      const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+      const prompt = generateOrchestratorStartupPrompt({ config, projectId, project });
+      const session = await sm.spawnOrchestrator({ projectId, systemPrompt, prompt });
       if (session.runtimeHandle?.id) {
         tmuxTarget = session.runtimeHandle.id;
       }

--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { generateOrchestratorPrompt } from "../orchestrator-prompt.js";
+import {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "../orchestrator-prompt.js";
 import type { OrchestratorConfig } from "../types.js";
 
 const config: OrchestratorConfig = {
@@ -53,5 +56,38 @@ describe("generateOrchestratorPrompt", () => {
     expect(prompt).toContain("must be delegated to a **worker session**");
     expect(prompt).toContain("Never claim a PR into `app-orchestrator`");
     expect(prompt).toContain("Delegate implementation, test execution, or PR claiming");
+  });
+});
+
+describe("generateOrchestratorStartupPrompt", () => {
+  it("kicks off an immediate tracker triage pass when a tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: {
+        ...config.projects["my-app"]!,
+        tracker: {
+          plugin: "github",
+          issueFilters: { labels: ["ready"], state: "open" },
+        },
+      },
+    });
+
+    expect(prompt).toContain("Do an initial orchestration pass");
+    expect(prompt).toContain("ao session ls -p my-app");
+    expect(prompt).toContain("configured github tracker");
+    expect(prompt).toContain("labels=ready");
+    expect(prompt).toContain("ao batch-spawn my-app");
+  });
+
+  it("falls back to monitoring guidance when no tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: config.projects["my-app"]!,
+    });
+
+    expect(prompt).toContain("There is no tracker configured for this project");
+    expect(prompt).not.toContain("ao batch-spawn my-app");
   });
 });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -3806,6 +3806,53 @@ describe("spawnOrchestrator", () => {
     expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
   });
 
+  it("passes the initial orchestrator prompt to the agent launch config", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Check ready issues and spawn workers.",
+    });
+
+    expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "app-orchestrator",
+        prompt: "Check ready issues and spawn workers.",
+      }),
+    );
+  });
+
+  it("sends the initial orchestrator prompt post-launch when the agent requires it", async () => {
+    vi.useFakeTimers();
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const spawnPromise = sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Check ready issues and spawn workers.",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await spawnPromise;
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+      "Check ready issues and spawn workers.",
+    );
+    vi.useRealTimers();
+  });
+
   it("throws for unknown project", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,7 +75,10 @@ export type {
 } from "./decomposer.js";
 
 // Orchestrator prompt — generates orchestrator context for `ao start`
-export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
+export {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -13,6 +13,37 @@ export interface OrchestratorPromptConfig {
   project: ProjectConfig;
 }
 
+function formatTrackerIssueFilters(project: ProjectConfig): string | null {
+  const rawFilters = project.tracker?.["issueFilters"];
+  if (!rawFilters || typeof rawFilters !== "object" || Array.isArray(rawFilters)) {
+    return null;
+  }
+
+  const filters = rawFilters as Record<string, unknown>;
+  const parts: string[] = [];
+
+  if (typeof filters["state"] === "string" && filters["state"].trim().length > 0) {
+    parts.push(`state=${filters["state"]}`);
+  }
+
+  if (Array.isArray(filters["labels"])) {
+    const labels = filters["labels"].filter((label): label is string => typeof label === "string");
+    if (labels.length > 0) {
+      parts.push(`labels=${labels.join(", ")}`);
+    }
+  }
+
+  if (typeof filters["assignee"] === "string" && filters["assignee"].trim().length > 0) {
+    parts.push(`assignee=${filters["assignee"]}`);
+  }
+
+  if (typeof filters["limit"] === "number" && Number.isFinite(filters["limit"])) {
+    parts.push(`limit=${filters["limit"]}`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
 /**
  * Generate orchestrator prompt content.
  * Provides orchestrator agent with context about available commands,
@@ -241,4 +272,41 @@ ${project.orchestratorRules}`);
   }
 
   return sections.join("\n\n");
+}
+
+/**
+ * Generate the initial user prompt that kicks off orchestration work after
+ * `ao start`. Without this, interactive agents like Codex just open a REPL and
+ * sit idle even though the orchestrator session appears healthy.
+ */
+export function generateOrchestratorStartupPrompt(opts: OrchestratorPromptConfig): string {
+  const { projectId, project } = opts;
+  const trackerPlugin = typeof project.tracker?.plugin === "string" ? project.tracker.plugin : null;
+  const trackerFilters = formatTrackerIssueFilters(project);
+
+  if (!trackerPlugin) {
+    return [
+      `Do an initial orchestration pass for ${project.name} now.`,
+      `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+      "2. There is no tracker configured for this project, so do not invent new work.",
+      "3. If workers already exist, monitor them for CI failures, review comments, blocked states, and merge-ready PRs.",
+      "4. If nothing needs action, report that the project is idle and remain available.",
+      "Do not implement code yourself from the orchestrator session.",
+    ].join("\n");
+  }
+
+  const filterClause = trackerFilters
+    ? ` matching these configured tracker filters: ${trackerFilters}.`
+    : ".";
+
+  return [
+    `Do an initial orchestration pass for ${project.name} now.`,
+    `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+    `2. Query the configured ${trackerPlugin} tracker for open issues${filterClause}`,
+    "3. Identify issues that are ready to work and do not already have an active AO worker session.",
+    `4. Spawn missing workers for those issues. Prefer \`ao batch-spawn ${projectId} ...\` when multiple issues qualify.`,
+    "5. After spawning, switch back to monitoring mode: watch worker progress, CI failures, review comments, blocked sessions, and merge-ready PRs.",
+    "6. If no issue needs action, say so briefly and remain available.",
+    "Do not implement code yourself from the orchestrator session.",
+  ].join("\n");
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1350,6 +1350,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
         },
       },
+      prompt: orchestratorConfig.prompt,
       permissions: "permissionless" as const,
       model: selection.model,
       systemPromptFile,
@@ -1443,6 +1444,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         /* best effort */
       }
       throw err;
+    }
+
+    if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+        await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+      } catch {
+        // Non-fatal: the orchestrator is running; user can retry with `ao send`.
+      }
     }
 
     return session;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,8 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Initial user prompt that kicks off the first orchestration pass. */
+  prompt?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

- pass a real kickoff prompt when starting orchestrators
- support prompt delivery for orchestrators like worker sessions
- ensure Codex-based orchestrators immediately inspect ready issues and spawn workers

## Root cause

`ao start` launched orchestrators with only a system prompt.

For Codex, that left the orchestrator idle in the interactive REPL, so a project could have ready issues while no workers were ever spawned.

## What changed

- added a real orchestrator startup prompt generator
- passed both the system prompt and a kickoff prompt during orchestrator startup
- extended orchestrator spawning so it supports prompt delivery like worker sessions
- added post-launch prompt delivery for orchestrators when the selected agent requires it

## Verification

- reproduced an idle orchestrator with ready issues on `ao-tui`
- `pnpm --filter @composio/ao-core test -- src/__tests__/orchestrator-prompt.test.ts src/__tests__/session-manager.test.ts`
- `pnpm --filter @composio/ao-cli test -- __tests__/commands/start.test.ts`
- `pnpm --filter @composio/ao-core build`
- `pnpm --filter @composio/ao-core typecheck`
- `pnpm --filter @composio/ao-cli typecheck`
- `pnpm --filter @composio/ao-cli build`