### PR TITLE
fix: scope gitleaks push/schedule scan to last 10 commits

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -56,7 +56,7 @@ jobs:
             git fetch origin ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} --depth=1
             gitleaks detect --source . --verbose --log-opts "${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}"
           else
-            gitleaks detect --source . --verbose
+            gitleaks detect --source . --verbose --log-opts "HEAD~10..HEAD"
           fi
 
   dependency-review:


### PR DESCRIPTION
## Summary
- Scopes push-to-main and scheduled gitleaks scans to the last 10 commits (`HEAD~10..HEAD`) instead of the entire repo history
- Prevents false positives from historical commits triggering CI failures
- PR scans continue to use the exact `base..head` range

Closes #721

## Test plan
- [ ] Verify the Security workflow passes on this PR (gitleaks scans only PR commits)
- [ ] After merge, verify push-to-main scan scopes to `HEAD~10..HEAD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)