### PR TITLE
feat(core): add formatDuration utility to convert ms to human readable

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isRetryableHttpStatus, normalizeRetryConfig, readLastJsonlEntry } from "../utils.js";
+import {
+  formatDuration,
+  isRetryableHttpStatus,
+  normalizeRetryConfig,
+  readLastJsonlEntry,
+} from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
 
 describe("readLastJsonlEntry", () => {
@@ -137,5 +142,55 @@ describe("parsePrFromUrl", () => {
 
   it("returns null when the URL has no PR number", () => {
     expect(parsePrFromUrl("https://example.com/foo/bar/pull/not-a-number")).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats milliseconds for durations under 1 second", () => {
+    expect(formatDuration(0)).toBe("0ms");
+    expect(formatDuration(1)).toBe("1ms");
+    expect(formatDuration(500)).toBe("500ms");
+    expect(formatDuration(999)).toBe("999ms");
+  });
+
+  it("rounds milliseconds to nearest integer", () => {
+    expect(formatDuration(500.4)).toBe("500ms");
+    expect(formatDuration(500.6)).toBe("501ms");
+  });
+
+  it("formats seconds for durations under 1 minute", () => {
+    expect(formatDuration(1000)).toBe("1s");
+    expect(formatDuration(45000)).toBe("45s");
+    expect(formatDuration(59000)).toBe("59s");
+  });
+
+  it("formats minutes and seconds for durations under 1 hour", () => {
+    expect(formatDuration(60000)).toBe("1m");
+    expect(formatDuration(90000)).toBe("1m 30s");
+    expect(formatDuration(5 * 60000 + 10000)).toBe("5m 10s");
+    expect(formatDuration(59 * 60000 + 59000)).toBe("59m 59s");
+  });
+
+  it("formats hours and minutes for durations under 1 day", () => {
+    expect(formatDuration(60 * 60000)).toBe("1h");
+    expect(formatDuration(2 * 60 * 60000 + 30 * 60000)).toBe("2h 30m");
+    expect(formatDuration(23 * 60 * 60000 + 59 * 60000)).toBe("23h 59m");
+  });
+
+  it("formats days and hours for longer durations", () => {
+    expect(formatDuration(24 * 60 * 60000)).toBe("1d");
+    expect(formatDuration(24 * 60 * 60000 + 3 * 60 * 60000)).toBe("1d 3h");
+    expect(formatDuration(7 * 24 * 60 * 60000 + 12 * 60 * 60000)).toBe("7d 12h");
+  });
+
+  it("omits zero units in the second position", () => {
+    expect(formatDuration(2 * 60 * 60000)).toBe("2h");
+    expect(formatDuration(5 * 60000)).toBe("5m");
+    expect(formatDuration(2 * 24 * 60 * 60000)).toBe("2d");
+  });
+
+  it("handles negative values", () => {
+    expect(formatDuration(-1)).toBe("0ms");
+    expect(formatDuration(-1000)).toBe("0ms");
   });
 });

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -149,3 +149,38 @@ export function resolveProjectIdForSessionId(
   }
   return undefined;
 }
+
+/**
+ * Formats a duration in milliseconds to a human-readable string.
+ * Shows up to two units for readability.
+ * Examples: "2h 30m", "5m 10s", "1d 3h", "500ms"
+ */
+export function formatDuration(ms: number): string {
+  if (ms < 0) return "0ms";
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+  const days = Math.floor(hours / 24);
+
+  const parts: string[] = [];
+
+  if (days > 0) {
+    parts.push(`${days}d`);
+    const remainingHours = hours % 24;
+    if (remainingHours > 0) parts.push(`${remainingHours}h`);
+  } else if (hours > 0) {
+    parts.push(`${hours}h`);
+    const remainingMinutes = minutes % 60;
+    if (remainingMinutes > 0) parts.push(`${remainingMinutes}m`);
+  } else if (minutes > 0) {
+    parts.push(`${minutes}m`);
+    const remainingSeconds = seconds % 60;
+    if (remainingSeconds > 0) parts.push(`${remainingSeconds}s`);
+  } else {
+    parts.push(`${seconds}s`);
+  }
+
+  return parts.join(" ");
+}


### PR DESCRIPTION
## Summary
- Adds a new `formatDuration` utility function in `packages/core/src/utils.ts`
- Converts milliseconds to human-readable format (e.g., `'2h 30m'`, `'5m 10s'`, `'1d 3h'`)
- Shows up to two units for readability
- Handles edge cases: negative values (returns `'0ms'`), sub-second durations, and zero units

## Test plan
- [x] Unit tests for all duration ranges (ms, seconds, minutes, hours, days)
- [x] Tests for edge cases (negative values, rounding, zero units)
- [x] All existing tests pass
- [x] TypeScript type checks pass
- [x] Lint passes for modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)