### PR TITLE
Fix dashboard command to start full web stack

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,9 +1,16 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
 import { findWebDir, buildDashboardEnv, waitForPortAndOpen } from "../lib/web-dir.js";
-import { cleanNextCache, findRunningDashboardPid, findProcessWebDir, waitForPortFree } from "../lib/dashboard-rebuild.js";
+import {
+  cleanNextCache,
+  findRunningDashboardPid,
+  findProcessWebDir,
+  waitForPortFree,
+} from "../lib/dashboard-rebuild.js";
 
 export function registerDashboard(program: Command): void {
   program
@@ -31,9 +38,7 @@ export function registerDashboard(program: Command): void {
 
         if (runningPid) {
           // Kill the running server, clean .next, then start fresh below.
-          console.log(
-            chalk.dim(`Stopping dashboard (PID ${runningPid}) on port ${port}...`),
-          );
+          console.log(chalk.dim(`Stopping dashboard (PID ${runningPid}) on port ${port}...`));
           try {
             process.kill(parseInt(runningPid, 10), "SIGTERM");
           } catch {
@@ -58,11 +63,19 @@ export function registerDashboard(program: Command): void {
         config.directTerminalPort,
       );
 
-      const child = spawn("npx", ["next", "dev", "-p", String(port)], {
-        cwd: webDir,
-        stdio: ["inherit", "inherit", "pipe"],
-        env,
-      });
+      const isDevMode = existsSync(resolve(webDir, "server"));
+
+      const child = isDevMode
+        ? spawn("pnpm", ["run", "dev"], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          })
+        : spawn("node", [resolve(webDir, "dist-server", "start-all.js")], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          });
 
       const stderrChunks: string[] = [];
 


### PR DESCRIPTION
## Summary
- make `ao dashboard` launch the full web dev stack in monorepo mode instead of only `next dev`
- use the packaged `dist-server/start-all.js` path in installed mode to match the existing `ao start` launcher split
- verify that one dashboard command brings up the dashboard and both terminal sidecars on ports 3000, 14800, and 14801