### PR TITLE
feat(web): add error boundaries for graceful error handling

### DIFF
--- a/packages/web/src/app/error.tsx
+++ b/packages/web/src/app/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+
+/**
+ * Route-level error boundary — catches errors in all pages except the root layout.
+ * Renders within the existing layout (preserves sidebar/nav).
+ */
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  const handleReset = () => {
+    reset();
+    router.refresh(); // Re-fetches server data (critical for recovering from stale state)
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
+      <ErrorDisplay
+        title="Something went wrong"
+        message="The dashboard encountered an error. Try again to reload the page data."
+        icon="warning"
+        showReset
+        onReset={handleReset}
+        showBackLink
+        error={error}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/global-error.tsx
+++ b/packages/web/src/app/global-error.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * True catch-all error boundary — catches errors in the root layout itself.
+ * Must render full <html> and <body> since it replaces the root layout.
+ */
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const [showDetails, setShowDetails] = useState(false);
+
+  return (
+    <html lang="en" className="dark">
+      <body
+        style={{
+          margin: 0,
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0d12",
+          color: "#eef3ff",
+          fontFamily: "system-ui, -apple-system, sans-serif",
+        }}
+      >
+        <div style={{ textAlign: "center", maxWidth: 480, padding: 24 }}>
+          {/* Terminal icon with error dot */}
+          <svg
+            style={{ marginBottom: 16, width: 32, height: 32, color: "#ef4444" }}
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+          >
+            <rect x="2" y="4" width="20" height="16" rx="2" />
+            <path d="M6 9l4 3-4 3M13 15h5" />
+            <circle cx="19" cy="7" r="3" fill="#ef4444" stroke="none" />
+          </svg>
+
+          <h2 style={{ fontSize: 15, fontWeight: 500, marginBottom: 8 }}>
+            Something went wrong
+          </h2>
+          <p style={{ fontSize: 13, color: "#6f7c94", marginBottom: 24 }}>
+            An unexpected error occurred. Please try again or reload the page.
+          </p>
+
+          <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
+            <button
+              onClick={() => reset()}
+              style={{
+                padding: "8px 16px",
+                fontSize: 13,
+                fontWeight: 500,
+                border: "1px solid #272a2f",
+                borderRadius: 6,
+                backgroundColor: "#1a1d22",
+                color: "#eef3ff",
+                cursor: "pointer",
+              }}
+            >
+              Try again
+            </button>
+            <button
+              onClick={() => window.location.reload()}
+              style={{
+                padding: "8px 16px",
+                fontSize: 13,
+                fontWeight: 500,
+                border: "1px solid #272a2f",
+                borderRadius: 6,
+                backgroundColor: "#1a1d22",
+                color: "#eef3ff",
+                cursor: "pointer",
+              }}
+            >
+              Reload page
+            </button>
+          </div>
+
+          <div style={{ marginTop: 24 }}>
+            <button
+              onClick={() => setShowDetails((prev) => !prev)}
+              style={{
+                fontSize: 12,
+                color: "#6f7c94",
+                textDecoration: "underline",
+                textDecorationStyle: "dotted",
+                textUnderlineOffset: 2,
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+              }}
+            >
+              {showDetails ? "Hide" : "Show"} technical details
+            </button>
+            {showDetails && (
+              <pre
+                style={{
+                  marginTop: 12,
+                  maxWidth: 480,
+                  overflow: "auto",
+                  borderRadius: 6,
+                  border: "1px solid #272a2f",
+                  backgroundColor: "#141720",
+                  padding: 12,
+                  textAlign: "left",
+                  fontSize: 11,
+                  color: "#6f7c94",
+                  fontFamily: "monospace",
+                }}
+              >
+                {error.digest ? `Digest: ${error.digest}\n\n` : ""}
+                {error.message}
+                {"\n\n"}
+                {error.stack}
+              </pre>
+            )}
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/packages/web/src/app/sessions/[id]/error.tsx
+++ b/packages/web/src/app/sessions/[id]/error.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ErrorDisplay } from "@/components/ErrorDisplay";
+
+/**
+ * Session-specific error boundary — catches errors when loading a single session.
+ * Renders within the existing layout.
+ */
+export default function SessionError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const router = useRouter();
+
+  const handleReset = () => {
+    reset();
+    router.refresh();
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
+      <ErrorDisplay
+        title="Failed to load session"
+        message="Something went wrong while loading this session. It may have been deleted or the server may be unavailable."
+        icon="error"
+        showReset
+        onReset={handleReset}
+        showBackLink
+        error={error}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useParams } from "next/navigation";
+import { useParams, notFound } from "next/navigation";
 import { isOrchestratorSession } from "@composio/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, getAttentionLevel, type AttentionLevel } from "@/lib/types";
@@ -55,6 +55,7 @@ export default function SessionPage() {
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
   const [loading, setLoading] = useState(true);
+  const [is404, setIs404] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const sessionProjectId = session?.projectId ?? null;
   const sessionIsOrchestrator = session ? isOrchestratorSession(session) : false;
@@ -84,7 +85,7 @@ export default function SessionPage() {
     try {
       const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
       if (res.status === 404) {
-        setError("Session not found");
+        setIs404(true);
         setLoading(false);
         return;
       }
@@ -167,6 +168,11 @@ export default function SessionPage() {
     return () => clearInterval(interval);
   }, [fetchSession, fetchProjectSessions]);
 
+  // Delegate 404 to Next.js not-found boundary
+  if (is404) {
+    notFound();
+  }
+
   if (loading) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg-base)]">
@@ -175,17 +181,13 @@ export default function SessionPage() {
     );
   }
 
-  if (error || !session) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-[var(--color-bg-base)]">
-        <div className="text-[13px] text-[var(--color-status-error)]">
-          {error ?? "Session not found"}
-        </div>
-        <a href="/" className="text-[12px] text-[var(--color-accent)] hover:underline">
-          ← Back to dashboard
-        </a>
-      </div>
-    );
+  // Throw during render so the error boundary catches it
+  if (error) {
+    throw new Error(error);
+  }
+
+  if (!session) {
+    throw new Error("Session data unavailable");
   }
 
   return (

--- a/packages/web/src/components/ErrorDisplay.tsx
+++ b/packages/web/src/components/ErrorDisplay.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState } from "react";
+
+interface ErrorDisplayProps {
+  title: string;
+  message: string;
+  icon?: "error" | "warning";
+  showReset?: boolean;
+  onReset?: () => void;
+  showReload?: boolean;
+  showBackLink?: boolean;
+  error?: Error;
+}
+
+function ErrorIcon({ variant }: { variant: "error" | "warning" }) {
+  if (variant === "error") {
+    return (
+      <svg
+        className="mb-4 h-8 w-8 text-[var(--color-status-error)]"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        viewBox="0 0 24 24"
+      >
+        <rect x="2" y="4" width="20" height="16" rx="2" />
+        <path d="M6 9l4 3-4 3M13 15h5" />
+        <circle cx="19" cy="7" r="3" fill="var(--color-status-error)" stroke="none" />
+      </svg>
+    );
+  }
+
+  return (
+    <svg
+      className="mb-4 h-8 w-8 text-[var(--color-status-attention)]"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      viewBox="0 0 24 24"
+    >
+      <rect x="2" y="4" width="20" height="16" rx="2" />
+      <path d="M6 9l4 3-4 3M13 15h5" />
+      <path d="M12 8v3M12 14h.01" strokeWidth="2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function ErrorDisplay({
+  title,
+  message,
+  icon = "error",
+  showReset = false,
+  onReset,
+  showReload = false,
+  showBackLink = false,
+  error,
+}: ErrorDisplayProps) {
+  const [showDetails, setShowDetails] = useState(false);
+
+  return (
+    <div className="flex min-h-[400px] flex-col items-center justify-center py-24 text-center">
+      <ErrorIcon variant={icon} />
+
+      <h2
+        className="mb-2 text-[15px] font-medium text-[var(--color-text-primary)]"
+        style={{ fontFamily: "var(--font-geist-sans), sans-serif" }}
+      >
+        {title}
+      </h2>
+
+      <p className="mb-6 max-w-sm text-[13px] text-[var(--color-text-muted)]">
+        {message}
+      </p>
+
+      <div className="flex items-center gap-3">
+        {showReset && onReset && (
+          <button
+            onClick={onReset}
+            className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-2 text-[13px] font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
+          >
+            Try again
+          </button>
+        )}
+        {showReload && (
+          <button
+            onClick={() => window.location.reload()}
+            className="rounded-md border border-[var(--color-border-default)] bg-[var(--color-bg-surface)] px-4 py-2 text-[13px] font-medium text-[var(--color-text-primary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
+          >
+            Reload page
+          </button>
+        )}
+        {showBackLink && (
+          <a
+            href="/"
+            className="rounded-md bg-[var(--color-accent)] px-4 py-2 text-[13px] font-medium text-white transition-opacity hover:opacity-90"
+          >
+            Go to dashboard
+          </a>
+        )}
+      </div>
+
+      {error && (
+        <div className="mt-6">
+          <button
+            onClick={() => setShowDetails((prev) => !prev)}
+            className="text-[12px] text-[var(--color-text-muted)] underline decoration-dotted underline-offset-2 transition-colors hover:text-[var(--color-text-secondary)]"
+          >
+            {showDetails ? "Hide" : "Show"} technical details
+          </button>
+          {showDetails && (
+            <pre
+              className="mt-3 max-w-lg overflow-auto rounded-md border border-[var(--color-border-subtle)] bg-[var(--color-bg-subtle)] p-3 text-left text-[11px] text-[var(--color-text-muted)]"
+              style={{ fontFamily: "var(--font-jetbrains-mono), monospace" }}
+            >
+              {error.message}
+              {"\n\n"}
+              {error.stack}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #798

- **ErrorDisplay component** (`components/ErrorDisplay.tsx`): Reusable, terminal-themed error UI matching the existing EmptyState pattern. Supports configurable icons, reset/reload buttons, back links, and collapsible technical details.
- **`app/global-error.tsx`**: True catch-all that replaces the root layout on fatal errors. Renders full `<html>`/`<body>` with inline styles (no CSS vars available). Provides "Try again" and "Reload page" buttons.
- **`app/error.tsx`**: Route-level boundary that preserves the existing layout. Calls both `reset()` and `router.refresh()` to re-fetch server data on retry.
- **`app/sessions/[id]/error.tsx`**: Session-specific boundary with contextual messaging and a "Go to dashboard" link.
- **`app/sessions/[id]/page.tsx`**: Replaced manual error/404 inline UI with `notFound()` for 404s and `throw` during render so error boundaries catch failures properly.

## What's NOT changed

`lib/dashboard-page-data.ts` silent catch is untouched — partial dashboard data is better than no dashboard.

## Test plan

- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (0 errors, only pre-existing warnings)
- [x] `pnpm build` succeeds (web package builds cleanly)
- [x] All 475 web tests pass (26 test files)
- [ ] Manual: throw in root layout → `global-error.tsx` renders full page
- [ ] Manual: throw in dashboard → `error.tsx` renders within layout
- [ ] Manual: visit `/sessions/invalid-id` → not-found page
- [ ] Manual: click "Try again" → data re-fetches and re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)