### PR TITLE
fix: use TERMINAL_STATUSES in lifecycle poll accounting

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -8,6 +8,7 @@ import type {
   SessionManager,
   Agent,
   ActivityState,
+  SessionStatus,
 } from "../types.js";
 import {
   createTestEnvironment,
@@ -776,6 +777,137 @@ describe("reactions", () => {
     expect(notifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "merge.completed" }),
     );
+  });
+});
+
+describe("pollAll terminal status accounting", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("treats all TERMINAL_STATUSES as inactive for all-complete", async () => {
+    const notifier = createMockNotifier();
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    // All sessions in various terminal states — should count as inactive
+    const terminalSessions = [
+      makeSession({ id: "s-1", status: "killed" as SessionStatus }),
+      makeSession({ id: "s-2", status: "merged" as SessionStatus }),
+      makeSession({ id: "s-3", status: "done" as SessionStatus }),
+      makeSession({ id: "s-4", status: "errored" as SessionStatus }),
+      makeSession({ id: "s-5", status: "terminated" as SessionStatus }),
+      makeSession({ id: "s-6", status: "cleanup" as SessionStatus }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(terminalSessions);
+
+    // Route info-priority notifications to desktop so we can observe them
+    config.notificationRouting.info = ["desktop"];
+    config.reactions = {
+      "all-complete": { auto: true, action: "notify" },
+    };
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(60_000);
+    // Let the immediate pollAll() run
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.triggered" }),
+    );
+
+    lm.stop();
+  });
+
+  it("does not fire all-complete when a session is in non-terminal status like done is missing", async () => {
+    const notifier = createMockNotifier();
+    const registryWithNotifier: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    // Mix of terminal and active sessions
+    const sessions = [
+      makeSession({ id: "s-1", status: "killed" as SessionStatus }),
+      makeSession({ id: "s-2", status: "working" as SessionStatus }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    config.reactions = {
+      "all-complete": { auto: true, action: "notify" },
+    };
+
+    const lm = createLifecycleManager({
+      config,
+      registry: registryWithNotifier,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // all-complete should NOT have fired — "working" is still active
+    const allCompleteNotifications = vi.mocked(notifier.notify).mock.calls.filter(
+      (call: unknown[]) => {
+        const event = call[0] as Record<string, unknown> | undefined;
+        const data = event?.data as Record<string, unknown> | undefined;
+        return event?.type === "reaction.triggered" && data?.reactionKey === "all-complete";
+      },
+    );
+    expect(allCompleteNotifications).toHaveLength(0);
+
+    lm.stop();
+  });
+
+  it("skips polling sessions in terminal statuses like done or errored", async () => {
+    // Sessions in "done" / "errored" should not be polled
+    const sessions = [
+      makeSession({ id: "s-done", status: "done" as SessionStatus }),
+      makeSession({ id: "s-errored", status: "errored" as SessionStatus }),
+    ];
+
+    vi.mocked(mockSessionManager.list).mockResolvedValue(sessions);
+
+    // If these sessions were polled, determineStatus would call runtime.isAlive.
+    // Reset call count and verify it's not called.
+    vi.mocked(plugins.runtime.isAlive).mockClear();
+
+    const lm = createLifecycleManager({
+      config,
+      registry: mockRegistry,
+      sessionManager: mockSessionManager,
+    });
+
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Terminal sessions should not be polled — runtime.isAlive should not be called
+    expect(plugins.runtime.isAlive).not.toHaveBeenCalled();
+
+    lm.stop();
   });
 });
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -15,6 +15,7 @@ import {
   SESSION_STATUS,
   PR_STATE,
   CI_STATUS,
+  TERMINAL_STATUSES,
   type LifecycleManager,
   type SessionManager,
   type SessionId,
@@ -547,7 +548,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const humanReactionKey = "changes-requested";
     const automatedReactionKey = "bugbot-comments";
 
-    if (newStatus === "merged" || newStatus === "killed") {
+    if (TERMINAL_STATUSES.has(newStatus)) {
       clearReactionTracker(session.id, humanReactionKey);
       clearReactionTracker(session.id, automatedReactionKey);
       updateSessionMetadata(session, {
@@ -728,7 +729,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
 
       // Reset allCompleteEmitted when any session becomes active again
-      if (newStatus !== "merged" && newStatus !== "killed") {
+      if (!TERMINAL_STATUSES.has(newStatus)) {
         allCompleteEmitted = false;
       }
 
@@ -806,7 +807,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // (e.g., list() detected a dead runtime and marked it "killed" — we need to
       // process that transition even though the new status is terminal)
       const sessionsToCheck = sessions.filter((s) => {
-        if (s.status !== "merged" && s.status !== "killed") return true;
+        if (!TERMINAL_STATUSES.has(s.status)) return true;
         const tracked = states.get(s.id);
         return tracked !== undefined && tracked !== s.status;
       });
@@ -830,7 +831,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       // Check if all sessions are complete (trigger reaction only once)
-      const activeSessions = sessions.filter((s) => s.status !== "merged" && s.status !== "killed");
+      const activeSessions = sessions.filter((s) => !TERMINAL_STATUSES.has(s.status));
       if (sessions.length > 0 && activeSessions.length === 0 && !allCompleteEmitted) {
         allCompleteEmitted = true;
 


### PR DESCRIPTION
## Summary

- Replaces hardcoded `"merged" / "killed"` checks in `pollAll()` with the canonical `TERMINAL_STATUSES` set from `types.ts`
- Ensures sessions in `done`, `terminated`, `cleanup`, or `errored` states are correctly treated as inactive for polling, active-session count, and `all-complete` detection
- Also fixes `maybeDispatchReviewBacklog` to clear trackers for all terminal statuses, not just merged/killed

## What changed

**`packages/core/src/lifecycle-manager.ts`** — 4 locations updated:
1. `sessionsToCheck` filter now uses `TERMINAL_STATUSES.has()` instead of `!== "merged" && !== "killed"`
2. `allCompleteEmitted` reset guard uses `TERMINAL_STATUSES.has()`
3. `activeSessions` count uses `TERMINAL_STATUSES.has()`
4. `maybeDispatchReviewBacklog` cleanup uses `TERMINAL_STATUSES.has()`

**`packages/core/src/__tests__/lifecycle-manager.test.ts`** — 3 new tests:
- Verifies `all-complete` fires when all sessions are in various terminal states
- Verifies `all-complete` does NOT fire when any session is still active
- Verifies terminal sessions are skipped during polling

## Test plan

- [x] All 33 lifecycle-manager tests pass
- [x] All 308 core package tests pass
- [ ] CI passes

Closes #752