### PR TITLE
fix(core): log notifier errors and notify human on first reaction dispatch

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -425,6 +425,19 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     switch (action) {
       case "send-to-agent": {
         if (reactionConfig.message) {
+          // On first trigger, also notify the human so they know a reaction
+          // was dispatched (e.g. "CI failed — agent notified").  Subsequent
+          // retries stay silent until escalation.
+          if (tracker.attempts === 1) {
+            const firstTriggerEvent = createEvent("reaction.triggered", {
+              sessionId,
+              projectId,
+              message: `${reactionKey}: dispatching to agent (${sessionId})`,
+              data: { reactionKey, action: "send-to-agent", attempt: 1 },
+            });
+            await notifyHuman(firstTriggerEvent, reactionConfig.priority ?? "info");
+          }
+
           try {
             await sessionManager.send(sessionId, reactionConfig.message);
 
@@ -693,8 +706,23 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (notifier) {
         try {
           await notifier.notify(eventWithPriority);
-        } catch {
-          // Notifier failed — not much we can do
+        } catch (err) {
+          // Log notifier failures so they are visible in observability output
+          // instead of being silently swallowed.
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "notifyHuman",
+            outcome: "failure",
+            correlationId: createCorrelationId("notify-error"),
+            projectId: event.projectId ?? "unknown",
+            sessionId: event.sessionId ?? "unknown",
+            data: {
+              notifier: name,
+              eventType: event.type,
+              error: err instanceof Error ? err.message : String(err),
+            },
+            level: "error",
+          });
         }
       }
     }


### PR DESCRIPTION
## Summary

Two targeted fixes in the lifecycle-manager notification path.

### 1. Log notifier errors instead of silently swallowing them

**Before:** `notifyHuman()` had a bare `catch {}` that silently discarded all notifier errors.
**After:** Errors are logged via the observability system (`lifecycle_poll` metric, `failure` outcome) with notifier name, event type, and error message.

### 2. Notify human on first reaction dispatch

**Before:** When a `send-to-agent` reaction fires (e.g. CI failed → send fix request to agent), `reactionHandledNotify = true` suppresses *all* human notification. The human only learns about the issue when the reaction escalates after retries.

**After:** On the first trigger (`attempts === 1`), a `reaction.triggered` event is sent to the human so they know a reaction was dispatched. Subsequent retries remain silent until escalation.

## Verification

```bash
pnpm --filter @composio/ao-core typecheck   # pass
pnpm --filter @composio/ao-core build       # pass
pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts  # 30/30 pass
```