### PR TITLE
feat(core): add formatDuration utility with comprehensive tests

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isRetryableHttpStatus, normalizeRetryConfig, readLastJsonlEntry } from "../utils.js";
+import {
+  formatDuration,
+  isRetryableHttpStatus,
+  normalizeRetryConfig,
+  readLastJsonlEntry,
+} from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
 
 describe("readLastJsonlEntry", () => {
@@ -137,5 +142,59 @@ describe("parsePrFromUrl", () => {
 
   it("returns null when the URL has no PR number", () => {
     expect(parsePrFromUrl("https://example.com/foo/bar/pull/not-a-number")).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats zero milliseconds as '0s'", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("formats negative values as '0s'", () => {
+    expect(formatDuration(-1000)).toBe("0s");
+    expect(formatDuration(-1)).toBe("0s");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatDuration(1000)).toBe("1s");
+    expect(formatDuration(30_000)).toBe("30s");
+    expect(formatDuration(59_000)).toBe("59s");
+  });
+
+  it("rounds down partial seconds", () => {
+    expect(formatDuration(1500)).toBe("1s");
+    expect(formatDuration(1999)).toBe("1s");
+    expect(formatDuration(500)).toBe("0s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(60_000)).toBe("1m");
+    expect(formatDuration(90_000)).toBe("1m 30s");
+    expect(formatDuration(125_000)).toBe("2m 5s");
+    expect(formatDuration(3_540_000)).toBe("59m");
+  });
+
+  it("formats hours, minutes, and seconds", () => {
+    expect(formatDuration(3_600_000)).toBe("1h");
+    expect(formatDuration(3_661_000)).toBe("1h 1m 1s");
+    expect(formatDuration(3_723_000)).toBe("1h 2m 3s");
+    expect(formatDuration(7_200_000)).toBe("2h");
+    expect(formatDuration(7_320_000)).toBe("2h 2m");
+    expect(formatDuration(7_325_000)).toBe("2h 2m 5s");
+  });
+
+  it("handles large durations", () => {
+    expect(formatDuration(86_400_000)).toBe("24h");
+    expect(formatDuration(90_061_000)).toBe("25h 1m 1s");
+  });
+
+  it("handles non-finite values as '0s'", () => {
+    expect(formatDuration(NaN)).toBe("0s");
+    expect(formatDuration(Infinity)).toBe("0s");
+    expect(formatDuration(-Infinity)).toBe("0s");
+  });
+
+  it("omits zero components in the middle", () => {
+    expect(formatDuration(3_603_000)).toBe("1h 3s");
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export {
   normalizeRetryConfig,
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
+  formatDuration,
 } from "./utils.js";
 export {
   getWebhookHeader,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -134,6 +134,34 @@ export async function readLastJsonlEntry(
 }
 
 /**
+ * Format a duration in milliseconds to a human-readable string.
+ * Examples:
+ *   - 1500 -> "1s"
+ *   - 90000 -> "1m 30s"
+ *   - 3723000 -> "1h 2m 3s"
+ *
+ * @param ms - Duration in milliseconds
+ * @returns Human-readable duration string, or "0s" for zero/negative values
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) {
+    return "0s";
+  }
+
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const parts: string[] = [];
+  if (hours > 0) parts.push(`${hours}h`);
+  if (minutes > 0) parts.push(`${minutes}m`);
+  if (seconds > 0 || parts.length === 0) parts.push(`${seconds}s`);
+
+  return parts.join(" ");
+}
+
+/**
  * Given a session ID and the orchestrator config, find which project it belongs
  * to by matching session prefixes.
  */


### PR DESCRIPTION
## Summary
- Add `formatDuration` function to `packages/core/src/utils.ts` that converts milliseconds to human-readable duration strings (e.g., `"1h 2m 3s"`)
- Add comprehensive unit tests covering edge cases: zero, negative, NaN, Infinity, partial seconds, large durations
- This is the inverse of the existing `parseDuration` function in `lifecycle-manager.ts`

## Test plan
- [x] Run `pnpm test --filter @composio/ao-core` - 26 utils tests pass
- [x] Run `pnpm typecheck` - passes
- [x] Run lint on modified files - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)