### PR TITLE
fix: runtime truth & status correctness (consolidated C1)

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -644,6 +644,30 @@ describe("start command — browser open waits for port", () => {
       "my-app",
     );
   });
+
+  it("passes an initial orchestration prompt into spawnOrchestrator", async () => {
+    mockConfigRef.current = makeConfig({
+      "my-app": makeProject({
+        tracker: { plugin: "github", issueFilters: { labels: ["ready"] } },
+      }),
+    });
+
+    mockSessionManager.get.mockResolvedValue(null);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        systemPrompt: expect.stringContaining("You are the **orchestrator agent**"),
+        prompt: expect.stringContaining("initial orchestration pass"),
+      }),
+    );
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining("labels=ready") }),
+    );
+  });
 });
 
 describe("start command — orchestrator session strategy display", () => {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -388,10 +388,11 @@ describe("status command", () => {
     expect(output).toContain("Branch");
     expect(output).toContain("PR");
     expect(output).toContain("CI");
+    expect(output).toContain("State");
     expect(output).toContain("Activity");
   });
 
-  it("shows PR number, CI status, review decision, and threads", async () => {
+  it("shows state, PR number, CI status, review decision, and threads", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
       "worktree=/tmp/wt\nbranch=feat/test\nstatus=working\n",
@@ -438,10 +439,57 @@ describe("status command", () => {
     await program.parseAsync(["node", "test", "status"]);
 
     const output = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(output).toContain("working");
     expect(output).toContain("#42");
     expect(output).toContain("pass");
     expect(output).toContain("ok"); // approved
     expect(output).toContain("2"); // pending threads
+  });
+
+  it("shows lifecycle state separately from activity", async () => {
+    writeFileSync(
+      join(sessionsDir, "app-1"),
+      "worktree=/tmp/wt\nbranch=feat/review\nstatus=pr_open\npr=https://github.com/org/repo/pull/42\n",
+    );
+
+    mockTmux.mockImplementation(async (...args: string[]) => {
+      if (args[0] === "list-sessions") return "app-1";
+      if (args[0] === "display-message") return String(Math.floor(Date.now() / 1000) - 60);
+      return null;
+    });
+    mockGit.mockResolvedValue("feat/review");
+
+    mockDetectPR.mockResolvedValue({
+      number: 42,
+      url: "https://github.com/org/repo/pull/42",
+      title: "Review PR",
+      owner: "org",
+      repo: "repo",
+      branch: "feat/review",
+      baseBranch: "main",
+      isDraft: false,
+    });
+    mockGetCISummary.mockResolvedValue("none");
+    mockGetReviewDecision.mockResolvedValue("none");
+    mockGetPendingComments.mockResolvedValue([]);
+
+    mockSessionManager.list.mockResolvedValue([
+      makeSession({
+        id: "app-1",
+        projectId: "my-app",
+        status: "pr_open",
+        activity: "active",
+        branch: "feat/review",
+        workspacePath: "/tmp/wt",
+        metadata: { pr: "https://github.com/org/repo/pull/42", status: "pr_open" },
+      }),
+    ]);
+
+    await program.parseAsync(["node", "test", "status"]);
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("pr_open");
+    expect(output).toContain("active");
   });
 
   it("shows failing CI and changes_requested review", async () => {

--- a/packages/cli/__tests__/commands/status.test.ts
+++ b/packages/cli/__tests__/commands/status.test.ts
@@ -670,7 +670,7 @@ describe("status command", () => {
     expect(parsed[0].activity).toBe("ready");
   });
 
-  it("shows null activity when session has no activity set", async () => {
+  it("shows active fallback when working session has no activity set", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
       "worktree=/tmp/wt\nbranch=feat/thr\nstatus=working\n",
@@ -688,10 +688,11 @@ describe("status command", () => {
 
     const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
     const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBeNull();
+    // Working sessions without explicit activity get "active" as fallback
+    expect(parsed[0].activity).toBe("active");
   });
 
-  it("shows null activity when session activity is null", async () => {
+  it("shows active fallback when working session activity is null", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
       "worktree=/tmp/wt\nbranch=feat/err\nstatus=working\n",
@@ -709,10 +710,11 @@ describe("status command", () => {
 
     const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
     const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBeNull();
+    // Working sessions without explicit activity get "active" as fallback
+    expect(parsed[0].activity).toBe("active");
   });
 
-  it("shows null activity when session activity is explicitly null", async () => {
+  it("shows active fallback when working session activity is explicitly null", async () => {
     writeFileSync(
       join(sessionsDir, "app-1"),
       "worktree=/tmp/wt\nbranch=feat/null\nstatus=working\n",
@@ -733,7 +735,8 @@ describe("status command", () => {
 
     const jsonCalls = consoleSpy.mock.calls.map((c) => c[0]).join("");
     const parsed = JSON.parse(jsonCalls);
-    expect(parsed[0].activity).toBeNull();
+    // Working sessions without explicit activity get "active" as fallback
+    expect(parsed[0].activity).toBe("active");
   });
 
   it("shows exited activity from session manager", async () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -19,6 +19,7 @@ import type { Command } from "commander";
 import {
   loadConfig,
   generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
   generateSessionPrefix,
   findConfigFile,
   isRepoUrl,
@@ -574,7 +575,8 @@ async function runStartup(
     try {
       spinner.start("Creating orchestrator session");
       const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-      const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+      const prompt = generateOrchestratorStartupPrompt({ config, projectId, project });
+      const session = await sm.spawnOrchestrator({ projectId, systemPrompt, prompt });
       if (session.runtimeHandle?.id) {
         tmuxTarget = session.runtimeHandle.id;
       }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -63,6 +63,12 @@ async function gatherSessionInfo(
     if (liveBranch) branch = liveBranch;
   }
 
+  // Keep downstream lookups aligned with the live branch shown in the table.
+  // Without this, status could display the current worktree branch while SCM
+  // detection still queried against stale session metadata, causing PR/CI/review
+  // columns to show "-" for sessions that actually had an open PR.
+  const scmSession = branch && branch !== session.branch ? { ...session, branch } : session;
+
   // Get last activity time from tmux
   const tmuxTarget = session.runtimeHandle?.id ?? session.id;
   const activityTs = await getTmuxActivity(tmuxTarget);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -21,6 +21,7 @@ import {
   activityIcon,
   ciStatusIcon,
   reviewDecisionIcon,
+  statusColor,
   padCol,
 } from "../lib/format.js";
 import { getAgentByName, getSCM } from "../lib/plugins.js";
@@ -155,6 +156,7 @@ async function gatherSessionInfo(
 const COL = {
   session: 14,
   branch: 24,
+  state: 11,
   pr: 6,
   ci: 6,
   review: 6,
@@ -167,6 +169,7 @@ function printTableHeader(): void {
   const hdr =
     padCol("Session", COL.session) +
     padCol("Branch", COL.branch) +
+    padCol("State", COL.state) +
     padCol("PR", COL.pr) +
     padCol("CI", COL.ci) +
     padCol("Rev", COL.review) +
@@ -175,16 +178,26 @@ function printTableHeader(): void {
     "Age";
   console.log(chalk.dim(`  ${hdr}`));
   const totalWidth =
-    COL.session + COL.branch + COL.pr + COL.ci + COL.review + COL.threads + COL.activity + 3;
+    COL.session +
+    COL.branch +
+    COL.state +
+    COL.pr +
+    COL.ci +
+    COL.review +
+    COL.threads +
+    COL.activity +
+    3;
   console.log(chalk.dim(`  ${"─".repeat(totalWidth)}`));
 }
 
 function printSessionRow(info: SessionInfo): void {
   const prStr = info.prNumber ? `#${info.prNumber}` : "-";
+  const stateStr = info.status ? statusColor(info.status) : chalk.dim("-");
 
   const row =
     padCol(chalk.green(info.name), COL.session) +
     padCol(info.branch ? chalk.cyan(info.branch) : chalk.dim("-"), COL.branch) +
+    padCol(stateStr, COL.state) +
     padCol(info.prNumber ? chalk.blue(prStr) : chalk.dim(prStr), COL.pr) +
     padCol(ciStatusIcon(info.ciStatus), COL.ci) +
     padCol(reviewDecisionIcon(info.reviewDecision), COL.review) +
@@ -221,7 +234,7 @@ function printOrchestratorRow(info: SessionInfo): void {
 export function registerStatus(program: Command): void {
   program
     .command("status")
-    .description("Show all sessions with branch, activity, PR, and CI status")
+    .description("Show all sessions with branch, state, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
     .option("--json", "Output as JSON")
     .action(async (opts: { project?: string; json?: boolean }) => {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -150,7 +150,7 @@ async function gatherSessionInfo(
 const COL = {
   session: 14,
   branch: 24,
-  state: 11,
+  state: 18,
   pr: 6,
   ci: 6,
   review: 6,

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -64,12 +64,6 @@ async function gatherSessionInfo(
     if (liveBranch) branch = liveBranch;
   }
 
-  // Keep downstream lookups aligned with the live branch shown in the table.
-  // Without this, status could display the current worktree branch while SCM
-  // detection still queried against stale session metadata, causing PR/CI/review
-  // columns to show "-" for sessions that actually had an open PR.
-  const scmSession = branch && branch !== session.branch ? { ...session, branch } : session;
-
   // Get last activity time from tmux
   const tmuxTarget = session.runtimeHandle?.id ?? session.id;
   const activityTs = await getTmuxActivity(tmuxTarget);

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -77,8 +77,11 @@ async function gatherSessionInfo(
     // Summary extraction failed — not critical
   }
 
-  // Use activity from session (already enriched by sessionManager.list())
-  const activity = session.activity;
+  // Use activity from session (already enriched by sessionManager.list()).
+  // If enrichment revived status to working but did not infer a more specific
+  // activity state, fall back so the status table doesn't misleadingly show
+  // "unknown" for a live worker.
+  const activity = session.activity ?? (status === "working" ? "active" : null);
 
   // Fetch PR, CI, and review data from SCM
   let prNumber: number | null = null;
@@ -98,7 +101,12 @@ async function gatherSessionInfo(
     try {
       const project = projectConfig.projects[session.projectId];
       if (project) {
-        const prInfo: PRInfo | null = await scm.detectPR(session, project);
+        // Use a session copy with the live branch so detectPR queries
+        // GitHub for the actual worktree branch, not stale metadata.
+        const scmSession = branch !== session.branch
+          ? { ...session, branch }
+          : session;
+        const prInfo: PRInfo | null = await scm.detectPR(scmSession, project);
         if (prInfo) {
           prNumber = prInfo.number;
 

--- a/packages/cli/src/lib/format.ts
+++ b/packages/cli/src/lib/format.ts
@@ -88,7 +88,7 @@ export function reviewDecisionIcon(decision: ReviewDecision | null): string {
 export function activityIcon(activity: ActivityState | null): string {
   switch (activity) {
     case "active":
-      return chalk.green("working");
+      return chalk.green("active");
     case "ready":
       return chalk.cyan("ready");
     case "idle":

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -661,6 +661,55 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
   });
 
+  it("clears PR metadata when SCM reports a closed PR", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("closed"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "pr_open", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+      pr: "https://example.com/pr/1",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("killed");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["pr"] ?? "").toBe("");
+  });
+
   it("skips PR auto-detection when metadata disables it", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",

--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { generateOrchestratorPrompt } from "../orchestrator-prompt.js";
+import {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "../orchestrator-prompt.js";
 import type { OrchestratorConfig } from "../types.js";
 
 const config: OrchestratorConfig = {
@@ -53,5 +56,38 @@ describe("generateOrchestratorPrompt", () => {
     expect(prompt).toContain("must be delegated to a **worker session**");
     expect(prompt).toContain("Never claim a PR into `app-orchestrator`");
     expect(prompt).toContain("Delegate implementation, test execution, or PR claiming");
+  });
+});
+
+describe("generateOrchestratorStartupPrompt", () => {
+  it("kicks off an immediate tracker triage pass when a tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: {
+        ...config.projects["my-app"]!,
+        tracker: {
+          plugin: "github",
+          issueFilters: { labels: ["ready"], state: "open" },
+        },
+      },
+    });
+
+    expect(prompt).toContain("Do an initial orchestration pass");
+    expect(prompt).toContain("ao session ls -p my-app");
+    expect(prompt).toContain("configured github tracker");
+    expect(prompt).toContain("labels=ready");
+    expect(prompt).toContain("ao batch-spawn my-app");
+  });
+
+  it("falls back to monitoring guidance when no tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: config.projects["my-app"]!,
+    });
+
+    expect(prompt).toContain("There is no tracker configured for this project");
+    expect(prompt).not.toContain("ao batch-spawn my-app");
   });
 });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -3847,6 +3847,53 @@ describe("spawnOrchestrator", () => {
     expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
   });
 
+  it("passes the initial orchestrator prompt to the agent launch config", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Check ready issues and spawn workers.",
+    });
+
+    expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "app-orchestrator",
+        prompt: "Check ready issues and spawn workers.",
+      }),
+    );
+  });
+
+  it("sends the initial orchestrator prompt post-launch when the agent requires it", async () => {
+    vi.useFakeTimers();
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const spawnPromise = sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Check ready issues and spawn workers.",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await spawnPromise;
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+      "Check ready issues and spawn workers.",
+    );
+    vi.useRealTimers();
+  });
+
   it("throws for unknown project", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -1471,6 +1471,47 @@ describe("list", () => {
     expect(agentWithSpy.getActivityState).not.toHaveBeenCalled();
   });
 
+  it("revives stale killed sessions when tmux runtime and agent activity are alive", async () => {
+    const expectedTmuxName = "hash-app-1";
+    const aliveRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi
+        .fn()
+        .mockImplementation(async (handle: RuntimeHandle) => handle.id === expectedTmuxName),
+    };
+    const agentWithLiveState: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue({ state: "active" }),
+    };
+    const registryWithAliveRuntime: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return aliveRuntime;
+        if (slot === "agent") return agentWithLiveState;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "feat/issue-53",
+      status: "killed",
+      project: "my-app",
+      tmuxName: expectedTmuxName,
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithAliveRuntime });
+    const sessions = await sm.list("my-app");
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].runtimeHandle?.id).toBe(expectedTmuxName);
+    expect(sessions[0].status).toBe("working");
+    expect(sessions[0].activity).toBe("active");
+    expect(aliveRuntime.isAlive).toHaveBeenCalled();
+    expect(agentWithLiveState.getActivityState).toHaveBeenCalled();
+  });
+
   it("keeps existing activity when getActivityState throws", async () => {
     const agentWithError: Agent = {
       ...mockAgent,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,7 +75,10 @@ export type {
 } from "./decomposer.js";
 
 // Orchestrator prompt — generates orchestrator context for `ao start`
-export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
+export {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -313,7 +313,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       try {
         const prState = await scm.getPRState(session.pr);
         if (prState === PR_STATE.MERGED) return "merged";
-        if (prState === PR_STATE.CLOSED) return "killed";
+        if (prState === PR_STATE.CLOSED) {
+          // Closed PRs are terminal for this session; clear persisted PR metadata
+          // so killed sessions don't get re-polled forever via `if (s.pr) return true`.
+          session.pr = undefined;
+          try {
+            const sessionsDir = getSessionsDir(config.configPath, project.path);
+            updateMetadata(sessionsDir, session.id, { pr: "" });
+          } catch {
+            // Best effort — lifecycle status should still proceed to killed.
+          }
+          return "killed";
+        }
 
         // Check CI
         const ciStatus = await scm.getCISummary(session.pr);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -338,7 +338,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         if (prState === PR_STATE.CLOSED) {
           // Closed PRs are terminal for this session; clear persisted PR metadata
           // so killed sessions don't get re-polled forever via `if (s.pr) return true`.
-          session.pr = undefined;
+          session.pr = null;
           try {
             const sessionsDir = getSessionsDir(config.configPath, project.path);
             updateMetadata(sessionsDir, session.id, { pr: "" });

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -294,7 +294,29 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       !session.id.endsWith("-orchestrator")
     ) {
       try {
-        const detectedPR = await scm.detectPR(session, project);
+        // Resolve the live worktree branch — the session metadata branch may
+        // be stale if the agent switched branches after spawn.
+        let scmSession: Session = session;
+        if (session.workspacePath) {
+          try {
+            const { execFileSync } = await import("node:child_process");
+            const liveBranch = execFileSync("git", ["branch", "--show-current"], {
+              cwd: session.workspacePath,
+              encoding: "utf8",
+              timeout: 5000,
+            }).trim();
+            if (liveBranch && liveBranch !== session.branch) {
+              scmSession = { ...session, branch: liveBranch };
+              // Self-heal stale branch metadata
+              const sessionsDir = getSessionsDir(config.configPath, project.path);
+              updateMetadata(sessionsDir, session.id, { branch: liveBranch });
+              session.branch = liveBranch;
+            }
+          } catch {
+            // Worktree gone or git failed — use metadata branch
+          }
+        }
+        const detectedPR = await scm.detectPR(scmSession, project);
         if (detectedPR) {
           session.pr = detectedPR;
           // Persist PR URL so subsequent polls don't need to re-query.

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -11,7 +11,10 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { execFileSync } from "node:child_process";
+import { execFile as execFileCb } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFileCb);
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -300,11 +303,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         let scmSession: Session = session;
         if (session.workspacePath) {
           try {
-            const liveBranch = execFileSync("git", ["branch", "--show-current"], {
+            const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
               cwd: session.workspacePath,
               encoding: "utf8",
               timeout: 5000,
-            }).trim();
+            });
+            const liveBranch = stdout.trim();
             if (liveBranch && liveBranch !== session.branch) {
               scmSession = { ...session, branch: liveBranch };
               // Self-heal stale branch metadata

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -11,6 +11,7 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import {
   SESSION_STATUS,
   PR_STATE,
@@ -299,7 +300,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         let scmSession: Session = session;
         if (session.workspacePath) {
           try {
-            const { execFileSync } = await import("node:child_process");
             const liveBranch = execFileSync("git", ["branch", "--show-current"], {
               cwd: session.workspacePath,
               encoding: "utf8",

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -13,6 +13,37 @@ export interface OrchestratorPromptConfig {
   project: ProjectConfig;
 }
 
+function formatTrackerIssueFilters(project: ProjectConfig): string | null {
+  const rawFilters = project.tracker?.["issueFilters"];
+  if (!rawFilters || typeof rawFilters !== "object" || Array.isArray(rawFilters)) {
+    return null;
+  }
+
+  const filters = rawFilters as Record<string, unknown>;
+  const parts: string[] = [];
+
+  if (typeof filters["state"] === "string" && filters["state"].trim().length > 0) {
+    parts.push(`state=${filters["state"]}`);
+  }
+
+  if (Array.isArray(filters["labels"])) {
+    const labels = filters["labels"].filter((label): label is string => typeof label === "string");
+    if (labels.length > 0) {
+      parts.push(`labels=${labels.join(", ")}`);
+    }
+  }
+
+  if (typeof filters["assignee"] === "string" && filters["assignee"].trim().length > 0) {
+    parts.push(`assignee=${filters["assignee"]}`);
+  }
+
+  if (typeof filters["limit"] === "number" && Number.isFinite(filters["limit"])) {
+    parts.push(`limit=${filters["limit"]}`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
 /**
  * Generate orchestrator prompt content.
  * Provides orchestrator agent with context about available commands,
@@ -241,4 +272,41 @@ ${project.orchestratorRules}`);
   }
 
   return sections.join("\n\n");
+}
+
+/**
+ * Generate the initial user prompt that kicks off orchestration work after
+ * `ao start`. Without this, interactive agents like Codex just open a REPL and
+ * sit idle even though the orchestrator session appears healthy.
+ */
+export function generateOrchestratorStartupPrompt(opts: OrchestratorPromptConfig): string {
+  const { projectId, project } = opts;
+  const trackerPlugin = typeof project.tracker?.plugin === "string" ? project.tracker.plugin : null;
+  const trackerFilters = formatTrackerIssueFilters(project);
+
+  if (!trackerPlugin) {
+    return [
+      `Do an initial orchestration pass for ${project.name} now.`,
+      `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+      "2. There is no tracker configured for this project, so do not invent new work.",
+      "3. If workers already exist, monitor them for CI failures, review comments, blocked states, and merge-ready PRs.",
+      "4. If nothing needs action, report that the project is idle and remain available.",
+      "Do not implement code yourself from the orchestrator session.",
+    ].join("\n");
+  }
+
+  const filterClause = trackerFilters
+    ? ` matching these configured tracker filters: ${trackerFilters}.`
+    : ".";
+
+  return [
+    `Do an initial orchestration pass for ${project.name} now.`,
+    `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+    `2. Query the configured ${trackerPlugin} tracker for open issues${filterClause}`,
+    "3. Identify issues that are ready to work and do not already have an active AO worker session.",
+    `4. Spawn missing workers for those issues. Prefer \`ao batch-spawn ${projectId} ...\` when multiple issues qualify.`,
+    "5. After spawning, switch back to monitoring mode: watch worker progress, CI failures, review comments, blocked sessions, and merge-ready PRs.",
+    "6. If no issue needs action, say so briefly and remain available.",
+    "Do not implement code yourself from the orchestrator session.",
+  ].join("\n");
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -830,13 +830,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    * Enrich session with live runtime state (alive/exited) and activity detection.
    * Mutates the session object in place.
    */
-  const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
+  const TERMINAL_SESSION_STATUSES = new Set(["done", "merged", "terminated", "cleanup"]);
 
   async function enrichSessionWithRuntimeState(
     session: Session,
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
+    reviveKilledStatus = true,
   ): Promise<void> {
+    const wasKilled = session.status === "killed";
+    let runtimeConfirmedAlive = false;
+    let detectedActivityState: Session["activity"] | null = null;
+
     // Skip all subprocess/IO work for sessions already known to be terminal.
     if (TERMINAL_SESSION_STATUSES.has(session.status)) {
       session.activity = "exited";
@@ -855,6 +860,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           session.activity = "exited";
           return;
         }
+        runtimeConfirmedAlive = true;
       } catch {
         // Can't check liveness — continue to activity detection
       }
@@ -868,6 +874,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       try {
         const detected = await plugins.agent.getActivityState(session, config.readyThresholdMs);
         if (detected !== null) {
+          detectedActivityState = detected.state;
           session.activity = detected.state;
           if (detected.timestamp && detected.timestamp > session.lastActivityAt) {
             session.lastActivityAt = detected.timestamp;
@@ -886,6 +893,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       } catch {
         // Can't get session info — keep existing values
       }
+    }
+
+    // "killed" is terminal only when process/runtime checks still support that.
+    // If we can confirm the session is alive again, surface it as working.
+    if (
+      reviveKilledStatus &&
+      wasKilled &&
+      (runtimeConfirmedAlive || (detectedActivityState !== null && detectedActivityState !== "exited"))
+    ) {
+      session.status = "working";
     }
   }
 
@@ -2254,7 +2271,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     //    and isRestorable would reject it.
     const session = metadataToSession(sessionId, raw, projectId);
     const plugins = resolvePlugins(project, selection.agentName);
-    await enrichSessionWithRuntimeState(session, plugins, true);
+    await enrichSessionWithRuntimeState(session, plugins, true, false);
 
     // 3. Validate restorability
     if (!isRestorable(session)) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1370,6 +1370,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
         },
       },
+      prompt: orchestratorConfig.prompt,
       permissions: "permissionless" as const,
       model: selection.model,
       systemPromptFile,
@@ -1463,6 +1464,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         /* best effort */
       }
       throw err;
+    }
+
+    if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+        await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+      } catch {
+        // Non-fatal: the orchestrator is running; user can retry with `ao send`.
+      }
     }
 
     return session;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -895,15 +895,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    // "killed" is terminal only when process/runtime checks still support that.
-    // If we can confirm the session is alive again, surface it as working.
-    // However, if the agent process has exited (activity === "exited") we
-    // should NOT revive — the tmux shell may linger after the agent exits.
+    // "killed" is terminal only when runtime liveness can be confirmed again.
+    // JSONL activity can be stale after kill, so do not revive based solely on
+    // activity detection. Also never revive if effective activity is exited.
+    const effectiveActivityState = detectedActivityState ?? session.activity;
     if (
       reviveKilledStatus &&
       wasKilled &&
-      detectedActivityState !== "exited" &&
-      (runtimeConfirmedAlive || (detectedActivityState !== null))
+      runtimeConfirmedAlive === true &&
+      effectiveActivityState !== "exited"
     ) {
       session.status = "working";
     }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -897,10 +897,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // "killed" is terminal only when process/runtime checks still support that.
     // If we can confirm the session is alive again, surface it as working.
+    // However, if the agent process has exited (activity === "exited") we
+    // should NOT revive — the tmux shell may linger after the agent exits.
     if (
       reviveKilledStatus &&
       wasKilled &&
-      (runtimeConfirmedAlive || (detectedActivityState !== null && detectedActivityState !== "exited"))
+      detectedActivityState !== "exited" &&
+      (runtimeConfirmedAlive || (detectedActivityState !== null))
     ) {
       session.status = "working";
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,8 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Initial user prompt that kicks off the first orchestration pass. */
+  prompt?: string;
 }
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Consolidated fix for runtime truth and status correctness issues. This PR combines and supersedes 5 individual PRs that addressed related aspects of the same problem: `ao status` and the lifecycle manager were not reflecting actual runtime state accurately.

### What this fixes

1. **Live worktree branch detection** — Status and lifecycle now query the actual worktree branch via `git` instead of relying on stale metadata, fixing incorrect PR/CI state display (`d467348`, `12c3224`, `310f705`, `c158a2e`)

2. **Stale/killed session revival** — Sessions marked as `killed` are now correctly revived when their tmux runtime is confirmed alive, with a liveness guard to prevent false revivals (`6d34e3a`, `80e9896`)

3. **Orchestrator startup prompt** — Startup kickoff prompt now correctly triggers on fresh orchestrator sessions (`c057c56`)

4. **Status activity labels** — Activity labels in `ao status` are now clean and consistent, with proper fallback for working sessions (`457b01a`, `ffc6896`)

5. **PRInfo type safety** — Uses `null` instead of `undefined` for closed PR metadata to maintain type compatibility (`8929e95`)

### Files changed

- `packages/cli/src/commands/status.ts` — live branch PR query
- `packages/cli/src/commands/start.ts` — startup prompt trigger
- `packages/cli/src/lib/format.ts` — activity label formatting
- `packages/core/src/lifecycle-manager.ts` — PR metadata clearing, status display
- `packages/core/src/session-manager.ts` — stale session revival with liveness guard
- `packages/core/src/orchestrator-prompt.ts` — startup kickoff logic
- `packages/core/src/types.ts` — PRInfo type update
- Tests added/updated for all changed components

### Supersedes

This PR consolidates and supersedes the following PRs:
- #565 (`fix/status-display-bugs`)
- #544 (`fix/status-live-pr-query`)
- #542 (`fix/stale-killed-session-state`)
- #623 (`fix/status-activity-labels-clean`)
- #540 (`fix/orchestrator-startup-prompt`)

These can be closed once this PR is merged.

### Test status

All existing tests pass. New tests added for:
- Live branch detection in status command
- Session revival with liveness confirmation
- Orchestrator prompt startup behavior
- Activity label fallback logic

> **Note:** `doctor-script.test.ts` has a pre-existing flaky failure on `main` (unrelated ENOENT in temp file handling).