### PR TITLE
feat(web): migrate direct terminal to ghostty-web

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -35,13 +35,11 @@
     "@composio/ao-plugin-tracker-github": "workspace:*",
     "@composio/ao-plugin-tracker-linear": "workspace:*",
     "@composio/ao-plugin-workspace-worktree": "workspace:*",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-web-links": "^0.12.0",
+    "ghostty-web": "^0.4.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "ws": "^8.19.0",
-    "xterm": "^5.3.0"
+    "ws": "^8.19.0"
   },
   "optionalDependencies": {
     "node-pty": "^1.1.0"

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -1,10 +1,9 @@
 /**
  * Direct WebSocket terminal server using node-pty.
- * Connects browser xterm.js directly to tmux sessions via WebSocket.
+ * Connects the browser terminal emulator directly to tmux sessions via WebSocket.
  *
  * This bypasses ttyd and gives us control over terminal initialization,
- * allowing us to implement the XDA (Extended Device Attributes) handler
- * that tmux requires for clipboard support.
+ * reconnection, and resize behavior while keeping a native PTY bridge.
  */
 
 import { createServer, type Server } from "node:http";
@@ -283,7 +282,7 @@ export function createDirectTerminalServer(tmuxPath?: string): DirectTerminalSer
     ws.on("message", (data) => {
       const message = data.toString("utf8");
 
-      // Handle resize messages (sent by xterm.js FitAddon)
+      // Handle resize messages from the browser terminal
       if (message.startsWith("{")) {
         try {
           const parsed = JSON.parse(message) as { type?: string; cols?: number; rows?: number };

--- a/packages/web/src/app/dev/terminal-test/page.tsx
+++ b/packages/web/src/app/dev/terminal-test/page.tsx
@@ -557,8 +557,8 @@ function TerminalTestPageContent() {
               </h3>
               <ul className="ml-6 list-disc space-y-1">
                 <li>tmux source analysis: DeepWiki.com (Feb 15, 2026)</li>
-                <li>xterm.js parser API documentation</li>
-                <li>XTerm Control Sequences: XTVERSION / Device Attributes</li>
+                <li>ghostty-web API and WASM runtime</li>
+                <li>Ghostty terminal behavior for VT/OSC responses</li>
                 <li>
                   tmux <code className="rounded bg-black px-1 py-0.5">tty-keys.c</code>: Terminal
                   type detection logic
@@ -578,7 +578,7 @@ function TerminalTestPageContent() {
               <code className="rounded bg-black px-1 py-0.5">
                 packages/web/src/components/DirectTerminal.tsx
               </code>{" "}
-              - Main component with XDA handler
+              - Main component using ghostty-web
             </li>
             <li>
               <code className="rounded bg-black px-1 py-0.5">
@@ -598,7 +598,7 @@ function TerminalTestPageContent() {
         {/* Footer */}
         <div className="mt-8 border-t border-[var(--color-border-default)] pt-4 text-center text-xs text-[var(--color-text-secondary)]">
           <p>Investigation: Feb 15-16, 2026 • Duration: 12+ hours • Status: ✅ Resolved</p>
-          <p className="mt-1">Node 20.20.0 • node-pty 1.1.0 • xterm.js 5.3.0</p>
+          <p className="mt-1">Node 20.20.0 • node-pty 1.1.0 • ghostty-web 0.4.0</p>
         </div>
       </div>
     </div>

--- a/packages/web/src/app/test-direct/page.tsx
+++ b/packages/web/src/app/test-direct/page.tsx
@@ -8,16 +8,12 @@ import { Suspense } from "react";
 export const dynamic = "force-dynamic";
 
 /**
- * Test page for DirectTerminal with XDA clipboard support.
+ * Test page for DirectTerminal using ghostty-web.
  *
  * Examples:
  * - http://localhost:3000/test-direct
  * - http://localhost:3000/test-direct?session=ao-20
  * - http://localhost:3000/test-direct?session=ao-20&fullscreen=true
- *
- * This uses native xterm.js with registered XDA handler,
- * which should enable clipboard (OSC 52) in tmux without
- * requiring iTerm2 attachment.
  */
 function TestDirectPageContent() {
   const searchParams = useSearchParams();
@@ -28,12 +24,12 @@ function TestDirectPageContent() {
       <div className="mx-auto max-w-7xl">
         <div className="mb-6">
           <h1 className="text-2xl font-bold text-[var(--color-text-primary)]">
-            DirectTerminal Test - XDA Clipboard Support
+            DirectTerminal Test - Ghostty Web
           </h1>
           <p className="mt-2 text-sm text-[var(--color-text-muted)]">
-            This terminal has XDA (Extended Device Attributes) handler registered.
+            This terminal uses Ghostty's web terminal emulator.
             <br />
-            tmux should recognize it as XTerm and enable clipboard support (OSC 52).
+            Clipboard, selection, resize, and shell I/O should behave through the native PTY bridge.
           </p>
           <div className="mt-4 rounded-lg border border-[var(--color-border-default)] bg-[var(--color-bg-secondary)] p-4">
             <h2 className="mb-2 text-sm font-semibold text-[var(--color-text-primary)]">
@@ -45,8 +41,8 @@ function TestDirectPageContent() {
             <ol className="list-inside list-decimal space-y-1 text-sm text-[var(--color-text-muted)]">
               <li>Connected to tmux session: {sessionId}</li>
               <li>
-                Verify XDA badge shows{" "}
-                <span className="text-[var(--color-accent-green)]">✓ XDA</span>
+                Verify emulator badge shows{" "}
+                <span className="text-[var(--color-accent-green)]">✓ Ghostty</span>
               </li>
               <li>Drag-select text in the terminal</li>
               <li>Press Cmd+C (macOS) or Ctrl+C (Linux/Windows)</li>
@@ -61,10 +57,10 @@ function TestDirectPageContent() {
               Technical Details:
             </h2>
             <ul className="list-inside list-disc space-y-1 text-sm text-[var(--color-text-muted)]">
-              <li>Registers CSI &gt; q (XDA) handler in xterm.js parser</li>
-              <li>Responds with DCS &gt; | XTerm(370) ST sequence</li>
-              <li>tmux detects "XTerm(" and enables TTYC_MS (clipboard capability)</li>
-              <li>OSC 52 sequences flow: tmux → WebSocket → xterm.js → navigator.clipboard</li>
+              <li>Uses `ghostty-web` instead of `xterm.js` in the browser</li>
+              <li>Keeps the existing node-pty + WebSocket transport to tmux</li>
+              <li>Auto-fits the canvas to the terminal container</li>
+              <li>Preserves copy, paste, resize, reconnect, and link detection behavior</li>
             </ul>
           </div>
         </div>

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -4,12 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { cn } from "@/lib/cn";
 
-// Import xterm CSS (must be imported in client component)
-import "xterm/css/xterm.css";
-
-// Dynamically import xterm types for TypeScript
-import type { Terminal as TerminalType } from "xterm";
-import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
+import type { FitAddon as FitAddonType, Terminal as TerminalType } from "ghostty-web";
 
 interface DirectTerminalProps {
   sessionId: string;
@@ -37,6 +32,20 @@ interface DirectTerminalWsUrlOptions {
   directTerminalPort?: string;
 }
 
+type GhosttyWebModule = typeof import("ghostty-web");
+
+let ghosttyWebInitPromise: Promise<GhosttyWebModule> | null = null;
+
+function loadGhosttyWeb(): Promise<GhosttyWebModule> {
+  if (!ghosttyWebInitPromise) {
+    ghosttyWebInitPromise = import("ghostty-web").then(async (mod) => {
+      await mod.init();
+      return mod;
+    });
+  }
+  return ghosttyWebInitPromise;
+}
+
 export function buildDirectTerminalWsUrl({
   location,
   sessionId,
@@ -57,16 +66,7 @@ export function buildDirectTerminalWsUrl({
   return `${protocol}//${location.hostname}:${port}/ws?session=${encodeURIComponent(sessionId)}`;
 }
 
-/**
- * Direct xterm.js terminal with native WebSocket connection.
- * Implements Extended Device Attributes (XDA) handler to enable
- * tmux clipboard support (OSC 52) without requiring iTerm2 attachment.
- *
- * Based on DeepWiki analysis:
- * - tmux queries for XDA (CSI > q / XTVERSION) to detect terminal type
- * - When tmux sees "XTerm(" in response, it enables TTYC_MS (clipboard)
- * - xterm.js doesn't implement XDA by default, so we register custom handler
- */
+/** Direct Ghostty terminal with native WebSocket connection. */
 export function DirectTerminal({
   sessionId,
   startFullscreen = false,
@@ -152,7 +152,7 @@ export function DirectTerminal({
     permanentErrorRef.current = false;
     reconnectAttemptRef.current = 0;
 
-    // Dynamically import xterm.js to avoid SSR issues
+    // Dynamically import ghostty-web to avoid SSR issues
     let mounted = true;
     let cleanup: (() => void) | null = null;
     let inputDisposable: { dispose(): void } | null = null;
@@ -160,12 +160,8 @@ export function DirectTerminal({
     const PERMANENT_CLOSE_CODES = new Set([4001, 4004]); // auth failure, session not found
     const MAX_RECONNECT_DELAY = 15_000;
 
-    Promise.all([
-      import("xterm").then((mod) => mod.Terminal),
-      import("@xterm/addon-fit").then((mod) => mod.FitAddon),
-      import("@xterm/addon-web-links").then((mod) => mod.WebLinksAddon),
-    ])
-      .then(([Terminal, FitAddon, WebLinksAddon]) => {
+    loadGhosttyWeb()
+      .then(({ Terminal, FitAddon, UrlRegexProvider }) => {
         if (!mounted || !terminalRef.current) return;
 
         // Cursor and selection color differ by variant:
@@ -174,7 +170,7 @@ export function DirectTerminal({
         const selectionColor =
           variant === "orchestrator" ? "rgba(163, 113, 247, 0.25)" : "rgba(91, 126, 248, 0.3)";
 
-        // Initialize xterm.js Terminal
+        // Initialize Ghostty terminal
         const terminal = new Terminal({
           cursorBlink: true,
           fontSize: 13,
@@ -204,54 +200,13 @@ export function DirectTerminal({
             brightWhite: "#eeeef5",
           },
           scrollback: 10000,
-          allowProposedApi: true,
-          fastScrollModifier: "alt",
-          fastScrollSensitivity: 3,
-          scrollSensitivity: 1,
         });
 
-        // Add FitAddon for responsive sizing
         const fit = new FitAddon();
         terminal.loadAddon(fit);
         fitAddon.current = fit;
 
-        // Add WebLinksAddon for clickable links
-        const webLinks = new WebLinksAddon();
-        terminal.loadAddon(webLinks);
-
-        // **CRITICAL FIX**: Register XDA (Extended Device Attributes) handler
-        // This makes tmux recognize our terminal and enable clipboard support
-        terminal.parser.registerCsiHandler(
-          { prefix: ">", final: "q" }, // CSI > q is XTVERSION / XDA
-          () => {
-            // Respond with XTerm identification that tmux recognizes
-            // tmux looks for "XTerm(" in the response (see tmux tty-keys.c)
-            // Format: DCS > | XTerm(version) ST
-            // DCS = \x1bP, ST = \x1b\\
-            terminal.write("\x1bP>|XTerm(370)\x1b\\");
-            console.log("[DirectTerminal] Sent XDA response for clipboard support");
-            return true; // Handled
-          },
-        );
-
-        // Register OSC 52 handler for clipboard support
-        // tmux sends OSC 52 with base64-encoded text when copying
-        terminal.parser.registerOscHandler(52, (data) => {
-          const parts = data.split(";");
-          if (parts.length < 2) return false;
-          const b64 = parts[parts.length - 1];
-          try {
-            // Decode base64 → binary string → Uint8Array → UTF-8 text
-            // atob() alone only handles Latin-1; TextDecoder is needed for UTF-8
-            const binary = atob(b64);
-            const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-            const text = new TextDecoder().decode(bytes);
-            navigator.clipboard?.writeText(text).catch(() => {});
-          } catch {
-            // Ignore decode errors
-          }
-          return true;
-        });
+        terminal.registerLinkProvider(new UrlRegexProvider(terminal));
 
         // Open terminal in DOM
         terminal.open(terminalRef.current);
@@ -271,7 +226,7 @@ export function DirectTerminal({
         });
 
         // ── Preserve selection while terminal receives output ────────
-        // xterm.js clears the selection on every terminal.write(). We
+        // Terminal output can interrupt interactive selection/copy flows. We
         // buffer incoming data while a selection is active so the
         // highlight stays visible for Cmd+C. The buffer is flushed
         // when the selection is cleared (click, keypress, etc.).
@@ -310,10 +265,9 @@ export function DirectTerminal({
         });
 
         // Intercept Cmd+C (Mac) and Ctrl+Shift+C (Linux/Win) for copy.
-        // Paste (Cmd+V / Ctrl+Shift+V) is handled natively by xterm.js
-        // via its internal textarea — no custom handler needed.
+        // Paste is handled by ghostty-web's internal input handling.
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-          if (e.type !== "keydown") return true;
+          if (e.type !== "keydown") return false;
 
           // Cmd+C / Ctrl+Shift+C — copy selection
           const isCopy =
@@ -323,10 +277,11 @@ export function DirectTerminal({
             navigator.clipboard?.writeText(terminal.getSelection()).catch(() => {});
             // Clear selection so the terminal resumes receiving output
             terminal.clearSelection();
-            return false;
+            e.preventDefault();
+            return true;
           }
 
-          return true;
+          return false;
         });
 
         // Handle window resize (works with whatever ws is current)
@@ -441,7 +396,7 @@ export function DirectTerminal({
         };
       })
       .catch((err) => {
-        console.error("[DirectTerminal] Failed to load xterm.js:", err);
+        console.error("[DirectTerminal] Failed to load ghostty-web:", err);
         permanentErrorRef.current = true;
         setStatus("error");
         setError("Failed to load terminal");
@@ -490,9 +445,7 @@ export function DirectTerminal({
       }
 
       // Container is at target size, now resize terminal
-      terminal.refresh(0, terminal.rows - 1);
       fit.fit();
-      terminal.refresh(0, terminal.rows - 1);
 
       // Send new size to server (use ws.current in case WebSocket reconnected)
       const currentWs = ws.current;
@@ -587,7 +540,7 @@ export function DirectTerminal({
         >
           {statusText}
         </span>
-        {/* XDA clipboard badge */}
+        {/* Emulator badge */}
         <span
           className="rounded px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
           style={{
@@ -595,7 +548,7 @@ export function DirectTerminal({
             background: `color-mix(in srgb, ${accentColor} 12%, transparent)`,
           }}
         >
-          XDA
+          Ghostty
         </span>
         {isOpenCodeSession ? (
           <button

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,12 +574,9 @@ importers:
       '@composio/ao-plugin-workspace-worktree':
         specifier: workspace:*
         version: link:../plugins/workspace-worktree
-      '@xterm/addon-fit':
-        specifier: ^0.11.0
-        version: 0.11.0
-      '@xterm/addon-web-links':
-        specifier: ^0.12.0
-        version: 0.12.0
+      ghostty-web:
+        specifier: ^0.4.0
+        version: 0.4.0
       next:
         specifier: ^15.1.0
         version: 15.5.12(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -592,9 +589,6 @@ importers:
       ws:
         specifier: ^8.19.0
         version: 8.19.0
-      xterm:
-        specifier: ^5.3.0
-        version: 5.3.0
     optionalDependencies:
       node-pty:
         specifier: ^1.1.0
@@ -2072,12 +2066,6 @@ packages:
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
-  '@xterm/addon-fit@0.11.0':
-    resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
-
-  '@xterm/addon-web-links@0.12.0':
-    resolution: {integrity: sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==}
-
   abbrev@4.0.0:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2661,6 +2649,9 @@ packages:
 
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  ghostty-web@0.4.0:
+    resolution: {integrity: sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -3638,6 +3629,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
@@ -4022,10 +4014,6 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
-
-  xterm@5.3.0:
-    resolution: {integrity: sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==}
-    deprecated: This package is now deprecated. Move to @xterm/xterm instead.
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -5479,10 +5467,6 @@ snapshots:
       '@vitest/pretty-format': 4.0.18
       tinyrainbow: 3.0.3
 
-  '@xterm/addon-fit@0.11.0': {}
-
-  '@xterm/addon-web-links@0.12.0': {}
-
   abbrev@4.0.0: {}
 
   acorn-jsx@5.3.2(acorn@8.15.0):
@@ -6090,6 +6074,8 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  ghostty-web@0.4.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7401,8 +7387,6 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
-
-  xterm@5.3.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- replace the direct browser terminal's xterm.js dependency stack with `ghostty-web`
- keep the existing node-pty + WebSocket transport and adapt the client to ghostty-web's API differences
- update terminal-related test/dev pages and dependency metadata to reflect the Ghostty-backed emulator

## Testing
- `pnpm --filter @composio/ao-web exec vitest run src/components/__tests__/DirectTerminal.test.ts`

## Notes
- Full `pnpm --filter @composio/ao-web typecheck` and `pnpm --filter @composio/ao-web build` are currently blocked by pre-existing `@composio/ao-core/types` resolution failures elsewhere in `packages/web`.