### PR TITLE
fix(core): auto-archive stale orchestrator sessions when runtime dead and no open work

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -2225,7 +2225,7 @@ describe("cleanup", () => {
     expect(result.skipped).toContain("app-1");
   });
 
-  it("skips orchestrator sessions by role metadata", async () => {
+  it("cleans dead orchestrator sessions when no open work exists (role metadata)", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -2240,8 +2240,7 @@ describe("cleanup", () => {
       }),
     };
 
-    // Session with role=orchestrator but a name that does NOT end in "-orchestrator"
-    // so only the role metadata check can protect it (not the name fallback)
+    // Dead orchestrator with no sibling workers and no tracker → should be cleaned
     writeMetadata(sessionsDir, "app-99", {
       worktree: "/tmp",
       branch: "main",
@@ -2254,11 +2253,10 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const result = await sm.cleanup();
 
-    expect(result.killed).toHaveLength(0);
-    expect(result.skipped).toContain("app-99");
+    expect(result.killed).toContain("app-99");
   });
 
-  it("skips orchestrator sessions by name fallback (no role metadata)", async () => {
+  it("cleans dead orchestrator sessions when no open work exists (name fallback)", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -2273,7 +2271,7 @@ describe("cleanup", () => {
       }),
     };
 
-    // Pre-existing orchestrator session without role field
+    // Dead orchestrator (by name convention) with no sibling workers → should be cleaned
     writeMetadata(sessionsDir, "app-orchestrator", {
       worktree: "/tmp",
       branch: "main",
@@ -2285,11 +2283,27 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const result = await sm.cleanup();
 
+    expect(result.killed).toContain("app-orchestrator");
+  });
+
+  it("skips live orchestrator sessions even with no open work", async () => {
+    // Live orchestrator should never be killed
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-orch")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const result = await sm.cleanup();
+
     expect(result.killed).toHaveLength(0);
     expect(result.skipped).toContain("app-orchestrator");
   });
 
-  it("never cleans the canonical orchestrator session even with stale worker-like metadata", async () => {
+  it("cleans dead orchestrator with stale metadata when tracker reports no open issues", async () => {
     const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator.log");
     const mockBin = installMockOpencode("[]", deleteLogPath);
     process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
@@ -2354,9 +2368,52 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithSignals });
     const result = await sm.cleanup();
 
-    expect(result.killed).not.toContain("app-orchestrator");
+    // Dead orchestrator + no open issues (tracker has no listIssues, no sibling workers)
+    // → should be cleaned up
+    expect(result.killed).toContain("app-orchestrator");
+  });
+
+  it("skips dead orchestrator when tracker reports open issues", async () => {
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const trackerWithOpenIssues: Tracker = {
+      name: "mock-tracker",
+      getIssue: vi.fn(),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockReturnValue("https://example.com/1"),
+      branchName: vi.fn().mockReturnValue("feat/1"),
+      generatePrompt: vi.fn().mockResolvedValue(""),
+      listIssues: vi.fn().mockResolvedValue([
+        { id: "1", title: "Open issue", description: "", url: "https://example.com/1", state: "open", labels: [] },
+      ]),
+    };
+    const registryWithTracker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return trackerWithOpenIssues;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-orch")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithTracker });
+    const result = await sm.cleanup();
+
+    // Dead orchestrator BUT tracker reports open issues → keep it for watchdog to restart
+    expect(result.killed).toHaveLength(0);
     expect(result.skipped).toContain("app-orchestrator");
-    expect(existsSync(deleteLogPath)).toBe(false);
   });
 
   it("never cleans archived orchestrator mappings even when metadata looks stale", async () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1669,12 +1669,74 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           continue;
         }
 
+        const plugins = resolvePlugins(project);
+
+        // Orchestrator sessions are normally protected from cleanup, but stale
+        // orchestrators (runtime dead + no open work) should be archived so
+        // they don't linger in `ao status` indefinitely.
         if (isCleanupProtectedSession(project, session.id, session.metadata)) {
-          pushSkipped(session.projectId, session.id);
+          let orchestratorStale = false;
+          if (session.runtimeHandle && plugins.runtime) {
+            try {
+              const alive = await plugins.runtime.isAlive(session.runtimeHandle);
+              if (!alive) orchestratorStale = true;
+            } catch {
+              orchestratorStale = true;
+            }
+          } else {
+            // No runtime handle → already dead
+            orchestratorStale = true;
+          }
+
+          if (!orchestratorStale) {
+            // Orchestrator is still alive — don't touch it
+            pushSkipped(session.projectId, session.id);
+            continue;
+          }
+
+          // Runtime is dead — check if there's still open work by looking at
+          // sibling worker sessions in this project.
+          let hasOpenWork = false;
+
+          // Quick local check: are there any non-orchestrator active sessions?
+          const siblingWorkers = sessions.filter(
+            (s) =>
+              s.projectId === session.projectId &&
+              s.id !== session.id &&
+              !isOrchestratorSession({ id: s.id, metadata: s.metadata }),
+          );
+          if (siblingWorkers.length > 0) {
+            hasOpenWork = true;
+          }
+
+          // Also check the tracker for open issues if available
+          if (!hasOpenWork && plugins.tracker?.listIssues) {
+            try {
+              const openIssues = await plugins.tracker.listIssues(
+                { state: "open", limit: 1 },
+                project,
+              );
+              if (openIssues && openIssues.length > 0) hasOpenWork = true;
+            } catch {
+              // Can't check — assume there might be work, keep it safe
+              hasOpenWork = true;
+            }
+          }
+
+          if (hasOpenWork) {
+            // Still has work but runtime dead — skip, watchdog will restart it
+            pushSkipped(session.projectId, session.id);
+            continue;
+          }
+
+          // Dead orchestrator with no open work → kill it
+          if (!options?.dryRun) {
+            await kill(session.id, { purgeOpenCode: shouldPurgeOpenCode });
+          }
+          pushKilled(session.projectId, session.id);
           continue;
         }
 
-        const plugins = resolvePlugins(project);
         let shouldKill = false;
 
         // Check if PR is merged


### PR DESCRIPTION
## Summary
Orchestrator sessions were unconditionally protected from `ao session cleanup`, causing dead orchestrators to persist in `ao status` indefinitely after all work was complete.

## Root cause
`isCleanupProtectedSession()` returned `true` for any session with `role=orchestrator` or name ending in `-orchestrator`, regardless of runtime liveness or project work state.

## What changed
When cleanup encounters an orchestrator session, it now:
1. Checks if the runtime (tmux) is still alive → if alive, skip (protected as before)
2. If dead, checks for sibling worker sessions in the same project
3. If no workers, optionally queries the tracker for open issues (`listIssues`)
4. Only if there is **no remaining work** does it proceed with kill/archive

This means:
- Live orchestrators → **never touched** (same as before)
- Dead orchestrators with open issues/workers → **skipped** (watchdog will restart)
- Dead orchestrators with no work left → **cleaned up** ✅

## Verification
- 176/176 session-manager tests pass (3 existing tests updated + 2 new tests added)
- Typecheck + build pass for both core and cli packages