### PR TITLE
fix(core): implement auto-merge and runtime cleanup on terminal transitions

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -942,6 +942,63 @@ describe("check (single session)", () => {
     expect(dockerRuntime.destroy).not.toHaveBeenCalled();
   });
 
+  it("uses runtimeHandle.runtimeName for liveness checks", async () => {
+    const tmuxRuntime: Runtime = {
+      ...mockRuntime,
+      name: "tmux",
+      isAlive: vi.fn().mockResolvedValue(true),
+      getOutput: vi.fn().mockResolvedValue(""),
+    };
+    const dockerRuntime: Runtime = {
+      ...mockRuntime,
+      name: "docker",
+      isAlive: vi.fn().mockResolvedValue(false),
+      getOutput: vi.fn().mockResolvedValue(""),
+    };
+
+    config.defaults.runtime = "docker";
+    config.projects["my-app"] = {
+      ...config.projects["my-app"],
+      runtime: "docker",
+    };
+
+    const registryWithRuntimeMismatch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime" && name === "tmux") return tmuxRuntime;
+        if (slot === "runtime" && name === "docker") return dockerRuntime;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+    };
+
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      runtimeHandle: { id: "tmux-app-1", runtimeName: "tmux", data: {} },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithRuntimeMismatch,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(tmuxRuntime.isAlive).toHaveBeenCalledWith(session.runtimeHandle);
+    expect(dockerRuntime.isAlive).not.toHaveBeenCalled();
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
   it("detects mergeable when approved + CI green", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -230,9 +230,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
 
+    const resolvedRuntimeName =
+      session.runtimeHandle?.runtimeName ?? project.runtime ?? config.defaults.runtime;
+
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
-      const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
+      const runtime = registry.get<Runtime>("runtime", resolvedRuntimeName);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
         if (!alive) return "killed";
@@ -259,10 +262,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
-          const runtime = registry.get<Runtime>(
-            "runtime",
-            project.runtime ?? config.defaults.runtime,
-          );
+          const runtime = registry.get<Runtime>("runtime", resolvedRuntimeName);
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);


### PR DESCRIPTION
## Summary

Two critical bugs that prevented AO from completing the PR lifecycle autonomously:

### Bug 1: auto-merge reaction was a no-op
The `auto-merge` case in `executeReaction()` only sent a notification but never called `scm.mergePR()`. PRs that reached `mergeable` status were never actually merged — they sat open until a human intervened.

**Fix:** Resolve the SCM plugin via registry, look up the session's PR info, and call `scm.mergePR()` with a configurable merge method (default: squash). Errors are logged via observability and the reaction reports failure so it can retry.

### Bug 2: merged/killed sessions never cleaned up runtime
When a session transitioned to `merged` or `killed`, the tmux session was never destroyed. Workers sat idle on Codex/agent prompts indefinitely after their PRs were merged.

**Fix:** On terminal transitions (merged/killed), resolve the runtime plugin and call `runtime.destroy()` to clean up the tmux session.

### Verification
- `pnpm --filter @composio/ao-core typecheck` ✅
- `pnpm --filter @composio/ao-core build` ✅  
- `pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts` — 30/30 passed ✅

Closes #545