### PR TITLE
chore: add changeset to trigger npm publish for onboarding improvements

### DIFF
--- a/.changeset/onboarding-improvements.md
+++ b/.changeset/onboarding-improvements.md
@@ -1,0 +1,12 @@
+---
+"@composio/ao-core": minor
+"@composio/ao-cli": minor
+"@composio/ao": minor
+"@composio/ao-web": minor
+"@composio/ao-plugin-agent-claude-code": patch
+"@composio/ao-plugin-agent-aider": patch
+"@composio/ao-plugin-agent-codex": patch
+"@composio/ao-plugin-agent-opencode": patch
+---
+
+Zero-friction onboarding: `ao start` auto-detects project, generates config, and launches dashboard — no prompts, no manual setup. Renamed npm package to `@composio/ao`. Made `@composio/ao-web` publishable with production entry point. Cross-platform agent detection. Auto-port-finding. Permission auto-retry in shell scripts.


### PR DESCRIPTION
## Summary

Adds a changeset file so the release workflow publishes updated packages to npm.

The onboarding improvements from #463 and #537 are merged but never published because no changeset was included. This triggers a version bump and publish for:

- `@composio/ao` — minor (renamed from `@composio/agent-orchestrator`)
- `@composio/ao-cli` — minor (`ao start` auto-creates config)
- `@composio/ao-core` — minor (`ConfigNotFoundError` class)
- `@composio/ao-web` — minor (production entry point, publishable)
- Agent plugins — patch (cross-platform `detect()`)

Once merged, the release workflow will:
1. Create a "Version Packages" PR with bumped versions
2. When that PR is merged, publish to npm

After that, `npm install -g @composio/ao && ao start` will work out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)