### PR TITLE
fix(core): consolidate control-plane recovery and self-heal

### DIFF
--- a/.changeset/orchestrator-respawn-recovery.md
+++ b/.changeset/orchestrator-respawn-recovery.md
@@ -1,0 +1,6 @@
+---
+"@composio/ao-core": patch
+"@composio/ao-web": patch
+---
+
+Respawn project orchestrators when open worker sessions still exist, and pass the startup prompt through the web orchestrator creation route.

--- a/.changeset/start-watchdog-recovery.md
+++ b/.changeset/start-watchdog-recovery.md
@@ -1,0 +1,6 @@
+---
+"@composio/ao-cli": patch
+"@composio/ao": patch
+---
+
+Let non-interactive `ao start` calls reuse an already running dashboard while still starting lifecycle recovery for the requested project.

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -24,6 +24,8 @@ const {
   mockSpawn,
   mockEnsureLifecycleWorker,
   mockStopLifecycleWorker,
+  mockIsAlreadyRunning,
+  mockIsHumanCaller,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockExecSilent: vi.fn(),
@@ -42,6 +44,8 @@ const {
   mockSpawn: vi.fn(),
   mockEnsureLifecycleWorker: vi.fn(),
   mockStopLifecycleWorker: vi.fn(),
+  mockIsAlreadyRunning: vi.fn().mockResolvedValue(null),
+  mockIsHumanCaller: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../src/lib/shell.js", () => ({
@@ -119,13 +123,13 @@ vi.mock("../../src/lib/preflight.js", () => ({
 vi.mock("../../src/lib/running-state.js", () => ({
   register: vi.fn(),
   unregister: vi.fn(),
-  isAlreadyRunning: vi.fn().mockReturnValue(null),
+  isAlreadyRunning: (...args: unknown[]) => mockIsAlreadyRunning(...args),
   getRunning: vi.fn().mockReturnValue(null),
   waitForExit: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("../../src/lib/caller-context.js", () => ({
-  isHumanCaller: vi.fn().mockReturnValue(true),
+  isHumanCaller: (...args: unknown[]) => mockIsHumanCaller(...args),
   getCallerType: vi.fn().mockReturnValue("human"),
 }));
 
@@ -206,6 +210,10 @@ beforeEach(() => {
   });
   mockStopLifecycleWorker.mockReset();
   mockStopLifecycleWorker.mockResolvedValue(true);
+  mockIsAlreadyRunning.mockReset();
+  mockIsAlreadyRunning.mockResolvedValue(null);
+  mockIsHumanCaller.mockReset();
+  mockIsHumanCaller.mockReturnValue(true);
   mockSpawn.mockClear();
 });
 
@@ -361,6 +369,41 @@ describe("start command — project resolution", () => {
 // ---------------------------------------------------------------------------
 // URL detection — `ao start <url>` triggers handleUrlStart
 // ---------------------------------------------------------------------------
+
+describe("start command — already running recovery", () => {
+  it("reuses the existing dashboard for non-human callers and still starts the requested project", async () => {
+    mockConfigRef.current = makeConfig({
+      frontend: makeProject({ name: "Frontend", sessionPrefix: "fe" }),
+      backend: makeProject({ name: "Backend", sessionPrefix: "api" }),
+    });
+    mockIsHumanCaller.mockReturnValue(false);
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 4242,
+      port: 3000,
+      startedAt: "2026-03-20T20:00:00.000Z",
+      projects: ["frontend", "backend"],
+    });
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "api-orchestrator" });
+
+    await program.parseAsync(["node", "test", "start", "backend"]);
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: expect.any(String) }),
+      "backend",
+    );
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "backend" }),
+    );
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("AO is already running.");
+    expect(output).toContain("Reused existing dashboard on port 3000.");
+  });
+});
 
 describe("start command — URL argument", () => {
   it("reuses existing clone and generates config", async () => {

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -23,6 +23,7 @@ const {
   mockWaitForPortAndOpen,
   mockSpawn,
   mockEnsureLifecycleWorker,
+  mockGetLifecycleWorkerStatus,
   mockStopLifecycleWorker,
   mockIsAlreadyRunning,
   mockIsHumanCaller,
@@ -43,6 +44,12 @@ const {
   mockWaitForPortAndOpen: vi.fn().mockResolvedValue(undefined),
   mockSpawn: vi.fn(),
   mockEnsureLifecycleWorker: vi.fn(),
+  mockGetLifecycleWorkerStatus: vi.fn().mockReturnValue({
+    running: true,
+    pid: 4243,
+    pidFile: "/tmp/lifecycle-worker.pid",
+    logFile: "/tmp/lifecycle-worker.log",
+  }),
   mockStopLifecycleWorker: vi.fn(),
   mockIsAlreadyRunning: vi.fn().mockResolvedValue(null),
   mockIsHumanCaller: vi.fn().mockReturnValue(true),
@@ -95,6 +102,7 @@ vi.mock("../../src/lib/create-session-manager.js", () => ({
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({
   ensureLifecycleWorker: (...args: unknown[]) => mockEnsureLifecycleWorker(...args),
+  getLifecycleWorkerStatus: (...args: unknown[]) => mockGetLifecycleWorkerStatus(...args),
   stopLifecycleWorker: (...args: unknown[]) => mockStopLifecycleWorker(...args),
 }));
 
@@ -135,7 +143,13 @@ vi.mock("../../src/lib/caller-context.js", () => ({
 
 vi.mock("../../src/lib/detect-env.js", () => ({
   detectEnvironment: vi.fn().mockResolvedValue({
-    git: { isRepo: true, remoteUrl: null, ownerRepo: null, currentBranch: "main", defaultBranch: "main" },
+    git: {
+      isRepo: true,
+      remoteUrl: null,
+      ownerRepo: null,
+      currentBranch: "main",
+      defaultBranch: "main",
+    },
     tools: { hasTmux: true, hasGh: false, ghAuthed: false },
     apiKeys: { hasLinear: false, hasSlack: false },
   }),
@@ -205,6 +219,13 @@ beforeEach(() => {
     running: true,
     started: true,
     pid: 12345,
+    pidFile: "/tmp/lifecycle-worker.pid",
+    logFile: "/tmp/lifecycle-worker.log",
+  });
+  mockGetLifecycleWorkerStatus.mockReset();
+  mockGetLifecycleWorkerStatus.mockReturnValue({
+    running: true,
+    pid: 4243,
     pidFile: "/tmp/lifecycle-worker.pid",
     logFile: "/tmp/lifecycle-worker.log",
   });
@@ -401,6 +422,45 @@ describe("start command — already running recovery", () => {
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(output).toContain("AO is already running.");
+    expect(output).toContain("Reused existing dashboard on port 3000.");
+  });
+
+  it("auto-recovers the requested project for human callers when the control plane is missing", async () => {
+    mockConfigRef.current = makeConfig({
+      frontend: makeProject({ name: "Frontend", sessionPrefix: "fe" }),
+      backend: makeProject({ name: "Backend", sessionPrefix: "api" }),
+    });
+    mockIsHumanCaller.mockReturnValue(true);
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 4242,
+      port: 3000,
+      startedAt: "2026-03-20T20:00:00.000Z",
+      projects: ["frontend", "backend"],
+    });
+    mockGetLifecycleWorkerStatus.mockReturnValue({
+      running: false,
+      pid: null,
+      pidFile: "/tmp/lifecycle-worker.pid",
+      logFile: "/tmp/lifecycle-worker.log",
+    });
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "api-orchestrator" });
+
+    await program.parseAsync(["node", "test", "start", "backend"]);
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: expect.any(String) }),
+      "backend",
+    );
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({ projectId: "backend" }),
+    );
+    expect(mockSpawn).not.toHaveBeenCalled();
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("lost its lifecycle worker or orchestrator");
     expect(output).toContain("Reused existing dashboard on port 3000.");
   });
 });

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -747,6 +747,30 @@ describe("start command — browser open waits for port", () => {
       "my-app",
     );
   });
+
+  it("passes an initial orchestration prompt into spawnOrchestrator", async () => {
+    mockConfigRef.current = makeConfig({
+      "my-app": makeProject({
+        tracker: { plugin: "github", issueFilters: { labels: ["ready"] } },
+      }),
+    });
+
+    mockSessionManager.get.mockResolvedValue(null);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: "my-app",
+        systemPrompt: expect.stringContaining("You are the **orchestrator agent**"),
+        prompt: expect.stringContaining("initial orchestration pass"),
+      }),
+    );
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({ prompt: expect.stringContaining("labels=ready") }),
+    );
+  });
 });
 
 describe("start command — orchestrator session strategy display", () => {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -36,7 +36,11 @@ import {
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { exec, execSilent, git } from "../lib/shell.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
-import { ensureLifecycleWorker, stopLifecycleWorker } from "../lib/lifecycle-service.js";
+import {
+  ensureLifecycleWorker,
+  getLifecycleWorkerStatus,
+  stopLifecycleWorker,
+} from "../lib/lifecycle-service.js";
 import {
   findWebDir,
   buildDashboardEnv,
@@ -47,7 +51,13 @@ import {
 } from "../lib/web-dir.js";
 import { cleanNextCache } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
-import { register, unregister, isAlreadyRunning, getRunning, waitForExit } from "../lib/running-state.js";
+import {
+  register,
+  unregister,
+  isAlreadyRunning,
+  getRunning,
+  waitForExit,
+} from "../lib/running-state.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
 import { detectAgentRuntime } from "../lib/detect-agent.js";
@@ -59,10 +69,35 @@ import {
 } from "../lib/project-detection.js";
 
 const DEFAULT_PORT = 3000;
+const TERMINAL_CONTROL_PLANE_STATUSES = new Set([
+  "done",
+  "merged",
+  "terminated",
+  "cleanup",
+  "killed",
+]);
 
 // =============================================================================
 // HELPERS
 // =============================================================================
+
+async function isProjectControlPlaneHealthy(
+  config: OrchestratorConfig,
+  projectId: string,
+  project: ProjectConfig,
+): Promise<boolean> {
+  if (!getLifecycleWorkerStatus(config, projectId).running) {
+    return false;
+  }
+
+  try {
+    const sm = await getSessionManager(config);
+    const orchestrator = await sm.get(`${project.sessionPrefix}-orchestrator`);
+    return !!orchestrator && !TERMINAL_CONTROL_PLANE_STATUSES.has(orchestrator.status);
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Resolve project from config.
@@ -357,7 +392,9 @@ async function addProjectToConfig(
     let i = 2;
     while (config.projects[`${projectId}-${i}`]) i++;
     const newId = `${projectId}-${i}`;
-    console.log(chalk.yellow(`  ⚠ Project "${projectId}" already exists — using "${newId}" instead.`));
+    console.log(
+      chalk.yellow(`  ⚠ Project "${projectId}" already exists — using "${newId}" instead.`),
+    );
     projectId = newId;
   }
 
@@ -737,7 +774,8 @@ export function registerStart(program: Command): void {
 
               // Check if project is already in config (match by path)
               const existingEntry = Object.entries(config.projects).find(
-                ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
+                ([, p]) =>
+                  resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
               );
 
               if (existingEntry) {
@@ -772,7 +810,26 @@ export function registerStart(program: Command): void {
           // ── Already-running detection (Step 9) ──
           const running = await isAlreadyRunning();
           if (running) {
+            const controlPlaneHealthy = await isProjectControlPlaneHealthy(
+              config,
+              projectId,
+              project,
+            );
             if (isHumanCaller()) {
+              if (!controlPlaneHealthy) {
+                console.log(
+                  chalk.yellow(
+                    `\n⚠ AO dashboard is running, but ${project.name} lost its lifecycle worker or orchestrator.`,
+                  ),
+                );
+                await runStartup(config, projectId, project, {
+                  ...opts,
+                  dashboard: false,
+                });
+                console.log(`Reused existing dashboard on port ${running.port}.`);
+                return;
+              }
+
               console.log(chalk.cyan(`\nℹ AO is already running.`));
               console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
               console.log(`  PID: ${running.pid} | Up since: ${running.startedAt}`);
@@ -803,9 +860,9 @@ export function registerStart(program: Command): void {
 
                 // Collect existing prefixes to avoid collisions
                 const existingPrefixes = new Set(
-                  Object.values(rawConfig.projects as Record<string, Record<string, unknown>>).map(
-                    (p) => p.sessionPrefix as string,
-                  ).filter(Boolean),
+                  Object.values(rawConfig.projects as Record<string, Record<string, unknown>>)
+                    .map((p) => p.sessionPrefix as string)
+                    .filter(Boolean),
                 );
 
                 let newId: string;
@@ -827,10 +884,18 @@ export function registerStart(program: Command): void {
                 project = config.projects[newId];
                 // Continue to startup below
               } else if (choice.trim() === "3") {
-                try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
+                try {
+                  process.kill(running.pid, "SIGTERM");
+                } catch {
+                  /* already dead */
+                }
                 if (!(await waitForExit(running.pid, 5000))) {
                   console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
-                  try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
+                  try {
+                    process.kill(running.pid, "SIGKILL");
+                  } catch {
+                    /* already dead */
+                  }
                 }
                 await unregister();
                 console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));
@@ -911,9 +976,7 @@ export function registerStop(program: Command): void {
                 // Already dead
               }
               await unregister();
-              console.log(
-                chalk.green(`\n✓ Stopped AO on port ${running.port}`),
-              );
+              console.log(chalk.green(`\n✓ Stopped AO on port ${running.port}`));
               console.log(chalk.dim(`  Projects: ${running.projects.join(", ")}\n`));
             } else {
               console.log(chalk.yellow("No running AO instance found in running.json."));
@@ -961,12 +1024,8 @@ export function registerStop(program: Command): void {
           await stopDashboard(running?.port ?? port);
 
           console.log(chalk.bold.green("\n✓ Orchestrator stopped\n"));
-          console.log(
-            chalk.dim(`  Uptime: since ${running?.startedAt ?? "unknown"}`),
-          );
-          console.log(
-            chalk.dim(`  Projects: ${Object.keys(config.projects).join(", ")}\n`),
-          );
+          console.log(chalk.dim(`  Uptime: since ${running?.startedAt ?? "unknown"}`));
+          console.log(chalk.dim(`  Projects: ${Object.keys(config.projects).join(", ")}\n`));
         } catch (err) {
           if (err instanceof Error) {
             console.error(chalk.red("\nError:"), err.message);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -839,13 +839,20 @@ export function registerStart(program: Command): void {
                 process.exit(0);
               }
             } else {
-              // Agent/non-TTY caller — print info and exit
+              // Agent/non-TTY caller — reuse the existing dashboard and ensure
+              // the requested project's lifecycle/orchestrator are actually up.
               console.log(`AO is already running.`);
               console.log(`Dashboard: http://localhost:${running.port}`);
               console.log(`PID: ${running.pid}`);
               console.log(`Projects: ${running.projects.join(", ")}`);
-              console.log(`To restart: ao stop && ao start`);
-              process.exit(0);
+
+              await runStartup(config, projectId, project, {
+                ...opts,
+                dashboard: false,
+              });
+
+              console.log(`Reused existing dashboard on port ${running.port}.`);
+              return;
             }
           }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -19,6 +19,7 @@ import type { Command } from "commander";
 import {
   loadConfig,
   generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
   generateSessionPrefix,
   findConfigFile,
   isRepoUrl,
@@ -611,7 +612,8 @@ async function runStartup(
     try {
       spinner.start("Creating orchestrator session");
       const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-      const session = await sm.spawnOrchestrator({ projectId, systemPrompt });
+      const prompt = generateOrchestratorStartupPrompt({ config, projectId, project });
+      const session = await sm.spawnOrchestrator({ projectId, systemPrompt, prompt });
       if (session.runtimeHandle?.id) {
         tmuxTarget = session.runtimeHandle.id;
       }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -76,6 +76,7 @@ const TERMINAL_CONTROL_PLANE_STATUSES = new Set([
   "terminated",
   "cleanup",
   "killed",
+  "errored",
 ]);
 
 // =============================================================================

--- a/packages/cli/src/lib/lifecycle-service.ts
+++ b/packages/cli/src/lib/lifecycle-service.ts
@@ -15,6 +15,7 @@ const LIFECYCLE_PID_FILE = "lifecycle-worker.pid";
 const LIFECYCLE_LOG_FILE = "lifecycle-worker.log";
 const DEFAULT_START_TIMEOUT_MS = 5_000;
 const STOP_TIMEOUT_MS = 5_000;
+let systemdRunAvailable: boolean | null = null;
 
 export interface LifecycleWorkerStatus {
   running: boolean;
@@ -41,6 +42,24 @@ export function getLifecycleLogFile(config: OrchestratorConfig, projectId: strin
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function canUseSystemdRunScope(): boolean {
+  if (process.platform !== "linux" || process.env.AO_DISABLE_SYSTEMD_SCOPE === "1") {
+    return false;
+  }
+  if (systemdRunAvailable !== null) {
+    return systemdRunAvailable;
+  }
+  try {
+    execFileSync("systemd-run", ["--user", "--version"], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    systemdRunAvailable = true;
+  } catch {
+    systemdRunAvailable = false;
+  }
+  return systemdRunAvailable;
 }
 
 function isProcessRunning(pid: number): boolean {
@@ -183,23 +202,45 @@ export async function ensureLifecycleWorker(
 
   try {
     const launch = resolveLifecycleWorkerLaunch(projectId);
-    const child = spawn(launch.command, launch.args, {
-      cwd: process.cwd(),
-      detached: true,
-      stdio: ["ignore", stdoutFd, stderrFd],
-      env: {
-        ...process.env,
-        AO_LIFECYCLE_PROJECT: projectId,
-        AO_CONFIG_PATH: config.configPath,
-      },
-    });
+    const useSystemdScope = canUseSystemdRunScope();
+    const child = useSystemdScope
+      ? spawn(
+          "systemd-run",
+          [
+            "--user",
+            "--scope",
+            "--quiet",
+            "--same-dir",
+            "env",
+            `AO_LIFECYCLE_PROJECT=${projectId}`,
+            `AO_CONFIG_PATH=${config.configPath}`,
+            launch.command,
+            ...launch.args,
+          ],
+          {
+            cwd: process.cwd(),
+            detached: true,
+            stdio: ["ignore", stdoutFd, stderrFd],
+            env: process.env,
+          },
+        )
+      : spawn(launch.command, launch.args, {
+          cwd: process.cwd(),
+          detached: true,
+          stdio: ["ignore", stdoutFd, stderrFd],
+          env: {
+            ...process.env,
+            AO_LIFECYCLE_PROJECT: projectId,
+            AO_CONFIG_PATH: config.configPath,
+          },
+        });
 
     child.unref();
 
-    // Write PID from the parent immediately after spawn to close the TOCTOU
-    // window: without this, a second concurrent `ensureLifecycleWorker` call
-    // could pass the "not running" check before the child writes its own PID.
-    if (child.pid) {
+    // Only the direct-spawn path can safely use the immediate child PID.
+    // The systemd-run path launches an intermediate wrapper process; the
+    // lifecycle worker writes its own PID once it is fully running.
+    if (!useSystemdScope && child.pid) {
       writeLifecycleWorkerPid(config, projectId, child.pid);
     }
   } finally {

--- a/packages/cli/src/lib/lifecycle-service.ts
+++ b/packages/cli/src/lib/lifecycle-service.ts
@@ -1,4 +1,4 @@
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import {
   closeSync,
   existsSync,

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1149,6 +1149,84 @@ describe("reactions", () => {
     expect(mockNotifier.notify).not.toHaveBeenCalled();
   });
 
+  it("retries a failed ci_failed send-to-agent reaction on subsequent polls", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const pr = makePR();
+    const session = makeSession({ status: "pr_open", pr });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send)
+      .mockRejectedValueOnce(new Error("delivery failed"))
+      .mockResolvedValueOnce(undefined);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "pr_open",
+      project: "my-app",
+      pr: pr.url,
+    });
+
+    const configWithReaction = {
+      ...config,
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Fix CI",
+          retries: 3,
+          escalateAfter: 3,
+        },
+      },
+    };
+
+    const lm = createLifecycleManager({
+      config: configWithReaction,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    session.status = "ci_failed";
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "ci_failed",
+      project: "my-app",
+      pr: pr.url,
+    });
+
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.send).toHaveBeenLastCalledWith("app-1", "Fix CI");
+  });
+
   it("dispatches unresolved review comments even when reviewDecision stays unchanged", async () => {
     config.reactions = {
       "changes-requested": {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -242,6 +242,61 @@ describe("start / stop", () => {
     lm.stop();
   });
 
+  it("treats 'terminated' orchestrators as dead and respawns when open work exists", async () => {
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({
+        id: "app-orchestrator",
+        status: "terminated" as any,
+        branch: "main",
+        metadata: { role: "orchestrator" },
+      }),
+      makeSession({ id: "app-1", status: "working", runtimeHandle: undefined }),
+    ]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    lm.start(60_000);
+
+    await vi.waitFor(() => {
+      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalled();
+    });
+
+    lm.stop();
+  });
+
+  it("does not treat 'done' sessions as open work", async () => {
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({
+        id: "app-orchestrator",
+        status: "killed",
+        branch: "main",
+        metadata: { role: "orchestrator" },
+      }),
+      makeSession({ id: "app-1", status: "done" as any }),
+    ]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    lm.start(60_000);
+
+    await vi.waitFor(() => {
+      expect(mockSessionManager.list).toHaveBeenCalledWith("my-app");
+    });
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+
+    lm.stop();
+  });
+
   it("refreshes sessions after respawning the orchestrator so stale killed metadata is not re-applied", async () => {
     vi.useFakeTimers();
     vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => handle.id !== "rt-dead");

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -175,6 +175,72 @@ describe("start / stop", () => {
     // Should not throw on double stop
     lm.stop();
   });
+
+  it("respawns the orchestrator when open work exists but the orchestrator is dead", async () => {
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({ id: "app-1", status: "working" }),
+      makeSession({
+        id: "app-orchestrator",
+        status: "killed",
+        branch: "main",
+        metadata: { role: "orchestrator" },
+      }),
+    ]);
+    vi.mocked(mockSessionManager.spawnOrchestrator).mockResolvedValue(
+      makeSession({
+        id: "app-orchestrator",
+        status: "working",
+        branch: "main",
+        metadata: { role: "orchestrator" },
+      }),
+    );
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    lm.start(60_000);
+
+    await vi.waitFor(() => {
+      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
+        projectId: "my-app",
+        systemPrompt: expect.stringContaining("# My App Orchestrator"),
+        prompt: expect.stringContaining("Do an initial orchestration pass"),
+      });
+    });
+
+    lm.stop();
+  });
+
+  it("does not respawn the orchestrator when there is no open work", async () => {
+    vi.mocked(mockSessionManager.list).mockResolvedValue([
+      makeSession({
+        id: "app-orchestrator",
+        status: "killed",
+        branch: "main",
+        metadata: { role: "orchestrator" },
+      }),
+    ]);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    lm.start(60_000);
+
+    await vi.waitFor(() => {
+      expect(mockSessionManager.list).toHaveBeenCalledWith("my-app");
+    });
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+
+    lm.stop();
+  });
 });
 
 describe("check (single session)", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -241,6 +241,72 @@ describe("start / stop", () => {
 
     lm.stop();
   });
+
+  it("refreshes sessions after respawning the orchestrator so stale killed metadata is not re-applied", async () => {
+    vi.useFakeTimers();
+    vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => handle.id !== "rt-dead");
+
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: join(tmpDir, "my-app"),
+      branch: "main",
+      status: "working",
+      role: "orchestrator",
+      project: "my-app",
+      runtimeHandle: JSON.stringify({ id: "rt-live", runtimeName: "mock", data: {} }),
+    });
+
+    const worker = makeSession({ id: "app-1", status: "working", runtimeHandle: undefined });
+    const liveOrchestrator = makeSession({
+      id: "app-orchestrator",
+      status: "working",
+      branch: "main",
+      runtimeHandle: { id: "rt-live", runtimeName: "mock", data: {} },
+      metadata: { role: "orchestrator" },
+    });
+    const deadOrchestrator = makeSession({
+      id: "app-orchestrator",
+      status: "killed",
+      branch: "main",
+      runtimeHandle: { id: "rt-dead", runtimeName: "mock", data: {} },
+      metadata: { role: "orchestrator" },
+    });
+    const respawnedOrchestrator = makeSession({
+      id: "app-orchestrator",
+      status: "working",
+      branch: "main",
+      runtimeHandle: { id: "rt-new", runtimeName: "mock", data: {} },
+      metadata: { role: "orchestrator" },
+    });
+
+    vi.mocked(mockSessionManager.list)
+      .mockResolvedValueOnce([worker, liveOrchestrator])
+      .mockResolvedValueOnce([worker, deadOrchestrator])
+      .mockResolvedValue([worker, respawnedOrchestrator]);
+    vi.mocked(mockSessionManager.spawnOrchestrator).mockResolvedValue(respawnedOrchestrator);
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+      projectId: "my-app",
+    });
+
+    lm.start(1_000);
+    await vi.waitFor(() => {
+      expect(lm.getStates().get("app-orchestrator")).toBe("working");
+    });
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await vi.waitFor(() => {
+      expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledTimes(1);
+    });
+
+    expect(readMetadataRaw(sessionsDir, "app-orchestrator")?.["status"]).toBe("working");
+    expect(lm.getStates().get("app-orchestrator")).toBe("working");
+
+    lm.stop();
+    vi.useRealTimers();
+  });
 });
 
 describe("check (single session)", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1227,6 +1227,70 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenLastCalledWith("app-1", "Fix CI");
   });
 
+  it("replays a ci_failed follow-up after lifecycle restart when no dispatch marker was persisted", async () => {
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const pr = makePR();
+    const session = makeSession({ status: "ci_failed", pr });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "ci_failed",
+      project: "my-app",
+      pr: pr.url,
+    });
+
+    const configWithReaction = {
+      ...config,
+      reactions: {
+        "ci-failed": {
+          auto: true,
+          action: "send-to-agent" as const,
+          message: "Fix CI",
+          retries: 3,
+          escalateAfter: 3,
+        },
+      },
+    };
+
+    const lm = createLifecycleManager({
+      config: configWithReaction,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
+  });
+
   it("dispatches unresolved review comments even when reviewDecision stays unchanged", async () => {
     config.reactions = {
       "changes-requested": {

--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { generateOrchestratorPrompt } from "../orchestrator-prompt.js";
+import {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "../orchestrator-prompt.js";
 import type { OrchestratorConfig } from "../types.js";
 
 const config: OrchestratorConfig = {
@@ -53,5 +56,38 @@ describe("generateOrchestratorPrompt", () => {
     expect(prompt).toContain("must be delegated to a **worker session**");
     expect(prompt).toContain("Never claim a PR into `app-orchestrator`");
     expect(prompt).toContain("Delegate implementation, test execution, or PR claiming");
+  });
+});
+
+describe("generateOrchestratorStartupPrompt", () => {
+  it("kicks off an immediate tracker triage pass when a tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: {
+        ...config.projects["my-app"]!,
+        tracker: {
+          plugin: "github",
+          issueFilters: { labels: ["ready"], state: "open" },
+        },
+      },
+    });
+
+    expect(prompt).toContain("Do an initial orchestration pass");
+    expect(prompt).toContain("ao session ls -p my-app");
+    expect(prompt).toContain("configured github tracker");
+    expect(prompt).toContain("labels=ready");
+    expect(prompt).toContain("ao batch-spawn my-app");
+  });
+
+  it("falls back to monitoring guidance when no tracker is configured", () => {
+    const prompt = generateOrchestratorStartupPrompt({
+      config,
+      projectId: "my-app",
+      project: config.projects["my-app"]!,
+    });
+
+    expect(prompt).toContain("There is no tracker configured for this project");
+    expect(prompt).not.toContain("ao batch-spawn my-app");
   });
 });

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -3788,6 +3788,7 @@ describe("spawnOrchestrator", () => {
     await sm.spawnOrchestrator({
       projectId: "my-app",
       systemPrompt: "You are the orchestrator.",
+      prompt: "Do an initial orchestration pass.",
     });
 
     // Should pass systemPromptFile (not inline systemPrompt) to avoid tmux truncation
@@ -3795,6 +3796,7 @@ describe("spawnOrchestrator", () => {
       expect.objectContaining({
         sessionId: "app-orchestrator",
         systemPromptFile: expect.stringContaining("orchestrator-prompt.md"),
+        prompt: "Do an initial orchestration pass.",
       }),
     );
 
@@ -3804,6 +3806,53 @@ describe("spawnOrchestrator", () => {
     expect(existsSync(promptFile)).toBe(true);
     const { readFileSync } = await import("node:fs");
     expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
+  });
+
+  it("passes the initial orchestrator prompt to the agent launch config", async () => {
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Check ready issues and spawn workers.",
+    });
+
+    expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "app-orchestrator",
+        prompt: "Check ready issues and spawn workers.",
+      }),
+    );
+  });
+
+  it("sends orchestrator prompt post-launch when agent.promptDelivery is 'post-launch'", async () => {
+    vi.useFakeTimers();
+    const postLaunchAgent = {
+      ...mockAgent,
+      promptDelivery: "post-launch" as const,
+    };
+    const registryWithPostLaunch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return postLaunchAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({ config, registry: registryWithPostLaunch });
+    const spawnPromise = sm.spawnOrchestrator({
+      projectId: "my-app",
+      prompt: "Do an initial orchestration pass.",
+    });
+    await vi.advanceTimersByTimeAsync(5_000);
+    await spawnPromise;
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+      "Do an initial orchestration pass.",
+    );
+    vi.useRealTimers();
   });
 
   it("throws for unknown project", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,7 +75,10 @@ export type {
 } from "./decomposer.js";
 
 // Orchestrator prompt — generates orchestrator context for `ao start`
-export { generateOrchestratorPrompt } from "./orchestrator-prompt.js";
+export {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "./orchestrator-prompt.js";
 export type { OrchestratorPromptConfig } from "./orchestrator-prompt.js";
 
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -185,6 +185,7 @@ export interface LifecycleManagerDeps {
 interface ReactionTracker {
   attempts: number;
   firstTriggered: Date;
+  pendingRetry?: boolean;
 }
 
 /** Create a LifecycleManager instance. */
@@ -375,7 +376,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     let tracker = reactionTrackers.get(trackerKey);
 
     if (!tracker) {
-      tracker = { attempts: 0, firstTriggered: new Date() };
+      tracker = { attempts: 0, firstTriggered: new Date(), pendingRetry: false };
       reactionTrackers.set(trackerKey, tracker);
     }
 
@@ -403,6 +404,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     if (shouldEscalate) {
+      tracker.pendingRetry = false;
       // Escalate to human
       const event = createEvent("reaction.escalated", {
         sessionId,
@@ -428,6 +430,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           try {
             await sessionManager.send(sessionId, reactionConfig.message);
 
+            tracker.pendingRetry = false;
             return {
               reactionType: reactionKey,
               success: true,
@@ -437,6 +440,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             };
           } catch {
             // Send failed — allow retry on next poll cycle (don't escalate immediately)
+            tracker.pendingRetry = true;
             return {
               reactionType: reactionKey,
               success: false,
@@ -456,6 +460,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           data: { reactionKey },
         });
         await notifyHuman(event, reactionConfig.priority ?? "info");
+        tracker.pendingRetry = false;
         return {
           reactionType: reactionKey,
           success: true,
@@ -465,24 +470,61 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       case "auto-merge": {
-        // Auto-merge is handled by the SCM plugin
-        // For now, just notify
-        const event = createEvent("reaction.triggered", {
-          sessionId,
-          projectId,
-          message: `Reaction '${reactionKey}' triggered auto-merge`,
-          data: { reactionKey },
-        });
-        await notifyHuman(event, "action");
-        return {
-          reactionType: reactionKey,
-          success: true,
-          action: "auto-merge",
-          escalated: false,
-        };
+        const project = config.projects[projectId];
+        const scmPlugin = project?.scm
+          ? registry.get<SCM>("scm", project.scm.plugin)
+          : null;
+        const targetSession = await sessionManager.get(sessionId);
+        if (!scmPlugin || !targetSession?.pr || targetSession.projectId !== projectId) {
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: false,
+          };
+        }
+        try {
+          const mergeMethod =
+            (reactionConfig as ReactionConfig & { mergeMethod?: MergeMethod }).mergeMethod ??
+            "squash";
+          await scmPlugin.mergePR(targetSession.pr, mergeMethod);
+          const event = createEvent("merge.completed", {
+            sessionId,
+            projectId,
+            message: `Auto-merged PR via '${reactionKey}' reaction (${mergeMethod})`,
+            data: { reactionKey, mergeMethod },
+          });
+          await notifyHuman(event, "action");
+          tracker.pendingRetry = false;
+          return {
+            reactionType: reactionKey,
+            success: true,
+            action: "auto-merge",
+            escalated: false,
+          };
+        } catch (err) {
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "lifecycle.auto-merge",
+            outcome: "failure",
+            correlationId: createCorrelationId("auto-merge"),
+            projectId,
+            sessionId,
+            data: { error: err instanceof Error ? err.message : String(err) },
+            level: "warn",
+          });
+          tracker.pendingRetry = true;
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: false,
+          };
+        }
       }
     }
 
+    tracker.pendingRetry = true;
     return {
       reactionType: reactionKey,
       success: false,
@@ -786,6 +828,23 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     } else {
       // No transition but track current state
       states.set(session.id, newStatus);
+
+      const stableEventType = statusToEventType(oldStatus, newStatus);
+      const stableReactionKey = stableEventType ? eventToReactionKey(stableEventType) : null;
+      const stableTracker = stableReactionKey
+        ? reactionTrackers.get(`${session.id}:${stableReactionKey}`)
+        : undefined;
+
+      if (stableReactionKey && stableTracker?.pendingRetry) {
+        const reactionConfig = getReactionConfigForSession(session, stableReactionKey);
+        if (
+          reactionConfig &&
+          reactionConfig.action &&
+          (reactionConfig.auto !== false || reactionConfig.action === "notify")
+        ) {
+          await executeReaction(session.id, session.projectId, stableReactionKey, reactionConfig);
+        }
+      }
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -884,8 +884,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
   }
 
-  async function ensureOrchestratorsForOpenWork(sessions: Session[]): Promise<void> {
+  async function ensureOrchestratorsForOpenWork(sessions: Session[]): Promise<boolean> {
     const projectIds = scopedProjectId ? [scopedProjectId] : Object.keys(config.projects);
+    let spawnedOrchestrator = false;
 
     await Promise.allSettled(
       projectIds.map(async (projectId) => {
@@ -911,8 +912,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           systemPrompt: generateOrchestratorPrompt({ config, projectId, project }),
           prompt: generateOrchestratorStartupPrompt({ config, projectId, project }),
         });
+        spawnedOrchestrator = true;
       }),
     );
+
+    return spawnedOrchestrator;
   }
 
   /** Run one polling cycle across all sessions. */
@@ -924,8 +928,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     polling = true;
 
     try {
-      const sessions = await sessionManager.list(scopedProjectId);
-      await ensureOrchestratorsForOpenWork(sessions);
+      let sessions = await sessionManager.list(scopedProjectId);
+      const spawnedOrchestrator = await ensureOrchestratorsForOpenWork(sessions);
+      if (spawnedOrchestrator) {
+        sessions = await sessionManager.list(scopedProjectId);
+      }
 
       // Include sessions that are active OR whose status changed from what we last saw
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -15,6 +15,7 @@ import {
   SESSION_STATUS,
   PR_STATE,
   CI_STATUS,
+  TERMINAL_STATUSES,
   isOrchestratorSession,
   type LifecycleManager,
   type SessionManager,
@@ -897,13 +898,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const hasOpenWork = projectSessions.some(
           (session) =>
             !isOrchestratorSession(session) &&
-            session.status !== "merged" &&
-            !(session.status === "killed" && !session.pr),
+            !TERMINAL_STATUSES.has(session.status),
         );
         if (!hasOpenWork) return;
 
         const hasLiveOrchestrator = projectSessions.some(
-          (session) => isOrchestratorSession(session) && session.status !== "killed",
+          (session) => isOrchestratorSession(session) && !TERMINAL_STATUSES.has(session.status),
         );
         if (hasLiveOrchestrator) return;
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -173,6 +173,10 @@ function transitionLogLevel(status: SessionStatus): "info" | "warn" | "error" {
   return "info";
 }
 
+function reactionDispatchMarkerKey(reactionKey: string): string {
+  return `reactionDispatch_${reactionKey}`;
+}
+
 export interface LifecycleManagerDeps {
   config: OrchestratorConfig;
   registry: PluginRegistry;
@@ -780,6 +784,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const oldReactionKey = eventToReactionKey(oldEventType);
         if (oldReactionKey) {
           clearReactionTracker(session.id, oldReactionKey);
+          updateSessionMetadata(session, {
+            [reactionDispatchMarkerKey(oldReactionKey)]: "",
+          });
         }
       }
 
@@ -801,6 +808,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
                 reactionKey,
                 reactionConfig,
               );
+              if (reactionResult.success) {
+                updateSessionMetadata(session, {
+                  [reactionDispatchMarkerKey(reactionKey)]: newStatus,
+                });
+              }
               transitionReaction = { key: reactionKey, result: reactionResult };
               // Reaction is handling this event — suppress immediate human notification.
               // "send-to-agent" retries + escalates on its own; "notify"/"auto-merge"
@@ -834,15 +846,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const stableTracker = stableReactionKey
         ? reactionTrackers.get(`${session.id}:${stableReactionKey}`)
         : undefined;
+      const stableDispatchMarker = stableReactionKey
+        ? session.metadata[reactionDispatchMarkerKey(stableReactionKey)]
+        : undefined;
+      const needsStableReactionReplay =
+        !!stableReactionKey &&
+        ((stableTracker?.pendingRetry ?? false) || stableDispatchMarker !== newStatus);
 
-      if (stableReactionKey && stableTracker?.pendingRetry) {
+      if (stableReactionKey && needsStableReactionReplay) {
         const reactionConfig = getReactionConfigForSession(session, stableReactionKey);
         if (
           reactionConfig &&
           reactionConfig.action &&
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
-          await executeReaction(session.id, session.projectId, stableReactionKey, reactionConfig);
+          const reactionResult = await executeReaction(
+            session.id,
+            session.projectId,
+            stableReactionKey,
+            reactionConfig,
+          );
+          if (reactionResult.success) {
+            updateSessionMetadata(session, {
+              [reactionDispatchMarkerKey(stableReactionKey)]: newStatus,
+            });
+          }
         }
       }
     }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -15,6 +15,7 @@ import {
   SESSION_STATUS,
   PR_STATE,
   CI_STATUS,
+  isOrchestratorSession,
   type LifecycleManager,
   type SessionManager,
   type SessionId,
@@ -38,6 +39,10 @@ import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import {
+  generateOrchestratorPrompt,
+  generateOrchestratorStartupPrompt,
+} from "./orchestrator-prompt.js";
 
 /** Parse a duration string like "10m", "30s", "1h" to milliseconds. */
 function parseDuration(str: string): number {
@@ -879,6 +884,37 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
   }
 
+  async function ensureOrchestratorsForOpenWork(sessions: Session[]): Promise<void> {
+    const projectIds = scopedProjectId ? [scopedProjectId] : Object.keys(config.projects);
+
+    await Promise.allSettled(
+      projectIds.map(async (projectId) => {
+        const project = config.projects[projectId];
+        if (!project) return;
+
+        const projectSessions = sessions.filter((session) => session.projectId === projectId);
+        const hasOpenWork = projectSessions.some(
+          (session) =>
+            !isOrchestratorSession(session) &&
+            session.status !== "merged" &&
+            !(session.status === "killed" && !session.pr),
+        );
+        if (!hasOpenWork) return;
+
+        const hasLiveOrchestrator = projectSessions.some(
+          (session) => isOrchestratorSession(session) && session.status !== "killed",
+        );
+        if (hasLiveOrchestrator) return;
+
+        await sessionManager.spawnOrchestrator({
+          projectId,
+          systemPrompt: generateOrchestratorPrompt({ config, projectId, project }),
+          prompt: generateOrchestratorStartupPrompt({ config, projectId, project }),
+        });
+      }),
+    );
+  }
+
   /** Run one polling cycle across all sessions. */
   async function pollAll(): Promise<void> {
     const correlationId = createCorrelationId("lifecycle-poll");
@@ -889,6 +925,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     try {
       const sessions = await sessionManager.list(scopedProjectId);
+      await ensureOrchestratorsForOpenWork(sessions);
 
       // Include sessions that are active OR whose status changed from what we last saw
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -31,6 +31,7 @@ import {
   type Notifier,
   type Session,
   type EventPriority,
+  type MergeMethod,
   type ProjectConfig as _ProjectConfig,
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -325,7 +325,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       try {
         const prState = await scm.getPRState(session.pr);
         if (prState === PR_STATE.MERGED) return "merged";
-        if (prState === PR_STATE.CLOSED) return "killed";
+        if (prState === PR_STATE.CLOSED) {
+          // Closed PRs are terminal for this session; clear persisted PR metadata
+          // so killed sessions don't get re-polled forever via `if (s.pr) return true`.
+          session.pr = null;
+          try {
+            const sessionsDir = getSessionsDir(config.configPath, project.path);
+            updateMetadata(sessionsDir, session.id, { pr: "" });
+          } catch {
+            // Best effort — lifecycle status should still proceed to killed.
+          }
+          return "killed";
+        }
 
         // Check CI
         const ciStatus = await scm.getCISummary(session.pr);

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -13,6 +13,49 @@ export interface OrchestratorPromptConfig {
   project: ProjectConfig;
 }
 
+export function generateOrchestratorStartupPrompt(opts: OrchestratorPromptConfig): string {
+  const { projectId, project } = opts;
+
+  return `Do an initial orchestration pass for ${project.name} (${projectId}).
+
+Start by:
+1. Running \`ao status\` to inspect the current session/PR state.
+2. Checking whether any worker session needs help, takeover, or a follow-up message.
+3. Spawning or directing worker sessions if open work is not currently owned.
+4. Staying in read-only coordination mode yourself — delegate implementation to workers.`;
+}
+
+function formatTrackerIssueFilters(project: ProjectConfig): string | null {
+  const rawFilters = project.tracker?.["issueFilters"];
+  if (!rawFilters || typeof rawFilters !== "object" || Array.isArray(rawFilters)) {
+    return null;
+  }
+
+  const filters = rawFilters as Record<string, unknown>;
+  const parts: string[] = [];
+
+  if (typeof filters["state"] === "string" && filters["state"].trim().length > 0) {
+    parts.push(`state=${filters["state"]}`);
+  }
+
+  if (Array.isArray(filters["labels"])) {
+    const labels = filters["labels"].filter((label): label is string => typeof label === "string");
+    if (labels.length > 0) {
+      parts.push(`labels=${labels.join(", ")}`);
+    }
+  }
+
+  if (typeof filters["assignee"] === "string" && filters["assignee"].trim().length > 0) {
+    parts.push(`assignee=${filters["assignee"]}`);
+  }
+
+  if (typeof filters["limit"] === "number" && Number.isFinite(filters["limit"])) {
+    parts.push(`limit=${filters["limit"]}`);
+  }
+
+  return parts.length > 0 ? parts.join(", ") : null;
+}
+
 /**
  * Generate orchestrator prompt content.
  * Provides orchestrator agent with context about available commands,

--- a/packages/core/src/orchestrator-prompt.ts
+++ b/packages/core/src/orchestrator-prompt.ts
@@ -13,18 +13,6 @@ export interface OrchestratorPromptConfig {
   project: ProjectConfig;
 }
 
-export function generateOrchestratorStartupPrompt(opts: OrchestratorPromptConfig): string {
-  const { projectId, project } = opts;
-
-  return `Do an initial orchestration pass for ${project.name} (${projectId}).
-
-Start by:
-1. Running \`ao status\` to inspect the current session/PR state.
-2. Checking whether any worker session needs help, takeover, or a follow-up message.
-3. Spawning or directing worker sessions if open work is not currently owned.
-4. Staying in read-only coordination mode yourself — delegate implementation to workers.`;
-}
-
 function formatTrackerIssueFilters(project: ProjectConfig): string | null {
   const rawFilters = project.tracker?.["issueFilters"];
   if (!rawFilters || typeof rawFilters !== "object" || Array.isArray(rawFilters)) {
@@ -284,4 +272,41 @@ ${project.orchestratorRules}`);
   }
 
   return sections.join("\n\n");
+}
+
+/**
+ * Generate the initial user prompt that kicks off orchestration work after
+ * `ao start`. Without this, interactive agents like Codex just open a REPL and
+ * sit idle even though the orchestrator session appears healthy.
+ */
+export function generateOrchestratorStartupPrompt(opts: OrchestratorPromptConfig): string {
+  const { projectId, project } = opts;
+  const trackerPlugin = typeof project.tracker?.plugin === "string" ? project.tracker.plugin : null;
+  const trackerFilters = formatTrackerIssueFilters(project);
+
+  if (!trackerPlugin) {
+    return [
+      `Do an initial orchestration pass for ${project.name} now.`,
+      `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+      "2. There is no tracker configured for this project, so do not invent new work.",
+      "3. If workers already exist, monitor them for CI failures, review comments, blocked states, and merge-ready PRs.",
+      "4. If nothing needs action, report that the project is idle and remain available.",
+      "Do not implement code yourself from the orchestrator session.",
+    ].join("\n");
+  }
+
+  const filterClause = trackerFilters
+    ? ` matching these configured tracker filters: ${trackerFilters}.`
+    : ".";
+
+  return [
+    `Do an initial orchestration pass for ${project.name} now.`,
+    `1. Inspect the current AO state with \`ao status\` and \`ao session ls -p ${projectId}\`.`,
+    `2. Query the configured ${trackerPlugin} tracker for open issues${filterClause}`,
+    "3. Identify issues that are ready to work and do not already have an active AO worker session.",
+    `4. Spawn missing workers for those issues. Prefer \`ao batch-spawn ${projectId} ...\` when multiple issues qualify.`,
+    "5. After spawning, switch back to monitoring mode: watch worker progress, CI failures, review comments, blocked sessions, and merge-ready PRs.",
+    "6. If no issue needs action, say so briefly and remain available.",
+    "Do not implement code yourself from the orchestrator session.",
+  ].join("\n");
 }

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1350,6 +1350,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ...(reusableOpenCodeSessionId ? { opencodeSessionId: reusableOpenCodeSessionId } : {}),
         },
       },
+      prompt: orchestratorConfig.prompt,
       permissions: "permissionless" as const,
       model: selection.model,
       systemPromptFile,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1445,6 +1445,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw err;
     }
 
+    if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+      try {
+        await new Promise((resolve) => setTimeout(resolve, 5_000));
+        await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+      } catch {
+        // Non-fatal: agent is running but didn't receive the initial prompt.
+        // User can retry with `ao send`.
+      }
+    }
+
     return session;
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -199,6 +199,8 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Initial user prompt that kicks off the first orchestration pass. */
+  prompt?: string;
 }
 
 // =============================================================================

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -1,4 +1,4 @@
-import { execFile } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { promisify } from "node:util";
 import { setTimeout as sleep } from "node:timers/promises";
 import { randomUUID } from "node:crypto";
@@ -16,6 +16,7 @@ import type {
 
 const execFileAsync = promisify(execFile);
 const TMUX_COMMAND_TIMEOUT_MS = 5_000;
+let systemdRunAvailable: boolean | null = null;
 
 export const manifest = {
   name: "tmux",
@@ -34,8 +35,31 @@ function assertValidSessionId(id: string): void {
 }
 
 /** Run a tmux command and return stdout */
+function canUseSystemdRunScope(): boolean {
+  if (process.platform !== "linux" || process.env.AO_DISABLE_SYSTEMD_SCOPE === "1") {
+    return false;
+  }
+  if (systemdRunAvailable !== null) {
+    return systemdRunAvailable;
+  }
+  try {
+    execFileSync("systemd-run", ["--user", "--version"], {
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    systemdRunAvailable = true;
+  } catch {
+    systemdRunAvailable = false;
+  }
+  return systemdRunAvailable;
+}
+
 async function tmux(...args: string[]): Promise<string> {
-  const { stdout } = await execFileAsync("tmux", args, {
+  const useSystemdScope = args[0] === "new-session" && canUseSystemdRunScope();
+  const command = useSystemdScope ? "systemd-run" : "tmux";
+  const commandArgs = useSystemdScope
+    ? ["--user", "--scope", "--quiet", "tmux", ...args]
+    : args;
+  const { stdout } = await execFileAsync(command, commandArgs, {
     timeout: TMUX_COMMAND_TIMEOUT_MS,
   });
   return stdout.trimEnd();

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -446,7 +446,7 @@ describe("API Routes", () => {
   });
 
   describe("POST /api/orchestrators", () => {
-    it("creates a per-project orchestrator with the generated prompt", async () => {
+    it("creates a per-project orchestrator with the generated prompts", async () => {
       (mockSessionManager.spawnOrchestrator as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
         makeSession({
           id: "my-app-orchestrator",
@@ -466,6 +466,7 @@ describe("API Routes", () => {
       expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledWith({
         projectId: "my-app",
         systemPrompt: expect.stringContaining("# My App Orchestrator"),
+        prompt: expect.stringContaining("Do an initial orchestration pass"),
       });
 
       const data = await res.json();

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { generateOrchestratorPrompt } from "@composio/ao-core";
+import { generateOrchestratorPrompt, generateOrchestratorStartupPrompt } from "@composio/ao-core";
 import { getServices } from "@/lib/services";
 import { validateIdentifier } from "@/lib/validation";
 
@@ -24,7 +24,8 @@ export async function POST(request: NextRequest) {
     }
 
     const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
-    const session = await sessionManager.spawnOrchestrator({ projectId, systemPrompt });
+    const prompt = generateOrchestratorStartupPrompt({ config, projectId, project });
+    const session = await sessionManager.spawnOrchestrator({ projectId, systemPrompt, prompt });
 
     return NextResponse.json(
       {


### PR DESCRIPTION
## Summary

This consolidates the control-plane recovery line onto a clean branch from `main`.

Included work:
- `#613` follow-up replay after restart
- `#587` orchestrator respawn when open work remains
- `#588` dashboard reuse for non-interactive `ao start`
- the two control-plane recovery commits from `#629`

During consolidation two explicit prerequisites/fixes were required to make the line clean on top of current `main`:
- cherry-pick the narrow orchestrator kickoff prompt wiring from `#540` (`OrchestratorSpawnConfig.prompt` + post-launch delivery path), because `#587` depends on it
- add the missing `execFileSync` import in `packages/cli/src/lib/lifecycle-service.ts`, because the `systemd-run` scope detection from the `#629` extra commit referenced it without importing it

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @composio/ao-core build
pnpm --filter @composio/ao-plugin-agent-claude-code build
pnpm --filter @composio/ao-plugin-agent-codex build
pnpm --filter @composio/ao-plugin-agent-aider build
pnpm --filter @composio/ao-plugin-agent-opencode build
pnpm --filter @composio/ao-plugin-scm-github build
pnpm --filter @composio/ao-plugin-runtime-tmux build
pnpm --filter @composio/ao-plugin-workspace-worktree build
pnpm --filter @composio/ao-plugin-tracker-github build
pnpm --filter @composio/ao-plugin-tracker-linear build
pnpm --filter @composio/ao-cli build
pnpm --filter @composio/ao-web build
pnpm --filter @composio/ao-cli test -- __tests__/commands/start.test.ts
pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts src/__tests__/session-manager.test.ts
pnpm --filter @composio/ao-web test -- src/__tests__/api-routes.test.ts
```
