### PR TITLE
fix: cleanup and session lifecycle safety

### DIFF
--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -37,6 +37,7 @@ projects:
     repo: owner/repo          # GitHub "owner/repo" format
     path: ~/code/my-app       # Local path to the repo
     defaultBranch: main       # main | master | next | develop
+    maxActiveWorkers: 1       # Optional cap on concurrent worker sessions for this project
     sessionPrefix: myapp      # Prefix for session names (e.g. myapp-1, myapp-2)
 
     # ── Per-project plugin overrides (optional) ───────────────────

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -70,6 +70,21 @@ describe("Config Validation - Project Uniqueness", () => {
 
     expect(() => validateConfig(config)).not.toThrow();
   });
+
+  it("accepts maxActiveWorkers as a positive integer", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/integrator",
+          repo: "org/integrator",
+          defaultBranch: "main",
+          maxActiveWorkers: 1,
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).not.toThrow();
+  });
 });
 
 describe("Config Validation - Session Prefix Uniqueness", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -873,17 +873,7 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("merged");
   });
 
-  it("destroys the runtime using the session handle runtime name on terminal transitions", async () => {
-    const tmuxRuntime: Runtime = {
-      ...mockRuntime,
-      name: "tmux",
-      destroy: vi.fn().mockResolvedValue(undefined),
-    };
-    const dockerRuntime: Runtime = {
-      ...mockRuntime,
-      name: "docker",
-      destroy: vi.fn().mockResolvedValue(undefined),
-    };
+  it("cleans terminal sessions via sessionManager.kill on terminal transitions", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",
       detectPR: vi.fn(),
@@ -899,17 +889,9 @@ describe("check (single session)", () => {
       getMergeability: vi.fn(),
     };
 
-    config.defaults.runtime = "docker";
-    config.projects["my-app"] = {
-      ...config.projects["my-app"],
-      runtime: "docker",
-    };
-
-    const registryWithRuntimeMismatch: PluginRegistry = {
+    const registryWithSCM: PluginRegistry = {
       ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime" && name === "tmux") return tmuxRuntime;
-        if (slot === "runtime" && name === "docker") return dockerRuntime;
+      get: vi.fn().mockImplementation((slot: string) => {
         if (slot === "agent") return mockAgent;
         if (slot === "scm") return mockSCM;
         return null;
@@ -932,14 +914,13 @@ describe("check (single session)", () => {
 
     const lm = createLifecycleManager({
       config,
-      registry: registryWithRuntimeMismatch,
+      registry: registryWithSCM,
       sessionManager: mockSessionManager,
     });
 
     await lm.check("app-1");
 
-    expect(tmuxRuntime.destroy).toHaveBeenCalledWith(session.runtimeHandle);
-    expect(dockerRuntime.destroy).not.toHaveBeenCalled();
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-1");
   });
 
   it("uses runtimeHandle.runtimeName for liveness checks", async () => {
@@ -1121,7 +1102,7 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("mergeable");
     expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr, "squash");
     expect(mockSessionManager.list).not.toHaveBeenCalled();
-    expect(mockSessionManager.get).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.get).toHaveBeenCalledTimes(3);
   });
 
   it("auto-merges steady-state mergeable sessions after lifecycle restart", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -873,6 +873,75 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("merged");
   });
 
+  it("destroys the runtime using the session handle runtime name on terminal transitions", async () => {
+    const tmuxRuntime: Runtime = {
+      ...mockRuntime,
+      name: "tmux",
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const dockerRuntime: Runtime = {
+      ...mockRuntime,
+      name: "docker",
+      destroy: vi.fn().mockResolvedValue(undefined),
+    };
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("merged"),
+      mergePR: vi.fn(),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn(),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn(),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn(),
+    };
+
+    config.defaults.runtime = "docker";
+    config.projects["my-app"] = {
+      ...config.projects["my-app"],
+      runtime: "docker",
+    };
+
+    const registryWithRuntimeMismatch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime" && name === "tmux") return tmuxRuntime;
+        if (slot === "runtime" && name === "docker") return dockerRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    const session = makeSession({
+      status: "approved",
+      pr: makePR(),
+      runtimeHandle: { id: "tmux-app-1", runtimeName: "tmux", data: {} },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithRuntimeMismatch,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(tmuxRuntime.destroy).toHaveBeenCalledWith(session.runtimeHandle);
+    expect(dockerRuntime.destroy).not.toHaveBeenCalled();
+  });
+
   it("detects mergeable when approved + CI green", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",
@@ -924,6 +993,78 @@ describe("check (single session)", () => {
     await lm.check("app-1");
 
     expect(lm.getStates().get("app-1")).toBe("mergeable");
+  });
+
+  it("auto-merge reaction uses direct session lookup instead of listing all sessions", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "approved", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+    vi.mocked(mockSessionManager.list).mockRejectedValue(
+      new Error("auto-merge should not list all sessions"),
+    );
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "approved",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("mergeable");
+    expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr, "squash");
+    expect(mockSessionManager.list).not.toHaveBeenCalled();
+    expect(mockSessionManager.get).toHaveBeenCalledTimes(2);
   });
 
   it("throws for nonexistent session", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1067,6 +1067,73 @@ describe("check (single session)", () => {
     expect(mockSessionManager.get).toHaveBeenCalledTimes(2);
   });
 
+  it("auto-merges steady-state mergeable sessions after lifecycle restart", async () => {
+    config.reactions = {
+      "approved-and-green": {
+        auto: true,
+        action: "auto-merge",
+      },
+    };
+
+    const mockSCM: SCM = {
+      name: "mock-scm",
+      detectPR: vi.fn(),
+      getPRState: vi.fn().mockResolvedValue("open"),
+      mergePR: vi.fn().mockResolvedValue(undefined),
+      closePR: vi.fn(),
+      getCIChecks: vi.fn(),
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      getReviews: vi.fn(),
+      getReviewDecision: vi.fn().mockResolvedValue("approved"),
+      getPendingComments: vi.fn(),
+      getAutomatedComments: vi.fn(),
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      }),
+    };
+
+    const mockNotifier: Notifier = {
+      name: "desktop",
+      notify: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const registryWithSCM: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        return null;
+      }),
+    };
+
+    const session = makeSession({ status: "mergeable", pr: makePR() });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "mergeable",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithSCM,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(lm.getStates().get("app-1")).toBe("mergeable");
+    expect(mockSCM.mergePR).toHaveBeenCalledWith(session.pr, "squash");
+  });
+
   it("throws for nonexistent session", async () => {
     vi.mocked(mockSessionManager.get).mockResolvedValue(null);
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -942,6 +942,63 @@ describe("check (single session)", () => {
     expect(dockerRuntime.destroy).not.toHaveBeenCalled();
   });
 
+  it("uses runtimeHandle.runtimeName for liveness checks", async () => {
+    const tmuxRuntime: Runtime = {
+      ...mockRuntime,
+      name: "tmux",
+      isAlive: vi.fn().mockResolvedValue(true),
+      getOutput: vi.fn().mockResolvedValue(""),
+    };
+    const dockerRuntime: Runtime = {
+      ...mockRuntime,
+      name: "docker",
+      isAlive: vi.fn().mockResolvedValue(false),
+      getOutput: vi.fn().mockResolvedValue(""),
+    };
+
+    config.defaults.runtime = "docker";
+    config.projects["my-app"] = {
+      ...config.projects["my-app"],
+      runtime: "docker",
+    };
+
+    const registryWithRuntimeMismatch: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime" && name === "tmux") return tmuxRuntime;
+        if (slot === "runtime" && name === "docker") return dockerRuntime;
+        if (slot === "agent") return mockAgent;
+        return null;
+      }),
+    };
+
+    const session = makeSession({
+      status: "working",
+      pr: null,
+      runtimeHandle: { id: "tmux-app-1", runtimeName: "tmux", data: {} },
+    });
+    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+    });
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithRuntimeMismatch,
+      sessionManager: mockSessionManager,
+    });
+
+    await lm.check("app-1");
+
+    expect(tmuxRuntime.isAlive).toHaveBeenCalledWith(session.runtimeHandle);
+    expect(dockerRuntime.isAlive).not.toHaveBeenCalled();
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
   it("detects mergeable when approved + CI green", async () => {
     const mockSCM: SCM = {
       name: "mock-scm",

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -26,6 +26,7 @@ import {
   SessionNotRestorableError,
   WorkspaceMissingError,
   isIssueNotFoundError,
+  SESSION_STATUS,
   type OrchestratorConfig,
   type PluginRegistry,
   type Runtime,
@@ -304,6 +305,22 @@ describe("spawn", () => {
     expect(mockAgent.getLaunchCommand).toHaveBeenCalled();
     // Verify runtime was created
     expect(mockRuntime.create).toHaveBeenCalled();
+  });
+
+  it("blocks spawn when maxActiveWorkers limit is reached", async () => {
+    config.projects["my-app"].maxActiveWorkers = 1;
+    writeMetadata(sessionsDir, "app-9", {
+      worktree: join(tmpDir, "my-app", "app-9"),
+      branch: "feat/INT-9",
+      status: SESSION_STATUS.WORKING,
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await expect(sm.spawn({ projectId: "my-app" })).rejects.toThrow(/maxActiveWorkers=1/);
+    expect(mockRuntime.create).not.toHaveBeenCalled();
   });
 
   it("blocks spawn while the project is globally paused", async () => {

--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -2225,7 +2225,7 @@ describe("cleanup", () => {
     expect(result.skipped).toContain("app-1");
   });
 
-  it("skips orchestrator sessions by role metadata", async () => {
+  it("cleans dead orchestrator sessions when no open work exists (role metadata)", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -2240,8 +2240,7 @@ describe("cleanup", () => {
       }),
     };
 
-    // Session with role=orchestrator but a name that does NOT end in "-orchestrator"
-    // so only the role metadata check can protect it (not the name fallback)
+    // Dead orchestrator with no sibling workers and no tracker → should be cleaned
     writeMetadata(sessionsDir, "app-99", {
       worktree: "/tmp",
       branch: "main",
@@ -2254,11 +2253,10 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const result = await sm.cleanup();
 
-    expect(result.killed).toHaveLength(0);
-    expect(result.skipped).toContain("app-99");
+    expect(result.killed).toContain("app-99");
   });
 
-  it("skips orchestrator sessions by name fallback (no role metadata)", async () => {
+  it("cleans dead orchestrator sessions when no open work exists (name fallback)", async () => {
     const deadRuntime: Runtime = {
       ...mockRuntime,
       isAlive: vi.fn().mockResolvedValue(false),
@@ -2273,7 +2271,7 @@ describe("cleanup", () => {
       }),
     };
 
-    // Pre-existing orchestrator session without role field
+    // Dead orchestrator (by name convention) with no sibling workers → should be cleaned
     writeMetadata(sessionsDir, "app-orchestrator", {
       worktree: "/tmp",
       branch: "main",
@@ -2285,11 +2283,27 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const result = await sm.cleanup();
 
+    expect(result.killed).toContain("app-orchestrator");
+  });
+
+  it("skips live orchestrator sessions even with no open work", async () => {
+    // Live orchestrator should never be killed
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-orch")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const result = await sm.cleanup();
+
     expect(result.killed).toHaveLength(0);
     expect(result.skipped).toContain("app-orchestrator");
   });
 
-  it("never cleans the canonical orchestrator session even with stale worker-like metadata", async () => {
+  it("cleans dead orchestrator with stale metadata when tracker reports no open issues", async () => {
     const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator.log");
     const mockBin = installMockOpencode("[]", deleteLogPath);
     process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
@@ -2354,9 +2368,52 @@ describe("cleanup", () => {
     const sm = createSessionManager({ config, registry: registryWithSignals });
     const result = await sm.cleanup();
 
-    expect(result.killed).not.toContain("app-orchestrator");
+    // Dead orchestrator + no open issues (tracker has no listIssues, no sibling workers)
+    // → should be cleaned up
+    expect(result.killed).toContain("app-orchestrator");
+  });
+
+  it("skips dead orchestrator when tracker reports open issues", async () => {
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const trackerWithOpenIssues: Tracker = {
+      name: "mock-tracker",
+      getIssue: vi.fn(),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockReturnValue("https://example.com/1"),
+      branchName: vi.fn().mockReturnValue("feat/1"),
+      generatePrompt: vi.fn().mockResolvedValue(""),
+      listIssues: vi.fn().mockResolvedValue([
+        { id: "1", title: "Open issue", description: "", url: "https://example.com/1", state: "open", labels: [] },
+      ]),
+    };
+    const registryWithTracker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return trackerWithOpenIssues;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-orchestrator", {
+      worktree: "/tmp",
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-orch")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithTracker });
+    const result = await sm.cleanup();
+
+    // Dead orchestrator BUT tracker reports open issues → keep it for watchdog to restart
+    expect(result.killed).toHaveLength(0);
     expect(result.skipped).toContain("app-orchestrator");
-    expect(existsSync(deleteLogPath)).toBe(false);
   });
 
   it("never cleans archived orchestrator mappings even when metadata looks stale", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -147,6 +147,7 @@ const ProjectConfigSchema = z.object({
   repo: z.string(),
   path: z.string(),
   defaultBranch: z.string().default("main"),
+  maxActiveWorkers: z.number().int().positive().optional(),
   sessionPrefix: z
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/, "sessionPrefix must match [a-zA-Z0-9_-]+")

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -194,6 +194,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  const mergeConflictReactionFired = new Map<SessionId, boolean>();
+  const mergeReadyReactionFired = new Map<SessionId, boolean>();
+  const killedPrDetectionAttempts = new Map<SessionId, number>();
+  const MAX_KILLED_PR_DETECTION_ATTEMPTS = 10;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -824,6 +828,36 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
 
+    // Retry merge-ready auto-merge even without a fresh status transition.
+    // This covers lifecycle restarts where metadata already says "mergeable",
+    // so the transition-based reaction would otherwise never fire again.
+    if (session.pr && newStatus === "mergeable") {
+      const reactionConfig =
+        getReactionConfigForSession(session, "approved-and-green") ??
+        getReactionConfigForSession(session, "mergeable");
+      const transitionHandledMergeReady =
+        transitionReaction?.key === "approved-and-green" && transitionReaction.result?.success;
+      if (transitionHandledMergeReady) {
+        mergeReadyReactionFired.set(session.id, true);
+      }
+      const alreadyFired = mergeReadyReactionFired.get(session.id) === true;
+      if (reactionConfig && reactionConfig.auto !== false && !alreadyFired) {
+        const result = await executeReaction(
+          session.id,
+          session.projectId,
+          "approved-and-green",
+          reactionConfig,
+        );
+        if (result.success) {
+          mergeReadyReactionFired.set(session.id, true);
+        }
+      }
+    } else {
+      mergeReadyReactionFired.delete(session.id);
+      clearReactionTracker(session.id, "approved-and-green");
+      clearReactionTracker(session.id, "mergeable");
+    }
+
     // Check for merge conflicts on open PRs and trigger the merge-conflicts reaction.
     // This runs independently of status transitions because "pr_open" doesn't change
     // when conflicts appear — we need to actively detect them.
@@ -952,6 +986,21 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const sessionId = trackerKey.split(":")[0];
         if (sessionId && !currentSessionIds.has(sessionId)) {
           reactionTrackers.delete(trackerKey);
+        }
+      }
+      for (const sessionId of mergeConflictReactionFired.keys()) {
+        if (!currentSessionIds.has(sessionId)) {
+          mergeConflictReactionFired.delete(sessionId);
+        }
+      }
+      for (const sessionId of mergeReadyReactionFired.keys()) {
+        if (!currentSessionIds.has(sessionId)) {
+          mergeReadyReactionFired.delete(sessionId);
+        }
+      }
+      for (const sessionId of killedPrDetectionAttempts.keys()) {
+        if (!currentSessionIds.has(sessionId)) {
+          killedPrDetectionAttempts.delete(sessionId);
         }
       }
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -230,9 +230,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
 
+    const resolvedRuntimeName =
+      session.runtimeHandle?.runtimeName ?? project.runtime ?? config.defaults.runtime;
+
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
-      const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
+      const runtime = registry.get<Runtime>("runtime", resolvedRuntimeName);
       if (runtime) {
         const alive = await runtime.isAlive(session.runtimeHandle).catch(() => true);
         if (!alive) return "killed";
@@ -259,10 +262,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // proceed to PR checks below
         } else {
           // getActivityState returned null — fall back to terminal output parsing
-          const runtime = registry.get<Runtime>(
-            "runtime",
-            project.runtime ?? config.defaults.runtime,
-          );
+          const runtime = registry.get<Runtime>("runtime", resolvedRuntimeName);
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -853,21 +853,34 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // This covers lifecycle restarts where metadata already says "mergeable",
     // so the transition-based reaction would otherwise never fire again.
     if (session.pr && newStatus === "mergeable") {
-      const reactionConfig =
-        getReactionConfigForSession(session, "approved-and-green") ??
-        getReactionConfigForSession(session, "mergeable");
-      const transitionHandledMergeReady =
-        transitionReaction?.key === "approved-and-green" && transitionReaction.result?.success;
-      if (transitionHandledMergeReady) {
-        mergeReadyReactionFired.set(session.id, true);
-      }
+      const mergeReadyReaction =
+        getReactionConfigForSession(session, "approved-and-green") != null
+          ? {
+              key: "approved-and-green" as const,
+              config: getReactionConfigForSession(session, "approved-and-green")!,
+            }
+          : getReactionConfigForSession(session, "mergeable") != null
+            ? {
+                key: "mergeable" as const,
+                config: getReactionConfigForSession(session, "mergeable")!,
+              }
+            : null;
+
+      const transitionAttemptedMergeReady =
+        transitionReaction?.key === "approved-and-green" || transitionReaction?.key === "mergeable";
       const alreadyFired = mergeReadyReactionFired.get(session.id) === true;
-      if (reactionConfig && reactionConfig.auto !== false && !alreadyFired) {
+
+      if (
+        mergeReadyReaction &&
+        mergeReadyReaction.config.auto !== false &&
+        !alreadyFired &&
+        !transitionAttemptedMergeReady
+      ) {
         const result = await executeReaction(
           session.id,
           session.projectId,
-          "approved-and-green",
-          reactionConfig,
+          mergeReadyReaction.key,
+          mergeReadyReaction.config,
         );
         if (result.success) {
           mergeReadyReactionFired.set(session.id, true);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -465,21 +465,55 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       case "auto-merge": {
-        // Auto-merge is handled by the SCM plugin
-        // For now, just notify
-        const event = createEvent("reaction.triggered", {
-          sessionId,
-          projectId,
-          message: `Reaction '${reactionKey}' triggered auto-merge`,
-          data: { reactionKey },
-        });
-        await notifyHuman(event, "action");
-        return {
-          reactionType: reactionKey,
-          success: true,
-          action: "auto-merge",
-          escalated: false,
-        };
+        const project = config.projects[projectId];
+        const scmPlugin = project?.scm
+          ? registry.get<SCM>("scm", project.scm.plugin)
+          : null;
+        const targetSession = await sessionManager.get(sessionId);
+        if (!scmPlugin || !targetSession?.pr || targetSession.projectId !== projectId) {
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: false,
+          };
+        }
+        try {
+          const mergeMethod =
+            (reactionConfig as ReactionConfig & { mergeMethod?: MergeMethod }).mergeMethod ??
+            "squash";
+          await scmPlugin.mergePR(targetSession.pr, mergeMethod);
+          const event = createEvent("merge.completed", {
+            sessionId,
+            projectId,
+            message: `Auto-merged PR via '${reactionKey}' reaction (${mergeMethod})`,
+            data: { reactionKey, mergeMethod },
+          });
+          await notifyHuman(event, "action");
+          return {
+            reactionType: reactionKey,
+            success: true,
+            action: "auto-merge",
+            escalated: false,
+          };
+        } catch (err) {
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "lifecycle.auto-merge",
+            outcome: "failure",
+            correlationId: createCorrelationId("auto-merge"),
+            projectId,
+            sessionId,
+            data: { error: err instanceof Error ? err.message : String(err) },
+            level: "warn",
+          });
+          return {
+            reactionType: reactionKey,
+            success: false,
+            action: "auto-merge",
+            escalated: false,
+          };
+        }
       }
     }
 
@@ -789,6 +823,98 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
+
+    // Check for merge conflicts on open PRs and trigger the merge-conflicts reaction.
+    // This runs independently of status transitions because "pr_open" doesn't change
+    // when conflicts appear — we need to actively detect them.
+    if (session.pr && newStatus === "pr_open") {
+      const project = config.projects[session.projectId];
+      const scm = project?.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+      if (scm) {
+        try {
+          const mergeReady = await scm.getMergeability(session.pr);
+          if (!mergeReady.noConflicts) {
+            const reactionKey = "merge-conflicts";
+            const reactionConfig = getReactionConfigForSession(session, reactionKey);
+            const alreadyFired = mergeConflictReactionFired.get(session.id) === true;
+            if (reactionConfig && reactionConfig.auto !== false && !alreadyFired) {
+              const result = await executeReaction(
+                session.id,
+                session.projectId,
+                reactionKey,
+                reactionConfig,
+              );
+              if (result.success) {
+                mergeConflictReactionFired.set(session.id, true);
+              }
+            }
+          } else {
+            mergeConflictReactionFired.delete(session.id);
+            clearReactionTracker(session.id, "merge-conflicts");
+          }
+        } catch {
+          // Merge conflict detection is best-effort; don't block the poll cycle
+        }
+      }
+    } else {
+      mergeConflictReactionFired.delete(session.id);
+    }
+
+    // Clean up runtime for terminal sessions — kill the tmux session so workers
+    // don't sit idle on a Codex prompt after their PR is merged or the session
+    // is marked killed. Without this, merged sessions stay running forever.
+    if (
+      newStatus !== oldStatus &&
+      (newStatus === "merged" || newStatus === "killed") &&
+      session.runtimeHandle
+    ) {
+      try {
+        const project = config.projects[session.projectId];
+        const runtimeName =
+          session.runtimeHandle.runtimeName ??
+          (project ? (project.runtime ?? config.defaults.runtime) : config.defaults.runtime);
+        const runtimePlugin = registry.get<Runtime>("runtime", runtimeName);
+        if (runtimePlugin) {
+          await runtimePlugin.destroy(session.runtimeHandle);
+        }
+      } catch {
+        // Runtime cleanup is best-effort; don't fail the poll cycle
+      }
+    }
+  }
+
+  async function ensureOrchestratorsForOpenWork(sessions: Session[]): Promise<boolean> {
+    const projectIds = scopedProjectId ? [scopedProjectId] : Object.keys(config.projects);
+    let spawnedOrchestrator = false;
+
+    await Promise.allSettled(
+      projectIds.map(async (projectId) => {
+        const project = config.projects[projectId];
+        if (!project) return;
+
+        const projectSessions = sessions.filter((session) => session.projectId === projectId);
+        const hasOpenWork = projectSessions.some(
+          (session) =>
+            !isOrchestratorSession(session) &&
+            !TERMINAL_STATUSES.has(session.status),
+        );
+        if (!hasOpenWork) return;
+
+        const hasLiveOrchestrator = projectSessions.some(
+          (session) => isOrchestratorSession(session) && !TERMINAL_STATUSES.has(session.status),
+        );
+        if (hasLiveOrchestrator) return;
+
+        await sessionManager.spawnOrchestrator({
+          projectId,
+          systemPrompt: generateOrchestratorPrompt({ config, projectId, project }),
+          prompt: generateOrchestratorStartupPrompt({ config, projectId, project }),
+        });
+        spawnedOrchestrator = true;
+      }),
+    );
+
+    return spawnedOrchestrator;
   }
 
   /** Run one polling cycle across all sessions. */

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -854,12 +854,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // so the transition-based reaction would otherwise never fire again.
     if (session.pr && newStatus === "mergeable") {
       const mergeReadyReaction =
-        getReactionConfigForSession(session, "approved-and-green") != null
+        getReactionConfigForSession(session, "approved-and-green") !== null
           ? {
               key: "approved-and-green" as const,
               config: getReactionConfigForSession(session, "approved-and-green")!,
             }
-          : getReactionConfigForSession(session, "mergeable") != null
+          : getReactionConfigForSession(session, "mergeable") !== null
             ? {
                 key: "mergeable" as const,
                 config: getReactionConfigForSession(session, "mergeable")!,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -31,6 +31,7 @@ import {
   type Notifier,
   type Session,
   type EventPriority,
+  type MergeMethod,
   type ProjectConfig as _ProjectConfig,
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -196,8 +196,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
   const mergeConflictReactionFired = new Map<SessionId, boolean>();
   const mergeReadyReactionFired = new Map<SessionId, boolean>();
-  const killedPrDetectionAttempts = new Map<SessionId, number>();
-  const MAX_KILLED_PR_DETECTION_ATTEMPTS = 10;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -748,6 +746,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       tracked ?? ((session.metadata?.["status"] as SessionStatus | undefined) || session.status);
     const newStatus = await determineStatus(session);
     let transitionReaction: { key: string; result: ReactionResult | null } | undefined;
+    let killedThisCheck = false;
 
     if (newStatus !== oldStatus) {
       const correlationId = createCorrelationId("lifecycle-transition");
@@ -821,10 +820,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           await notifyHuman(event, priority);
         }
       }
+
+      // Clean up runtime and workspace for terminal sessions.
+      // When lifecycle detects a "merged" or "killed" transition, the metadata
+      // is updated but the runtime (tmux) and workspace (worktree) are left
+      // running. Calling sessionManager.kill() tears down runtime + workspace
+      // and archives the metadata — the same thing `ao session kill` does manually.
+      if (newStatus === "merged" || newStatus === "killed") {
+        try {
+          await sessionManager.kill(session.id);
+          killedThisCheck = true;
+        } catch {
+          // Session may already be partially cleaned up — not critical
+        }
+      }
     } else {
       // No transition but track current state
       states.set(session.id, newStatus);
     }
+
+    if (killedThisCheck) return;
+
+    // Avoid recreating archived metadata if the session was removed between
+    // transition handling and review backlog processing.
+    const stillExists = await sessionManager.get(session.id);
+    if (!stillExists) return;
 
     await maybeDispatchReviewBacklog(session, oldStatus, newStatus, transitionReaction);
 
@@ -894,61 +914,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       mergeConflictReactionFired.delete(session.id);
     }
 
-    // Clean up runtime for terminal sessions — kill the tmux session so workers
-    // don't sit idle on a Codex prompt after their PR is merged or the session
-    // is marked killed. Without this, merged sessions stay running forever.
-    if (
-      newStatus !== oldStatus &&
-      (newStatus === "merged" || newStatus === "killed") &&
-      session.runtimeHandle
-    ) {
-      try {
-        const project = config.projects[session.projectId];
-        const runtimeName =
-          session.runtimeHandle.runtimeName ??
-          (project ? (project.runtime ?? config.defaults.runtime) : config.defaults.runtime);
-        const runtimePlugin = registry.get<Runtime>("runtime", runtimeName);
-        if (runtimePlugin) {
-          await runtimePlugin.destroy(session.runtimeHandle);
-        }
-      } catch {
-        // Runtime cleanup is best-effort; don't fail the poll cycle
-      }
-    }
-  }
-
-  async function ensureOrchestratorsForOpenWork(sessions: Session[]): Promise<boolean> {
-    const projectIds = scopedProjectId ? [scopedProjectId] : Object.keys(config.projects);
-    let spawnedOrchestrator = false;
-
-    await Promise.allSettled(
-      projectIds.map(async (projectId) => {
-        const project = config.projects[projectId];
-        if (!project) return;
-
-        const projectSessions = sessions.filter((session) => session.projectId === projectId);
-        const hasOpenWork = projectSessions.some(
-          (session) =>
-            !isOrchestratorSession(session) &&
-            !TERMINAL_STATUSES.has(session.status),
-        );
-        if (!hasOpenWork) return;
-
-        const hasLiveOrchestrator = projectSessions.some(
-          (session) => isOrchestratorSession(session) && !TERMINAL_STATUSES.has(session.status),
-        );
-        if (hasLiveOrchestrator) return;
-
-        await sessionManager.spawnOrchestrator({
-          projectId,
-          systemPrompt: generateOrchestratorPrompt({ config, projectId, project }),
-          prompt: generateOrchestratorStartupPrompt({ config, projectId, project }),
-        });
-        spawnedOrchestrator = true;
-      }),
-    );
-
-    return spawnedOrchestrator;
   }
 
   /** Run one polling cycle across all sessions. */
@@ -996,11 +961,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       for (const sessionId of mergeReadyReactionFired.keys()) {
         if (!currentSessionIds.has(sessionId)) {
           mergeReadyReactionFired.delete(sessionId);
-        }
-      }
-      for (const sessionId of killedPrDetectionAttempts.keys()) {
-        if (!currentSessionIds.has(sessionId)) {
-          killedPrDetectionAttempts.delete(sessionId);
         }
       }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1669,12 +1669,74 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           continue;
         }
 
+        const plugins = resolvePlugins(project);
+
+        // Orchestrator sessions are normally protected from cleanup, but stale
+        // orchestrators (runtime dead + no open work) should be archived so
+        // they don't linger in `ao status` indefinitely.
         if (isCleanupProtectedSession(project, session.id, session.metadata)) {
-          pushSkipped(session.projectId, session.id);
+          let orchestratorStale = false;
+          if (session.runtimeHandle && plugins.runtime) {
+            try {
+              const alive = await plugins.runtime.isAlive(session.runtimeHandle);
+              if (!alive) orchestratorStale = true;
+            } catch {
+              orchestratorStale = true;
+            }
+          } else {
+            // No runtime handle → already dead
+            orchestratorStale = true;
+          }
+
+          if (!orchestratorStale) {
+            // Orchestrator is still alive — don't touch it
+            pushSkipped(session.projectId, session.id);
+            continue;
+          }
+
+          // Runtime is dead — check if there's still open work by looking at
+          // sibling worker sessions in this project.
+          let hasOpenWork = false;
+
+          // Quick local check: are there any non-orchestrator active sessions?
+          const siblingWorkers = sessions.filter(
+            (s) =>
+              s.projectId === session.projectId &&
+              s.id !== session.id &&
+              !isOrchestratorSession({ id: s.id, metadata: s.metadata }),
+          );
+          if (siblingWorkers.length > 0) {
+            hasOpenWork = true;
+          }
+
+          // Also check the tracker for open issues if available
+          if (!hasOpenWork && plugins.tracker?.listIssues) {
+            try {
+              const openIssues = await plugins.tracker.listIssues(
+                { state: "open", limit: 1 },
+                project,
+              );
+              if (openIssues && openIssues.length > 0) hasOpenWork = true;
+            } catch {
+              // Can't check — assume there might be work, keep it safe
+              hasOpenWork = true;
+            }
+          }
+
+          if (hasOpenWork) {
+            // Still has work but runtime dead — skip, watchdog will restart it
+            pushSkipped(session.projectId, session.id);
+            continue;
+          }
+
+          // Dead orchestrator with no open work → kill it
+          if (!options?.dryRun) {
+            await kill(session.id, { purgeOpenCode: shouldPurgeOpenCode });
+          }
+          pushKilled(session.projectId, session.id);
           continue;
         }
 
-        const plugins = resolvePlugins(project);
         let shouldKill = false;
 
         // Check if PR is merged

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1717,7 +1717,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             (s) =>
               s.projectId === session.projectId &&
               s.id !== session.id &&
-              !isOrchestratorSession({ id: s.id, metadata: s.metadata }),
+              !isOrchestratorSession({ id: s.id, metadata: s.metadata }) &&
+              !TERMINAL_STATUSES.has(s.status),
           );
           if (siblingWorkers.length > 0) {
             hasOpenWork = true;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -20,6 +20,7 @@ import {
   isIssueNotFoundError,
   isRestorable,
   NON_RESTORABLE_STATUSES,
+  TERMINAL_STATUSES,
   SessionNotFoundError,
   SessionNotRestorableError,
   WorkspaceMissingError,
@@ -933,6 +934,19 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           // Other error (auth, network, etc) - fail fast
           throw new Error(`Failed to fetch issue ${spawnConfig.issueId}: ${err}`, { cause: err });
         }
+      }
+    }
+
+    if (project.maxActiveWorkers !== undefined) {
+      const activeWorkers = loadActiveSessionRecords(project).filter(
+        ({ sessionName, raw }) =>
+          !isOrchestratorSessionRecord(sessionName, raw) &&
+          !TERMINAL_STATUSES.has((raw["status"] as Session["status"]) ?? "working"),
+      );
+      if (activeWorkers.length >= project.maxActiveWorkers) {
+        throw new Error(
+          `Project '${spawnConfig.projectId}' already has ${activeWorkers.length} active worker(s); maxActiveWorkers=${project.maxActiveWorkers}`,
+        );
       }
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -945,6 +945,9 @@ export interface ProjectConfig {
   /** Default branch (main, master, next, develop, etc.) */
   defaultBranch: string;
 
+  /** Maximum number of active worker sessions allowed for this project. */
+  maxActiveWorkers?: number;
+
   /** Session name prefix (e.g. "app" → "app-1", "app-2") */
   sessionPrefix: string;
 


### PR DESCRIPTION
## Summary
- rebuild C2 cleanly from current `main` in a fresh branch
- consolidate the intended cleanup/session-lifecycle scope from #580, #547 (excluding notifier-related pieces), #584, and #615
- explicitly strip control-plane/orchestrator-respawn spillover from the old contaminated C2 line

## Included scope
- #580 runtime-aware cleanup + direct session lookup for merge handling
- #547 terminal-session cleanup via `sessionManager.kill()` without notifier-related changes
- #584 auto-archive stale orchestrator sessions when runtime is dead and no open work remains
- #615 avoid recreating metadata after lifecycle kill and enforce max active worker limits

## Explicitly excluded
- notifier / notification-routing additions that belong to C5 / #659
- control-plane orchestrator-respawn spillover (`ensureOrchestratorsForOpenWork` and related accumulator residue)

## Verification
- `pnpm --filter @composio/ao-core typecheck`
- `pnpm --filter @composio/ao-core build`
- `pnpm --filter @composio/ao-core test -- src/__tests__/lifecycle-manager.test.ts src/__tests__/session-manager.test.ts src/__tests__/config-validation.test.ts`
- `pnpm --filter @composio/ao-plugin-agent-claude-code --filter @composio/ao-plugin-agent-codex --filter @composio/ao-plugin-agent-aider --filter @composio/ao-plugin-agent-opencode --filter @composio/ao-plugin-scm-github build`
- `pnpm --filter @composio/ao-cli typecheck`
- `pnpm --filter @composio/ao-cli build`

## Notes
This branch replaces the previous messy local C2 line; no protected history was rewritten.
