### PR TITLE
feat(web): redesign session detail page

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -2,53 +2,53 @@
 
 @theme {
   /* ── Base surfaces ────────────────────────────────────────────────── */
-  --color-bg-base:      #0d1117;
-  --color-bg-surface:   rgba(22, 27, 34, 0.8);
-  --color-bg-elevated:  rgba(28, 33, 40, 0.9);
-  --color-bg-subtle:    rgba(33, 38, 45, 0.7);
+  --color-bg-base: #0d1117;
+  --color-bg-surface: rgba(22, 27, 34, 0.8);
+  --color-bg-elevated: rgba(28, 33, 40, 0.9);
+  --color-bg-subtle: rgba(33, 38, 45, 0.7);
 
   /* Backward-compat aliases */
-  --color-bg-primary:   var(--color-bg-base);
+  --color-bg-primary: var(--color-bg-base);
   --color-bg-secondary: var(--color-bg-surface);
-  --color-bg-tertiary:  var(--color-bg-elevated);
+  --color-bg-tertiary: var(--color-bg-elevated);
 
   /* ── Borders ─────────────────────────────────────────────────────── */
-  --color-border-subtle:   rgba(48, 54, 61, 0.6);
-  --color-border-default:  rgba(48, 54, 61, 1);
-  --color-border-strong:   rgba(72, 79, 88, 1);
+  --color-border-subtle: rgba(48, 54, 61, 0.6);
+  --color-border-default: rgba(48, 54, 61, 1);
+  --color-border-strong: rgba(72, 79, 88, 1);
 
   /* Backward-compat aliases */
-  --color-border-muted:    var(--color-border-subtle);
+  --color-border-muted: var(--color-border-subtle);
   --color-border-emphasis: var(--color-border-strong);
 
   /* ── Text ─────────────────────────────────────────────────────────── */
-  --color-text-primary:   #e6edf3;
+  --color-text-primary: #e6edf3;
   --color-text-secondary: #7d8590;
-  --color-text-tertiary:  #484f58;
-  --color-text-muted:     #484f58;
-  --color-text-inverse:   #0d1117;
+  --color-text-tertiary: #484f58;
+  --color-text-muted: #484f58;
+  --color-text-inverse: #0d1117;
 
   /* ── Interactive accent ──────────────────────────────────────────── */
-  --color-accent:         #58a6ff;
-  --color-accent-hover:   #79b8ff;
-  --color-accent-subtle:  rgba(88, 166, 255, 0.12);
+  --color-accent: #58a6ff;
+  --color-accent-hover: #79b8ff;
+  --color-accent-subtle: rgba(88, 166, 255, 0.12);
 
   /* ── Status / semantic colors ────────────────────────────────────── */
-  --color-status-working:   #58a6ff;
-  --color-status-ready:     #3fb950;
+  --color-status-working: #58a6ff;
+  --color-status-ready: #3fb950;
   --color-status-attention: #d29922;
-  --color-status-idle:      #484f58;
-  --color-status-done:      #30363d;
-  --color-status-error:     #f85149;
+  --color-status-idle: #484f58;
+  --color-status-done: #30363d;
+  --color-status-error: #f85149;
 
   /* Semantic aliases */
-  --color-accent-blue:    #58a6ff;
-  --color-accent-green:   #3fb950;
-  --color-accent-yellow:  #d29922;
-  --color-accent-orange:  #d18616;
-  --color-accent-red:     #f85149;
-  --color-accent-violet:  #a371f7;
-  --color-accent-purple:  #bc8cff;
+  --color-accent-blue: #58a6ff;
+  --color-accent-green: #3fb950;
+  --color-accent-yellow: #d29922;
+  --color-accent-orange: #d18616;
+  --color-accent-red: #f85149;
+  --color-accent-violet: #a371f7;
+  --color-accent-purple: #bc8cff;
 
   /* ── Typography ──────────────────────────────────────────────────── */
   --font-sans: var(--font-ibm-plex-sans), "SF Pro Text", -apple-system, system-ui, sans-serif;
@@ -61,7 +61,7 @@
   --radius-xl: 12px;
 
   /* ── Transitions ──────────────────────────────────────────────────── */
-  --transition-quick:   0.1s;
+  --transition-quick: 0.1s;
   --transition-regular: 0.25s;
 }
 
@@ -88,56 +88,92 @@ a:hover {
 
 /* ── Scrollbar ────────────────────────────────────────────────────────── */
 
-::-webkit-scrollbar { width: 6px; height: 6px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.08); border-radius: 3px; }
-::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.15); }
-::-webkit-scrollbar-thumb:active { background: rgba(255,255,255,0.25); }
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+::-webkit-scrollbar-thumb:active {
+  background: rgba(255, 255, 255, 0.25);
+}
 
 /* ── Animations ──────────────────────────────────────────────────────── */
 
 @keyframes activity-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.45); }
-  50%       { box-shadow: 0 0 0 4px rgba(88, 166, 255, 0); }
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(88, 166, 255, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 4px rgba(88, 166, 255, 0);
+  }
 }
 
 @keyframes spin {
-  from { transform: rotate(0deg); }
-  to   { transform: rotate(360deg); }
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50%       { opacity: 0.4; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
 }
 
 @keyframes slide-up {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* ── Orchestrator button ──────────────────────────────────────────────── */
 
 .orchestrator-btn {
   color: var(--color-accent);
-  background: linear-gradient(175deg, rgba(88,166,255,0.12) 0%, rgba(88,166,255,0.06) 100%);
-  border: 1px solid rgba(88,166,255,0.25);
+  background: linear-gradient(175deg, rgba(88, 166, 255, 0.12) 0%, rgba(88, 166, 255, 0.06) 100%);
+  border: 1px solid rgba(88, 166, 255, 0.25);
   box-shadow:
-    0 1px 2px rgba(0,0,0,0.6),
-    0 3px 8px rgba(0,0,0,0.3),
-    inset 0 1px 0 rgba(255,255,255,0.08);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+    0 1px 2px rgba(0, 0, 0, 0.6),
+    0 3px 8px rgba(0, 0, 0, 0.3),
+    inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    background 0.12s ease,
+    border-color 0.12s ease;
 }
 
 .orchestrator-btn:hover {
   transform: translateY(-1px);
-  background: linear-gradient(175deg, rgba(88,166,255,0.18) 0%, rgba(88,166,255,0.1) 100%);
-  border-color: rgba(88,166,255,0.45);
+  background: linear-gradient(175deg, rgba(88, 166, 255, 0.18) 0%, rgba(88, 166, 255, 0.1) 100%);
+  border-color: rgba(88, 166, 255, 0.45);
   box-shadow:
-    0 2px 6px rgba(0,0,0,0.7),
-    0 8px 20px rgba(0,0,0,0.35),
-    0 0 20px rgba(88,166,255,0.12),
-    inset 0 1px 0 rgba(255,255,255,0.12);
+    0 2px 6px rgba(0, 0, 0, 0.7),
+    0 8px 20px rgba(0, 0, 0, 0.35),
+    0 0 20px rgba(88, 166, 255, 0.12),
+    inset 0 1px 0 rgba(255, 255, 255, 0.12);
 }
 
 /* ── Glass nav ────────────────────────────────────────────────────────── */
@@ -151,56 +187,172 @@ a:hover {
 /* ── Detail page cards — subtle depth, no hover lift ─────────────────── */
 
 .detail-card {
-  background: linear-gradient(175deg, rgba(24,31,40,1) 0%, rgba(17,22,29,1) 100%);
+  background: linear-gradient(175deg, rgba(24, 31, 40, 1) 0%, rgba(17, 22, 29, 1) 100%);
   box-shadow:
-    0 1px 3px rgba(0,0,0,0.6),
-    inset 0 1px 0 rgba(255,255,255,0.05);
+    0 1px 3px rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  border-radius: 0;
   --color-text-secondary: #8b949e;
-  --color-text-muted:     #656d76;
-  --color-text-tertiary:  #656d76;
+  --color-text-muted: #656d76;
+  --color-text-tertiary: #656d76;
+}
+
+.session-detail-page {
+  background:
+    radial-gradient(
+      circle at top right,
+      color-mix(in srgb, var(--color-accent) 6%, transparent),
+      transparent 28%
+    ),
+    var(--color-bg-base);
+}
+
+.session-page-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  border: 1px solid var(--color-border-default);
+  padding: 14px 16px;
+  background: linear-gradient(175deg, rgba(24, 31, 40, 1) 0%, rgba(17, 22, 29, 1) 100%);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.6),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+@media (min-width: 900px) {
+  .session-page-header {
+    gap: 12px;
+  }
+}
+
+.session-page-header__crumbs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.session-page-header__mode {
+  padding: 2px 8px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 20%, transparent);
+  color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+}
+
+.session-page-header__main {
+  display: grid;
+  gap: 12px;
+}
+
+.session-page-header__identity {
+  min-width: 0;
+}
+
+.session-page-header__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.session-page-header__side {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+@media (min-width: 1100px) {
+  .session-page-header__main {
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+  }
+
+  .session-page-header__side {
+    justify-content: flex-end;
+  }
+}
+
+.session-detail-link-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 0 10px;
+  border: 1px solid var(--color-border-subtle);
+  border-radius: 0;
+  background: color-mix(in srgb, var(--color-bg-elevated) 88%, transparent);
+  color: var(--color-text-secondary);
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.session-detail-link-pill {
+  transition:
+    border-color 0.14s ease,
+    color 0.14s ease,
+    background 0.14s ease;
+}
+
+.session-detail-link-pill:hover {
+  border-color: var(--color-border-strong);
+  color: var(--color-text-primary);
+}
+
+.session-detail-link-pill--accent {
+  color: var(--color-accent);
+  border-color: color-mix(in srgb, var(--color-accent) 20%, var(--color-border-subtle));
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
 }
 
 /* ── Session cards ────────────────────────────────────────────────────── */
 
 .session-card {
-  background: linear-gradient(175deg, rgba(28,36,47,1) 0%, rgba(18,23,31,1) 100%);
+  background: linear-gradient(175deg, rgba(28, 36, 47, 1) 0%, rgba(18, 23, 31, 1) 100%);
   box-shadow:
-    0 1px 2px rgba(0,0,0,0.9),
-    0 3px 10px rgba(0,0,0,0.55),
-    inset 0 1px 0 rgba(255,255,255,0.07);
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+    0 1px 2px rgba(0, 0, 0, 0.9),
+    0 3px 10px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  transition:
+    transform 0.12s ease,
+    box-shadow 0.12s ease,
+    border-color 0.12s ease;
 
   /* Bump dim text colors inside the card — the elevated surface is darker
      than the transparent bg these values were calibrated for */
   --color-text-secondary: #8b949e;
-  --color-text-muted:     #656d76;
-  --color-text-tertiary:  #656d76;
+  --color-text-muted: #656d76;
+  --color-text-tertiary: #656d76;
 }
 
 .session-card:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 4px 8px rgba(0,0,0,0.85),
-    0 14px 36px rgba(0,0,0,0.55),
-    inset 0 1px 0 rgba(255,255,255,0.1);
+    0 4px 8px rgba(0, 0, 0, 0.85),
+    0 14px 36px rgba(0, 0, 0, 0.55),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }
 
 .session-card.card-merge-ready {
-  background: linear-gradient(175deg, rgba(16,40,24,1) 0%, rgba(10,26,15,1) 100%);
+  background: linear-gradient(175deg, rgba(16, 40, 24, 1) 0%, rgba(10, 26, 15, 1) 100%);
   box-shadow:
-    0 0 0 1px rgba(63,185,80,0.22),
-    0 1px 2px rgba(0,0,0,0.9),
-    0 3px 10px rgba(0,0,0,0.55),
-    0 0 40px rgba(63,185,80,0.13),
-    inset 0 1px 0 rgba(255,255,255,0.07);
+    0 0 0 1px rgba(63, 185, 80, 0.22),
+    0 1px 2px rgba(0, 0, 0, 0.9),
+    0 3px 10px rgba(0, 0, 0, 0.55),
+    0 0 40px rgba(63, 185, 80, 0.13),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
 }
 
 .session-card.card-merge-ready:hover {
   transform: translateY(-2px);
   box-shadow:
-    0 0 0 1px rgba(63,185,80,0.35),
-    0 4px 8px rgba(0,0,0,0.85),
-    0 14px 36px rgba(0,0,0,0.55),
-    0 0 60px rgba(63,185,80,0.2),
-    inset 0 1px 0 rgba(255,255,255,0.1);
+    0 0 0 1px rgba(63, 185, 80, 0.35),
+    0 4px 8px rgba(0, 0, 0, 0.85),
+    0 14px 36px rgba(0, 0, 0, 0.55),
+    0 0 60px rgba(63, 185, 80, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1);
 }

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -571,7 +571,7 @@ export function DirectTerminal({
   return (
     <div
       className={cn(
-        "overflow-hidden rounded-[6px] border border-[var(--color-border-default)]",
+        "overflow-hidden border border-[var(--color-border-default)]",
         "bg-[#0a0a0f]",
         fullscreen && "fixed inset-0 z-50 rounded-none border-0",
       )}
@@ -589,7 +589,7 @@ export function DirectTerminal({
         </span>
         {/* XDA clipboard badge */}
         <span
-          className="rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
+          className="px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
           style={{
             color: accentColor,
             background: `color-mix(in srgb, ${accentColor} 12%, transparent)`,
@@ -603,7 +603,7 @@ export function DirectTerminal({
             disabled={reloading || status !== "connected"}
             title="Restart OpenCode session (/exit then resume mapped session)"
             aria-label="Restart OpenCode session"
-            className="ml-auto flex items-center gap-1 rounded px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-70"
+            className="ml-auto flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-70"
           >
             {reloading ? (
               <>
@@ -646,7 +646,7 @@ export function DirectTerminal({
         <button
           onClick={() => setFullscreen(!fullscreen)}
           className={cn(
-            "flex items-center gap-1 rounded px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)]",
+            "flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)]",
             !isOpenCodeSession && "ml-auto",
           )}
         >

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { type DashboardSession, type DashboardPR, isPRMergeReady } from "@/lib/types";
 import { CI_STATUS } from "@composio/ao-core/types";
@@ -43,18 +43,8 @@ function humanizeStatus(status: string): string {
     .replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
-function relativeTime(iso: string): string {
-  const ms = new Date(iso).getTime();
-  if (!iso || isNaN(ms)) return "unknown";
-  const diff = Date.now() - ms;
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
+function getSessionHeadline(session: DashboardSession): string {
+  return session.issueTitle ?? session.summary ?? session.id;
 }
 
 function cleanBugbotComment(body: string): { title: string; description: string } {
@@ -75,8 +65,97 @@ function buildGitHubBranchUrl(pr: DashboardPR): string {
   return `https://github.com/${pr.owner}/${pr.repo}/tree/${pr.branch}`;
 }
 
-function buildGitHubRepoUrl(pr: DashboardPR): string {
-  return `https://github.com/${pr.owner}/${pr.repo}`;
+function SessionTopStrip({
+  headline,
+  activityLabel,
+  activityColor,
+  branch,
+  pr,
+  isOrchestrator = false,
+  rightSlot,
+}: {
+  headline: string;
+  activityLabel: string;
+  activityColor: string;
+  branch: string | null;
+  pr: DashboardPR | null;
+  isOrchestrator?: boolean;
+  rightSlot?: ReactNode;
+}) {
+  return (
+    <section className="session-page-header">
+      <div className="session-page-header__crumbs">
+        <a
+          href="/"
+          className="flex items-center gap-1 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] hover:no-underline"
+        >
+          <svg
+            className="h-3 w-3 opacity-60"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            viewBox="0 0 24 24"
+          >
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+          Orchestrator
+        </a>
+        <span className="text-[var(--color-border-strong)]">/</span>
+        <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+          {headline}
+        </span>
+        {isOrchestrator ? <span className="session-page-header__mode">orchestrator</span> : null}
+      </div>
+      <div className="session-page-header__main">
+        <div className="session-page-header__identity">
+          <h1 className="truncate text-[17px] font-semibold tracking-[-0.03em] text-[var(--color-text-primary)]">
+            {headline}
+          </h1>
+          <div className="session-page-header__meta">
+            <div
+              className="flex items-center gap-1.5 border px-2.5 py-1"
+              style={{
+                background: `color-mix(in srgb, ${activityColor} 12%, transparent)`,
+                border: `1px solid color-mix(in srgb, ${activityColor} 20%, transparent)`,
+              }}
+            >
+              <span className="h-1.5 w-1.5 shrink-0" style={{ background: activityColor }} />
+              <span className="text-[11px] font-semibold" style={{ color: activityColor }}>
+                {activityLabel}
+              </span>
+            </div>
+            {branch ? (
+              pr ? (
+                <a
+                  href={buildGitHubBranchUrl(pr)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="session-detail-link-pill font-[var(--font-mono)] text-[10px] hover:no-underline"
+                >
+                  {branch}
+                </a>
+              ) : (
+                <span className="session-detail-link-pill font-[var(--font-mono)] text-[10px]">
+                  {branch}
+                </span>
+              )
+            ) : null}
+            {pr ? (
+              <a
+                href={pr.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="session-detail-link-pill session-detail-link-pill--accent hover:no-underline"
+              >
+                PR #{pr.number}
+              </a>
+            ) : null}
+          </div>
+        </div>
+        {rightSlot ? <div className="session-page-header__side">{rightSlot}</div> : null}
+      </div>
+    </section>
+  );
 }
 
 async function askAgentToFix(
@@ -106,9 +185,19 @@ async function askAgentToFix(
 function OrchestratorStatusStrip({
   zones,
   createdAt,
+  headline,
+  activityLabel,
+  activityColor,
+  branch,
+  pr,
 }: {
   zones: OrchestratorZones;
   createdAt: string;
+  headline: string;
+  activityLabel: string;
+  activityColor: string;
+  branch: string | null;
+  pr: DashboardPR | null;
 }) {
   const [uptime, setUptime] = useState<string>("");
 
@@ -137,52 +226,61 @@ function OrchestratorStatusStrip({
     zones.merge + zones.respond + zones.review + zones.working + zones.pending + zones.done;
 
   return (
-    <div
-      className="border-b border-[var(--color-border-subtle)] px-8 py-4"
-      style={{
-        background: "linear-gradient(to bottom, rgba(88,166,255,0.04) 0%, transparent 100%)",
-      }}
-    >
-      <div className="mx-auto flex max-w-[900px] items-center gap-3 flex-wrap">
-        {/* Total count */}
-        <div className="flex items-baseline gap-1.5 mr-2">
-          <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
-            {total}
-          </span>
-          <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
-        </div>
-
-        <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
-
-        {/* Per-zone pills */}
-        {stats.length > 0 ? (
-          stats.map((s) => (
-            <div
-              key={s.label}
-              className="flex items-center gap-1.5 rounded-full px-2.5 py-1"
-              style={{ background: s.bg }}
-            >
-              <span
-                className="text-[15px] font-bold leading-none tabular-nums"
-                style={{ color: s.color }}
-              >
-                {s.value}
+    <div className="mx-auto max-w-[1180px] px-5 pt-5 lg:px-8">
+      <SessionTopStrip
+        headline={headline}
+        activityLabel={activityLabel}
+        activityColor={activityColor}
+        branch={branch}
+        pr={pr}
+        isOrchestrator
+        rightSlot={
+          <div className="flex flex-wrap items-center gap-3 lg:justify-end">
+            <div className="flex items-baseline gap-1.5 mr-2">
+              <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+                {total}
               </span>
-              <span className="text-[10px] font-medium" style={{ color: s.color, opacity: 0.8 }}>
-                {s.label}
-              </span>
+              <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
             </div>
-          ))
-        ) : (
-          <span className="text-[12px] text-[var(--color-text-tertiary)]">no active agents</span>
-        )}
 
-        {uptime && (
-          <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
-            up {uptime}
-          </span>
-        )}
-      </div>
+            <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+
+            {/* Per-zone pills */}
+            {stats.length > 0 ? (
+              stats.map((s) => (
+                <div
+                  key={s.label}
+                  className="flex items-center gap-1.5 px-2.5 py-1"
+                  style={{ background: s.bg }}
+                >
+                  <span
+                    className="text-[15px] font-bold leading-none tabular-nums"
+                    style={{ color: s.color }}
+                  >
+                    {s.value}
+                  </span>
+                  <span
+                    className="text-[10px] font-medium"
+                    style={{ color: s.color, opacity: 0.8 }}
+                  >
+                    {s.label}
+                  </span>
+                </div>
+              ))
+            ) : (
+              <span className="text-[12px] text-[var(--color-text-tertiary)]">
+                no active agents
+              </span>
+            )}
+
+            {uptime && (
+              <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
+                up {uptime}
+              </span>
+            )}
+          </div>
+        }
+      />
     </div>
   );
 }
@@ -201,11 +299,12 @@ export function SessionDetail({
     label: session.activity ?? "unknown",
     color: "var(--color-text-muted)",
   };
+  const headline = getSessionHeadline(session);
 
   const accentColor = "var(--color-accent)";
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
 
-  const terminalHeight = isOrchestrator ? "calc(100vh - 240px)" : "max(440px, calc(100vh - 440px))";
+  const terminalHeight = isOrchestrator ? "clamp(560px, 76vh, 920px)" : "clamp(520px, 72vh, 860px)";
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
   const opencodeSessionId =
     typeof session.metadata["opencodeSessionId"] === "string" &&
@@ -217,229 +316,58 @@ export function SessionDetail({
     : undefined;
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-base)]">
-      {/* Nav bar — glass effect */}
-      <nav className="nav-glass sticky top-0 z-10 border-b border-[var(--color-border-subtle)]">
-        <div className="mx-auto flex max-w-[900px] items-center gap-2 px-8 py-2.5">
-          <a
-            href="/"
-            className="flex items-center gap-1 text-[11px] font-medium text-[var(--color-text-secondary)] transition-colors hover:text-[var(--color-text-primary)] hover:no-underline"
-          >
-            <svg
-              className="h-3 w-3 opacity-60"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              viewBox="0 0 24 24"
-            >
-              <path d="M15 18l-6-6 6-6" />
-            </svg>
-            Orchestrator
-          </a>
-          <span className="text-[var(--color-border-strong)]">/</span>
-          <span className="font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
-            {session.id}
-          </span>
-          {isOrchestrator && (
-            <span
-              className="ml-1 rounded px-2 py-0.5 text-[10px] font-semibold tracking-[0.05em]"
-              style={{
-                color: accentColor,
-                background: `color-mix(in srgb, ${accentColor} 10%, transparent)`,
-                border: `1px solid color-mix(in srgb, ${accentColor} 20%, transparent)`,
-              }}
-            >
-              orchestrator
-            </span>
-          )}
-        </div>
-      </nav>
-
-      {/* Orchestrator status strip */}
+    <div className="session-detail-page min-h-screen bg-[var(--color-bg-base)]">
       {isOrchestrator && orchestratorZones && (
-        <OrchestratorStatusStrip zones={orchestratorZones} createdAt={session.createdAt} />
+        <OrchestratorStatusStrip
+          zones={orchestratorZones}
+          createdAt={session.createdAt}
+          headline={headline}
+          activityLabel={activity.label}
+          activityColor={activity.color}
+          branch={session.branch}
+          pr={pr}
+        />
       )}
 
-      <div className="mx-auto max-w-[900px] px-8 py-6">
-        {/* ── Header card ─────────────────────────────────────────── */}
-        <div
-          className="detail-card mb-6 rounded-[8px] border border-[var(--color-border-default)] p-5"
-          style={{
-            borderLeft: isOrchestrator ? `3px solid ${accentColor}` : `3px solid ${activity.color}`,
-          }}
-        >
-          <div className="flex items-start gap-3">
-            <div className="flex-1 min-w-0">
-              <div className="flex flex-wrap items-center gap-2.5">
-                <h1 className="font-[var(--font-mono)] text-[17px] font-semibold tracking-[-0.01em] text-[var(--color-text-primary)]">
-                  {session.id}
-                </h1>
-                {/* Activity badge */}
-                <div
-                  className="flex items-center gap-1.5 rounded-full px-2.5 py-0.5"
-                  style={{
-                    background: `color-mix(in srgb, ${activity.color} 12%, transparent)`,
-                    border: `1px solid color-mix(in srgb, ${activity.color} 20%, transparent)`,
-                  }}
-                >
-                  <ActivityDot activity={session.activity} dotOnly size={6} />
-                  <span className="text-[11px] font-semibold" style={{ color: activity.color }}>
-                    {activity.label}
-                  </span>
-                </div>
-              </div>
-
-              {session.summary && (
-                <p className="mt-2 text-[13px] leading-relaxed text-[var(--color-text-secondary)]">
-                  {session.summary}
-                </p>
-              )}
-
-              {/* Meta chips */}
-              <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                {session.projectId && (
-                  <>
-                    {pr ? (
-                      <a
-                        href={buildGitHubRepoUrl(pr)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] hover:no-underline"
-                      >
-                        {session.projectId}
-                      </a>
-                    ) : (
-                      <span className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[11px] text-[var(--color-text-secondary)]">
-                        {session.projectId}
-                      </span>
-                    )}
-                    <span className="text-[var(--color-text-tertiary)]">&middot;</span>
-                  </>
-                )}
-
-                {pr && (
-                  <>
-                    <a
-                      href={pr.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[11px] text-[var(--color-accent)] transition-colors hover:border-[var(--color-accent)] hover:no-underline"
-                    >
-                      PR #{pr.number}
-                    </a>
-                    {(session.branch || session.issueUrl) && (
-                      <span className="text-[var(--color-text-tertiary)]">&middot;</span>
-                    )}
-                  </>
-                )}
-
-                {session.branch && (
-                  <>
-                    {pr ? (
-                      <a
-                        href={buildGitHubBranchUrl(pr)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 font-[var(--font-mono)] text-[10px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] hover:no-underline"
-                      >
-                        {session.branch}
-                      </a>
-                    ) : (
-                      <span className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 font-[var(--font-mono)] text-[10px] text-[var(--color-text-secondary)]">
-                        {session.branch}
-                      </span>
-                    )}
-                    {session.issueUrl && (
-                      <span className="text-[var(--color-text-tertiary)]">&middot;</span>
-                    )}
-                  </>
-                )}
-
-                {session.issueUrl && (
-                  <a
-                    href={session.issueUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="rounded-[4px] border border-[var(--color-border-subtle)] bg-[rgba(255,255,255,0.04)] px-2 py-0.5 text-[11px] text-[var(--color-text-secondary)] transition-colors hover:border-[var(--color-border-strong)] hover:text-[var(--color-text-primary)] hover:no-underline"
-                  >
-                    {session.issueLabel || session.issueUrl}
-                  </a>
-                )}
-              </div>
-
-              <ClientTimestamps
-                status={session.status}
-                createdAt={session.createdAt}
-                lastActivityAt={session.lastActivityAt}
-              />
-            </div>
-          </div>
-        </div>
-
-        {/* ── PR Card ─────────────────────────────────────────────── */}
-        {pr && <PRCard pr={pr} sessionId={session.id} />}
-
-        {/* ── Terminal ─────────────────────────────────────────────── */}
-        <div className={pr ? "mt-6" : ""}>
-          <div className="mb-3 flex items-center gap-2">
-            <div
-              className="h-3 w-0.5 rounded-full"
-              style={{ background: isOrchestrator ? accentColor : activity.color, opacity: 0.7 }}
+      <div className="mx-auto max-w-[1180px] px-5 py-5 lg:px-8">
+        <main className="min-w-0">
+          {!isOrchestrator && (
+            <SessionTopStrip
+              headline={headline}
+              activityLabel={activity.label}
+              activityColor={activity.color}
+              branch={session.branch}
+              pr={pr}
             />
-            <span className="text-[10px] font-bold uppercase tracking-[0.10em] text-[var(--color-text-tertiary)]">
-              Terminal
-            </span>
-          </div>
-          <DirectTerminal
-            sessionId={session.id}
-            startFullscreen={startFullscreen}
-            variant={terminalVariant}
-            height={terminalHeight}
-            isOpenCodeSession={isOpenCodeSession}
-            reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
-          />
-        </div>
+          )}
+
+          <section className="mt-5">
+            <div className="mb-3 flex items-center gap-2">
+              <div
+                className="h-3 w-0.5"
+                style={{ background: isOrchestrator ? accentColor : activity.color, opacity: 0.75 }}
+              />
+              <span className="text-[10px] font-bold uppercase tracking-[0.1em] text-[var(--color-text-tertiary)]">
+                Live Terminal
+              </span>
+            </div>
+            <DirectTerminal
+              sessionId={session.id}
+              startFullscreen={startFullscreen}
+              variant={terminalVariant}
+              height={terminalHeight}
+              isOpenCodeSession={isOpenCodeSession}
+              reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
+            />
+          </section>
+
+          {pr ? (
+            <section className="mt-6">
+              <PRCard pr={pr} sessionId={session.id} />
+            </section>
+          ) : null}
+        </main>
       </div>
-    </div>
-  );
-}
-
-// ── Client-side timestamps ────────────────────────────────────────────
-
-function ClientTimestamps({
-  status,
-  createdAt,
-  lastActivityAt,
-}: {
-  status: string;
-  createdAt: string;
-  lastActivityAt: string;
-}) {
-  const [created, setCreated] = useState<string | null>(null);
-  const [lastActive, setLastActive] = useState<string | null>(null);
-
-  useEffect(() => {
-    setCreated(relativeTime(createdAt));
-    setLastActive(relativeTime(lastActivityAt));
-  }, [createdAt, lastActivityAt]);
-
-  return (
-    <div className="mt-2.5 flex flex-wrap items-center gap-x-1.5 text-[11px] text-[var(--color-text-tertiary)]">
-      <span className="rounded-[3px] bg-[rgba(255,255,255,0.05)] px-1.5 py-0.5 text-[10px] font-medium">
-        {humanizeStatus(status)}
-      </span>
-      {created && (
-        <>
-          <span className="opacity-40">&middot;</span>
-          <span>created {created}</span>
-        </>
-      )}
-      {lastActive && (
-        <>
-          <span className="opacity-40">&middot;</span>
-          <span>active {lastActive}</span>
-        </>
-      )}
     </div>
   );
 }
@@ -527,7 +455,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
       : "var(--color-border-default)";
 
   return (
-    <div className="detail-card mb-6 overflow-hidden rounded-[8px] border" style={{ borderColor }}>
+    <div className="detail-card mb-6 overflow-hidden border" style={{ borderColor }}>
       {/* Title row */}
       <div className="border-b border-[var(--color-border-subtle)] px-5 py-3.5">
         <a
@@ -553,7 +481,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
             <>
               <span className="text-[var(--color-text-tertiary)]">&middot;</span>
               <span
-                className="rounded-full px-2 py-0.5 text-[10px] font-semibold"
+                className="px-2 py-0.5 text-[10px] font-semibold"
                 style={{ color: "#a371f7", background: "rgba(163,113,247,0.12)" }}
               >
                 Merged
@@ -567,7 +495,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
       <div className="px-5 py-4">
         {/* Ready-to-merge banner */}
         {allGreen ? (
-          <div className="flex items-center gap-2 rounded-[5px] border border-[rgba(63,185,80,0.25)] bg-[rgba(63,185,80,0.07)] px-3.5 py-2.5">
+          <div className="flex items-center gap-2 border border-[rgba(63,185,80,0.25)] bg-[rgba(63,185,80,0.07)] px-3.5 py-2.5">
             <svg
               className="h-4 w-4 shrink-0 text-[var(--color-status-ready)]"
               fill="none"
@@ -601,7 +529,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
             <h4 className="mb-2.5 flex items-center gap-2 text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--color-text-tertiary)]">
               Unresolved Comments
               <span
-                className="rounded-full px-1.5 py-0.5 text-[10px] font-bold normal-case tracking-normal"
+                className="px-1.5 py-0.5 text-[10px] font-bold normal-case tracking-normal"
                 style={{ color: "#f85149", background: "rgba(248,81,73,0.12)" }}
               >
                 {pr.unresolvedThreads}
@@ -612,7 +540,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
                 const { title, description } = cleanBugbotComment(c.body);
                 return (
                   <details key={c.url} className="group">
-                    <summary className="flex cursor-pointer list-none items-center gap-2 rounded-[5px] px-2 py-1.5 text-[12px] transition-colors hover:bg-[rgba(255,255,255,0.04)]">
+                    <summary className="flex cursor-pointer list-none items-center gap-2 px-2 py-1.5 text-[12px] transition-colors hover:bg-[rgba(255,255,255,0.04)]">
                       <svg
                         className="h-3 w-3 shrink-0 text-[var(--color-text-tertiary)] transition-transform group-open:rotate-90"
                         fill="none"
@@ -647,7 +575,7 @@ function PRCard({ pr, sessionId }: { pr: DashboardPR; sessionId: string }) {
                         onClick={() => handleAskAgentToFix(c)}
                         disabled={sendingComments.has(c.url)}
                         className={cn(
-                          "mt-1.5 rounded-[4px] px-3 py-1 text-[11px] font-semibold transition-all",
+                          "mt-1.5 px-3 py-1 text-[11px] font-semibold transition-all",
                           sentComments.has(c.url)
                             ? "bg-[var(--color-status-ready)] text-white"
                             : errorComments.has(c.url)

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/cn";
 import { CICheckList } from "./CIBadge";
 import { DirectTerminal } from "./DirectTerminal";
 import { ActivityDot } from "./ActivityDot";
+import { getSessionTitle } from "@/lib/format";
 
 interface OrchestratorZones {
   merge: number;
@@ -34,18 +35,6 @@ const activityMeta: Record<string, { label: string; color: string }> = {
   blocked: { label: "Blocked", color: "var(--color-status-error)" },
   exited: { label: "Exited", color: "var(--color-status-error)" },
 };
-
-function humanizeStatus(status: string): string {
-  return status
-    .replace(/_/g, " ")
-    .replace(/\bci\b/gi, "CI")
-    .replace(/\bpr\b/gi, "PR")
-    .replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
-function getSessionHeadline(session: DashboardSession): string {
-  return session.issueTitle ?? session.summary ?? session.id;
-}
 
 function cleanBugbotComment(body: string): { title: string; description: string } {
   const isBugbot = body.includes("<!-- DESCRIPTION START -->") || body.includes("### ");
@@ -191,7 +180,7 @@ function OrchestratorStatusStrip({
   branch,
   pr,
 }: {
-  zones: OrchestratorZones;
+  zones?: OrchestratorZones;
   createdAt: string;
   headline: string;
   activityLabel: string;
@@ -213,17 +202,60 @@ function OrchestratorStatusStrip({
     return () => clearInterval(id);
   }, [createdAt]);
 
-  const stats: Array<{ value: number; label: string; color: string; bg: string }> = [
-    { value: zones.merge, label: "merge-ready", color: "#3fb950", bg: "rgba(63,185,80,0.1)" },
-    { value: zones.respond, label: "responding", color: "#f85149", bg: "rgba(248,81,73,0.1)" },
-    { value: zones.review, label: "review", color: "#d18616", bg: "rgba(209,134,22,0.1)" },
-    { value: zones.working, label: "working", color: "#58a6ff", bg: "rgba(88,166,255,0.1)" },
-    { value: zones.pending, label: "pending", color: "#d29922", bg: "rgba(210,153,34,0.1)" },
-    { value: zones.done, label: "done", color: "#484f58", bg: "rgba(72,79,88,0.15)" },
-  ].filter((s) => s.value > 0);
+  const zoneSlot = zones ? (() => {
+    const stats: Array<{ value: number; label: string; color: string; bg: string }> = [
+      { value: zones.merge, label: "merge-ready", color: "#3fb950", bg: "rgba(63,185,80,0.1)" },
+      { value: zones.respond, label: "responding", color: "#f85149", bg: "rgba(248,81,73,0.1)" },
+      { value: zones.review, label: "review", color: "#d18616", bg: "rgba(209,134,22,0.1)" },
+      { value: zones.working, label: "working", color: "#58a6ff", bg: "rgba(88,166,255,0.1)" },
+      { value: zones.pending, label: "pending", color: "#d29922", bg: "rgba(210,153,34,0.1)" },
+      { value: zones.done, label: "done", color: "#484f58", bg: "rgba(72,79,88,0.15)" },
+    ].filter((s) => s.value > 0);
 
-  const total =
-    zones.merge + zones.respond + zones.review + zones.working + zones.pending + zones.done;
+    const total =
+      zones.merge + zones.respond + zones.review + zones.working + zones.pending + zones.done;
+
+    return (
+      <>
+        <div className="flex items-baseline gap-1.5 mr-2">
+          <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
+            {total}
+          </span>
+          <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
+        </div>
+
+        <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
+
+        {/* Per-zone pills */}
+        {stats.length > 0 ? (
+          stats.map((s) => (
+            <div
+              key={s.label}
+              className="flex items-center gap-1.5 px-2.5 py-1"
+              style={{ background: s.bg }}
+            >
+              <span
+                className="text-[15px] font-bold leading-none tabular-nums"
+                style={{ color: s.color }}
+              >
+                {s.value}
+              </span>
+              <span
+                className="text-[10px] font-medium"
+                style={{ color: s.color, opacity: 0.8 }}
+              >
+                {s.label}
+              </span>
+            </div>
+          ))
+        ) : (
+          <span className="text-[12px] text-[var(--color-text-tertiary)]">
+            no active agents
+          </span>
+        )}
+      </>
+    );
+  })() : null;
 
   return (
     <div className="mx-auto max-w-[1180px] px-5 pt-5 lg:px-8">
@@ -236,42 +268,7 @@ function OrchestratorStatusStrip({
         isOrchestrator
         rightSlot={
           <div className="flex flex-wrap items-center gap-3 lg:justify-end">
-            <div className="flex items-baseline gap-1.5 mr-2">
-              <span className="text-[22px] font-bold leading-none tabular-nums text-[var(--color-text-primary)]">
-                {total}
-              </span>
-              <span className="text-[11px] text-[var(--color-text-tertiary)]">agents</span>
-            </div>
-
-            <div className="h-5 w-px bg-[var(--color-border-subtle)] mr-1" />
-
-            {/* Per-zone pills */}
-            {stats.length > 0 ? (
-              stats.map((s) => (
-                <div
-                  key={s.label}
-                  className="flex items-center gap-1.5 px-2.5 py-1"
-                  style={{ background: s.bg }}
-                >
-                  <span
-                    className="text-[15px] font-bold leading-none tabular-nums"
-                    style={{ color: s.color }}
-                  >
-                    {s.value}
-                  </span>
-                  <span
-                    className="text-[10px] font-medium"
-                    style={{ color: s.color, opacity: 0.8 }}
-                  >
-                    {s.label}
-                  </span>
-                </div>
-              ))
-            ) : (
-              <span className="text-[12px] text-[var(--color-text-tertiary)]">
-                no active agents
-              </span>
-            )}
+            {zoneSlot}
 
             {uptime && (
               <span className="ml-auto font-[var(--font-mono)] text-[11px] text-[var(--color-text-tertiary)]">
@@ -299,7 +296,7 @@ export function SessionDetail({
     label: session.activity ?? "unknown",
     color: "var(--color-text-muted)",
   };
-  const headline = getSessionHeadline(session);
+  const headline = getSessionTitle(session);
 
   const accentColor = "var(--color-accent)";
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
@@ -317,7 +314,7 @@ export function SessionDetail({
 
   return (
     <div className="session-detail-page min-h-screen bg-[var(--color-bg-base)]">
-      {isOrchestrator && orchestratorZones && (
+      {isOrchestrator && (
         <OrchestratorStatusStrip
           zones={orchestratorZones}
           createdAt={session.createdAt}


### PR DESCRIPTION
## Summary
- redesign the session detail page around a compact unified header and terminal-first layout
- remove rounded treatment from the session detail surface and terminal chrome
- keep PR context below the terminal while simplifying redundant session metadata

## Verification
- pnpm --filter @composio/ao-web typecheck
