### PR TITLE
fix(core): resolve live worktree branch for PR autodetect in lifecycle

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -11,6 +11,8 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -37,6 +39,8 @@ import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+
+const execFileAsync = promisify(execFile);
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -98,6 +102,20 @@ function createEvent(
     message: opts.message,
     data: opts.data ?? {},
   };
+}
+
+async function resolveLiveBranch(session: Session): Promise<string | null | undefined> {
+  if (!session.workspacePath) return session.branch;
+  try {
+    const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+      cwd: session.workspacePath,
+      timeout: 5_000,
+    });
+    const branch = stdout.trim();
+    return branch || session.branch;
+  } catch {
+    return session.branch;
+  }
 }
 
 /** Determine which event type corresponds to a status transition. */
@@ -285,23 +303,30 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     //    OpenCode) that can't reliably write pr=<url> to metadata on their own.
     //    Skip orchestrator sessions — they sit on the base branch (e.g. master)
     //    and should never own a PR.
+    const liveBranch = await resolveLiveBranch(session);
+    const scmSession =
+      liveBranch && liveBranch !== session.branch ? { ...session, branch: liveBranch } : session;
+
     if (
       !session.pr &&
       scm &&
-      session.branch &&
+      liveBranch &&
       session.metadata["prAutoDetect"] !== "off" &&
       session.metadata["role"] !== "orchestrator" &&
       !session.id.endsWith("-orchestrator")
     ) {
       try {
-        const detectedPR = await scm.detectPR(session, project);
+        const detectedPR = await scm.detectPR(scmSession, project);
         if (detectedPR) {
           session.pr = detectedPR;
           // Persist PR URL so subsequent polls don't need to re-query.
-          // Don't write status here — step 4 below will determine the
-          // correct status (merged, ci_failed, etc.) on this same cycle.
+          // Also repair stale branch metadata so future lifecycle polls keep
+          // tracking the real PR/CI state even after branch drift.
           const sessionsDir = getSessionsDir(config.configPath, project.path);
-          updateMetadata(sessionsDir, session.id, { pr: detectedPR.url });
+          updateMetadata(sessionsDir, session.id, {
+            pr: detectedPR.url,
+            ...(liveBranch !== session.branch ? { branch: liveBranch } : {}),
+          });
         }
       } catch {
         // SCM detection failed — will retry next poll


### PR DESCRIPTION
## Summary

When agents switch branches during work (e.g. `feat/issue-53` → `feat/53`), the lifecycle manager still used the **stale session metadata branch** for PR auto-detection. This meant `detectPR()` returned null, so CI failure reactions (`ci-failed → send-to-agent`) never triggered.

## Root cause

`lifecycle-manager.ts` step 3 (PR auto-detect) passed `session.branch` directly to `scm.detectPR()`. If the agent had renamed or switched branches in its worktree, the metadata branch no longer matched the actual HEAD, so no PR was found.

## What changed

- Added `resolveLiveBranch()` — reads actual branch from worktree via `git branch --show-current`
- PR auto-detect now uses the resolved live branch instead of stale metadata
- On successful PR detection with branch drift, metadata is self-healed (`branch=` updated)
- Falls back gracefully to metadata branch if git probe fails

## Verification

```bash
pnpm --filter @composio/ao-core typecheck   # ✅
pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts  # 30/30 ✅
```

## Reproduction scenario

1. AO spawns worker on `feat/issue-53`
2. Agent renames branch to `feat/53` and pushes PR
3. Lifecycle polls: `session.branch` still says `feat/issue-53`
4. `detectPR()` finds nothing → no `session.pr` → CI check never runs
5. CI fails but AO never sends `ci-failed` reaction to agent

After fix: lifecycle resolves `feat/53` from worktree, finds PR, detects CI failure, triggers reaction.