### PR TITLE
fix: enforce maxActiveWorkers project limits

### DIFF
--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -37,6 +37,7 @@ projects:
     repo: owner/repo          # GitHub "owner/repo" format
     path: ~/code/my-app       # Local path to the repo
     defaultBranch: main       # main | master | next | develop
+    maxActiveWorkers: 1       # Optional cap on concurrent worker sessions for this project
     sessionPrefix: myapp      # Prefix for session names (e.g. myapp-1, myapp-2)
 
     # ── Per-project plugin overrides (optional) ───────────────────

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -70,6 +70,21 @@ describe("Config Validation - Project Uniqueness", () => {
 
     expect(() => validateConfig(config)).not.toThrow();
   });
+
+  it("accepts maxActiveWorkers as a positive integer", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/integrator",
+          repo: "org/integrator",
+          defaultBranch: "main",
+          maxActiveWorkers: 1,
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).not.toThrow();
+  });
 });
 
 describe("Config Validation - Session Prefix Uniqueness", () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -26,6 +26,7 @@ import {
   SessionNotRestorableError,
   WorkspaceMissingError,
   isIssueNotFoundError,
+  SESSION_STATUS,
   type OrchestratorConfig,
   type PluginRegistry,
   type Runtime,
@@ -304,6 +305,22 @@ describe("spawn", () => {
     expect(mockAgent.getLaunchCommand).toHaveBeenCalled();
     // Verify runtime was created
     expect(mockRuntime.create).toHaveBeenCalled();
+  });
+
+  it("blocks spawn when maxActiveWorkers limit is reached", async () => {
+    config.projects["my-app"].maxActiveWorkers = 1;
+    writeMetadata(sessionsDir, "app-9", {
+      worktree: join(tmpDir, "my-app", "app-9"),
+      branch: "feat/INT-9",
+      status: SESSION_STATUS.WORKING,
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await expect(sm.spawn({ projectId: "my-app" })).rejects.toThrow(/maxActiveWorkers=1/);
+    expect(mockRuntime.create).not.toHaveBeenCalled();
   });
 
   it("blocks spawn while the project is globally paused", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -147,6 +147,7 @@ const ProjectConfigSchema = z.object({
   repo: z.string(),
   path: z.string(),
   defaultBranch: z.string().default("main"),
+  maxActiveWorkers: z.number().int().positive().optional(),
   sessionPrefix: z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/, "sessionPrefix must match [a-zA-Z0-9_-]+")

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -20,6 +20,7 @@ import {
   isIssueNotFoundError,
   isRestorable,
   NON_RESTORABLE_STATUSES,
+  TERMINAL_STATUSES,
   SessionNotFoundError,
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -933,6 +934,19 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           // Other error (auth, network, etc) - fail fast
           throw new Error(`Failed to fetch issue ${spawnConfig.issueId}: ${err}`, { cause: err });
         }
+      }
+    }
+
+    if (project.maxActiveWorkers !== undefined) {
+      const activeWorkers = loadActiveSessionRecords(project).filter(
+        ({ sessionName, raw }) =>
+          !isOrchestratorSessionRecord(sessionName, raw) &&
+          !TERMINAL_STATUSES.has((raw["status"] as Session["status"]) ?? "working"),
+      );
+      if (activeWorkers.length >= project.maxActiveWorkers) {
+        throw new Error(
+          `Project '${spawnConfig.projectId}' already has ${activeWorkers.length} active worker(s); maxActiveWorkers=${project.maxActiveWorkers}`,
+        );
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -945,6 +945,9 @@ export interface ProjectConfig {
   /** Default branch (main, master, next, develop, etc.) */
   defaultBranch: string;
 
+  /** Maximum number of active worker sessions allowed for this project. */
+  maxActiveWorkers?: number;
+
   /** Session name prefix (e.g. "app" → "app-1", "app-2") */
   sessionPrefix: string;
 


### PR DESCRIPTION
## Summary
- restore `maxActiveWorkers` to project config validation/types
- block new worker spawns once the per-project active worker cap is reached
- add regression coverage for config validation and session-manager enforcement

## Testing
- pnpm --dir packages/core exec vitest run src/__tests__/session-manager.test.ts src/__tests__/config-validation.test.ts
- pnpm --filter @composio/ao-core build
- pnpm -r --filter @composio/ao-plugin-agent-claude-code --filter @composio/ao-plugin-agent-codex --filter @composio/ao-plugin-agent-aider --filter @composio/ao-plugin-agent-opencode --filter @composio/ao-plugin-scm-github --filter @composio/ao-cli build

## Notes
This is intentionally scoped to worker-limit enforcement only.
