### PR TITLE
fix(#545): centralize SCM metadata persistence to eliminate stale status data

### DIFF
--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -97,7 +97,15 @@ async function gatherSessionInfo(
   if (branch && !suppressPROwnership) {
     try {
       const project = projectConfig.projects[session.projectId];
-      if (project) {
+      const lastPoll = session.metadata["scm_last_poll"]
+        ? parseInt(session.metadata["scm_last_poll"], 10)
+        : 0;
+      const isFresh = Date.now() - lastPoll < 300_000;
+
+      if (isFresh && session.metadata["scm_pr_state"]) {
+        ciStatus = (session.metadata["scm_ci_status"] as CIStatus) || null;
+        reviewDecision = (session.metadata["scm_review_decision"] as ReviewDecision) || null;
+      } else if (project) {
         const prInfo: PRInfo | null = await scm.detectPR(session, project);
         if (prInfo) {
           prNumber = prInfo.number;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -312,15 +312,23 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (session.pr && scm) {
       try {
         const prState = await scm.getPRState(session.pr);
+        const ciStatus = await scm.getCISummary(session.pr);
+        const reviewDecision = await scm.getReviewDecision(session.pr);
+        const sessionsDir = getSessionsDir(config.configPath, project.path);
+
+        // Persist SCM metadata on every poll to ensure Dashboard/CLI stay fresh
+        updateMetadata(sessionsDir, session.id, {
+          scm_pr_state: prState,
+          scm_ci_status: ciStatus,
+          scm_review_decision: reviewDecision,
+          scm_last_poll: Date.now().toString(),
+        });
+
         if (prState === PR_STATE.MERGED) return "merged";
         if (prState === PR_STATE.CLOSED) return "killed";
-
-        // Check CI
-        const ciStatus = await scm.getCISummary(session.pr);
         if (ciStatus === CI_STATUS.FAILING) return "ci_failed";
 
         // Check reviews
-        const reviewDecision = await scm.getReviewDecision(session.pr);
         if (reviewDecision === "changes_requested") return "changes_requested";
         if (reviewDecision === "approved" || reviewDecision === "none") {
           // Check merge readiness — treat "none" (no reviewers required)


### PR DESCRIPTION
## Summary
Refactor the `LifecycleManager` to persist SCM metadata (PR state, CI status, review decisions) to session files during every polling cycle. Update the `status` command to prefer this cached metadata, ensuring the CLI and Dashboard show real-time state without redundant API overhead.

## Problem
Currently, `ao status` and the Dashboard perform a fresh SCM lookup (e.g., via GitHub API) every time they are rendered. This leads to stale data indicators (e.g. PR merged but review pending) and redundant API overhead.

## Solution
- **Atomic Persistence in Lifecycle**: Updated `LifecycleManager.checkSession` to save `scm_pr_state`, `scm_ci_status`, and `scm_review_decision` to the session metadata store whenever it polls.
- **Immediate Reporting**: Added `scm_last_poll` timestamp to verify freshness.
- **Cache-first CLI**: Updated the `status` command to use this cached metadata if it's recent (< 5 minutes), falling back to a live lookup only if necessary.
- **Fixes #545**

## Verification
- **Polling Test**: Confirmed that `sessions/<id>/metadata.json` is correctly updated with SCM stats after a poll.
- **CLI Performance**: Verified that `ao status` returns immediately using cached data.