### PR TITLE
feat(core): use formatDuration in session-manager.ts to display session age

### DIFF
--- a/packages/core/src/__tests__/session-manager.test.ts
+++ b/packages/core/src/__tests__/session-manager.test.ts
@@ -324,7 +324,7 @@ describe("spawn", () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
     await expect(sm.spawn({ projectId: "my-app" })).rejects.toThrow(
-      "Project is paused due to model rate limit until",
+      "Project is paused due to model rate limit for",
     );
     expect(mockRuntime.create).not.toHaveBeenCalled();
   });
@@ -2457,7 +2457,7 @@ describe("send", () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
     await expect(sm.send("app-1", "Fix the CI failures")).rejects.toThrow(
-      "Project is paused due to model rate limit until",
+      "Project is paused due to model rate limit for",
     );
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
@@ -2942,7 +2942,7 @@ describe("spawnOrchestrator", () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
     await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-      "Project is paused due to model rate limit until",
+      "Project is paused due to model rate limit for",
     );
     expect(mockRuntime.create).not.toHaveBeenCalled();
   });

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isRetryableHttpStatus, normalizeRetryConfig, readLastJsonlEntry } from "../utils.js";
+import {
+  isRetryableHttpStatus,
+  normalizeRetryConfig,
+  readLastJsonlEntry,
+  formatDuration,
+} from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
 
 describe("readLastJsonlEntry", () => {
@@ -137,5 +142,41 @@ describe("parsePrFromUrl", () => {
 
   it("returns null when the URL has no PR number", () => {
     expect(parsePrFromUrl("https://example.com/foo/bar/pull/not-a-number")).toBeNull();
+  });
+});
+
+describe("formatDuration", () => {
+  it("formats seconds", () => {
+    expect(formatDuration(5000)).toBe("5s");
+    expect(formatDuration(30000)).toBe("30s");
+    expect(formatDuration(59000)).toBe("59s");
+  });
+
+  it("formats minutes", () => {
+    expect(formatDuration(60000)).toBe("1m");
+    expect(formatDuration(120000)).toBe("2m");
+    expect(formatDuration(300000)).toBe("5m");
+    expect(formatDuration(3599000)).toBe("59m");
+  });
+
+  it("formats hours", () => {
+    expect(formatDuration(3600000)).toBe("1h");
+    expect(formatDuration(7200000)).toBe("2h");
+    expect(formatDuration(86399000)).toBe("23h");
+  });
+
+  it("formats days", () => {
+    expect(formatDuration(86400000)).toBe("1d");
+    expect(formatDuration(172800000)).toBe("2d");
+    expect(formatDuration(604800000)).toBe("7d");
+  });
+
+  it("handles zero duration", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("handles negative duration by using absolute value", () => {
+    expect(formatDuration(-5000)).toBe("5s");
+    expect(formatDuration(-60000)).toBe("1m");
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export {
   normalizeRetryConfig,
   readLastJsonlEntry,
   resolveProjectIdForSessionId,
+  formatDuration,
 } from "./utils.js";
 export {
   getWebhookHeader,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -74,6 +74,7 @@ import {
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse } from "./utils/validation.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import { formatDuration } from "./utils.js";
 
 const execFileAsync = promisify(execFile);
 const OPENCODE_DISCOVERY_TIMEOUT_MS = 2_000;
@@ -899,7 +900,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const pause = getProjectPause(project);
     if (pause) {
       throw new Error(
-        `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
+        `Project is paused due to model rate limit for ${formatDuration(pause.until.getTime() - Date.now())} (${pause.reason}; source: ${pause.sourceSessionId})`,
       );
     }
 
@@ -1202,7 +1203,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const pause = getProjectPause(project);
     if (pause) {
       throw new Error(
-        `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
+        `Project is paused due to model rate limit for ${formatDuration(pause.until.getTime() - Date.now())} (${pause.reason}; source: ${pause.sourceSessionId})`,
       );
     }
 
@@ -1790,7 +1791,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const orchestratorId = `${project.sessionPrefix}-orchestrator`;
     if (pause && sessionId !== orchestratorId) {
       throw new Error(
-        `Project is paused due to model rate limit until ${pause.until.toISOString()} (${pause.reason}; source: ${pause.sourceSessionId})`,
+        `Project is paused due to model rate limit for ${formatDuration(pause.until.getTime() - Date.now())} (${pause.reason}; source: ${pause.sourceSessionId})`,
       );
     }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -6,6 +6,23 @@ import { open, stat } from "node:fs/promises";
 import type { OrchestratorConfig } from "./types.js";
 
 /**
+ * Format a duration in milliseconds to a human-readable string.
+ * Examples: "5s", "3m", "2h", "1d"
+ *
+ * @param ms - Duration in milliseconds (can be negative)
+ * @returns Human-readable duration string
+ */
+export function formatDuration(ms: number): string {
+  const absMs = Math.abs(ms);
+  const seconds = Math.floor(absMs / 1000);
+
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+/**
  * POSIX-safe shell escaping: wraps value in single quotes,
  * escaping any embedded single quotes as '\\'' .
  *


### PR DESCRIPTION
## Summary

- Add `formatDuration` utility function to convert milliseconds to human-readable strings (e.g., "5s", "3m", "2h", "1d")
- Update session-manager.ts to use `formatDuration` for displaying pause durations in error messages
- Export `formatDuration` from @composio/ao-core for use by other packages

**Before:**
```
Project is paused due to model rate limit until 2024-01-15T10:30:00.000Z (Rate limit reached; source: app-9)
```

**After:**
```
Project is paused due to model rate limit for 5m (Rate limit reached; source: app-9)
```

## Test plan

- [x] Added unit tests for `formatDuration` function covering seconds, minutes, hours, days, zero, and negative values
- [x] Updated existing session-manager tests to match new error message format
- [x] Ran `pnpm build`, `pnpm typecheck`, and tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)