### PR TITLE
feat(core): extract shared test utilities and migrate lifecycle-manager tests

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1,164 +1,73 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
-import { join } from "node:path";
-import { tmpdir } from "node:os";
-import { randomUUID } from "node:crypto";
 import { createLifecycleManager } from "../lifecycle-manager.js";
 import { createSessionManager } from "../session-manager.js";
 import { writeMetadata, readMetadataRaw } from "../metadata.js";
-import { getSessionsDir, getProjectBaseDir } from "../paths.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
   SessionManager,
-  Session,
   Runtime,
   Agent,
-  SCM,
-  Notifier,
   ActivityState,
-  PRInfo,
+  SCM,
 } from "../types.js";
+import {
+  createTestEnvironment,
+  createMockPlugins,
+  createMockRegistry,
+  createMockSessionManager,
+  createMockSCM,
+  createMockNotifier,
+  makeSession,
+  makePR,
+  type TestEnvironment,
+  type MockPlugins,
+} from "./test-utils.js";
 
-let tmpDir: string;
-let configPath: string;
-let sessionsDir: string;
-let mockSessionManager: SessionManager;
-let mockRuntime: Runtime;
-let mockAgent: Agent;
+let env: TestEnvironment;
+let plugins: MockPlugins;
 let mockRegistry: PluginRegistry;
+let mockSessionManager: SessionManager;
 let config: OrchestratorConfig;
 
-function makeSession(overrides: Partial<Session> = {}): Session {
-  return {
-    id: "app-1",
-    projectId: "my-app",
-    status: "spawning",
-    activity: "active",
-    branch: "feat/test",
-    issueId: null,
-    pr: null,
-    workspacePath: "/tmp/ws",
-    runtimeHandle: { id: "rt-1", runtimeName: "mock", data: {} },
-    agentInfo: null,
-    createdAt: new Date(),
-    lastActivityAt: new Date(),
-    metadata: {},
-    ...overrides,
-  };
-}
-
-function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
-  return {
-    number: 42,
-    url: "https://github.com/org/repo/pull/42",
-    title: "Fix things",
-    owner: "org",
-    repo: "repo",
-    branch: "feat/test",
-    baseBranch: "main",
-    isDraft: false,
-    ...overrides,
-  };
-}
-
 beforeEach(() => {
-  tmpDir = join(tmpdir(), `ao-test-lifecycle-${randomUUID()}`);
-  mkdirSync(tmpDir, { recursive: true });
-
-  // Create a temporary config file
-  configPath = join(tmpDir, "agent-orchestrator.yaml");
-  writeFileSync(configPath, "projects: {}\n");
-
-  mockRuntime = {
-    name: "mock",
-    create: vi.fn(),
-    destroy: vi.fn(),
-    sendMessage: vi.fn().mockResolvedValue(undefined),
-    getOutput: vi.fn().mockResolvedValue("$ some terminal output\n"),
-    isAlive: vi.fn().mockResolvedValue(true),
-  };
-
-  mockAgent = {
-    name: "mock-agent",
-    processName: "mock",
-    getLaunchCommand: vi.fn(),
-    getEnvironment: vi.fn(),
-    detectActivity: vi.fn().mockReturnValue("active" as ActivityState),
-    getActivityState: vi.fn().mockResolvedValue({ state: "active" as ActivityState }),
-    isProcessRunning: vi.fn().mockResolvedValue(true),
-    getSessionInfo: vi.fn().mockResolvedValue(null),
-  };
-
-  mockRegistry = {
-    register: vi.fn(),
-    get: vi.fn().mockImplementation((slot: string) => {
-      if (slot === "runtime") return mockRuntime;
-      if (slot === "agent") return mockAgent;
-      return null;
-    }),
-    list: vi.fn().mockReturnValue([]),
-    loadBuiltins: vi.fn(),
-    loadFromConfig: vi.fn(),
-  };
-
-  mockSessionManager = {
-    spawn: vi.fn(),
-    spawnOrchestrator: vi.fn(),
-    restore: vi.fn(),
-    list: vi.fn().mockResolvedValue([]),
-    get: vi.fn().mockResolvedValue(null),
-    kill: vi.fn().mockResolvedValue(undefined),
-    cleanup: vi.fn(),
-    send: vi.fn().mockResolvedValue(undefined),
-    claimPR: vi.fn(),
-  } as SessionManager;
-
-  config = {
-    configPath,
-    port: 3000,
-    defaults: {
-      runtime: "mock",
-      agent: "mock-agent",
-      workspace: "mock-ws",
-      notifiers: ["desktop"],
-    },
-    projects: {
-      "my-app": {
-        name: "My App",
-        repo: "org/my-app",
-        path: join(tmpDir, "my-app"),
-        defaultBranch: "main",
-        sessionPrefix: "app",
-        scm: { plugin: "github" },
-      },
-    },
-    notifiers: {},
-    notificationRouting: {
-      urgent: ["desktop"],
-      action: ["desktop"],
-      warning: [],
-      info: [],
-    },
-    reactions: {},
-    readyThresholdMs: 300_000,
-  };
-
-  // Calculate sessions directory
-  sessionsDir = getSessionsDir(configPath, join(tmpDir, "my-app"));
-  mkdirSync(sessionsDir, { recursive: true });
+  env = createTestEnvironment();
+  plugins = createMockPlugins();
+  mockRegistry = createMockRegistry({ runtime: plugins.runtime, agent: plugins.agent });
+  mockSessionManager = createMockSessionManager();
+  config = env.config;
 });
 
 afterEach(() => {
-  // Clean up hash-based directories in ~/.agent-orchestrator
-  const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
-  if (existsSync(projectBaseDir)) {
-    rmSync(projectBaseDir, { recursive: true, force: true });
-  }
-
-  // Clean up tmpDir
-  rmSync(tmpDir, { recursive: true, force: true });
+  env.cleanup();
 });
+
+/** Helper: write standard session metadata and return a lifecycle manager */
+function setupCheck(
+  sessionId: string,
+  opts: {
+    session: ReturnType<typeof makeSession>;
+    metaOverrides?: Record<string, unknown>;
+    registry?: PluginRegistry;
+    configOverride?: OrchestratorConfig;
+  },
+) {
+  vi.mocked(mockSessionManager.get).mockResolvedValue(opts.session);
+
+  writeMetadata(env.sessionsDir, sessionId, {
+    worktree: "/tmp",
+    branch: opts.session.branch ?? "main",
+    status: opts.session.status,
+    project: "my-app",
+    ...opts.metaOverrides,
+  });
+
+  return createLifecycleManager({
+    config: opts.configOverride ?? config,
+    registry: opts.registry ?? mockRegistry,
+    sessionManager: mockSessionManager,
+  });
+}
 
 describe("start / stop", () => {
   it("starts and stops the polling loop", () => {
@@ -179,50 +88,37 @@ describe("start / stop", () => {
 
 describe("check (single session)", () => {
   it("detects transition from spawning to working", async () => {
-    const session = makeSession({ status: "spawning" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    // Write metadata so updateMetadata works
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "spawning",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "spawning" }),
     });
 
     await lm.check("app-1");
 
     expect(lm.getStates().get("app-1")).toBe("working");
-
-    // Metadata should be updated
-    const meta = readMetadataRaw(sessionsDir, "app-1");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
     expect(meta!["status"]).toBe("working");
   });
 
   it("uses worker-specific agent fallback when metadata does not persist an agent", async () => {
     const codexAgent: Agent = {
-      ...mockAgent,
+      ...plugins.agent,
       name: "codex",
       processName: "codex",
       getActivityState: vi.fn().mockResolvedValue({ state: "active" as ActivityState }),
     };
+
     const registryWithMultipleAgents: PluginRegistry = {
       ...mockRegistry,
       get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime") return mockRuntime;
+        if (slot === "runtime") return plugins.runtime;
         if (slot === "agent") {
           if (name === "codex") return codexAgent;
-          if (name === "mock-agent") return mockAgent;
+          if (name === "mock-agent") return plugins.agent;
         }
         return null;
       }),
     };
+
     const configWithWorkerAgent: OrchestratorConfig = {
       ...config,
       projects: {
@@ -230,260 +126,131 @@ describe("check (single session)", () => {
         "my-app": {
           ...config.projects["my-app"],
           agent: "mock-agent",
-          worker: {
-            agent: "codex",
-          },
+          worker: { agent: "codex" },
         },
       },
     };
-    const session = makeSession({ status: "working", metadata: {} });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
 
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config: configWithWorkerAgent,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working", metadata: {} }),
       registry: registryWithMultipleAgents,
-      sessionManager: mockSessionManager,
+      configOverride: configWithWorkerAgent,
     });
 
     await lm.check("app-1");
 
     expect(codexAgent.getActivityState).toHaveBeenCalled();
-    expect(mockAgent.getActivityState).not.toHaveBeenCalled();
+    expect(plugins.agent.getActivityState).not.toHaveBeenCalled();
   });
 
   it("detects killed state when runtime is dead", async () => {
-    vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(false);
 
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
   it("detects killed state when getActivityState returns exited", async () => {
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue({ state: "exited" });
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "exited" });
 
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
   it("detects killed via terminal fallback when getActivityState returns null", async () => {
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue(null);
-    vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");
-    vi.mocked(mockAgent.isProcessRunning).mockResolvedValue(false);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(false);
 
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("killed");
   });
 
   it("stays working when agent is idle but process is still running (fallback path)", async () => {
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue(null);
-    vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");
-    vi.mocked(mockAgent.isProcessRunning).mockResolvedValue(true);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.agent.detectActivity).mockReturnValue("idle");
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue(true);
 
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("working");
   });
 
   it("detects needs_input from agent", async () => {
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue({ state: "waiting_input" });
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({ state: "waiting_input" });
 
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("needs_input");
   });
 
   it("transitions to stuck when idle exceeds agent-stuck threshold (OpenCode-style activity)", async () => {
     config.reactions = {
-      "agent-stuck": {
-        auto: true,
-        action: "notify",
-        threshold: "1m",
-      },
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m" },
     };
 
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue({
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
       state: "idle",
       timestamp: new Date(Date.now() - 120_000),
     });
 
-    const session = makeSession({ status: "working", metadata: { agent: "opencode" } });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-      agent: "opencode",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working", metadata: { agent: "opencode" } }),
+      metaOverrides: { agent: "opencode" },
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
   it("uses global agent-stuck threshold when project override omits threshold", async () => {
     config.reactions = {
-      "agent-stuck": {
-        auto: true,
-        action: "notify",
-        threshold: "1m",
-      },
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m" },
     };
     config.projects["my-app"] = {
       ...config.projects["my-app"],
-      reactions: {
-        "agent-stuck": {
-          auto: true,
-          action: "notify",
-        },
-      },
+      reactions: { "agent-stuck": { auto: true, action: "notify" } },
     };
 
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue({
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
       state: "idle",
       timestamp: new Date(Date.now() - 120_000),
     });
 
-    const session = makeSession({ status: "working", metadata: { agent: "opencode" } });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-      agent: "opencode",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working", metadata: { agent: "opencode" } }),
+      metaOverrides: { agent: "opencode" },
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
   it("still auto-detects PR before marking idle sessions as stuck", async () => {
     config.reactions = {
-      "agent-stuck": {
-        auto: true,
-        action: "notify",
-        threshold: "1m",
-      },
+      "agent-stuck": { auto: true, action: "notify", threshold: "1m" },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
+    const mockSCM = createMockSCM({
       detectPR: vi.fn().mockResolvedValue(makePR()),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
       getMergeability: vi.fn().mockResolvedValue({
         mergeable: false,
         ciPassing: true,
@@ -491,203 +258,98 @@ describe("check (single session)", () => {
         noConflicts: true,
         blockers: [],
       }),
-    };
+    });
 
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
 
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue({
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue({
       state: "idle",
       timestamp: new Date(Date.now() - 120_000),
     });
 
-    const session = makeSession({
-      status: "working",
-      branch: "feat/test",
-      pr: null,
-      metadata: { agent: "opencode" },
-    });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "feat/test",
-      status: "working",
-      project: "my-app",
-      agent: "opencode",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({
+        status: "working",
+        branch: "feat/test",
+        pr: null,
+        metadata: { agent: "opencode" },
+      }),
+      metaOverrides: { branch: "feat/test", agent: "opencode" },
+      registry,
     });
 
     await lm.check("app-1");
 
     expect(mockSCM.detectPR).toHaveBeenCalledOnce();
-    const meta = readMetadataRaw(sessionsDir, "app-1");
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
     expect(meta?.["pr"]).toBe(makePR().url);
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
   it("preserves stuck state when getActivityState throws", async () => {
-    vi.mocked(mockAgent.getActivityState).mockRejectedValue(new Error("probe failed"));
+    vi.mocked(plugins.agent.getActivityState).mockRejectedValue(new Error("probe failed"));
 
-    const session = makeSession({ status: "stuck" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "stuck",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "stuck" }),
     });
 
     await lm.check("app-1");
-
-    // Should preserve "stuck" — NOT coerce to "working"
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
   it("preserves needs_input state when getActivityState throws", async () => {
-    vi.mocked(mockAgent.getActivityState).mockRejectedValue(new Error("probe failed"));
+    vi.mocked(plugins.agent.getActivityState).mockRejectedValue(new Error("probe failed"));
 
-    const session = makeSession({ status: "needs_input" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "needs_input",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "needs_input" }),
     });
 
     await lm.check("app-1");
-
-    // Should preserve "needs_input" — NOT coerce to "working"
     expect(lm.getStates().get("app-1")).toBe("needs_input");
   });
 
   it("preserves stuck state when getActivityState returns null and getOutput throws", async () => {
-    vi.mocked(mockAgent.getActivityState).mockResolvedValue(null);
-    vi.mocked(mockRuntime.getOutput).mockRejectedValue(new Error("tmux error"));
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.runtime.getOutput).mockRejectedValue(new Error("tmux error"));
 
-    const session = makeSession({ status: "stuck" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "stuck",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "stuck" }),
     });
 
     await lm.check("app-1");
-
-    // getOutput failure should hit the catch block and preserve "stuck"
     expect(lm.getStates().get("app-1")).toBe("stuck");
   });
 
   it("detects PR states from SCM", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("failing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
   });
 
   it("skips PR auto-detection when metadata disables it", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn().mockResolvedValue(makePR()),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
+    const mockSCM = createMockSCM({ detectPR: vi.fn().mockResolvedValue(makePR()) });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
 
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    writeMetadata(sessionsDir, "app-1", {
+    writeMetadata(env.sessionsDir, "app-1", {
       worktree: "/tmp",
       branch: "feat/test",
       status: "working",
@@ -695,10 +357,7 @@ describe("check (single session)", () => {
       prAutoDetect: "off",
     });
 
-    const realSessionManager = createSessionManager({
-      config,
-      registry: registryWithSCM,
-    });
+    const realSessionManager = createSessionManager({ config, registry });
     const session = await realSessionManager.get("app-1");
 
     expect(session).not.toBeNull();
@@ -706,7 +365,7 @@ describe("check (single session)", () => {
 
     const lm = createLifecycleManager({
       config,
-      registry: registryWithSCM,
+      registry,
       sessionManager: mockSessionManager,
     });
 
@@ -717,32 +376,14 @@ describe("check (single session)", () => {
   });
 
   it("skips PR auto-detection for orchestrator sessions", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn().mockResolvedValue(makePR()),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
+    const mockSCM = createMockSCM({ detectPR: vi.fn().mockResolvedValue(makePR()) });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
 
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    writeMetadata(sessionsDir, "app-1", {
+    writeMetadata(env.sessionsDir, "app-1", {
       worktree: "/tmp",
       branch: "master",
       status: "working",
@@ -750,10 +391,7 @@ describe("check (single session)", () => {
       role: "orchestrator",
     });
 
-    const realSessionManager = createSessionManager({
-      config,
-      registry: registryWithSCM,
-    });
+    const realSessionManager = createSessionManager({ config, registry });
     const session = await realSessionManager.get("app-1");
 
     expect(session).not.toBeNull();
@@ -761,7 +399,7 @@ describe("check (single session)", () => {
 
     const lm = createLifecycleManager({
       config,
-      registry: registryWithSCM,
+      registry,
       sessionManager: mockSessionManager,
     });
 
@@ -772,43 +410,21 @@ describe("check (single session)", () => {
   });
 
   it("skips PR auto-detection for orchestrator sessions identified by ID suffix (fallback)", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn().mockResolvedValue(makePR()),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
+    const mockSCM = createMockSCM({ detectPR: vi.fn().mockResolvedValue(makePR()) });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
 
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    // Session has no role metadata but ID ends with "-orchestrator"
-    writeMetadata(sessionsDir, "app-orchestrator", {
+    writeMetadata(env.sessionsDir, "app-orchestrator", {
       worktree: "/tmp",
       branch: "master",
       status: "working",
       project: "my-app",
     });
 
-    const realSessionManager = createSessionManager({
-      config,
-      registry: registryWithSCM,
-    });
+    const realSessionManager = createSessionManager({ config, registry });
     const session = await realSessionManager.get("app-orchestrator");
 
     expect(session).not.toBeNull();
@@ -816,7 +432,7 @@ describe("check (single session)", () => {
 
     const lm = createLifecycleManager({
       config,
-      registry: registryWithSCM,
+      registry,
       sessionManager: mockSessionManager,
     });
 
@@ -827,65 +443,25 @@ describe("check (single session)", () => {
   });
 
   it("detects merged PR", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("merged"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn(),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "approved", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "approved",
-      project: "my-app",
+    const mockSCM = createMockSCM({ getPRState: vi.fn().mockResolvedValue("merged") });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "approved", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("merged");
   });
 
   it("detects mergeable when approved + CI green", async () => {
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
+    const mockSCM = createMockSCM({
       getReviewDecision: vi.fn().mockResolvedValue("approved"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
       getMergeability: vi.fn().mockResolvedValue({
         mergeable: true,
         ciPassing: true,
@@ -893,36 +469,19 @@ describe("check (single session)", () => {
         noConflicts: true,
         blockers: [],
       }),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
-
     expect(lm.getStates().get("app-1")).toBe("mergeable");
   });
 
@@ -939,20 +498,8 @@ describe("check (single session)", () => {
   });
 
   it("does not change state when status is unchanged", async () => {
-    const session = makeSession({ status: "working" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "working",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "working" }),
     });
 
     await lm.check("app-1");
@@ -976,151 +523,62 @@ describe("reactions", () => {
       },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("failing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
-
     expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "CI is failing. Fix it.");
   });
 
   it("does not trigger reaction when auto=false", async () => {
     config.reactions = {
-      "ci-failed": {
-        auto: false,
-        action: "send-to-agent",
-        message: "CI is failing.",
-      },
+      "ci-failed": { auto: false, action: "send-to-agent", message: "CI is failing." },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("failing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
-
     expect(mockSessionManager.send).not.toHaveBeenCalled();
   });
+
   it("suppresses immediate notification when send-to-agent reaction handles the event", async () => {
-    const mockNotifier: Notifier = {
-      name: "mock-notifier",
-      notify: vi.fn().mockResolvedValue(undefined),
-    };
-
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
+    const notifier = createMockNotifier();
+    const mockSCM = createMockSCM({
       getCISummary: vi.fn().mockResolvedValue("failing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
+    });
 
-    const registryWithNotifier: PluginRegistry = {
+    const registry: PluginRegistry = {
       ...mockRegistry,
       get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
         if (slot === "scm") return mockSCM;
-        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        if (slot === "notifier" && name === "desktop") return notifier;
         return null;
       }),
     };
 
-    // Session transitions from pr_open → ci_failed, which maps to ci-failed reaction
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
     vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
 
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
-    });
-
-    // Configure send-to-agent reaction for ci-failed with retries
     const configWithReaction = {
       ...config,
       reactions: {
@@ -1134,19 +592,17 @@ describe("reactions", () => {
       },
     };
 
-    const lm = createLifecycleManager({
-      config: configWithReaction,
-      registry: registryWithNotifier,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+      configOverride: configWithReaction,
     });
 
     await lm.check("app-1");
 
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
-    // send-to-agent reaction should have been executed
     expect(mockSessionManager.send).toHaveBeenCalledWith("app-1", "Fix CI");
-    // Notifier should NOT have been called — the reaction is handling it
-    expect(mockNotifier.notify).not.toHaveBeenCalled();
+    expect(notifier.notify).not.toHaveBeenCalled();
   });
 
   it("dispatches unresolved review comments even when reviewDecision stays unchanged", async () => {
@@ -1158,16 +614,7 @@ describe("reactions", () => {
       },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
+    const mockSCM = createMockSCM({
       getPendingComments: vi.fn().mockResolvedValue([
         {
           id: "c1",
@@ -1181,34 +628,18 @@ describe("reactions", () => {
         },
       ]),
       getAutomatedComments: vi.fn().mockResolvedValue([]),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
@@ -1219,7 +650,7 @@ describe("reactions", () => {
     await lm.check("app-1");
     expect(mockSessionManager.send).not.toHaveBeenCalled();
 
-    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    const metadata = readMetadataRaw(env.sessionsDir, "app-1");
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
@@ -1232,15 +663,7 @@ describe("reactions", () => {
       },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
+    const mockSCM = createMockSCM({
       getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
       getPendingComments: vi.fn().mockResolvedValue([
         {
@@ -1255,34 +678,18 @@ describe("reactions", () => {
         },
       ]),
       getAutomatedComments: vi.fn().mockResolvedValue([]),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
@@ -1301,16 +708,7 @@ describe("reactions", () => {
       },
     };
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("open"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn().mockResolvedValue("passing"),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn().mockResolvedValue("none"),
+    const mockSCM = createMockSCM({
       getPendingComments: vi.fn().mockResolvedValue([]),
       getAutomatedComments: vi.fn().mockResolvedValue([
         {
@@ -1324,34 +722,18 @@ describe("reactions", () => {
           url: "https://example.com/comment/3",
         },
       ]),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithSCM: PluginRegistry = {
-      ...mockRegistry,
-      get: vi.fn().mockImplementation((slot: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
-        if (slot === "scm") return mockSCM;
-        return null;
-      }),
-    };
-
-    const session = makeSession({ status: "pr_open", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "pr_open",
-      project: "my-app",
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
     });
 
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithSCM,
-      sessionManager: mockSessionManager,
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
@@ -1365,65 +747,35 @@ describe("reactions", () => {
     await lm.check("app-1");
     expect(mockSessionManager.send).not.toHaveBeenCalled();
 
-    const metadata = readMetadataRaw(sessionsDir, "app-1");
+    const metadata = readMetadataRaw(env.sessionsDir, "app-1");
     expect(metadata?.["lastAutomatedReviewDispatchHash"]).toBe("bot-1");
   });
 
   it("notifies humans on significant transitions without reaction config", async () => {
-    const mockNotifier: Notifier = {
-      name: "mock-notifier",
-      notify: vi.fn().mockResolvedValue(undefined),
-    };
+    const notifier = createMockNotifier();
+    const mockSCM = createMockSCM({ getPRState: vi.fn().mockResolvedValue("merged") });
 
-    const mockSCM: SCM = {
-      name: "mock-scm",
-      detectPR: vi.fn(),
-      getPRState: vi.fn().mockResolvedValue("merged"),
-      mergePR: vi.fn(),
-      closePR: vi.fn(),
-      getCIChecks: vi.fn(),
-      getCISummary: vi.fn(),
-      getReviews: vi.fn(),
-      getReviewDecision: vi.fn(),
-      getPendingComments: vi.fn(),
-      getAutomatedComments: vi.fn(),
-      getMergeability: vi.fn(),
-    };
-
-    const registryWithNotifier: PluginRegistry = {
+    const registry: PluginRegistry = {
       ...mockRegistry,
       get: vi.fn().mockImplementation((slot: string, name: string) => {
-        if (slot === "runtime") return mockRuntime;
-        if (slot === "agent") return mockAgent;
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
         if (slot === "scm") return mockSCM;
-        if (slot === "notifier" && name === "desktop") return mockNotifier;
+        if (slot === "notifier" && name === "desktop") return notifier;
         return null;
       }),
     };
 
-    // merge.completed has "action" priority but NO reaction key mapping,
-    // so it must reach notifyHuman directly
-    const session = makeSession({ status: "approved", pr: makePR() });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "approved",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: registryWithNotifier,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "approved", pr: makePR() }),
+      registry,
     });
 
     await lm.check("app-1");
 
     expect(lm.getStates().get("app-1")).toBe("merged");
-    expect(mockNotifier.notify).toHaveBeenCalled();
-    expect(mockNotifier.notify).toHaveBeenCalledWith(
+    expect(notifier.notify).toHaveBeenCalled();
+    expect(notifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "merge.completed" }),
     );
   });
@@ -1431,20 +783,8 @@ describe("reactions", () => {
 
 describe("getStates", () => {
   it("returns copy of states map", async () => {
-    const session = makeSession({ status: "spawning" });
-    vi.mocked(mockSessionManager.get).mockResolvedValue(session);
-
-    writeMetadata(sessionsDir, "app-1", {
-      worktree: "/tmp",
-      branch: "main",
-      status: "spawning",
-      project: "my-app",
-    });
-
-    const lm = createLifecycleManager({
-      config,
-      registry: mockRegistry,
-      sessionManager: mockSessionManager,
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "spawning" }),
     });
 
     await lm.check("app-1");

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -1,0 +1,229 @@
+import { vi } from "vitest";
+import { mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import { getSessionsDir, getProjectBaseDir } from "../paths.js";
+import type {
+  OrchestratorConfig,
+  PluginRegistry,
+  SessionManager,
+  Session,
+  Runtime,
+  Agent,
+  Workspace,
+  SCM,
+  Notifier,
+  ActivityState,
+  PRInfo,
+} from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Data factories
+// ---------------------------------------------------------------------------
+
+export function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "app-1",
+    projectId: "my-app",
+    status: "spawning",
+    activity: "active",
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/tmp/ws",
+    runtimeHandle: { id: "rt-1", runtimeName: "mock", data: {} },
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+export function makePR(overrides: Partial<PRInfo> = {}): PRInfo {
+  return {
+    number: 42,
+    url: "https://github.com/org/repo/pull/42",
+    title: "Fix things",
+    owner: "org",
+    repo: "repo",
+    branch: "feat/test",
+    baseBranch: "main",
+    isDraft: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock plugin factories
+// ---------------------------------------------------------------------------
+
+export interface MockPlugins {
+  runtime: Runtime;
+  agent: Agent;
+  workspace: Workspace;
+}
+
+export function createMockPlugins(): MockPlugins {
+  const runtime: Runtime = {
+    name: "mock",
+    create: vi.fn(),
+    destroy: vi.fn(),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    getOutput: vi.fn().mockResolvedValue("$ some terminal output\n"),
+    isAlive: vi.fn().mockResolvedValue(true),
+  };
+
+  const agent: Agent = {
+    name: "mock-agent",
+    processName: "mock",
+    getLaunchCommand: vi.fn(),
+    getEnvironment: vi.fn(),
+    detectActivity: vi.fn().mockReturnValue("active" as ActivityState),
+    getActivityState: vi.fn().mockResolvedValue({ state: "active" as ActivityState }),
+    isProcessRunning: vi.fn().mockResolvedValue(true),
+    getSessionInfo: vi.fn().mockResolvedValue(null),
+  };
+
+  const workspace: Workspace = {
+    name: "mock-ws",
+    create: vi.fn(),
+    destroy: vi.fn(),
+  };
+
+  return { runtime, agent, workspace };
+}
+
+export function createMockSCM(overrides: Partial<SCM> = {}): SCM {
+  return {
+    name: "mock-scm",
+    detectPR: vi.fn(),
+    getPRState: vi.fn().mockResolvedValue("open"),
+    mergePR: vi.fn(),
+    closePR: vi.fn(),
+    getCIChecks: vi.fn(),
+    getCISummary: vi.fn().mockResolvedValue("passing"),
+    getReviews: vi.fn(),
+    getReviewDecision: vi.fn().mockResolvedValue("none"),
+    getPendingComments: vi.fn(),
+    getAutomatedComments: vi.fn(),
+    getMergeability: vi.fn(),
+    ...overrides,
+  };
+}
+
+export function createMockNotifier(): Notifier {
+  return {
+    name: "mock-notifier",
+    notify: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registry factory
+// ---------------------------------------------------------------------------
+
+export interface RegistryPlugins {
+  runtime: Runtime;
+  agent: Agent;
+  scm?: SCM;
+  notifier?: Notifier;
+}
+
+export function createMockRegistry(plugins: RegistryPlugins): PluginRegistry {
+  return {
+    register: vi.fn(),
+    get: vi.fn().mockImplementation((slot: string, name?: string) => {
+      if (slot === "runtime") return plugins.runtime;
+      if (slot === "agent") return plugins.agent;
+      if (slot === "scm") return plugins.scm ?? null;
+      if (slot === "notifier" && name === "desktop") return plugins.notifier ?? null;
+      return null;
+    }),
+    list: vi.fn().mockReturnValue([]),
+    loadBuiltins: vi.fn(),
+    loadFromConfig: vi.fn(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Test environment
+// ---------------------------------------------------------------------------
+
+export interface TestEnvironment {
+  tmpDir: string;
+  configPath: string;
+  sessionsDir: string;
+  config: OrchestratorConfig;
+  cleanup: () => void;
+}
+
+export function createTestEnvironment(): TestEnvironment {
+  const tmpDir = join(tmpdir(), `ao-test-lifecycle-${randomUUID()}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  const configPath = join(tmpDir, "agent-orchestrator.yaml");
+  writeFileSync(configPath, "projects: {}\n");
+
+  const config: OrchestratorConfig = {
+    configPath,
+    port: 3000,
+    defaults: {
+      runtime: "mock",
+      agent: "mock-agent",
+      workspace: "mock-ws",
+      notifiers: ["desktop"],
+    },
+    projects: {
+      "my-app": {
+        name: "My App",
+        repo: "org/my-app",
+        path: join(tmpDir, "my-app"),
+        defaultBranch: "main",
+        sessionPrefix: "app",
+        scm: { plugin: "github" },
+      },
+    },
+    notifiers: {},
+    notificationRouting: {
+      urgent: ["desktop"],
+      action: ["desktop"],
+      warning: [],
+      info: [],
+    },
+    reactions: {},
+    readyThresholdMs: 300_000,
+  };
+
+  const sessionsDir = getSessionsDir(configPath, join(tmpDir, "my-app"));
+  mkdirSync(sessionsDir, { recursive: true });
+
+  const cleanup = () => {
+    const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "my-app"));
+    if (existsSync(projectBaseDir)) {
+      rmSync(projectBaseDir, { recursive: true, force: true });
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  };
+
+  return { tmpDir, configPath, sessionsDir, config, cleanup };
+}
+
+// ---------------------------------------------------------------------------
+// Session manager mock
+// ---------------------------------------------------------------------------
+
+export function createMockSessionManager(): SessionManager {
+  return {
+    spawn: vi.fn(),
+    spawnOrchestrator: vi.fn(),
+    restore: vi.fn(),
+    list: vi.fn().mockResolvedValue([]),
+    get: vi.fn().mockResolvedValue(null),
+    kill: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn(),
+    send: vi.fn().mockResolvedValue(undefined),
+    claimPR: vi.fn(),
+  } as SessionManager;
+}


### PR DESCRIPTION
## Summary
- Created `packages/core/src/__tests__/test-utils.ts` with reusable test factories: `createTestEnvironment()`, `createMockPlugins()`, `createMockRegistry()`, `createMockSCM()`, `createMockNotifier()`, `createMockSessionManager()`, `makeSession()`, `makePR()`
- Refactored `lifecycle-manager.test.ts` to use shared utilities, reducing setup boilerplate from ~130 lines to ~38 lines (>70% reduction)
- Test file reduced from ~1460 lines to 799 lines overall by eliminating repeated inline mock definitions

## Test plan
- [x] All 30 lifecycle-manager tests pass (`vitest run`)
- [x] Fresh mock isolation preserved — each `beforeEach` creates new environment, plugins, registry, and session manager
- [x] No shared mutable state between tests

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)