### PR TITLE
perf(web): parallelize PR enrichment in GET /api/sessions

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -390,6 +390,37 @@ describe("API Routes", () => {
         sourceSessionId: "docs-orchestrator",
       });
     });
+
+    it("enriches all PRs concurrently, not sequentially", async () => {
+      const sessionsWithPRs = Array.from({ length: 6 }, (_, i) =>
+        makeSession({
+          id: `worker-${i}`,
+          status: "pr_open",
+          activity: "idle",
+          pr: {
+            number: 100 + i,
+            url: `https://github.com/acme/my-app/pull/${100 + i}`,
+            title: `PR ${i}`,
+            owner: "acme",
+            repo: "my-app",
+            branch: `feat/pr-${i}`,
+            baseBranch: "main",
+            isDraft: false,
+          },
+        }),
+      );
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(sessionsWithPRs);
+
+      const enrichSpy = vi
+        .spyOn(serialize, "enrichSessionPR")
+        .mockResolvedValue(true);
+
+      const res = await sessionsGET(makeRequest("http://localhost:3000/api/sessions"));
+      expect(res.status).toBe(200);
+      expect(enrichSpy.mock.calls.length).toBe(6);
+
+      enrichSpy.mockRestore();
+    });
   });
 
   // ── POST /api/spawn ────────────────────────────────────────────────

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -392,6 +392,8 @@ describe("API Routes", () => {
     });
 
     it("enriches all PRs concurrently, not sequentially", async () => {
+      vi.useFakeTimers();
+
       const sessionsWithPRs = Array.from({ length: 6 }, (_, i) =>
         makeSession({
           id: `worker-${i}`,
@@ -411,15 +413,31 @@ describe("API Routes", () => {
       );
       (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(sessionsWithPRs);
 
+      const metadataSpy = vi
+        .spyOn(serialize, "enrichSessionsMetadata")
+        .mockResolvedValue(undefined);
+
       const enrichSpy = vi
         .spyOn(serialize, "enrichSessionPR")
-        .mockResolvedValue(true);
+        .mockImplementation(
+          () => new Promise<void>((resolve) => { setTimeout(resolve, 1_000); }),
+        );
 
-      const res = await sessionsGET(makeRequest("http://localhost:3000/api/sessions"));
-      expect(res.status).toBe(200);
+      const responsePromise = sessionsGET(makeRequest("http://localhost:3000/api/sessions"));
+
+      // Flush microtasks so the handler reaches the PR enrichment loop
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Sequential would only have 1 call pending; parallel fires all 6 immediately
       expect(enrichSpy.mock.calls.length).toBe(6);
 
+      await vi.advanceTimersByTimeAsync(5_000);
+      const res = await responsePromise;
+      expect(res.status).toBe(200);
+
+      metadataSpy.mockRestore();
       enrichSpy.mockRestore();
+      vi.useRealTimers();
     });
   });
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -69,7 +69,7 @@ export async function GET(request: Request) {
     );
 
     if (metadataSettled) {
-      const prEnrichPromises: Promise<unknown>[] = [];
+      const prEnrichPromises: Promise<boolean>[] = [];
 
       for (let i = 0; i < workerSessions.length; i++) {
         const core = workerSessions[i];

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -69,22 +69,26 @@ export async function GET(request: Request) {
     );
 
     if (metadataSettled) {
-      const prDeadlineAt = Date.now() + PR_ENRICH_TIMEOUT_MS;
+      const prEnrichPromises: Promise<unknown>[] = [];
+
       for (let i = 0; i < workerSessions.length; i++) {
         const core = workerSessions[i];
         if (!core?.pr) continue;
-
-        const remainingMs = prDeadlineAt - Date.now();
-        if (remainingMs <= 0) break;
 
         const project = resolveProject(core, config.projects);
         const scm = getSCM(registry, project);
         if (!scm) continue;
 
-        await settlesWithin(
-          enrichSessionPR(dashboardSessions[i], scm, core.pr),
-          Math.min(remainingMs, PER_PR_ENRICH_TIMEOUT_MS),
+        prEnrichPromises.push(
+          settlesWithin(
+            enrichSessionPR(dashboardSessions[i], scm, core.pr),
+            PER_PR_ENRICH_TIMEOUT_MS,
+          ),
         );
+      }
+
+      if (prEnrichPromises.length > 0) {
+        await settlesWithin(Promise.allSettled(prEnrichPromises), PR_ENRICH_TIMEOUT_MS);
       }
     }
 


### PR DESCRIPTION
## What changed and why
                                                                                                                                                                                                                                       
  The `/api/sessions` endpoint enriched PRs sequentially where each `enrichSessionPR` call
  had to finish before the next one started. With a 1.5s per-PR timeout and a 4s global                                                                                                                                                
  deadline, sessions with 3+ open PRs would hit the deadline and skip enrichment for the
  remaining PRs entirely (starvation).                                                                                                                                                                                                 
                                                                                                                                                                                                                                       
  This PR replaces the sequential `await` loop with `Promise.allSettled` so all PR                                                                                                                                                     
  enrichment calls fire concurrently. Each call still has its own 1.5s timeout, and                                                                                                                                                    
  the batch is capped at the existing 4s global deadline.                          
                                                                                                                                                                                                                                       
  ## How to test it                                                                                                                                                                                                                    
                                                                                                                                                                                                                                       
  - `pnpm --filter @composio/ao-web test` then new test: `enriches all PRs concurrently, not sequentially`                                                                                                                                
  - Manual: run the dashboard with 4+ sessions that have open PRs, confirm all show enriched PR data                                                                                                                                   
                                                                                                    
  Closes #729         