### PR TITLE
Clarify CLI status vs activity labels

### DIFF
--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -388,10 +388,11 @@ describe("status command", () => {
     expect(output).toContain("Branch");
     expect(output).toContain("PR");
     expect(output).toContain("CI");
+    expect(output).toContain("State");
     expect(output).toContain("Activity");
   });
 
-  it("shows PR number, CI status, review decision, and threads", async () => {
+  it("shows state, PR number, CI status, review decision, and threads", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
       "worktree=/tmp/wt\nbranch=feat/test\nstatus=working\n",
@@ -438,10 +439,57 @@ describe("status command", () => {
     await program.parseAsync(["node", "test", "status"]);
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("working");
     expect(output).toContain("#42");
     expect(output).toContain("pass");
     expect(output).toContain("ok"); // approved
     expect(output).toContain("2"); // pending threads
+  });
+
+  it("shows lifecycle state separately from activity", async () => {
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/review\nstatus=pr_open\npr=https://github.com/org/repo/pull/42\n",
+    );
+
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000) - 60);
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/review");
+
+    mockDetectPR.mockResolvedValue({
+      number: 42,
+      url: "https://github.com/org/repo/pull/42",
+      title: "Review PR",
+      owner: "org",
+      repo: "repo",
+      branch: "feat/review",
+      baseBranch: "main",
+      isDraft: false,
+    });
+    mockGetCISummary.mockResolvedValue("none");
+    mockGetReviewDecision.mockResolvedValue("none");
+    mockGetPendingComments.mockResolvedValue([]);
+
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        projectId: "my-app",
+        status: "pr_open",
+        activity: "active",
+        branch: "feat/review",
+        workspacePath: "/tmp/wt",
+        metadata: { pr: "https://github.com/org/repo/pull/42", status: "pr_open" },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("pr_open");
+    expect(output).toContain("active");
   });
 
   it("shows failing CI and changes_requested review", async () => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -21,6 +21,7 @@ import {
   activityIcon,
   ciStatusIcon,
   reviewDecisionIcon,
+  statusColor,
   padCol,
 } from "../lib/format.js";
 import { getAgentByName, getSCM } from "../lib/plugins.js";
@@ -141,6 +142,7 @@ async function gatherSessionInfo(
 const COL = {
   session: 14,
   branch: 24,
+  state: 11,
   pr: 6,
   ci: 6,
   review: 6,
@@ -153,6 +155,7 @@ function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
     padCol("Branch", COL.branch) +
+    padCol("State", COL.state) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
     padCol("Rev", COL.review) +
@@ -161,16 +164,26 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session +
+    COL.branch +
+    COL.state +
+    COL.pr +
+    COL.ci +
+    COL.review +
+    COL.threads +
+    COL.activity +
+    3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
 function printSessionRow(info: SessionInfo): void {
   const prStr = info.prNumber ? `#${info.prNumber}` : "-";
+  const stateStr = info.status ? statusColor(info.status) : chalk.dim("-");
 
   const row =
     padCol(chalk.green(info.name), COL.session) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
+    padCol(stateStr, COL.state) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
     padCol(reviewDecisionIcon(info.reviewDecision), COL.review) +
@@ -207,7 +220,7 @@ function printOrchestratorRow(info: SessionInfo): void {
 export function registerStatus(program: Command): void {
   program
     .command("status")
-    .description("Show all sessions with branch, activity, PR, and CI status")
+    .description("Show all sessions with branch, state, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
     .action(async (opts: { project?: string; json?: boolean }) => {

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -88,7 +88,7 @@ export function reviewDecisionIcon(decision: ReviewDecision | null): string {
 export function activityIcon(activity: ActivityState | null): string {
   switch (activity) {
     case "active":
-      return chalk.green("working");
+      return chalk.green("active");
     case "ready":
       return chalk.cyan("ready");
     case "idle":


### PR DESCRIPTION
## Summary
- add a dedicated State column to `ao status`
- keep Activity separate from lifecycle state in the table output
- render activity `active` as `active` instead of `working`
- add regression coverage for the `pr_open` + `active` case

## Verification
- pnpm exec vitest run --run __tests__/commands/status.test.ts
- pnpm run typecheck
- pnpm run build