### PR TITLE
feat(core): auto-shutdown idle orchestrators after configurable timeout

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -209,8 +209,9 @@ export function registerStatus(program: Command): void {
     .command("status")
     .description("Show all sessions with branch, activity, PR, and CI status")
     .option("-p, --project <id>", "Filter by project ID")
+    .option("-a, --all", "Show all sessions including terminal/stale ones")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .action(async (opts: { project?: string; all?: boolean; json?: boolean }) => {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
@@ -253,9 +254,20 @@ export function registerStatus(program: Command): void {
         const projectConfig = config.projects[projectId];
         if (!projectConfig) continue;
 
-        const projectSessions = (byProject.get(projectId) ?? []).sort((a, b) =>
-          a.id.localeCompare(b.id),
-        );
+        // Filter out terminal sessions with no live runtime — these are stale
+        // metadata files that haven't been archived yet.  Only show them when
+        // the user explicitly passes --all.
+        const TERMINAL_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
+        const projectSessions = (byProject.get(projectId) ?? [])
+          .filter((s) => {
+            if (opts.all) return true;
+            if (!TERMINAL_STATUSES.has(s.status)) return true;
+            // Terminal status — keep only if runtime is still alive (enrichment
+            // would have revived it, so if status is still terminal the runtime
+            // is truly gone).
+            return false;
+          })
+          .sort((a, b) => a.id.localeCompare(b.id));
 
         // Resolve agent and SCM for this project
         const agentName = projectConfig.agent ?? config.defaults.agent;

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -257,7 +257,7 @@ export function registerStatus(program: Command): void {
         // Filter out terminal sessions with no live runtime — these are stale
         // metadata files that haven't been archived yet.  Only show them when
         // the user explicitly passes --all.
-        const TERMINAL_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
+        const TERMINAL_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup", "errored"]);
         const projectSessions = (byProject.get(projectId) ?? [])
           .filter((s) => {
             if (opts.all) return true;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -13,6 +13,7 @@
 import { randomUUID } from "node:crypto";
 import {
   SESSION_STATUS,
+  TERMINAL_STATUSES,
   PR_STATE,
   CI_STATUS,
   isOrchestratorSession,
@@ -854,12 +855,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const idleTimeoutMs = config.orchestratorIdleTimeoutMs ?? 600_000; // default 10 min
       if (idleTimeoutMs > 0 && scopedProjectId) {
         const workerSessions = sessions.filter(
-          (s) =>
-            s.status !== "merged" &&
-            s.status !== "killed" &&
-            !isOrchestratorSession(s),
+          (s) => !TERMINAL_STATUSES.has(s.status) && !isOrchestratorSession(s),
         );
-        const orchestratorSession = sessions.find((s) => isOrchestratorSession(s));
+        const orchestratorSession = sessions.find(
+          (s) => isOrchestratorSession(s) && !TERMINAL_STATUSES.has(s.status),
+        );
 
         if (workerSessions.length === 0 && orchestratorSession) {
           // Track when idle started
@@ -879,6 +879,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             });
             try {
               await sessionManager.kill(orchestratorSession.id);
+              states.set(orchestratorSession.id, SESSION_STATUS.KILLED);
+              orchestratorIdleSince.delete(scopedProjectId);
               // Emit event so notifiers can inform the user
               const event = createEvent("session.orchestrator_idle_shutdown", {
                 sessionId: orchestratorSession.id,
@@ -889,7 +891,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             } catch {
               // Kill failed — will retry next poll
             }
-            orchestratorIdleSince.delete(scopedProjectId);
           }
         } else {
           // Workers are active — reset idle timer

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -15,6 +15,7 @@ import {
   SESSION_STATUS,
   PR_STATE,
   CI_STATUS,
+  isOrchestratorSession,
   type LifecycleManager,
   type SessionManager,
   type SessionId,
@@ -194,6 +195,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  const orchestratorIdleSince = new Map<string, number>(); // projectId → timestamp when idle started
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -845,6 +847,56 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           }
         }
       }
+
+      // Idle orchestrator shutdown: if there are no active worker sessions
+      // and the orchestrator has been idle beyond the configured timeout,
+      // shut down the orchestrator session to free resources.
+      const idleTimeoutMs = config.orchestratorIdleTimeoutMs ?? 600_000; // default 10 min
+      if (idleTimeoutMs > 0 && scopedProjectId) {
+        const workerSessions = sessions.filter(
+          (s) =>
+            s.status !== "merged" &&
+            s.status !== "killed" &&
+            !isOrchestratorSession(s),
+        );
+        const orchestratorSession = sessions.find((s) => isOrchestratorSession(s));
+
+        if (workerSessions.length === 0 && orchestratorSession) {
+          // Track when idle started
+          if (!orchestratorIdleSince.has(scopedProjectId)) {
+            orchestratorIdleSince.set(scopedProjectId, Date.now());
+          }
+          const idleDuration = Date.now() - orchestratorIdleSince.get(scopedProjectId)!;
+          if (idleDuration >= idleTimeoutMs) {
+            observer.recordOperation({
+              metric: "lifecycle_poll",
+              operation: "lifecycle.orchestrator_idle_shutdown",
+              outcome: "success",
+              correlationId,
+              projectId: scopedProjectId,
+              data: { idleDurationMs: idleDuration, timeoutMs: idleTimeoutMs },
+              level: "info",
+            });
+            try {
+              await sessionManager.kill(orchestratorSession.id);
+              // Emit event so notifiers can inform the user
+              const event = createEvent("session.orchestrator_idle_shutdown", {
+                sessionId: orchestratorSession.id,
+                projectId: scopedProjectId,
+                message: `Orchestrator ${orchestratorSession.id} shut down after ${Math.round(idleDuration / 60_000)}m idle (no active workers).`,
+              });
+              await notifyHuman(event, "info");
+            } catch {
+              // Kill failed — will retry next poll
+            }
+            orchestratorIdleSince.delete(scopedProjectId);
+          }
+        } else {
+          // Workers are active — reset idle timer
+          orchestratorIdleSince.delete(scopedProjectId);
+        }
+      }
+
       if (scopedProjectId) {
         observer.recordOperation({
           metric: "lifecycle_poll",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -868,19 +868,19 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           }
           const idleDuration = Date.now() - orchestratorIdleSince.get(scopedProjectId)!;
           if (idleDuration >= idleTimeoutMs) {
-            observer.recordOperation({
-              metric: "lifecycle_poll",
-              operation: "lifecycle.orchestrator_idle_shutdown",
-              outcome: "success",
-              correlationId,
-              projectId: scopedProjectId,
-              data: { idleDurationMs: idleDuration, timeoutMs: idleTimeoutMs },
-              level: "info",
-            });
             try {
               await sessionManager.kill(orchestratorSession.id);
               states.set(orchestratorSession.id, SESSION_STATUS.KILLED);
               orchestratorIdleSince.delete(scopedProjectId);
+              observer.recordOperation({
+                metric: "lifecycle_poll",
+                operation: "lifecycle.orchestrator_idle_shutdown",
+                outcome: "success",
+                correlationId,
+                projectId: scopedProjectId,
+                data: { idleDurationMs: idleDuration, timeoutMs: idleTimeoutMs },
+                level: "info",
+              });
               // Emit event so notifiers can inform the user
               const event = createEvent("session.orchestrator_idle_shutdown", {
                 sessionId: orchestratorSession.id,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -820,7 +820,9 @@ export type EventType =
   | "reaction.triggered"
   | "reaction.escalated"
   // Summary
-  | "summary.all_complete";
+  | "summary.all_complete"
+  // Orchestrator lifecycle
+  | "session.orchestrator_idle_shutdown";
 
 /** An event emitted by the orchestrator */
 export interface OrchestratorEvent {
@@ -897,6 +899,13 @@ export interface OrchestratorConfig {
 
   /** Milliseconds before a "ready" session becomes "idle" (default: 300000 = 5 min) */
   readyThresholdMs: number;
+
+  /**
+   * Milliseconds an orchestrator can remain idle (no active workers, no open
+   * issues) before being automatically shut down.  Set to 0 to disable.
+   * Default: 600000 (10 minutes).
+   */
+  orchestratorIdleTimeoutMs?: number;
 
   /** Default plugin selections */
   defaults: DefaultPlugins;


### PR DESCRIPTION
## Summary

Consolidated idle-orchestrator shutdown line from `#546` onto a clean branch from `main`.

Included work:
- configurable `orchestratorIdleTimeoutMs`
- automatic orchestrator shutdown when a project has no active workers beyond the timeout
- `session.orchestrator_idle_shutdown` event emission for notifier visibility
- status output cleanup so terminal dead sessions stay hidden by default
- the follow-up hardening commit for terminal-state handling

## Verification

```bash
pnpm install --frozen-lockfile
pnpm --filter @composio/ao-core typecheck
pnpm --filter @composio/ao-core build
pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts
pnpm --filter @composio/ao-plugin-agent-claude-code build
pnpm --filter @composio/ao-plugin-agent-codex build
pnpm --filter @composio/ao-plugin-agent-aider build
pnpm --filter @composio/ao-plugin-agent-opencode build
pnpm --filter @composio/ao-plugin-scm-github build
pnpm --filter @composio/ao-cli typecheck
pnpm --filter @composio/ao-cli build
```

Closes #532.
