### PR TITLE
fix: disable husky in release workflow to unblock npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r --filter '!@composio/ao-web' build
+        # Disable husky hooks in CI — the pre-commit hook requires gitleaks
+        # which isn't installed on the runner. The changesets action commits
+        # version bumps internally and doesn't need secret scanning.
+      - run: echo "HUSKY=0" >> $GITHUB_ENV
       - uses: changesets/action@v1
         with:
           publish: pnpm release


### PR DESCRIPTION
## Summary

The release workflow fails because the husky pre-commit hook requires `gitleaks` which isn't installed on the CI runner. When the changesets action tries to commit version bumps, husky blocks it:

```
❌ gitleaks is not installed!
Commit blocked until gitleaks is installed.
husky - pre-commit script failed (code 1)
```

Fix: set `HUSKY=0` env var before the changesets action runs.

This also means the changeset from #578 will be picked up on the next run, triggering the npm publish of all updated packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)