### PR TITLE
fix: improve status display for PR detection, CI status, and activity state

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -661,6 +661,55 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
   });
 
+  it("clears PR metadata when SCM reports a closed PR", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("closed"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+      pr: "https://example.com/pr/1",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("killed");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["pr"] ?? "").toBe("");
+  });
+
   it("skips PR auto-detection when metadata disables it", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -313,7 +313,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       try {
         const prState = await scm.getPRState(session.pr);
         if (prState === PR_STATE.MERGED) return "merged";
-        if (prState === PR_STATE.CLOSED) return "killed";
+        if (prState === PR_STATE.CLOSED) {
+          // Closed PRs are terminal for this session; clear persisted PR metadata
+          // so killed sessions don't get re-polled forever via `if (s.pr) return true`.
+          session.pr = undefined;
+          try {
+            const sessionsDir = getSessionsDir(config.configPath, project.path);
+            updateMetadata(sessionsDir, session.id, { pr: "" });
+          } catch {
+            // Best effort — lifecycle status should still proceed to killed.
+          }
+          return "killed";
+        }
 
         // Check CI
         const ciStatus = await scm.getCISummary(session.pr);


### PR DESCRIPTION
## Problem

`ao status` shows incorrect data in three scenarios:

### Bug 1: PR detection fails on branch name mismatch
When the agent creates a PR on a different branch name than what's stored in session metadata (e.g., metadata says `feat/issue-9` but PR is on `feat/9`), `detectPR()` can't find the PR because it searches by the metadata branch.

### Bug 2: CI status not visible even for sessions with PRs
CI polling reads the branch from metadata (wrong name) instead of using the PR number directly, so CI/review status shows "-" even when a PR exists.

### Bug 3: Activity stuck on "unknown"
`getActivityState()` returns `null` when no JSONL session file is available (no workspace path, agent started externally, etc.), causing activity to display as "unknown" for running agents.

## Fix

### Bugs 1+2 (status.ts)
- Use the **live worktree branch** (from `git branch --show-current`) for `detectPR()` instead of stale metadata branch
- When branch-based `detectPR()` fails but a PR URL exists in metadata, **fall back to `resolvePR()`** using the PR number extracted from the URL
- Remove the `branch` guard so PR resolution can work even without a branch

### Bug 3 (session-manager.ts)
- When JSONL-based `getActivityState()` returns `null` (no session file, no workspace, etc.) but the agent process IS running, **fall back to terminal output parsing** via `detectActivity()` + `runtime.getOutput()`
- This prevents showing "unknown" for agents that are actively running but don't have JSONL session files

## Testing
- Build passes (`pnpm build`)
- Changes are minimal and targeted at the exact failure paths