### PR TITLE
feat: add built-in ACPX agent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Eight slots. Every abstraction is swappable.
 | Slot      | Default     | Alternatives             |
 | --------- | ----------- | ------------------------ |
 | Runtime   | tmux        | docker, k8s, process     |
-| Agent     | claude-code | codex, aider, opencode   |
+| Agent     | claude-code | codex, aider, acpx, opencode |
 | Workspace | worktree    | clone                    |
 | Tracker   | github      | linear                   |
 | SCM       | github      | —                        |

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -18,7 +18,7 @@ port: 3000
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
   runtime: tmux           # tmux | process | docker | kubernetes | ssh | e2b
-  agent: claude-code      # claude-code | codex | aider | goose | custom
+  agent: claude-code      # claude-code | codex | aider | acpx | goose | custom
   # orchestrator:
   #   agent: claude-code
   # worker:
@@ -62,6 +62,7 @@ projects:
     # agentConfig:
     #   permissions: skip    # --dangerously-skip-permissions
     #   model: opus
+    #   acpxAgent: pi        # when agent: acpx (currently only "pi" is supported)
 
     # Optional role-specific agent overrides
     # orchestrator:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -23,7 +23,7 @@ Every abstraction is a swappable plugin. All interfaces are defined in [`package
 | Slot      | Interface   | Default       | Alternatives                             |
 | --------- | ----------- | ------------- | ---------------------------------------- |
 | Runtime   | `Runtime`   | `tmux`        | `process`, `docker`, `k8s`, `ssh`, `e2b` |
-| Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `opencode`             |
+| Agent     | `Agent`     | `claude-code` | `codex`, `aider`, `acpx`, `opencode`     |
 | Workspace | `Workspace` | `worktree`    | `clone`                                  |
 | Tracker   | `Tracker`   | `github`      | `linear`                                 |
 | SCM       | `SCM`       | `github`      | —                                        |
@@ -107,7 +107,7 @@ agent-orchestrator/
 │   ├── web/               # Next.js dashboard
 │   ├── plugins/           # All plugin packages
 │   │   ├── runtime-*/     # Runtime plugins (tmux, docker, k8s)
-│   │   ├── agent-*/       # Agent adapters (claude-code, codex, aider)
+│   │   ├── agent-*/       # Agent adapters (claude-code, codex, aider, acpx)
 │   │   ├── workspace-*/   # Workspace providers (worktree, clone)
 │   │   ├── tracker-*/     # Issue trackers (github, linear)
 │   │   ├── scm-github/    # SCM adapter

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,6 +76,18 @@ Use this if:
 - You need agent-specific configuration
 - You're evaluating different AI coding assistants
 
+### [acpx-pi.yaml](./acpx-pi.yaml)
+
+**Using ACPX with the `pi` agent**
+
+Shows how to route AO prompts through the built-in ACPX bridge while keeping AO in control of the session lifecycle.
+
+Use this if:
+
+- You want AO sessions to dispatch work through the `acpx` CLI
+- You are starting with ACPX's `pi` agent
+- You need a minimal example for `agentConfig.acpxAgent`
+
 ## Configuration Tips
 
 1. **Start simple** - Use `simple-github.yaml` as a starting point

--- a/examples/acpx-pi.yaml
+++ b/examples/acpx-pi.yaml
@@ -1,0 +1,17 @@
+# ACPX worker setup using the built-in acpx agent plugin.
+
+defaults:
+  runtime: tmux
+  agent: acpx
+  workspace: worktree
+  notifiers: [desktop]
+
+projects:
+  my-app:
+    repo: owner/my-app
+    path: ~/code/my-app
+    defaultBranch: main
+    sessionPrefix: app
+    agentConfig:
+      acpxAgent: pi
+

--- a/packages/cli/__tests__/lib/plugins.test.ts
+++ b/packages/cli/__tests__/lib/plugins.test.ts
@@ -67,6 +67,10 @@ describe("getAgentByName", () => {
     expect(getAgentByName("aider").name).toBe("aider");
   });
 
+  it("returns agent for acpx", () => {
+    expect(getAgentByName("acpx").name).toBe("acpx");
+  });
+
   it("returns agent for opencode", () => {
     expect(getAgentByName("opencode").name).toBe("opencode");
   });

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@composio/ao-core": "workspace:*",
     "@composio/ao-plugin-agent-aider": "workspace:*",
+    "@composio/ao-plugin-agent-acpx": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-codex": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -19,7 +19,7 @@ readyThresholdMs: 300000      # Ms before "ready" session becomes "idle" (defaul
 
 defaults:
   runtime: tmux               # tmux | process
-  agent: claude-code          # claude-code | aider | codex | opencode
+  agent: claude-code          # claude-code | aider | codex | acpx | opencode
   workspace: worktree         # worktree | clone
   notifiers:                  # List of active notifier plugins
     - desktop                 # desktop | slack | webhook | composio | openclaw
@@ -46,8 +46,9 @@ projects:
 
     # ── Agent configuration (optional) ────────────────────────────
     agentConfig:
-      permissions: auto       # auto | manual — agent permission mode
+      permissions: auto-edit  # permissionless | default | auto-edit | suggest
       model: claude-sonnet-4-20250514
+      # acpxAgent: pi         # Required when agent: acpx (currently only "pi" is supported)
 
     # ── Agent rules (optional) ────────────────────────────────────
     agentRules: |             # Inline rules passed to every agent prompt
@@ -117,7 +118,7 @@ notificationRouting:
 
 # ── Available plugins ───────────────────────────────────────────────
 #
-# Agent:     claude-code, aider, codex, opencode
+# Agent:     claude-code, aider, codex, acpx, opencode
 # Runtime:   tmux, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -17,6 +17,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
   { name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
+  { name: "acpx", pkg: "@composio/ao-plugin-agent-acpx" },
   { name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
 ];
 

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -1,4 +1,5 @@
 import type { Agent, OrchestratorConfig, SCM } from "@composio/ao-core";
+import acpxPlugin from "@composio/ao-plugin-agent-acpx";
 import claudeCodePlugin from "@composio/ao-plugin-agent-claude-code";
 import codexPlugin from "@composio/ao-plugin-agent-codex";
 import aiderPlugin from "@composio/ao-plugin-agent-aider";
@@ -6,6 +7,7 @@ import opencodePlugin from "@composio/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@composio/ao-plugin-scm-github";
 
 const agentPlugins: Record<string, { create(): Agent }> = {
+  acpx: acpxPlugin,
   "claude-code": claudeCodePlugin,
   codex: codexPlugin,
   aider: aiderPlugin,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,7 +18,7 @@ Every interface the system uses is defined here. If you're working on any part o
 **Main interfaces:**
 
 - `Runtime` — where sessions execute (tmux, docker, k8s)
-- `Agent` — AI coding tool adapter (claude-code, codex, aider)
+- `Agent` — AI coding tool adapter (claude-code, codex, aider, acpx)
 - `Workspace` — code isolation (worktree, clone)
 - `Tracker` — issue tracking (GitHub Issues, Linear)
 - `SCM` — PR/CI/reviews (GitHub, GitLab)
@@ -93,7 +93,7 @@ Loads plugins and provides access to them:
 **Built-in plugins** (loaded by default):
 
 - runtime-tmux, runtime-process
-- agent-claude-code, agent-codex, agent-aider, agent-opencode
+- agent-claude-code, agent-codex, agent-aider, agent-acpx, agent-opencode
 - workspace-worktree, workspace-clone
 - tracker-github, tracker-linear
 - scm-github

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -234,6 +234,48 @@ describe("Config Validation - Session Prefix Uniqueness", () => {
   });
 });
 
+describe("Config Validation - Agent Specific Config", () => {
+  it("accepts acpxAgent in project agentConfig", () => {
+    const config = validateConfig({
+      defaults: {
+        runtime: "tmux",
+        agent: "acpx",
+        workspace: "worktree",
+        notifiers: [],
+      },
+      projects: {
+        proj1: {
+          path: "/repos/acpx-project",
+          repo: "org/acpx-project",
+          defaultBranch: "main",
+          agentConfig: {
+            acpxAgent: "pi",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.agentConfig?.acpxAgent).toBe("pi");
+  });
+
+  it("rejects unsupported acpxAgent values", () => {
+    expect(() =>
+      validateConfig({
+        projects: {
+          proj1: {
+            path: "/repos/acpx-project",
+            repo: "org/acpx-project",
+            defaultBranch: "main",
+            agentConfig: {
+              acpxAgent: "oracle",
+            },
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("Config Validation - Session Prefix Regex", () => {
   it("accepts valid session prefixes", () => {
     const validPrefixes = ["int", "app", "my-app", "app_v2", "app123"];

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -236,26 +236,30 @@ describe("Config Validation - Session Prefix Uniqueness", () => {
 
 describe("Config Validation - Agent Specific Config", () => {
   it("accepts acpxAgent in project agentConfig", () => {
-    const config = validateConfig({
-      defaults: {
-        runtime: "tmux",
-        agent: "acpx",
-        workspace: "worktree",
-        notifiers: [],
-      },
-      projects: {
-        proj1: {
-          path: "/repos/acpx-project",
-          repo: "org/acpx-project",
-          defaultBranch: "main",
-          agentConfig: {
-            acpxAgent: "pi",
+    const acceptedAgents = ["pi", "codex", "claude", "gemini"] as const;
+
+    for (const acpxAgent of acceptedAgents) {
+      const config = validateConfig({
+        defaults: {
+          runtime: "tmux",
+          agent: "acpx",
+          workspace: "worktree",
+          notifiers: [],
+        },
+        projects: {
+          proj1: {
+            path: "/repos/acpx-project",
+            repo: "org/acpx-project",
+            defaultBranch: "main",
+            agentConfig: {
+              acpxAgent,
+            },
           },
         },
-      },
-    });
+      });
 
-    expect(config.projects.proj1.agentConfig?.acpxAgent).toBe("pi");
+      expect(config.projects.proj1.agentConfig?.acpxAgent).toBe(acpxAgent);
+    }
   });
 
   it("rejects unsupported acpxAgent values", () => {

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -146,11 +146,13 @@ describe("loadBuiltins", () => {
 
     const fakeClaudeCode = makePlugin("agent", "claude-code");
     const fakeCodex = makePlugin("agent", "codex");
+    const fakeAcpx = makePlugin("agent", "acpx");
     const fakeOpenCode = makePlugin("agent", "opencode");
 
     await registry.loadBuiltins(undefined, async (pkg: string) => {
       if (pkg === "@composio/ao-plugin-agent-claude-code") return fakeClaudeCode;
       if (pkg === "@composio/ao-plugin-agent-codex") return fakeCodex;
+      if (pkg === "@composio/ao-plugin-agent-acpx") return fakeAcpx;
       if (pkg === "@composio/ao-plugin-agent-opencode") return fakeOpenCode;
       throw new Error(`Not found: ${pkg}`);
     });
@@ -158,10 +160,12 @@ describe("loadBuiltins", () => {
     const agents = registry.list("agent");
     expect(agents).toContainEqual(expect.objectContaining({ name: "claude-code", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "codex", slot: "agent" }));
+    expect(agents).toContainEqual(expect.objectContaining({ name: "acpx", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "opencode", slot: "agent" }));
 
     expect(registry.get("agent", "codex")).not.toBeNull();
     expect(registry.get("agent", "claude-code")).not.toBeNull();
+    expect(registry.get("agent", "acpx")).not.toBeNull();
     expect(registry.get("agent", "opencode")).not.toBeNull();
   });
 

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1221,6 +1221,49 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalled();
     vi.useRealTimers();
   });
+
+  it("forwards acpxAgent through project agentConfig to the selected agent", async () => {
+    const acpxAgent = {
+      ...mockAgent,
+      name: "acpx",
+    };
+    const registryWithAcpx: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return acpxAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const configWithAcpx: OrchestratorConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        agent: "acpx",
+      },
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          agentConfig: {
+            acpxAgent: "pi",
+          },
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithAcpx, registry: registryWithAcpx });
+    await sm.spawn({ projectId: "my-app", prompt: "Dispatch through ACPX" });
+
+    expect(acpxAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectConfig: expect.objectContaining({
+          agentConfig: expect.objectContaining({ acpxAgent: "pi" }),
+        }),
+      }),
+    );
+  });
 });
 
 describe("list", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -100,6 +100,7 @@ const AgentSpecificConfigSchema = z
     permissions: AgentPermissionSchema,
     model: z.string().optional(),
     orchestratorModel: z.string().optional(),
+    acpxAgent: z.enum(["pi"]).optional(),
     opencodeSessionId: z.string().optional(),
   })
   .passthrough();
@@ -111,6 +112,7 @@ const RoleAgentSpecificConfigSchema = z
       .optional(),
     model: z.string().optional(),
     orchestratorModel: z.string().optional(),
+    acpxAgent: z.enum(["pi"]).optional(),
     opencodeSessionId: z.string().optional(),
   })
   .passthrough();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -100,7 +100,7 @@ const AgentSpecificConfigSchema = z
     permissions: AgentPermissionSchema,
     model: z.string().optional(),
     orchestratorModel: z.string().optional(),
-    acpxAgent: z.enum(["pi"]).optional(),
+    acpxAgent: z.enum(["pi", "codex", "claude", "gemini"]).optional(),
     opencodeSessionId: z.string().optional(),
   })
   .passthrough();
@@ -112,7 +112,7 @@ const RoleAgentSpecificConfigSchema = z
       .optional(),
     model: z.string().optional(),
     orchestratorModel: z.string().optional(),
-    acpxAgent: z.enum(["pi"]).optional(),
+    acpxAgent: z.enum(["pi", "codex", "claude", "gemini"]).optional(),
     opencodeSessionId: z.string().optional(),
   })
   .passthrough();

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -31,6 +31,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "claude-code", pkg: "@composio/ao-plugin-agent-claude-code" },
   { slot: "agent", name: "codex", pkg: "@composio/ao-plugin-agent-codex" },
   { slot: "agent", name: "aider", pkg: "@composio/ao-plugin-agent-aider" },
+  { slot: "agent", name: "acpx", pkg: "@composio/ao-plugin-agent-acpx" },
   { slot: "agent", name: "opencode", pkg: "@composio/ao-plugin-agent-opencode" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@composio/ao-plugin-workspace-worktree" },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1042,7 +1042,6 @@ export interface AgentSpecificConfig {
   permissions?: AgentPermissionMode;
   model?: string;
   orchestratorModel?: string;
-  acpxAgent?: AcpxAgentName;
   [key: string]: unknown;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1042,7 +1042,14 @@ export interface AgentSpecificConfig {
   permissions?: AgentPermissionMode;
   model?: string;
   orchestratorModel?: string;
+  acpxAgent?: AcpxAgentName;
   [key: string]: unknown;
+}
+
+export type AcpxAgentName = "pi";
+
+export interface AcpxAgentConfig extends AgentSpecificConfig {
+  acpxAgent?: AcpxAgentName;
 }
 
 export interface OpenCodeAgentConfig extends AgentSpecificConfig {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1046,7 +1046,7 @@ export interface AgentSpecificConfig {
   [key: string]: unknown;
 }
 
-export type AcpxAgentName = "pi";
+export type AcpxAgentName = "pi" | "codex" | "claude" | "gemini";
 
 export interface AcpxAgentConfig extends AgentSpecificConfig {
   acpxAgent?: AcpxAgentName;

--- a/packages/plugins/agent-acpx/package.json
+++ b/packages/plugins/agent-acpx/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@composio/ao-plugin-agent-acpx",
+  "version": "0.2.0",
+  "description": "Agent plugin: ACPX bridge",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-acpx"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@composio/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-acpx/src/bridge.test.ts
+++ b/packages/plugins/agent-acpx/src/bridge.test.ts
@@ -28,8 +28,11 @@ describe("bridge helpers", () => {
     expect(composePrompt("Fix the bug\n", "You are ACPX")).toBe("You are ACPX\n\nFix the bug");
   });
 
-  it("builds pi args as positional prompt invocation", () => {
+  it("builds supported acpx args as positional prompt invocation", () => {
     expect(buildAcpxArgs({ acpxAgent: "pi", prompt: "hello" })).toEqual(["pi", "hello"]);
+    expect(buildAcpxArgs({ acpxAgent: "codex", prompt: "hello" })).toEqual(["codex", "hello"]);
+    expect(buildAcpxArgs({ acpxAgent: "claude", prompt: "hello" })).toEqual(["claude", "hello"]);
+    expect(buildAcpxArgs({ acpxAgent: "gemini", prompt: "hello" })).toEqual(["gemini", "hello"]);
   });
 
   it("loads the system prompt from a file when provided", async () => {

--- a/packages/plugins/agent-acpx/src/bridge.test.ts
+++ b/packages/plugins/agent-acpx/src/bridge.test.ts
@@ -3,7 +3,8 @@ import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   AcpxBridge,
-  buildAcpxArgs,
+  buildEnsureSessionArgs,
+  buildPromptArgs,
   composePrompt,
   DEFAULT_ACPX_AGENT,
   normalizeAcpxAgent,
@@ -28,11 +29,12 @@ describe("bridge helpers", () => {
     expect(composePrompt("Fix the bug\n", "You are ACPX")).toBe("You are ACPX\n\nFix the bug");
   });
 
-  it("builds supported acpx args as positional prompt invocation", () => {
-    expect(buildAcpxArgs({ acpxAgent: "pi", prompt: "hello" })).toEqual(["pi", "hello"]);
-    expect(buildAcpxArgs({ acpxAgent: "codex", prompt: "hello" })).toEqual(["codex", "hello"]);
-    expect(buildAcpxArgs({ acpxAgent: "claude", prompt: "hello" })).toEqual(["claude", "hello"]);
-    expect(buildAcpxArgs({ acpxAgent: "gemini", prompt: "hello" })).toEqual(["gemini", "hello"]);
+  it("builds supported acpx args for session ensure and prompt", () => {
+    expect(buildEnsureSessionArgs({ acpxAgent: "pi" })).toEqual(["pi", "sessions", "ensure"]);
+    expect(buildPromptArgs({ acpxAgent: "pi", prompt: "hello" })).toEqual(["pi", "prompt", "hello"]);
+    expect(buildPromptArgs({ acpxAgent: "codex", prompt: "hello" })).toEqual(["codex", "prompt", "hello"]);
+    expect(buildPromptArgs({ acpxAgent: "claude", prompt: "hello" })).toEqual(["claude", "prompt", "hello"]);
+    expect(buildPromptArgs({ acpxAgent: "gemini", prompt: "hello" })).toEqual(["gemini", "prompt", "hello"]);
   });
 
   it("loads the system prompt from a file when provided", async () => {
@@ -85,7 +87,12 @@ describe("AcpxBridge", () => {
     expect(calls).toEqual([
       {
         command: "acpx",
-        args: ["pi", "System rules\n\nLine one\nLine two"],
+        args: ["pi", "sessions", "ensure"],
+        cwd: "/workspace/test",
+      },
+      {
+        command: "acpx",
+        args: ["pi", "prompt", "System rules\n\nLine one\nLine two"],
         cwd: "/workspace/test",
       },
     ]);
@@ -95,9 +102,9 @@ describe("AcpxBridge", () => {
     const order: string[] = [];
     const spawnImpl = vi.fn((_command: string, args: readonly string[]) => {
       const child = new FakeChildProcess();
-      order.push(`start:${String(args[1])}`);
+      order.push(`start:${args.join(' ')}`);
       setTimeout(() => {
-        order.push(`end:${String(args[1])}`);
+        order.push(`end:${args.join(' ')}`);
         child.emit("close", 0, null);
       }, 5);
       return child as never;
@@ -111,7 +118,16 @@ describe("AcpxBridge", () => {
     await vi.runAllTimersAsync();
     await bridge.drain();
 
-    expect(order).toEqual(["start:first", "end:first", "start:second", "end:second"]);
+    expect(order).toEqual([
+      "start:pi sessions ensure",
+      "end:pi sessions ensure",
+      "start:pi prompt first",
+      "end:pi prompt first",
+      "start:pi sessions ensure",
+      "end:pi sessions ensure",
+      "start:pi prompt second",
+      "end:pi prompt second",
+    ]);
   });
 
   it("keeps running after a failed acpx invocation", async () => {
@@ -135,6 +151,28 @@ describe("AcpxBridge", () => {
     await bridge.drain();
 
     expect(stderr.read()?.toString("utf-8")).toContain("acpx pi failed with exit code 1");
-    expect(spawnImpl).toHaveBeenCalledTimes(2);
+    expect(spawnImpl).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not send the prompt when session ensure fails", async () => {
+    const calls: string[][] = [];
+    const stderr = new PassThrough();
+    const spawnImpl = vi.fn((_command: string, args: readonly string[]) => {
+      calls.push([...args]);
+      const child = new FakeChildProcess();
+      setTimeout(() => {
+        child.emit("close", 4, null);
+      }, 0);
+      return child as never;
+    });
+
+    const bridge = new AcpxBridge({ spawnImpl, stderr });
+    bridge.acceptInput("hello\n");
+    await vi.advanceTimersByTimeAsync(150);
+    await vi.runAllTimersAsync();
+    await bridge.drain();
+
+    expect(calls).toEqual([["pi", "sessions", "ensure"]]);
+    expect(stderr.read()?.toString("utf-8")).toContain("acpx pi failed with exit code 4");
   });
 });

--- a/packages/plugins/agent-acpx/src/bridge.test.ts
+++ b/packages/plugins/agent-acpx/src/bridge.test.ts
@@ -1,0 +1,137 @@
+import { PassThrough } from "node:stream";
+import { EventEmitter } from "node:events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AcpxBridge,
+  buildAcpxArgs,
+  composePrompt,
+  DEFAULT_ACPX_AGENT,
+  normalizeAcpxAgent,
+  readSystemPrompt,
+} from "./bridge.js";
+
+class FakeChildProcess extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+}
+
+describe("bridge helpers", () => {
+  it("defaults acpx agent to pi", () => {
+    expect(normalizeAcpxAgent(undefined)).toBe(DEFAULT_ACPX_AGENT);
+  });
+
+  it("rejects unsupported acpx agents", () => {
+    expect(() => normalizeAcpxAgent("oracle")).toThrow("Unsupported acpx agent");
+  });
+
+  it("prepends system prompt when composing prompts", () => {
+    expect(composePrompt("Fix the bug\n", "You are ACPX")).toBe("You are ACPX\n\nFix the bug");
+  });
+
+  it("builds pi args as positional prompt invocation", () => {
+    expect(buildAcpxArgs({ acpxAgent: "pi", prompt: "hello" })).toEqual(["pi", "hello"]);
+  });
+
+  it("loads the system prompt from a file when provided", async () => {
+    const { writeFile, mkdtemp, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const dir = await mkdtemp(join(tmpdir(), "acpx-bridge-test-"));
+    const file = join(dir, "prompt.md");
+    await writeFile(file, "Use ACPX carefully", "utf-8");
+
+    expect(readSystemPrompt({ systemPromptFile: file })).toBe("Use ACPX carefully");
+
+    await rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("AcpxBridge", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("batches stdin chunks into one multiline prompt", async () => {
+    const calls: Array<{ command: string; args: readonly string[]; cwd?: string }> = [];
+    const spawnImpl = vi.fn((command: string, args: readonly string[], options: { cwd?: string }) => {
+      calls.push({ command, args, cwd: options.cwd });
+      const child = new FakeChildProcess();
+      setTimeout(() => {
+        child.stdout.write("ok\n");
+        child.emit("close", 0, null);
+      }, 0);
+      return child as never;
+    });
+
+    const stdout = new PassThrough();
+    const bridge = new AcpxBridge({
+      acpxAgent: "pi",
+      cwd: "/workspace/test",
+      systemPrompt: "System rules",
+      spawnImpl,
+      stdout,
+    });
+
+    bridge.acceptInput("Line one\nLine two");
+    bridge.acceptInput("\n");
+    await vi.advanceTimersByTimeAsync(150);
+    await vi.runAllTimersAsync();
+    await bridge.drain();
+
+    expect(calls).toEqual([
+      {
+        command: "acpx",
+        args: ["pi", "System rules\n\nLine one\nLine two"],
+        cwd: "/workspace/test",
+      },
+    ]);
+  });
+
+  it("serializes queued prompts so only one acpx invocation runs at a time", async () => {
+    const order: string[] = [];
+    const spawnImpl = vi.fn((_command: string, args: readonly string[]) => {
+      const child = new FakeChildProcess();
+      order.push(`start:${String(args[1])}`);
+      setTimeout(() => {
+        order.push(`end:${String(args[1])}`);
+        child.emit("close", 0, null);
+      }, 5);
+      return child as never;
+    });
+
+    const bridge = new AcpxBridge({ spawnImpl });
+    bridge.acceptInput("first\n");
+    await vi.advanceTimersByTimeAsync(150);
+    bridge.acceptInput("second\n");
+    await vi.advanceTimersByTimeAsync(150);
+    await vi.runAllTimersAsync();
+    await bridge.drain();
+
+    expect(order).toEqual(["start:first", "end:first", "start:second", "end:second"]);
+  });
+
+  it("keeps running after a failed acpx invocation", async () => {
+    const stderr = new PassThrough();
+    let attempt = 0;
+    const spawnImpl = vi.fn(() => {
+      attempt += 1;
+      const child = new FakeChildProcess();
+      setTimeout(() => {
+        child.emit("close", attempt === 1 ? 1 : 0, null);
+      }, 0);
+      return child as never;
+    });
+
+    const bridge = new AcpxBridge({ spawnImpl, stderr });
+    bridge.acceptInput("first\n");
+    await vi.advanceTimersByTimeAsync(150);
+    bridge.acceptInput("second\n");
+    await vi.advanceTimersByTimeAsync(150);
+    await vi.runAllTimersAsync();
+    await bridge.drain();
+
+    expect(stderr.read()?.toString("utf-8")).toContain("acpx pi failed with exit code 1");
+    expect(spawnImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/plugins/agent-acpx/src/bridge.ts
+++ b/packages/plugins/agent-acpx/src/bridge.ts
@@ -245,43 +245,62 @@ function parseCliArgs(argv: readonly string[]): {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    const next = argv[index + 1];
-
-    if (!next) {
-      throw new Error(`Missing value for ${arg}`);
-    }
 
     if (arg === "--acpx-path") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.acpxPath = next;
       index += 1;
       continue;
     }
 
     if (arg === "--agent") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.acpxAgent = next;
       index += 1;
       continue;
     }
 
     if (arg === "--cwd") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.cwd = next;
       index += 1;
       continue;
     }
 
     if (arg === "--system-prompt") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.systemPrompt = next;
       index += 1;
       continue;
     }
 
     if (arg === "--system-prompt-file") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.systemPromptFile = next;
       index += 1;
       continue;
     }
 
     if (arg === "--flush-delay-ms") {
+      const next = argv[index + 1];
+      if (next == null) {
+        throw new Error(`Missing value for ${arg}`);
+      }
       parsed.flushDelayMs = Number(next);
       index += 1;
       continue;

--- a/packages/plugins/agent-acpx/src/bridge.ts
+++ b/packages/plugins/agent-acpx/src/bridge.ts
@@ -5,8 +5,9 @@ import type { SpawnOptions } from "node:child_process";
 
 export const DEFAULT_ACPX_AGENT = "pi";
 export const DEFAULT_PROMPT_FLUSH_DELAY_MS = 150;
+export const SUPPORTED_ACPX_AGENTS = [DEFAULT_ACPX_AGENT, "codex", "claude", "gemini"] as const;
 
-export type SupportedAcpxAgent = typeof DEFAULT_ACPX_AGENT;
+export type SupportedAcpxAgent = (typeof SUPPORTED_ACPX_AGENTS)[number];
 
 export interface BridgeSpawn {
   (
@@ -28,8 +29,12 @@ export interface AcpxBridgeOptions {
 }
 
 export function normalizeAcpxAgent(agent: string | undefined): SupportedAcpxAgent {
-  if (!agent || agent === DEFAULT_ACPX_AGENT) {
+  if (!agent) {
     return DEFAULT_ACPX_AGENT;
+  }
+
+  if ((SUPPORTED_ACPX_AGENTS as readonly string[]).includes(agent)) {
+    return agent as SupportedAcpxAgent;
   }
 
   throw new Error(`Unsupported acpx agent: ${agent}`);

--- a/packages/plugins/agent-acpx/src/bridge.ts
+++ b/packages/plugins/agent-acpx/src/bridge.ts
@@ -64,11 +64,17 @@ export function composePrompt(prompt: string, systemPrompt?: string): string {
   return `${trimmedSystemPrompt}\n\n${trimmedPrompt}`;
 }
 
-export function buildAcpxArgs(options: {
+export function buildEnsureSessionArgs(options: {
+  acpxAgent?: string;
+}): string[] {
+  return [normalizeAcpxAgent(options.acpxAgent), "sessions", "ensure"];
+}
+
+export function buildPromptArgs(options: {
   acpxAgent?: string;
   prompt: string;
 }): string[] {
-  return [normalizeAcpxAgent(options.acpxAgent), options.prompt];
+  return [normalizeAcpxAgent(options.acpxAgent), "prompt", options.prompt];
 }
 
 export class AcpxBridge {
@@ -173,10 +179,17 @@ export class AcpxBridge {
     }
   }
 
-  private dispatchPrompt(prompt: string): Promise<void> {
-    const composedPrompt = composePrompt(prompt, this.systemPrompt);
-    const args = buildAcpxArgs({ acpxAgent: this.acpxAgent, prompt: composedPrompt });
+  private async dispatchPrompt(prompt: string): Promise<void> {
+    const ensured = await this.runAcpxCommand(buildEnsureSessionArgs({ acpxAgent: this.acpxAgent }));
+    if (!ensured) {
+      return;
+    }
 
+    const composedPrompt = composePrompt(prompt, this.systemPrompt);
+    await this.runAcpxCommand(buildPromptArgs({ acpxAgent: this.acpxAgent, prompt: composedPrompt }));
+  }
+
+  private runAcpxCommand(args: string[]): Promise<boolean> {
     return new Promise((resolve) => {
       let settled = false;
       const child = this.spawnImpl(this.acpxPath, args, {
@@ -195,7 +208,7 @@ export class AcpxBridge {
         if (settled) return;
         settled = true;
         this.stderr.write(`[acpx bridge] failed to start acpx: ${error.message}\n`);
-        resolve();
+        resolve(false);
       });
 
       child.once("close", (code, signal) => {
@@ -204,8 +217,10 @@ export class AcpxBridge {
         if (code !== 0) {
           const reason = signal ? `signal ${signal}` : `exit code ${String(code)}`;
           this.stderr.write(`[acpx bridge] acpx ${this.acpxAgent} failed with ${reason}\n`);
+          resolve(false);
+          return;
         }
-        resolve();
+        resolve(true);
       });
     });
   }

--- a/packages/plugins/agent-acpx/src/bridge.ts
+++ b/packages/plugins/agent-acpx/src/bridge.ts
@@ -1,7 +1,6 @@
-import { spawn, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
-import type { SpawnOptions } from "node:child_process";
 
 export const DEFAULT_ACPX_AGENT = "pi";
 export const DEFAULT_PROMPT_FLUSH_DELAY_MS = 150;
@@ -248,7 +247,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--acpx-path") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.acpxPath = next;
@@ -258,7 +257,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--agent") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.acpxAgent = next;
@@ -268,7 +267,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--cwd") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.cwd = next;
@@ -278,7 +277,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--system-prompt") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.systemPrompt = next;
@@ -288,7 +287,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--system-prompt-file") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.systemPromptFile = next;
@@ -298,7 +297,7 @@ function parseCliArgs(argv: readonly string[]): {
 
     if (arg === "--flush-delay-ms") {
       const next = argv[index + 1];
-      if (next == null) {
+      if (next === undefined || next === null) {
         throw new Error(`Missing value for ${arg}`);
       }
       parsed.flushDelayMs = Number(next);

--- a/packages/plugins/agent-acpx/src/bridge.ts
+++ b/packages/plugins/agent-acpx/src/bridge.ts
@@ -1,0 +1,307 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import type { SpawnOptions } from "node:child_process";
+
+export const DEFAULT_ACPX_AGENT = "pi";
+export const DEFAULT_PROMPT_FLUSH_DELAY_MS = 150;
+
+export type SupportedAcpxAgent = typeof DEFAULT_ACPX_AGENT;
+
+export interface BridgeSpawn {
+  (
+    command: string,
+    args: readonly string[],
+    options: SpawnOptions,
+  ): ChildProcess;
+}
+
+export interface AcpxBridgeOptions {
+  acpxPath?: string;
+  acpxAgent?: string;
+  cwd?: string;
+  systemPrompt?: string;
+  flushDelayMs?: number;
+  spawnImpl?: BridgeSpawn;
+  stdout?: NodeJS.WritableStream;
+  stderr?: NodeJS.WritableStream;
+}
+
+export function normalizeAcpxAgent(agent: string | undefined): SupportedAcpxAgent {
+  if (!agent || agent === DEFAULT_ACPX_AGENT) {
+    return DEFAULT_ACPX_AGENT;
+  }
+
+  throw new Error(`Unsupported acpx agent: ${agent}`);
+}
+
+export function readSystemPrompt(options: {
+  systemPrompt?: string;
+  systemPromptFile?: string;
+}): string | undefined {
+  if (options.systemPromptFile) {
+    return readFileSync(options.systemPromptFile, "utf-8");
+  }
+  return options.systemPrompt;
+}
+
+export function composePrompt(prompt: string, systemPrompt?: string): string {
+  const trimmedPrompt = prompt.replace(/\r/g, "").replace(/\n+$/, "");
+  if (!systemPrompt || systemPrompt.trim().length === 0) {
+    return trimmedPrompt;
+  }
+
+  const trimmedSystemPrompt = systemPrompt.replace(/\r/g, "").trimEnd();
+  if (trimmedPrompt.length === 0) {
+    return trimmedSystemPrompt;
+  }
+
+  return `${trimmedSystemPrompt}\n\n${trimmedPrompt}`;
+}
+
+export function buildAcpxArgs(options: {
+  acpxAgent?: string;
+  prompt: string;
+}): string[] {
+  return [normalizeAcpxAgent(options.acpxAgent), options.prompt];
+}
+
+export class AcpxBridge {
+  private readonly acpxPath: string;
+  private readonly acpxAgent: SupportedAcpxAgent;
+  private readonly cwd: string;
+  private readonly systemPrompt?: string;
+  private readonly flushDelayMs: number;
+  private readonly spawnImpl: BridgeSpawn;
+  private readonly stdout: NodeJS.WritableStream;
+  private readonly stderr: NodeJS.WritableStream;
+
+  private bufferedInput = "";
+  private flushTimer: NodeJS.Timeout | null = null;
+  private queue: string[] = [];
+  private dispatching = false;
+  private idleWaiters: Array<() => void> = [];
+
+  constructor(options: AcpxBridgeOptions = {}) {
+    this.acpxPath = options.acpxPath ?? "acpx";
+    this.acpxAgent = normalizeAcpxAgent(options.acpxAgent);
+    this.cwd = options.cwd ?? process.cwd();
+    this.systemPrompt = options.systemPrompt;
+    this.flushDelayMs = options.flushDelayMs ?? DEFAULT_PROMPT_FLUSH_DELAY_MS;
+    this.spawnImpl = options.spawnImpl ?? spawn;
+    this.stdout = options.stdout ?? process.stdout;
+    this.stderr = options.stderr ?? process.stderr;
+  }
+
+  acceptInput(chunk: Buffer | string): void {
+    this.bufferedInput += chunk.toString();
+    this.scheduleFlush();
+  }
+
+  flushBufferedPrompt(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+
+    const prompt = this.bufferedInput.replace(/\r/g, "").replace(/\n+$/, "");
+    this.bufferedInput = "";
+    if (!prompt.trim()) {
+      return;
+    }
+
+    this.queuePrompt(prompt);
+  }
+
+  async drain(): Promise<void> {
+    this.flushBufferedPrompt();
+    if (!this.dispatching && this.queue.length === 0) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+    }
+
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null;
+      this.flushBufferedPrompt();
+    }, this.flushDelayMs);
+  }
+
+  private queuePrompt(prompt: string): void {
+    this.queue.push(prompt);
+    if (!this.dispatching) {
+      void this.processQueue();
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    this.dispatching = true;
+    try {
+      while (this.queue.length > 0) {
+        const prompt = this.queue.shift();
+        if (!prompt) continue;
+        await this.dispatchPrompt(prompt);
+      }
+    } finally {
+      this.dispatching = false;
+      if (this.queue.length === 0) {
+        this.notifyIdle();
+      }
+    }
+  }
+
+  private notifyIdle(): void {
+    if (this.dispatching || this.queue.length > 0) {
+      return;
+    }
+
+    for (const waiter of this.idleWaiters.splice(0)) {
+      waiter();
+    }
+  }
+
+  private dispatchPrompt(prompt: string): Promise<void> {
+    const composedPrompt = composePrompt(prompt, this.systemPrompt);
+    const args = buildAcpxArgs({ acpxAgent: this.acpxAgent, prompt: composedPrompt });
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const child = this.spawnImpl(this.acpxPath, args, {
+        cwd: this.cwd,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+
+      child.stdout?.on("data", (chunk) => {
+        this.stdout.write(chunk);
+      });
+      child.stderr?.on("data", (chunk) => {
+        this.stderr.write(chunk);
+      });
+
+      child.once("error", (error) => {
+        if (settled) return;
+        settled = true;
+        this.stderr.write(`[acpx bridge] failed to start acpx: ${error.message}\n`);
+        resolve();
+      });
+
+      child.once("close", (code, signal) => {
+        if (settled) return;
+        settled = true;
+        if (code !== 0) {
+          const reason = signal ? `signal ${signal}` : `exit code ${String(code)}`;
+          this.stderr.write(`[acpx bridge] acpx ${this.acpxAgent} failed with ${reason}\n`);
+        }
+        resolve();
+      });
+    });
+  }
+}
+
+function parseCliArgs(argv: readonly string[]): {
+  acpxPath?: string;
+  acpxAgent?: string;
+  cwd?: string;
+  systemPrompt?: string;
+  systemPromptFile?: string;
+  flushDelayMs?: number;
+} {
+  const parsed: {
+    acpxPath?: string;
+    acpxAgent?: string;
+    cwd?: string;
+    systemPrompt?: string;
+    systemPromptFile?: string;
+    flushDelayMs?: number;
+  } = {};
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = argv[index + 1];
+
+    if (!next) {
+      throw new Error(`Missing value for ${arg}`);
+    }
+
+    if (arg === "--acpx-path") {
+      parsed.acpxPath = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--agent") {
+      parsed.acpxAgent = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--cwd") {
+      parsed.cwd = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--system-prompt") {
+      parsed.systemPrompt = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--system-prompt-file") {
+      parsed.systemPromptFile = next;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--flush-delay-ms") {
+      parsed.flushDelayMs = Number(next);
+      index += 1;
+      continue;
+    }
+  }
+
+  return parsed;
+}
+
+export async function runBridgeCli(argv = process.argv.slice(2)): Promise<void> {
+  const parsed = parseCliArgs(argv);
+  const systemPrompt = readSystemPrompt({
+    systemPrompt: parsed.systemPrompt,
+    systemPromptFile: parsed.systemPromptFile,
+  });
+  const bridge = new AcpxBridge({
+    acpxPath: parsed.acpxPath,
+    acpxAgent: parsed.acpxAgent,
+    cwd: parsed.cwd,
+    systemPrompt,
+    flushDelayMs: parsed.flushDelayMs,
+  });
+
+  process.stdin.on("data", (chunk) => {
+    bridge.acceptInput(chunk);
+  });
+
+  process.stdin.on("end", () => {
+    void bridge.drain().then(() => {
+      process.exitCode = 0;
+    });
+  });
+
+  process.stdin.resume();
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void runBridgeCli().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`[acpx bridge] ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/packages/plugins/agent-acpx/src/index.test.ts
+++ b/packages/plugins/agent-acpx/src/index.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentLaunchConfig, RuntimeHandle, Session } from "@composio/ao-core";
+
+const { mockExecFileAsync, mockExecFileSync } = vi.hoisted(() => ({
+  mockExecFileAsync: vi.fn(),
+  mockExecFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => {
+  const execFile = Object.assign((..._args: unknown[]) => {}, {
+    [Symbol.for("nodejs.util.promisify.custom")]: mockExecFileAsync,
+  });
+  return {
+    execFile,
+    execFileSync: mockExecFileSync,
+  };
+});
+
+import { create, default as defaultExport, detect, manifest } from "./index.js";
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {
+        acpxAgent: "pi",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "app-1",
+    projectId: "my-app",
+    status: "working",
+    activity: "active",
+    branch: null,
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/repo",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "app-1"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+describe("plugin manifest and exports", () => {
+  it("exports the expected manifest", () => {
+    expect(manifest).toEqual({
+      name: "acpx",
+      slot: "agent",
+      description: "Agent plugin: ACPX bridge",
+      version: "0.1.0",
+      displayName: "ACPX",
+    });
+  });
+
+  it("exports a valid plugin module", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+describe("create()", () => {
+  const agent = create();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates a post-launch agent", () => {
+    expect(agent.name).toBe("acpx");
+    expect(agent.processName).toBe("node");
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("builds a bridge launch command with the configured acpx agent", () => {
+    const command = agent.getLaunchCommand(makeLaunchConfig());
+    expect(command).toContain("bridge.js");
+    expect(command).toContain("--agent 'pi'");
+    expect(command).not.toContain("Fix the bug");
+  });
+
+  it("forwards systemPromptFile to the bridge", () => {
+    const command = agent.getLaunchCommand(
+      makeLaunchConfig({ systemPromptFile: "/tmp/orchestrator-prompt.md" }),
+    );
+    expect(command).toContain("--system-prompt-file '/tmp/orchestrator-prompt.md'");
+  });
+
+  it("sets AO session environment values", () => {
+    expect(agent.getEnvironment(makeLaunchConfig({ issueId: "INT-42" }))).toEqual({
+      AO_SESSION_ID: "sess-1",
+      AO_ISSUE_ID: "INT-42",
+    });
+  });
+
+  it("returns null activity while the bridge process is running", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const result = await agent.getActivityState(
+      makeSession({
+        runtimeHandle: { id: "proc-1", runtimeName: "process", data: { pid: 123 } },
+      }),
+    );
+    expect(result).toBeNull();
+    killSpy.mockRestore();
+  });
+
+  it("returns exited when the bridge process is gone", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    const result = await agent.getActivityState(
+      makeSession({
+        runtimeHandle: { id: "proc-1", runtimeName: "process", data: { pid: 123 } },
+      }),
+    );
+    expect(result?.state).toBe("exited");
+    killSpy.mockRestore();
+  });
+
+  it("detects the bridge inside tmux panes", async () => {
+    mockExecFileAsync.mockImplementation((command: string) => {
+      if (command === "tmux") {
+        return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      }
+      if (command === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  321 ttys003  /usr/bin/node /tmp/agent-acpx/dist/bridge.js --agent pi\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error(`unexpected ${command}`));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+});
+
+describe("detect()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns true when acpx --help succeeds", () => {
+    mockExecFileSync.mockReturnValue(Buffer.from(""));
+    expect(detect()).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledWith("acpx", ["--help"], { stdio: "ignore" });
+  });
+
+  it("returns false when acpx is unavailable", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});

--- a/packages/plugins/agent-acpx/src/index.ts
+++ b/packages/plugins/agent-acpx/src/index.ts
@@ -1,0 +1,162 @@
+import {
+  DEFAULT_READY_THRESHOLD_MS,
+  shellEscape,
+  type Agent,
+  type AgentLaunchConfig,
+  type AgentSessionInfo,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type RuntimeHandle,
+  type Session,
+  type AcpxAgentConfig,
+} from "@composio/ao-core";
+import { execFile, execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const BRIDGE_PATH = join(dirname(fileURLToPath(import.meta.url)), "bridge.js");
+
+async function isTmuxProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+  try {
+    const { stdout: ttyOut } = await execFileAsync(
+      "tmux",
+      ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+      { timeout: 30_000 },
+    );
+    const ttys = ttyOut
+      .trim()
+      .split("\n")
+      .map((value) => value.trim())
+      .filter(Boolean);
+    if (ttys.length === 0) return false;
+
+    const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+      timeout: 30_000,
+    });
+    const ttySet = new Set(ttys.map((tty) => tty.replace(/^\/dev\//, "")));
+    for (const line of psOut.split("\n")) {
+      const cols = line.trimStart().split(/\s+/);
+      if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+      const args = cols.slice(2).join(" ");
+      if (args.includes("bridge.js") && args.includes("agent-acpx")) {
+        return true;
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+function createAcpxAgent(): Agent {
+  return {
+    name: "acpx",
+    processName: "node",
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      const projectAgentConfig = config.projectConfig.agentConfig as AcpxAgentConfig | undefined;
+      const parts = [shellEscape(process.execPath), shellEscape(BRIDGE_PATH)];
+
+      const acpxAgent = projectAgentConfig?.acpxAgent ?? "pi";
+      parts.push("--agent", shellEscape(acpxAgent));
+
+      if (config.systemPromptFile) {
+        parts.push("--system-prompt-file", shellEscape(config.systemPromptFile));
+      } else if (config.systemPrompt) {
+        parts.push("--system-prompt", shellEscape(config.systemPrompt));
+      }
+
+      return parts.join(" ");
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {
+        AO_SESSION_ID: config.sessionId,
+      };
+
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      if (!terminalOutput.trim()) return "idle";
+      return "active";
+    },
+
+    async getActivityState(
+      session: Session,
+      _readyThresholdMs = DEFAULT_READY_THRESHOLD_MS,
+    ): Promise<ActivityDetection | null> {
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) {
+        return { state: "exited", timestamp: exitedAt };
+      }
+
+      return null;
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          return isTmuxProcessRunning(handle);
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (error: unknown) {
+            if (error instanceof Error && "code" in error && error.code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(_session: Session): Promise<AgentSessionInfo | null> {
+      return null;
+    },
+  };
+}
+
+export const manifest = {
+  name: "acpx",
+  slot: "agent" as const,
+  description: "Agent plugin: ACPX bridge",
+  version: "0.1.0",
+  displayName: "ACPX",
+};
+
+export function create(): Agent {
+  return createAcpxAgent();
+}
+
+export function detect(): boolean {
+  try {
+    execFileSync("acpx", ["--help"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-acpx/tsconfig.json
+++ b/packages/plugins/agent-acpx/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -2,6 +2,7 @@
 const nextConfig = {
   transpilePackages: [
     "@composio/ao-core",
+    "@composio/ao-plugin-agent-acpx",
     "@composio/ao-plugin-agent-claude-code",
     "@composio/ao-plugin-agent-opencode",
     "@composio/ao-plugin-runtime-tmux",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "@composio/ao-core": "workspace:*",
+    "@composio/ao-plugin-agent-acpx": "workspace:*",
     "@composio/ao-plugin-agent-claude-code": "workspace:*",
     "@composio/ao-plugin-agent-opencode": "workspace:*",
     "@composio/ao-plugin-runtime-tmux": "workspace:*",

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -6,6 +6,7 @@ const {
   mockCreateSessionManager,
   mockRegistry,
   tmuxPlugin,
+  acpxPlugin,
   claudePlugin,
   opencodePlugin,
   worktreePlugin,
@@ -30,6 +31,7 @@ const {
     mockCreateSessionManager,
     mockRegistry,
     tmuxPlugin: { manifest: { name: "tmux" } },
+    acpxPlugin: { manifest: { name: "acpx" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     opencodePlugin: { manifest: { name: "opencode" } },
     worktreePlugin: { manifest: { name: "worktree" } },
@@ -58,6 +60,7 @@ vi.mock("@composio/ao-core", () => ({
 }));
 
 vi.mock("@composio/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
+vi.mock("@composio/ao-plugin-agent-acpx", () => ({ default: acpxPlugin }));
 vi.mock("@composio/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
 vi.mock("@composio/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));
 vi.mock("@composio/ao-plugin-workspace-worktree", () => ({ default: worktreePlugin }));
@@ -97,6 +100,14 @@ describe("services", () => {
     await getServices();
 
     expect(mockRegister).toHaveBeenCalledWith(opencodePlugin);
+  });
+
+  it("registers the ACPX agent plugin with web services", async () => {
+    const { getServices } = await import("../lib/services");
+
+    await getServices();
+
+    expect(mockRegister).toHaveBeenCalledWith(acpxPlugin);
   });
 
   it("caches initialized services across repeated calls", async () => {

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -36,6 +36,7 @@ import {
 
 // Static plugin imports — webpack needs these to be string literals
 import pluginRuntimeTmux from "@composio/ao-plugin-runtime-tmux";
+import pluginAgentAcpx from "@composio/ao-plugin-agent-acpx";
 import pluginAgentClaudeCode from "@composio/ao-plugin-agent-claude-code";
 import pluginAgentOpencode from "@composio/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@composio/ao-plugin-workspace-worktree";
@@ -78,6 +79,7 @@ async function initServices(): Promise<Services> {
 
   // Register plugins explicitly (webpack can't handle dynamic import() in core)
   registry.register(pluginRuntimeTmux);
+  registry.register(pluginAgentAcpx);
   registry.register(pluginAgentClaudeCode);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@composio/ao-core':
         specifier: workspace:*
         version: link:../core
+      '@composio/ao-plugin-agent-acpx':
+        specifier: workspace:*
+        version: link:../plugins/agent-acpx
       '@composio/ao-plugin-agent-aider':
         specifier: workspace:*
         version: link:../plugins/agent-aider
@@ -215,6 +218,22 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.0.0
         version: 3.2.4(vitest@3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.2.3)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/plugins/agent-acpx:
+    dependencies:
+      '@composio/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.2.3
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -553,6 +572,9 @@ importers:
       '@composio/ao-core':
         specifier: workspace:*
         version: link:../core
+      '@composio/ao-plugin-agent-acpx':
+        specifier: workspace:*
+        version: link:../plugins/agent-acpx
       '@composio/ao-plugin-agent-claude-code':
         specifier: workspace:*
         version: link:../plugins/agent-claude-code


### PR DESCRIPTION
## Summary
Adds a built-in agent plugin for ACPX (ACP-based agents), enabling AO to orchestrate ACPX sessions natively alongside Claude Code, Codex, and other agent types.

## Changes
- New `packages/plugins/agent-acpx/` package with bridge and plugin implementation
- Core type extensions: `acpxAgent` config field in `types.ts` + `config.ts` schema
- Plugin registration in CLI (`plugins.ts`, `detect-agent.ts`, `config-instruction.ts`)
- Web dashboard awareness (`services.ts`, `next.config.js`)
- Example config (`examples/acpx-pi.yaml`)
- Comprehensive test coverage (bridge + plugin unit tests, config validation, session-manager integration)
- Documentation updates (README, DEVELOPMENT.md, core README)

## Key features
- Session-aware ACPX bridge with proper lifecycle management
- Support for multiple additional ACPX agents via config
- Scoped config type (`acpxAgent` only exposed on ACPX config entries)

## Consolidation note
This is a clean rebased replacement for #618, as part of PR consolidation. Supersedes #618.
