### PR TITLE
fix: auto-detect project from cwd in multi-project configs

### DIFF
--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -97,10 +97,10 @@ function resolveProject(
   }
 
   // Multiple projects — try matching cwd to a project path
+  // Note: loadConfig() already expands ~ in project paths via expandPaths()
   const currentDir = resolve(cwd());
   for (const [id, proj] of Object.entries(config.projects)) {
-    const projPath = resolve(proj.path.replace(/^~/, process.env["HOME"] || ""));
-    if (projPath === currentDir) {
+    if (resolve(proj.path) === currentDir) {
       return { projectId: id, project: proj };
     }
   }


### PR DESCRIPTION
## Summary

When multiple projects are configured and no project argument is given, `ao start` and `ao stop` error with "Multiple projects configured. Specify which one to start." — even when the user is inside a project directory.

This fix adds cwd-to-project-path matching in `resolveProject()`, matching the same pattern already used in `spawn`'s `autoDetectProject()`.

**Before:**
```
~/Desktop/agent-orchestrator $ ao start
Error: Multiple projects configured. Specify which one to start:
  ao start agent-orchestrator
  ao start mono
```

**After:**
```
~/Desktop/agent-orchestrator $ ao start
Starting orchestrator for agent-orchestrator
```

## Test plan

- [x] `ao start` from a project directory with multi-project config auto-selects the correct project
- [x] `ao start` from a non-project directory still shows the helpful error
- [x] `ao start <project-name>` explicit argument still works
- [x] Typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)