### PR TITLE
fix(scm-github): filter bot review comments by GraphQL __typename

### DIFF
--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -790,7 +790,7 @@ function createGitHubSCM(): SCM {
                     comments(first: 1) {
                       nodes {
                         id
-                        author { login }
+                        author { __typename login }
                         body
                         path
                         line
@@ -815,7 +815,7 @@ function createGitHubSCM(): SCM {
                     comments: {
                       nodes: Array<{
                         id: string;
-                        author: { login: string } | null;
+                        author: { __typename: string; login: string } | null;
                         body: string;
                         path: string | null;
                         line: number | null;
@@ -838,7 +838,9 @@ function createGitHubSCM(): SCM {
             const c = t.comments.nodes[0];
             if (!c) return false; // skip threads with no comments
             const author = c.author?.login ?? "";
-            return !BOT_AUTHORS.has(author);
+            const isBot =
+              c.author?.__typename === "Bot" || BOT_AUTHORS.has(author);
+            return !isBot;
           })
           .map((t) => {
             const c = t.comments.nodes[0];

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -772,6 +772,7 @@ describe("scm-github plugin", () => {
         isResolved: boolean;
         id: string;
         author: string | null;
+        authorType?: string;
         body: string;
         path: string | null;
         line: number | null;
@@ -790,7 +791,9 @@ describe("scm-github plugin", () => {
                     nodes: [
                       {
                         id: t.id,
-                        author: t.author ? { login: t.author } : null,
+                        author: t.author
+                          ? { __typename: t.authorType ?? "User", login: t.author }
+                          : null,
                         body: t.body,
                         path: t.path,
                         line: t.line,
@@ -845,6 +848,7 @@ describe("scm-github plugin", () => {
             isResolved: false,
             id: "C1",
             author: "alice",
+            authorType: "User",
             body: "Fix this",
             path: "a.ts",
             line: 1,
@@ -854,7 +858,8 @@ describe("scm-github plugin", () => {
           {
             isResolved: false,
             id: "C2",
-            author: "cursor[bot]",
+            author: "cursor",
+            authorType: "Bot",
             body: "Bot says",
             path: "a.ts",
             line: 2,
@@ -864,10 +869,88 @@ describe("scm-github plugin", () => {
           {
             isResolved: false,
             id: "C3",
-            author: "codecov[bot]",
+            author: "codecov",
+            authorType: "Bot",
             body: "Coverage",
             path: "a.ts",
             line: 3,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+        ]),
+      );
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].author).toBe("alice");
+    });
+
+    it("filters out GitHub App bots by __typename even without [bot] suffix", async () => {
+      mockGh(
+        makeGraphQLThreads([
+          {
+            isResolved: false,
+            id: "C1",
+            author: "alice",
+            authorType: "User",
+            body: "Human review",
+            path: "a.ts",
+            line: 1,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            isResolved: false,
+            id: "C2",
+            author: "cursor",
+            authorType: "Bot",
+            body: "Bugbot found issue",
+            path: "a.ts",
+            line: 2,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            isResolved: false,
+            id: "C3",
+            author: "some-new-bot",
+            authorType: "Bot",
+            body: "New bot review",
+            path: "a.ts",
+            line: 3,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+        ]),
+      );
+
+      const comments = await scm.getPendingComments(pr);
+      expect(comments).toHaveLength(1);
+      expect(comments[0]).toMatchObject({ id: "C1", author: "alice" });
+    });
+
+    it("filters non-App bots via BOT_AUTHORS even with __typename User", async () => {
+      mockGh(
+        makeGraphQLThreads([
+          {
+            isResolved: false,
+            id: "C1",
+            author: "alice",
+            authorType: "User",
+            body: "Human review",
+            path: "a.ts",
+            line: 1,
+            url: "u",
+            createdAt: "2025-01-01T00:00:00Z",
+          },
+          {
+            isResolved: false,
+            id: "C2",
+            author: "snyk-bot",
+            authorType: "User",
+            body: "Snyk found vulnerability",
+            path: "a.ts",
+            line: 2,
             url: "u",
             createdAt: "2025-01-01T00:00:00Z",
           },


### PR DESCRIPTION
## Summary

- **Root cause**: `getPendingComments()` uses GitHub's GraphQL API, which returns bot logins without the `[bot]` suffix (e.g. `"cursor"` not `"cursor[bot]"`). `BOT_AUTHORS` contains entries with `[bot]`, so the check fails and bot comments leak through as human pending comments.
- **Impact**: The lifecycle manager dispatches both `changes-requested` and `bugbot-comments` reactions for the same bot review thread — the agent gets duplicate instructions.
- **Fix**: Add `__typename` to the GraphQL author field. Check `author.__typename === "Bot"` in addition to the existing `BOT_AUTHORS` name check. This catches all GitHub App bots regardless of login format.

## Before → After

| Scenario | Before | After |
|----------|--------|-------|
| Cursor bot leaves unresolved review threads | Leak into `getPendingComments` as "human" | Filtered out (`__typename === "Bot"`) |
| Human + bot review same PR | `getPendingComments` returns human + bot | Returns human only |
| Reaction dispatch for bot threads | Dispatched twice (`changes-requested` + `bugbot-comments`) | Dispatched once (`bugbot-comments` only) |
| `getAutomatedComments` (REST) | Unaffected | No change |

## Changes

| File | Change |
|------|--------|
| `packages/plugins/scm-github/src/index.ts` | Add `__typename` to GraphQL author selection; check `author.__typename === "Bot"` in filter |
| `packages/plugins/scm-github/test/index.test.ts` | Update existing bot test to use realistic GraphQL data; add tests for `__typename`-based filtering |

## Test plan

- [x] Bot with `__typename: "Bot"` and login without `[bot]` suffix is filtered out
- [x] Human with `__typename: "User"` passes through (regression)
- [x] Non-App bot in `BOT_AUTHORS` (`snyk-bot`, `__typename: "User"`) still filtered by name
- [x] Existing tests updated to use realistic GraphQL login format
- [ ] Verify against live PR with Cursor bot review threads

Closes #702