### PR TITLE
feat(core): multi-project portfolio foundation [1/3]

### DIFF
--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -19,9 +19,6 @@ describe("Config Loading", () => {
     originalCwd = process.cwd();
     originalEnv = { ...process.env };
 
-    // Clear AO_CONFIG_PATH to ensure test isolation
-    delete process.env.AO_CONFIG_PATH;
-
     // Change to test directory
     process.chdir(testDir);
   });
@@ -70,6 +67,25 @@ describe("Config Loading", () => {
     it("should return null if no config found", () => {
       const found = findConfigFile();
       expect(found).toBeNull();
+    });
+
+    it("should skip flat local configs (no projects: wrapper) when searching up tree", () => {
+      // Write a flat behavior-only config (post-migration format)
+      const flatConfig = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(flatConfig, "repo: org/my-project\nagent: claude-code\nruntime: tmux\n");
+
+      // Should NOT return the flat config — it has no `projects:` key
+      const found = findConfigFile();
+      expect(found).toBeNull();
+    });
+
+    it("should return an old-format config that has a projects: wrapper", () => {
+      const oldFormatConfig = join(testDir, "agent-orchestrator.yaml");
+      writeFileSync(oldFormatConfig, `projects:\n  my-project:\n    repo: org/repo\n    path: ${testDir}\n`);
+
+      const found = findConfigFile();
+      expect(found).not.toBeNull();
+      expect(realpathSync(found!)).toBe(realpathSync(oldFormatConfig));
     });
   });
 

--- a/packages/core/src/__tests__/config-generator.test.ts
+++ b/packages/core/src/__tests__/config-generator.test.ts
@@ -17,6 +17,7 @@ import {
   isRepoAlreadyCloned,
   resolveCloneTarget,
   sanitizeProjectId,
+  readOriginRemoteUrl,
 } from "../config-generator.js";
 
 // =============================================================================
@@ -505,5 +506,69 @@ describe("resolveCloneTarget", () => {
     const parsed = parseRepoUrl("https://github.com/owner/my-app");
     const result = resolveCloneTarget(parsed, tmpDir);
     expect(result).toBe(join(tmpDir, "my-app"));
+  });
+});
+
+// =============================================================================
+// readOriginRemoteUrl
+// =============================================================================
+
+describe("readOriginRemoteUrl", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ao-test-origin-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null for non-git directory", () => {
+    expect(readOriginRemoteUrl(tmpDir)).toBeNull();
+  });
+
+  it("returns null when .git/config has no origin remote", () => {
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".git", "config"),
+      '[core]\n\trepositoryformatversion = 0\n\tbare = false\n',
+    );
+    expect(readOriginRemoteUrl(tmpDir)).toBeNull();
+  });
+
+  it("returns HTTPS origin URL", () => {
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".git", "config"),
+      '[core]\n\tbare = false\n[remote "origin"]\n\turl = https://github.com/owner/repo.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n',
+    );
+    expect(readOriginRemoteUrl(tmpDir)).toBe("https://github.com/owner/repo.git");
+  });
+
+  it("returns SSH origin URL", () => {
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".git", "config"),
+      '[core]\n\tbare = false\n[remote "origin"]\n\turl = git@github.com:owner/repo.git\n\tfetch = +refs/heads/*:refs/remotes/origin/*\n',
+    );
+    expect(readOriginRemoteUrl(tmpDir)).toBe("git@github.com:owner/repo.git");
+  });
+
+  it("picks origin when multiple remotes exist", () => {
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".git", "config"),
+      [
+        '[remote "upstream"]',
+        "\turl = https://github.com/upstream/repo.git",
+        "\tfetch = +refs/heads/*:refs/remotes/upstream/*",
+        '[remote "origin"]',
+        "\turl = https://github.com/myuser/repo.git",
+        "\tfetch = +refs/heads/*:refs/remotes/origin/*",
+        "",
+      ].join("\n"),
+    );
+    expect(readOriginRemoteUrl(tmpDir)).toBe("https://github.com/myuser/repo.git");
   });
 });

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -149,21 +149,17 @@ describe("Instance ID Generation", () => {
     expect(id1).toBe(id2);
   });
 
-  it("same config + different projects = different instance IDs with same hash", () => {
+  it("same config + different projects = different instance IDs", () => {
     const id1 = generateInstanceId(configPath, "/repos/integrator");
     const id2 = generateInstanceId(configPath, "/repos/backend");
 
-    // Extract hash prefix
-    const hash1 = id1.split("-")[0];
-    const hash2 = id2.split("-")[0];
-
-    expect(hash1).toBe(hash2); // Same hash
-    expect(id1).not.toBe(id2); // Different instance IDs
+    // Different project paths → different hashes and instance IDs
+    expect(id1).not.toBe(id2);
     expect(id1).toContain("integrator");
     expect(id2).toContain("backend");
   });
 
-  it("different config + same project = different instance IDs", () => {
+  it("different config + same project = same instance IDs (hash is project-path-based)", () => {
     const otherDir = join(tmpdir(), "other-config-test");
     mkdirSync(otherDir, { recursive: true });
     const config2Path = join(otherDir, "agent-orchestrator.yaml");
@@ -172,7 +168,9 @@ describe("Instance ID Generation", () => {
     const id1 = generateInstanceId(configPath, "/repos/integrator");
     const id2 = generateInstanceId(config2Path, "/repos/integrator");
 
-    expect(id1).not.toBe(id2);
+    // Instance ID is now based on projectPath, so same project = same ID
+    // regardless of config location (needed for local→global config migration)
+    expect(id1).toBe(id2);
 
     rmSync(otherDir, { recursive: true, force: true });
   });
@@ -351,13 +349,13 @@ describe("Tmux Naming", () => {
   });
 
   it("generateTmuxName format is {hash}-{prefix}-{num}", () => {
-    const tmuxName = generateTmuxName(configPath, "int", 1);
+    const tmuxName = generateTmuxName(tmpDir, "int", 1);
 
     expect(tmuxName).toMatch(/^[a-f0-9]{12}-int-1$/);
   });
 
   it("ALWAYS includes hash for global uniqueness", () => {
-    const tmuxName = generateTmuxName(configPath, "int", 1);
+    const tmuxName = generateTmuxName(tmpDir, "int", 1);
 
     expect(tmuxName).toMatch(/^[a-f0-9]{12}-/);
   });
@@ -401,7 +399,7 @@ describe("Tmux Naming", () => {
 
   it("user-facing name does NOT include hash", () => {
     const userFacing = generateSessionName("int", 1);
-    const tmuxName = generateTmuxName(configPath, "int", 1);
+    const tmuxName = generateTmuxName(tmpDir, "int", 1);
 
     expect(userFacing).toBe("int-1");
     expect(tmuxName).toMatch(/^[a-f0-9]{12}-int-1$/);
@@ -446,34 +444,22 @@ describe("Origin File Management", () => {
     }).not.toThrow();
   });
 
-  it("call with different config path throws hash collision error", () => {
+  it("call with different config path updates .origin (config migration)", () => {
     // First config
     validateAndStoreOrigin(configPath, projectPath);
 
-    // Create second config that would have same hash (simulate collision)
-    // This is hard to simulate naturally, so we'll manually edit .origin
+    // Simulate config migration: .origin still has old path
     const originPath = getOriginFilePath(configPath, projectPath);
     writeFileSync(originPath, "/fake/other/config/path");
 
+    // Should NOT throw — gracefully updates .origin to new config path
     expect(() => {
       validateAndStoreOrigin(configPath, projectPath);
-    }).toThrow(/Hash collision detected/);
-  });
+    }).not.toThrow();
 
-  it("error message includes both config paths", () => {
-    validateAndStoreOrigin(configPath, projectPath);
-
-    const originPath = getOriginFilePath(configPath, projectPath);
-    writeFileSync(originPath, "/fake/other/path");
-
-    try {
-      validateAndStoreOrigin(configPath, projectPath);
-      expect.fail("Should have thrown");
-    } catch (err) {
-      const message = (err as Error).message;
-      expect(message).toContain("/fake/other/path");
-      expect(message).toContain(realpathSync(configPath));
-    }
+    // .origin should now contain the current config path
+    const stored = readFileSync(originPath, "utf-8").trim();
+    expect(stored).toBe(realpathSync(configPath));
   });
 
   it("creates parent directory if needed", () => {

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -40,13 +40,11 @@ export function resolveAgentSelection(params: {
 
   const agentName = persistedAgent
     ? persistedAgent
-    : role === "worker"
-      ? (spawnAgentOverride ??
-        roleProjectConfig?.agent ??
-        project.agent ??
-        roleDefaults?.agent ??
-        defaults.agent)
-      : (roleProjectConfig?.agent ?? project.agent ?? roleDefaults?.agent ?? defaults.agent);
+    : (spawnAgentOverride ??
+      roleProjectConfig?.agent ??
+      project.agent ??
+      roleDefaults?.agent ??
+      defaults.agent);
 
   const agentConfig: AgentSpecificConfig = {
     ...sharedConfig,

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -40,11 +40,13 @@ export function resolveAgentSelection(params: {
 
   const agentName = persistedAgent
     ? persistedAgent
-    : (spawnAgentOverride ??
-      roleProjectConfig?.agent ??
-      project.agent ??
-      roleDefaults?.agent ??
-      defaults.agent);
+    : role === "worker"
+      ? (spawnAgentOverride ??
+        roleProjectConfig?.agent ??
+        project.agent ??
+        roleDefaults?.agent ??
+        defaults.agent)
+      : (roleProjectConfig?.agent ?? project.agent ?? roleDefaults?.agent ?? defaults.agent);
 
   const agentConfig: AgentSpecificConfig = {
     ...sharedConfig,

--- a/packages/core/src/config-generator.ts
+++ b/packages/core/src/config-generator.ts
@@ -297,6 +297,48 @@ export function isRepoAlreadyCloned(dir: string, expectedCloneUrl: string): bool
 }
 
 /**
+ * Read the origin remote URL from a local git repo's .git/config.
+ * Returns null if the directory is not a git repo or has no origin remote.
+ */
+export function readOriginRemoteUrl(repoDir: string): string | null {
+  const gitDir = join(repoDir, ".git");
+  if (!existsSync(gitDir)) return null;
+
+  const configPath = join(gitDir, "config");
+  if (!existsSync(configPath)) return null;
+
+  let gitConfig: string;
+  try {
+    gitConfig = readFileSync(configPath, "utf-8");
+  } catch {
+    return null;
+  }
+
+  // Parse ini-style git config: find [remote "origin"] section and extract url
+  const lines = gitConfig.split("\n");
+  let inOriginSection = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Section header
+    if (trimmed.startsWith("[")) {
+      inOriginSection = /^\[remote\s+"origin"\]$/i.test(trimmed);
+      continue;
+    }
+
+    if (inOriginSection) {
+      const urlMatch = trimmed.match(/^url\s*=\s*(.+)$/);
+      if (urlMatch) {
+        return urlMatch[1].trim();
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Determine the target directory for cloning a repo.
  * If CWD matches the repo, return CWD. Otherwise return CWD/repo-name.
  */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,6 +17,7 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { ConfigNotFoundError, type OrchestratorConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
+import { getGlobalConfigPath } from "./global-config.js";
 
 function inferScmPlugin(project: {
   repo: string;
@@ -151,6 +152,8 @@ const ProjectConfigSchema = z.object({
     .string()
     .regex(/^[a-zA-Z0-9_-]+$/, "sessionPrefix must match [a-zA-Z0-9_-]+")
     .optional(),
+  /** Unix timestamp of last shadow sync from local config (set by global config, read-only here). */
+  _shadowSyncedAt: z.number().optional(),
   runtime: z.string().optional(),
   agent: z.string().optional(),
   workspace: z.string().optional(),
@@ -399,14 +402,35 @@ export function findConfigFile(startDir?: string): string | null {
   }
 
   // 2. Search up directory tree from CWD (like git)
+  //    Skip flat local configs (behavior-only, no `projects:` wrapper) — they are
+  //    read via loadLocalProjectConfig(), not through this search path. After
+  //    migration to the hybrid model, the per-project agent-orchestrator.yaml is a
+  //    flat behavior file; the authoritative registry is the global config.
   const searchUpTree = (dir: string): string | null => {
     const configFiles = ["agent-orchestrator.yaml", "agent-orchestrator.yml"];
 
     for (const filename of configFiles) {
       const configPath = resolve(dir, filename);
-      if (existsSync(configPath)) {
-        return configPath;
+      if (!existsSync(configPath)) continue;
+
+      // Peek at file: skip flat local configs (no top-level `projects:` key)
+      try {
+        const raw = readFileSync(configPath, "utf-8");
+        const parsed = parseYaml(raw);
+        if (
+          !parsed ||
+          typeof parsed !== "object" ||
+          !("projects" in (parsed as Record<string, unknown>))
+        ) {
+          // Flat local config — skip, keep searching upward
+          continue;
+        }
+      } catch {
+        // Unreadable or malformed — skip, keep searching
+        continue;
       }
+
+      return configPath;
     }
 
     const parent = resolve(dir, "..");
@@ -425,17 +449,41 @@ export function findConfigFile(startDir?: string): string | null {
   }
 
   // 3. Check explicit startDir if provided
+  //    Same flat-config check as step 2: after migration, project directories
+  //    contain a flat behavior-only config that should not be returned here.
   if (startDir) {
     const files = ["agent-orchestrator.yaml", "agent-orchestrator.yml"];
     for (const filename of files) {
       const path = resolve(startDir, filename);
-      if (existsSync(path)) {
-        return path;
+      if (!existsSync(path)) continue;
+
+      try {
+        const raw = readFileSync(path, "utf-8");
+        const parsed = parseYaml(raw);
+        if (
+          !parsed ||
+          typeof parsed !== "object" ||
+          !("projects" in (parsed as Record<string, unknown>))
+        ) {
+          continue;
+        }
+      } catch {
+        continue;
       }
+
+      return path;
     }
   }
 
-  // 4. Check home directory locations
+  // 4. Check global config path (new hybrid mode: ~/.agent-orchestrator/config.yaml)
+  //    This takes priority over legacy home-directory locations so that users who
+  //    have migrated to the hybrid model always load from the canonical global path.
+  const globalConfigPath = getGlobalConfigPath();
+  if (existsSync(globalConfigPath)) {
+    return globalConfigPath;
+  }
+
+  // 5. Legacy home directory locations (backward compatibility)
   const homePaths = [
     resolve(homedir(), ".agent-orchestrator.yaml"),
     resolve(homedir(), ".agent-orchestrator.yml"),

--- a/packages/core/src/global-config.ts
+++ b/packages/core/src/global-config.ts
@@ -1,0 +1,646 @@
+/**
+ * Global config — the fixed-location registry + shadow copies.
+ *
+ * Option C (Hybrid Local + Shadow) architecture:
+ *
+ *   Global config  (~/.agent-orchestrator/config.yaml, XDG-aware)
+ *     - Project registry: identity fields (name, path) per project
+ *     - Shadow copies: behavior fields synced from local on `ao start`
+ *     - Global operational settings: port, defaults, notifiers, reactions
+ *
+ *   Local config  (<project>/agent-orchestrator.yaml)
+ *     - Behavior fields only (repo, agent, runtime, workspace, tracker, …)
+ *     - No identity fields (name, path, sessionPrefix)
+ *     - Flat YAML — no `projects:` wrapper
+ *     - Source of truth; shadow is a convenience copy for remote/Docker use
+ *
+ * Load modes:
+ *   In-project:  global (identity) + local (behavior) → merged effective config
+ *   Remote:      global shadow only (no local config access needed)
+ *   ao start:    validate local → sync shadow atomically → start daemon
+ *
+ * Sync rules:
+ *   - Shadow updated ONLY on `ao start`
+ *   - Fields matching *Token/*Key/*Secret/*Password excluded with warning
+ *   - Identity fields (name, path) never overwritten by shadow sync
+ *   - Unknown / future fields preserved as opaque passthrough
+ *   - Write is always atomic (temp-file + rename)
+ */
+
+import { readFileSync, existsSync, mkdirSync, statSync } from "node:fs";
+import { resolve, join, dirname, basename } from "node:path";
+import { homedir } from "node:os";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { z } from "zod";
+import { atomicWriteFileSync } from "./atomic-write.js";
+
+// =============================================================================
+// CONSTANTS
+// =============================================================================
+
+/** Identity fields owned by the global registry — never overwritten by shadow. */
+const IDENTITY_FIELDS = new Set(["name", "path"]);
+
+/** Internal fields prefixed with underscore (e.g. _shadowSyncedAt). */
+const INTERNAL_FIELD_PREFIX = "_";
+
+/** Fields excluded from shadow sync (secret hygiene). Case-insensitive suffix match. */
+const SECRET_SUFFIX_PATTERN = /(token|key|secret|password)$/i;
+
+// =============================================================================
+// GLOBAL CONFIG PATH (XDG-aware)
+// =============================================================================
+
+/**
+ * Return the canonical path to the global config file.
+ *
+ * Priority:
+ *   1. AO_GLOBAL_CONFIG environment variable (explicit global config override)
+ *   2. $XDG_CONFIG_HOME/agent-orchestrator/config.yaml
+ *   3. ~/.agent-orchestrator/config.yaml  (default)
+ *
+ * NOTE: This intentionally does NOT read AO_CONFIG_PATH. That env var is used
+ * by findConfigFile() to locate any config (including project-local ones).
+ * Using it here would risk overwriting a project-local config with global-format
+ * YAML when syncProjectShadow/registerProjectInGlobalConfig call this function.
+ */
+export function getGlobalConfigPath(): string {
+  if (process.env["AO_GLOBAL_CONFIG"]) {
+    return resolve(process.env["AO_GLOBAL_CONFIG"]);
+  }
+
+  const xdgConfigHome = process.env["XDG_CONFIG_HOME"];
+  if (xdgConfigHome) {
+    return join(xdgConfigHome, "agent-orchestrator", "config.yaml");
+  }
+
+  return join(homedir(), ".agent-orchestrator", "config.yaml");
+}
+
+// =============================================================================
+// GLOBAL CONFIG SCHEMA
+// =============================================================================
+
+/**
+ * Per-project entry in the global registry.
+ * Contains identity fields + shadow behavior fields (passthrough).
+ * Internal _shadowSyncedAt tracks last successful sync timestamp.
+ */
+export const GlobalProjectEntrySchema = z
+  .object({
+    /** Display name (identity — never overwritten by shadow sync). */
+    name: z.string().optional(),
+    /** Absolute path to the project root (identity). */
+    path: z.string(),
+    /** Unix timestamp of last successful shadow sync from local config. */
+    _shadowSyncedAt: z.number().optional(),
+  })
+  .passthrough();
+
+export type GlobalProjectEntry = z.infer<typeof GlobalProjectEntrySchema>;
+
+/**
+ * Global config schema.
+ * Operational settings + project registry with shadow behavior fields.
+ */
+export const GlobalConfigSchema = z
+  .object({
+    /** Web dashboard port. Default: 3000 */
+    port: z.number().default(3000),
+    terminalPort: z.number().optional(),
+    directTerminalPort: z.number().optional(),
+    /** Time before a "ready" session becomes "idle". Default: 300 000 ms (5 min). */
+    readyThresholdMs: z.number().nonnegative().default(300_000),
+    /** Cross-project defaults — projects inherit when fields are omitted. */
+    defaults: z
+      .object({
+        runtime: z.string().default("tmux"),
+        agent: z.string().default("claude-code"),
+        workspace: z.string().default("worktree"),
+        notifiers: z.array(z.string()).default(["composio", "desktop"]),
+        orchestrator: z.object({ agent: z.string().optional() }).optional(),
+        worker: z.object({ agent: z.string().optional() }).optional(),
+      })
+      .default({}),
+    /** Project registry — map key is the canonical project ID. */
+    projects: z.record(GlobalProjectEntrySchema).default({}),
+    /** Optional explicit project ordering for sidebar / portfolio display. */
+    projectOrder: z.array(z.string()).optional(),
+    /** Notification channel configurations. */
+    notifiers: z.record(z.object({ plugin: z.string() }).passthrough()).default({}),
+    /** Maps priority levels to notifier channel IDs. */
+    notificationRouting: z.record(z.array(z.string())).default({
+      urgent: ["desktop", "composio"],
+      action: ["desktop", "composio"],
+      warning: ["composio"],
+      info: ["composio"],
+    }),
+    /** Reaction rules (default reactions merged at load time). */
+    reactions: z.record(z.object({}).passthrough()).default({}),
+  })
+  .passthrough();
+
+export type GlobalConfig = z.infer<typeof GlobalConfigSchema>;
+
+// =============================================================================
+// LOCAL PROJECT CONFIG SCHEMA (flat, behavior-only)
+// =============================================================================
+
+/**
+ * Flat, behavior-only local project config.
+ * Lives at <project>/agent-orchestrator.yaml.
+ *
+ * Does NOT contain identity fields: name, path, sessionPrefix.
+ * Those are owned by the global registry.
+ *
+ * Uses passthrough() for forward compatibility — unknown fields from
+ * future ao versions are stored in the shadow without re-parsing.
+ */
+export const LocalProjectConfigSchema = z
+  .object({
+    repo: z.string().optional(),
+    defaultBranch: z.string().optional(),
+    runtime: z.string().optional(),
+    agent: z.string().optional(),
+    workspace: z.string().optional(),
+    tracker: z.object({ plugin: z.string() }).passthrough().optional(),
+    scm: z
+      .object({
+        plugin: z.string(),
+        webhook: z
+          .object({
+            enabled: z.boolean().optional(),
+            path: z.string().optional(),
+            secretEnvVar: z.string().optional(),
+            signatureHeader: z.string().optional(),
+            eventHeader: z.string().optional(),
+            deliveryHeader: z.string().optional(),
+            maxBodyBytes: z.number().optional(),
+          })
+          .optional(),
+      })
+      .passthrough()
+      .optional(),
+    symlinks: z.array(z.string()).optional(),
+    postCreate: z.array(z.string()).optional(),
+    agentConfig: z
+      .object({
+        permissions: z
+          .enum(["permissionless", "default", "auto-edit", "suggest", "skip"])
+          .optional(),
+        model: z.string().optional(),
+        orchestratorModel: z.string().optional(),
+      })
+      .passthrough()
+      .optional(),
+    orchestrator: z
+      .object({ agent: z.string().optional(), agentConfig: z.object({}).passthrough().optional() })
+      .optional(),
+    worker: z
+      .object({ agent: z.string().optional(), agentConfig: z.object({}).passthrough().optional() })
+      .optional(),
+    reactions: z.record(z.object({}).passthrough()).optional(),
+    agentRules: z.string().optional(),
+    agentRulesFile: z.string().optional(),
+    orchestratorRules: z.string().optional(),
+    orchestratorSessionStrategy: z
+      .enum(["reuse", "delete", "ignore", "delete-new", "ignore-new", "kill-previous"])
+      .optional(),
+    opencodeIssueSessionStrategy: z.enum(["reuse", "delete", "ignore"]).optional(),
+    decomposer: z.object({}).passthrough().optional(),
+  })
+  .passthrough();
+
+export type LocalProjectConfig = z.infer<typeof LocalProjectConfigSchema>;
+
+// =============================================================================
+// LOAD / SAVE
+// =============================================================================
+
+/**
+ * Load and validate the global config.
+ * Returns null if the file does not exist (not an error — first run).
+ */
+export function loadGlobalConfig(configPath?: string): GlobalConfig | null {
+  const path = configPath ?? getGlobalConfigPath();
+  if (!existsSync(path)) return null;
+
+  const raw = readFileSync(path, "utf-8");
+  const parsed = parseYaml(raw);
+  if (!parsed || typeof parsed !== "object") return null;
+
+  const config = GlobalConfigSchema.parse(parsed);
+
+  // Expand ~ in project paths
+  for (const entry of Object.values(config.projects)) {
+    if (typeof entry.path === "string" && entry.path.startsWith("~/")) {
+      entry.path = join(homedir(), entry.path.slice(2));
+    }
+  }
+
+  return config;
+}
+
+/**
+ * Save the global config atomically (temp-file + rename).
+ * Creates parent directories if they don't exist.
+ */
+export function saveGlobalConfig(config: GlobalConfig, configPath?: string): void {
+  const path = configPath ?? getGlobalConfigPath();
+  const dir = dirname(path);
+  mkdirSync(dir, { recursive: true });
+  atomicWriteFileSync(path, stringifyYaml(config, { indent: 2 }));
+}
+
+/**
+ * Load a flat local project config from <projectPath>/agent-orchestrator.yaml.
+ *
+ * Returns null when:
+ *   - No config file found at projectPath
+ *   - File has a `projects:` wrapper (old format — use loadConfig() instead)
+ *   - File is empty or malformed
+ */
+export function loadLocalProjectConfig(projectPath: string): LocalProjectConfig | null {
+  const candidates = [
+    join(projectPath, "agent-orchestrator.yaml"),
+    join(projectPath, "agent-orchestrator.yml"),
+  ];
+
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+
+    let parsed: unknown;
+    try {
+      const raw = readFileSync(path, "utf-8");
+      parsed = parseYaml(raw);
+    } catch {
+      return null;
+    }
+
+    if (!parsed || typeof parsed !== "object") return null;
+
+    // Old format: has `projects:` wrapper → not a flat local config
+    if ("projects" in (parsed as Record<string, unknown>)) return null;
+
+    try {
+      return LocalProjectConfigSchema.parse(parsed);
+    } catch {
+      return null;
+    }
+  }
+
+  return null;
+}
+
+// =============================================================================
+// SHADOW SYNC
+// =============================================================================
+
+/**
+ * Sync local project behavior fields into the global config shadow, atomically.
+ *
+ * Called by `ao start` after validating local config.
+ *
+ * Rules:
+ *   - Identity fields (name, path) are never overwritten
+ *   - Fields starting with `_` (internal) are excluded
+ *   - Fields matching *Token/*Key/*Secret/*Password are excluded (warn)
+ *   - All other fields from localConfig are written verbatim (passthrough)
+ *   - _shadowSyncedAt is set to current Unix timestamp
+ *   - Write is atomic
+ */
+export function syncProjectShadow(
+  projectId: string,
+  localConfig: LocalProjectConfig,
+  globalConfigPath?: string,
+): void {
+  const configPath = globalConfigPath ?? getGlobalConfigPath();
+  const globalConfig = loadGlobalConfig(configPath) ?? makeEmptyGlobalConfig();
+
+  const existing = globalConfig.projects[projectId] as
+    | (GlobalProjectEntry & Record<string, unknown>)
+    | undefined;
+
+  // Build shadow from local config fields
+  const shadowFields: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(localConfig as Record<string, unknown>)) {
+    if (IDENTITY_FIELDS.has(key)) continue;
+    if (key.startsWith(INTERNAL_FIELD_PREFIX)) continue;
+    if (SECRET_SUFFIX_PATTERN.test(key)) {
+      process.stderr.write(
+        `ao: warning — excluding "${key}" from shadow sync (secret-like field name). ` +
+          `Use environment variables for secrets.\n`,
+      );
+      continue;
+    }
+    shadowFields[key] = value;
+  }
+
+  // Rebuild project entry: preserve identity, overwrite behavior
+  globalConfig.projects[projectId] = {
+    ...(existing?.name !== null && existing?.name !== undefined ? { name: existing.name } : {}),
+    path: existing?.path ?? "",
+    ...shadowFields,
+    _shadowSyncedAt: Math.floor(Date.now() / 1000),
+  };
+
+  saveGlobalConfig(globalConfig, configPath);
+}
+
+// =============================================================================
+// REGISTRATION
+// =============================================================================
+
+/**
+ * Register or update a project in the global registry.
+ *
+ * - If the project already exists, identity fields are preserved and only
+ *   updated if explicitly provided.
+ * - If localConfig is provided, the shadow is synced immediately after
+ *   writing the registry entry.
+ * - Write is atomic.
+ */
+export function registerProjectInGlobalConfig(
+  projectId: string,
+  name: string,
+  projectPath: string,
+  localConfig?: LocalProjectConfig,
+  globalConfigPath?: string,
+): void {
+  const configPath = globalConfigPath ?? getGlobalConfigPath();
+  const globalConfig = loadGlobalConfig(configPath) ?? makeEmptyGlobalConfig();
+
+  const existing = globalConfig.projects[projectId] as
+    | (GlobalProjectEntry & Record<string, unknown>)
+    | undefined;
+
+  // Preserve existing shadow behavior fields; update identity
+  globalConfig.projects[projectId] = {
+    ...(existing ?? {}),
+    name,
+    path: projectPath,
+  };
+
+  saveGlobalConfig(globalConfig, configPath);
+
+  if (localConfig) {
+    syncProjectShadow(projectId, localConfig, configPath);
+  }
+}
+
+// =============================================================================
+// EFFECTIVE CONFIG BUILD
+// =============================================================================
+
+/**
+ * Build effective project configuration by merging global registry identity
+ * with local behavior config.
+ *
+ * Load order:
+ *   1. Global entry supplies identity (name, path) + shadow behavior
+ *   2. Local flat config (if present) overrides shadow behavior with fresh fields
+ *   3. Shadow-fallback mode: global shadow used when local config is absent
+ *
+ * Returns a plain object compatible with ProjectConfig from config.ts.
+ * Returns null if the project is not registered in the global config.
+ */
+export function buildEffectiveProjectConfig(
+  projectId: string,
+  globalConfig: GlobalConfig,
+): (Record<string, unknown> & { name: string; path: string }) | null {
+  const entry = globalConfig.projects[projectId] as
+    | (GlobalProjectEntry & Record<string, unknown>)
+    | undefined;
+  if (!entry || !entry.path) return null;
+
+  const projectPath = entry.path as string;
+  const name = (entry.name as string | undefined) ?? projectId;
+
+  const localConfig = loadLocalProjectConfig(projectPath);
+
+  if (localConfig) {
+    // In-project mode: global identity + local behavior (override shadow)
+    const { name: _name, path: _path, _shadowSyncedAt: _ts, ...shadowBehavior } = entry;
+    void _name;
+    void _path;
+    void _ts;
+
+    return {
+      name,
+      path: projectPath,
+      ...shadowBehavior,
+      ...(localConfig as Record<string, unknown>),
+    };
+  }
+
+  // Shadow-fallback mode: use shadow as-is
+  const { _shadowSyncedAt: _ts, ...rest } = entry;
+  void _ts;
+  return {
+    ...rest,
+    name,
+    path: projectPath,
+  };
+}
+
+// =============================================================================
+// STALENESS DETECTION
+// =============================================================================
+
+/**
+ * Returns true if the local config file is newer than the last shadow sync.
+ * Used by `ao status` to warn the user to restart ao.
+ */
+export function isProjectShadowStale(projectId: string, globalConfig: GlobalConfig): boolean {
+  const entry = globalConfig.projects[projectId] as
+    | (GlobalProjectEntry & { _shadowSyncedAt?: number })
+    | undefined;
+  if (!entry) return false;
+
+  const syncedAt = entry._shadowSyncedAt;
+  if (!syncedAt) return true; // Never synced
+
+  const projectPath = entry.path as string;
+  const candidates = [
+    join(projectPath, "agent-orchestrator.yaml"),
+    join(projectPath, "agent-orchestrator.yml"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    try {
+      const stat = statSync(candidate);
+      const mtimeSeconds = Math.floor(stat.mtimeMs / 1000);
+      return mtimeSeconds > syncedAt;
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+// =============================================================================
+// MIGRATION
+// =============================================================================
+
+/**
+ * Detect if a raw parsed YAML object uses the old single-file config format.
+ * Old format: top-level `projects:` map where each entry has `path` + behavior.
+ */
+export function isOldConfigFormat(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  const obj = raw as Record<string, unknown>;
+  if (!("projects" in obj) || typeof obj["projects"] !== "object") return false;
+
+  // Confirm at least one project entry has `path` (old format)
+  const projects = obj["projects"] as Record<string, unknown>;
+  return Object.values(projects).some(
+    (entry) =>
+      entry !== null && entry !== undefined && typeof entry === "object" && "path" in (entry as Record<string, unknown>),
+  );
+}
+
+/**
+ * Migrate an old single-file config to the new hybrid format.
+ *
+ * What happens:
+ *   1. Read old config from oldConfigPath
+ *   2. Create global config at ~/.agent-orchestrator/config.yaml with:
+ *      - Global settings (port, defaults, notifiers, reactions)
+ *      - Project registry entries (identity) + full behavior as shadow
+ *      - _shadowSyncedAt = now (treating existing config as synced)
+ *   3. Rewrite local config at oldConfigPath to flat behavior-only format
+ *      (removes name, path, sessionPrefix from each project entry, removes
+ *       the `projects:` wrapper — only the first/matched project is written
+ *       when the old config is inside the project directory)
+ *   4. Returns the new global config path
+ *
+ * The old storage directories (based on sha256(project.path)) remain valid
+ * because the hash derivation is unchanged — configPath dirname = project.path.
+ *
+ * @param oldConfigPath  Absolute path to the old agent-orchestrator.yaml
+ * @param globalConfigPath  Override for global config path (default: getGlobalConfigPath())
+ * @returns The global config path
+ */
+export function migrateToGlobalConfig(oldConfigPath: string, globalConfigPath?: string): string {
+  const targetGlobalPath = globalConfigPath ?? getGlobalConfigPath();
+
+  const raw = readFileSync(oldConfigPath, "utf-8");
+  const parsed = parseYaml(raw) as Record<string, unknown>;
+
+  if (!isOldConfigFormat(parsed)) {
+    throw new Error(`File at ${oldConfigPath} is not an old-format config.`);
+  }
+
+  const oldProjects = (parsed["projects"] ?? {}) as Record<string, Record<string, unknown>>;
+
+  // Build new global config
+  const newGlobal: GlobalConfig = makeEmptyGlobalConfig();
+
+  // Preserve global operational settings
+  if (typeof parsed["port"] === "number") newGlobal.port = parsed["port"];
+  if (parsed["terminalPort"] !== null && parsed["terminalPort"] !== undefined) newGlobal.terminalPort = parsed["terminalPort"] as number;
+  if (parsed["directTerminalPort"] !== null && parsed["directTerminalPort"] !== undefined)
+    newGlobal.directTerminalPort = parsed["directTerminalPort"] as number;
+  if (parsed["readyThresholdMs"] !== null && parsed["readyThresholdMs"] !== undefined)
+    newGlobal.readyThresholdMs = parsed["readyThresholdMs"] as number;
+  if (parsed["defaults"] !== null && parsed["defaults"] !== undefined)
+    newGlobal.defaults = parsed["defaults"] as GlobalConfig["defaults"];
+  if (parsed["notifiers"] !== null && parsed["notifiers"] !== undefined)
+    newGlobal.notifiers = parsed["notifiers"] as GlobalConfig["notifiers"];
+  if (parsed["notificationRouting"] !== null && parsed["notificationRouting"] !== undefined)
+    newGlobal.notificationRouting = parsed[
+      "notificationRouting"
+    ] as GlobalConfig["notificationRouting"];
+  if (parsed["reactions"] !== null && parsed["reactions"] !== undefined)
+    newGlobal.reactions = parsed["reactions"] as GlobalConfig["reactions"];
+
+  const now = Math.floor(Date.now() / 1000);
+
+  // Build project registry entries
+  for (const [projectId, project] of Object.entries(oldProjects)) {
+    if (!project["path"]) continue;
+
+    const projectPath =
+      typeof project["path"] === "string" && project["path"].startsWith("~/")
+        ? join(homedir(), (project["path"] as string).slice(2))
+        : (project["path"] as string);
+
+    // Extract behavior fields (everything except identity + internal)
+    const shadowFields: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(project)) {
+      if (key === "name" || key === "path" || key === "sessionPrefix") continue;
+      if (key.startsWith(INTERNAL_FIELD_PREFIX)) continue;
+      if (SECRET_SUFFIX_PATTERN.test(key)) continue;
+      shadowFields[key] = value;
+    }
+
+    newGlobal.projects[projectId] = {
+      name: (project["name"] as string | undefined) ?? projectId,
+      path: projectPath,
+      ...shadowFields,
+      _shadowSyncedAt: now,
+    };
+  }
+
+  // Write global config atomically
+  saveGlobalConfig(newGlobal, targetGlobalPath);
+
+  // Rewrite each old project's local config to flat format.
+  // Each old project had its config inside the multi-project file.
+  // For single-project configs at the project root: rewrite in place.
+  // For multi-project configs: write each project's local config to its path.
+  const oldConfigDir = dirname(resolve(oldConfigPath));
+  for (const [_projectId, project] of Object.entries(oldProjects)) {
+    if (!project["path"]) continue;
+
+    const projectPath =
+      typeof project["path"] === "string" && project["path"].startsWith("~/")
+        ? join(homedir(), (project["path"] as string).slice(2))
+        : (project["path"] as string);
+
+    // Only rewrite if the old config lives inside this project's directory
+    // (single-project setup: the config IS in the project root)
+    if (resolve(projectPath) !== resolve(oldConfigDir)) continue;
+
+    const behaviorFields: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(project)) {
+      if (key === "name" || key === "path" || key === "sessionPrefix") continue;
+      if (key.startsWith(INTERNAL_FIELD_PREFIX)) continue;
+      behaviorFields[key] = value;
+    }
+
+    // Write flat local config
+    const localConfigPath = join(projectPath, basename(oldConfigPath));
+    atomicWriteFileSync(localConfigPath, stringifyYaml(behaviorFields, { indent: 2 }));
+  }
+
+  return targetGlobalPath;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function makeEmptyGlobalConfig(): GlobalConfig {
+  return {
+    port: 3000,
+    readyThresholdMs: 300_000,
+    defaults: {
+      runtime: "tmux",
+      agent: "claude-code",
+      workspace: "worktree",
+      notifiers: ["composio", "desktop"],
+    },
+    projects: {},
+    notifiers: {},
+    notificationRouting: {
+      urgent: ["desktop", "composio"],
+      action: ["desktop", "composio"],
+      warning: ["composio"],
+      info: ["composio"],
+    },
+    reactions: {},
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -115,7 +115,6 @@ export {
 export type {
   ObservabilityMetricName,
   ObservabilityHealthStatus,
-  ObservabilityLevel,
   ObservabilitySummary,
   ProjectObserver,
 } from "./observability.js";
@@ -142,6 +141,7 @@ export type {
 // Path utilities — hash-based directory structure
 export {
   generateConfigHash,
+  generateProjectHash,
   generateProjectId,
   generateInstanceId,
   generateSessionPrefix,
@@ -159,6 +159,21 @@ export {
   validateAndStoreOrigin,
 } from "./paths.js";
 
+// Global config — Option C hybrid architecture (global registry + local behavior)
+export {
+  getGlobalConfigPath,
+  loadGlobalConfig,
+  saveGlobalConfig,
+  loadLocalProjectConfig,
+  syncProjectShadow,
+  registerProjectInGlobalConfig,
+  buildEffectiveProjectConfig,
+  isProjectShadowStale,
+  isOldConfigFormat,
+  migrateToGlobalConfig,
+} from "./global-config.js";
+export type { GlobalConfig, GlobalProjectEntry, LocalProjectConfig } from "./global-config.js";
+
 // Config generator — auto-generate config from repo URL
 export {
   isRepoUrl,
@@ -171,6 +186,7 @@ export {
   isRepoAlreadyCloned,
   resolveCloneTarget,
   sanitizeProjectId,
+  readOriginRemoteUrl,
 } from "./config-generator.js";
 export type {
   ParsedRepoUrl,
@@ -178,3 +194,46 @@ export type {
   DetectedProjectInfo,
   GenerateConfigOptions,
 } from "./config-generator.js";
+
+// Portfolio — cross-project aggregation
+export type {
+  PortfolioProject,
+  PortfolioPreferences,
+  PortfolioRegistered,
+  PortfolioSession,
+} from "./types.js";
+
+export {
+  getAoBaseDir,
+  getPortfolioDir,
+  getPreferencesPath,
+  getRegisteredPath,
+} from "./paths.js";
+
+export {
+  discoverProjects,
+  loadRegistered,
+  loadPreferences,
+  savePreferences,
+  saveRegistered,
+  getPortfolio,
+  registerProject,
+  unregisterProject,
+  refreshProject,
+} from "./portfolio-registry.js";
+
+export {
+  resolveProjectConfig,
+  clearConfigCache,
+} from "./portfolio-projects.js";
+
+export {
+  listPortfolioSessions,
+  getPortfolioSessionCounts,
+} from "./portfolio-session-service.js";
+
+export {
+  resolvePortfolioProject,
+  resolvePortfolioSession,
+  derivePortfolioProjectId,
+} from "./portfolio-routing.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,6 +113,7 @@ export {
   readObservabilitySummary,
 } from "./observability.js";
 export type {
+  ObservabilityLevel,
   ObservabilityMetricName,
   ObservabilityHealthStatus,
   ObservabilitySummary,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -32,7 +32,6 @@ import {
   type Session,
   type EventPriority,
   type ProjectConfig as _ProjectConfig,
-  type PREnrichmentData,
 } from "./types.js";
 import { updateMetadata } from "./metadata.js";
 import { getSessionsDir } from "./paths.js";
@@ -199,133 +198,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
 
-  /**
-   * Cache for PR enrichment data within a single poll cycle.
-   * Cleared at the start of each pollAll() call.
-   * Key format: "${owner}/${repo}#${number}"
-   */
-  const prEnrichmentCache = new Map<string, PREnrichmentData>();
-
-  /**
-   * Populate the PR enrichment cache using batch GraphQL queries.
-   * This is called once per poll cycle to fetch data for all PRs efficiently.
-   */
-  async function populatePREnrichmentCache(sessions: Session[]): Promise<void> {
-    // Clear previous cache
-    prEnrichmentCache.clear();
-
-    // Collect all unique PRs
-    const prs = sessions
-      .map((s) => s.pr)
-      .filter((pr): pr is NonNullable<typeof pr> => pr !== null);
-
-    // Deduplicate by key
-    const uniquePRs = Array.from(
-      new Map(prs.map((pr) => [`${pr.owner}/${pr.repo}#${pr.number}`, pr])).values(),
-    );
-
-    if (uniquePRs.length === 0) return;
-
-    // Group by SCM plugin and batch fetch for each group
-    const prsByPlugin = new Map<string, typeof uniquePRs>();
-    for (const pr of uniquePRs) {
-      // Find the project for this PR
-      const project = Object.values(config.projects).find((p) => {
-        const [owner, repo] = p.repo.split("/");
-        return owner === pr.owner && repo === pr.repo;
-      });
-      if (!project?.scm) continue;
-
-      const pluginKey = project.scm.plugin;
-      if (!prsByPlugin.has(pluginKey)) {
-        prsByPlugin.set(pluginKey, []);
-      }
-      const pluginPRs = prsByPlugin.get(pluginKey);
-      if (pluginPRs) {
-        pluginPRs.push(pr);
-      }
-    }
-
-    // Fetch enrichment data for each plugin's PRs
-    for (const [pluginKey, pluginPRs] of prsByPlugin) {
-      const scm = registry.get<SCM>("scm", pluginKey);
-      if (!scm?.enrichSessionsPRBatch) continue;
-
-      const batchStartTime = Date.now();
-      try {
-        const enrichmentData = await scm.enrichSessionsPRBatch(
-          pluginPRs,
-          {
-            recordSuccess(_data) {
-              const batchDuration = Date.now() - batchStartTime;
-              observer?.recordOperation({
-                metric: "graphql_batch",
-                operation: "batch_enrichment",
-                correlationId: createCorrelationId("graphql-batch"),
-                outcome: "success",
-                projectId: scopedProjectId,
-                durationMs: batchDuration,
-                data: {
-                  plugin: pluginKey,
-                  prCount: pluginPRs.length,
-                  prKeys: pluginPRs.map((pr) => `${pr.owner}/${pr.repo}#${pr.number}`),
-                },
-                level: "info",
-              });
-            },
-            recordFailure(data) {
-              const batchDuration = Date.now() - batchStartTime;
-              observer?.recordOperation({
-                metric: "graphql_batch",
-                operation: "batch_enrichment",
-                correlationId: createCorrelationId("graphql-batch"),
-                outcome: "failure",
-                reason: data.error,
-                level: "warn",
-                data: {
-                  plugin: pluginKey,
-                  prCount: pluginPRs.length,
-                  error: data.error,
-                  durationMs: batchDuration,
-                },
-              });
-            },
-            log(level, message) {
-              // Log to stderr for observability
-              process.stderr.write(
-                JSON.stringify({
-                  source: "ao-graphql-batch",
-                  level,
-                  message,
-                  plugin: pluginKey,
-                  timestamp: new Date().toISOString(),
-                }) + "\n"
-              );
-            },
-          },
-        );
-
-        // Merge into cache
-        for (const [key, data] of enrichmentData) {
-          prEnrichmentCache.set(key, data);
-        }
-      } catch (err) {
-        // Batch fetch failed - individual calls will still work
-        const errorMsg = err instanceof Error ? err.message : String(err);
-        const batchCorrelationId = createCorrelationId("batch-enrichment");
-        observer?.recordOperation?.({
-          metric: "lifecycle_poll",
-          operation: "batch_enrichment",
-          correlationId: batchCorrelationId,
-          outcome: "failure",
-          reason: errorMsg,
-          level: "warn",
-          data: { plugin: pluginKey, prCount: pluginPRs.length },
-        });
-      }
-    }
-  }
-
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
     const stuckReaction = getReactionConfigForSession(session, "agent-stuck");
@@ -439,43 +311,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // 4. Check PR state if PR exists
     if (session.pr && scm) {
       try {
-        // Try to use cached enrichment data from batch GraphQL query
-        const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-        const cachedData = prEnrichmentCache.get(prKey);
-
-        if (cachedData) {
-          // Use cached enrichment data - avoids individual API calls
-          if (cachedData.state === PR_STATE.MERGED) return "merged";
-          if (cachedData.state === PR_STATE.CLOSED) return "killed";
-
-          // Check CI
-          if (cachedData.ciStatus === CI_STATUS.FAILING) return "ci_failed";
-
-          // Check reviews
-          if (cachedData.reviewDecision === "changes_requested")
-            return "changes_requested";
-          if (cachedData.reviewDecision === "approved" || cachedData.reviewDecision === "none") {
-            // Check merge readiness — treat "none" (no reviewers required)
-            // as "approved" so CI-green PRs reach "mergeable" status
-            // and fire the merge.ready event / approved-and-green reaction.
-            if (cachedData.mergeable) return "mergeable";
-            if (cachedData.reviewDecision === "approved") return "approved";
-          }
-          if (cachedData.reviewDecision === "pending") return "review_pending";
-
-          // 4b. Post-PR stuck detection: agent has a PR open but is idle beyond
-          // threshold. This catches the case where step 2's stuck check was
-          // bypassed (getActivityState returned null) or the idle timestamp
-          // wasn't available during step 2 but the session has been at pr_open
-          // for a long time. Without this, sessions get stuck at "pr_open" forever.
-          if (detectedIdleTimestamp && isIdleBeyondThreshold(session, detectedIdleTimestamp)) {
-            return "stuck";
-          }
-
-          return "pr_open";
-        }
-
-        // Fall back to individual API calls if no cached data
         const prState = await scm.getPRState(session.pr);
         if (prState === PR_STATE.MERGED) return "merged";
         if (prState === PR_STATE.CLOSED) return "killed";
@@ -489,7 +324,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         if (reviewDecision === "changes_requested") return "changes_requested";
         if (reviewDecision === "approved" || reviewDecision === "none") {
           // Check merge readiness — treat "none" (no reviewers required)
-          // as "approved" so CI-green PRs reach "mergeable" status
+          // the same as "approved" so CI-green PRs reach "mergeable" status
           // and fire the merge.ready event / approved-and-green reaction.
           const mergeReady = await scm.getMergeability(session.pr);
           if (mergeReady.mergeable) return "mergeable";
@@ -975,10 +810,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const tracked = states.get(s.id);
         return tracked !== undefined && tracked !== s.status;
       });
-
-      // Populate PR enrichment cache using batch GraphQL queries
-      // This reduces API calls from N×3 to 1 per poll cycle
-      await populatePREnrichmentCache(sessionsToCheck);
 
       // Poll all sessions concurrently
       await Promise.allSettled(sessionsToCheck.map((s) => checkSession(s)));

--- a/packages/core/src/observability.ts
+++ b/packages/core/src/observability.ts
@@ -18,7 +18,6 @@ export type ObservabilityMetricName =
   | "api_request"
   | "claim_pr"
   | "cleanup"
-  | "graphql_batch"
   | "kill"
   | "lifecycle_poll"
   | "restore"

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -2,25 +2,56 @@
  * Path utilities for hash-based directory structure.
  *
  * Architecture:
- * - Config location determines hash: sha256(dirname(configPath)).slice(0, 12)
+ * - Project path determines hash: sha256(projectPath).slice(0, 12)
  * - Each project gets directory: ~/.agent-orchestrator/{hash}-{projectId}/
  * - Sessions inside: sessions/{sessionName} (no hash prefix, already namespaced)
  * - Tmux names include hash for global uniqueness: {hash}-{prefix}-{num}
+ * - Both session dirs and tmux names use generateProjectHash(projectPath) for consistency
  */
 
 import { createHash } from "node:crypto";
-import { dirname, basename, join } from "node:path";
+import { dirname, basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
 import { realpathSync, existsSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
 
 /**
  * Generate a 12-character hash from a config directory path.
- * Always resolves symlinks before hashing to ensure consistency.
+ *
+ * The hash is derived from dirname(configPath), which equals the project root
+ * directory when configPath is <project>/agent-orchestrator.yaml.
+ *
+ * Handles non-existent paths gracefully (e.g. synthesized paths in remote/
+ * Docker mode where no local config file exists) by falling back to
+ * resolve() when realpathSync fails.
  */
 export function generateConfigHash(configPath: string): string {
-  const resolved = realpathSync(configPath);
+  let resolved: string;
+  try {
+    resolved = realpathSync(configPath);
+  } catch {
+    // File may not exist (remote mode, Docker, pre-creation) — use resolved path
+    resolved = resolve(configPath);
+  }
   const configDir = dirname(resolved);
   const hash = createHash("sha256").update(configDir).digest("hex");
+  return hash.slice(0, 12);
+}
+
+/**
+ * Generate a 12-character hash directly from a project directory path.
+ *
+ * Equivalent to generateConfigHash(<project>/agent-orchestrator.yaml) but
+ * does not require a config file to exist. Used in remote / Docker / shadow
+ * mode where the local config is absent.
+ */
+export function generateProjectHash(projectPath: string): string {
+  let resolved: string;
+  try {
+    resolved = realpathSync(projectPath);
+  } catch {
+    resolved = resolve(projectPath);
+  }
+  const hash = createHash("sha256").update(resolved).digest("hex");
   return hash.slice(0, 12);
 }
 
@@ -36,9 +67,17 @@ export function generateProjectId(projectPath: string): string {
  * Generate instance ID combining hash and project ID.
  * Format: {hash}-{projectId}
  * Example: "a3b4c5d6e7f8-integrator"
+ *
+ * Uses generateProjectHash(projectPath) so the hash is stable regardless of
+ * where the config file lives.  When the config was local
+ * (<project>/agent-orchestrator.yaml), dirname(configPath) === projectPath,
+ * so the two hash functions produced the same value.  After migration to the
+ * global config (~/.agent-orchestrator/config.yaml), generateConfigHash would
+ * produce a different (wrong) hash.  Keying on projectPath keeps existing
+ * session directories reachable.
  */
-export function generateInstanceId(configPath: string, projectPath: string): string {
-  const hash = generateConfigHash(configPath);
+export function generateInstanceId(_configPath: string, projectPath: string): string {
+  const hash = generateProjectHash(projectPath);
   const projectId = generateProjectId(projectPath);
   return `${hash}-${projectId}`;
 }
@@ -148,9 +187,16 @@ export function generateSessionName(prefix: string, num: number): string {
  * Generate tmux session name (globally unique).
  * Format: {hash}-{prefix}-{num}
  * Example: "a3b4c5d6e7f8-int-1"
+ *
+ * Uses generateProjectHash(projectPath) so the hash matches the session
+ * directory hash from generateInstanceId.  When the config was local
+ * (<project>/agent-orchestrator.yaml), dirname(configPath) === projectPath,
+ * so the values were identical.  After migration to the global config,
+ * generateConfigHash would hash ~/.agent-orchestrator/ — a completely
+ * different value, breaking the mapping between session dirs and tmux names.
  */
-export function generateTmuxName(configPath: string, prefix: string, num: number): string {
-  const hash = generateConfigHash(configPath);
+export function generateTmuxName(projectPath: string, prefix: string, num: number): string {
+  const hash = generateProjectHash(projectPath);
   return `${hash}-${prefix}-${num}`;
 }
 
@@ -183,24 +229,49 @@ export function expandHome(filepath: string): string {
   return filepath;
 }
 
+/** Get the base AO directory (~/.agent-orchestrator/) */
+export function getAoBaseDir(): string {
+  return expandHome("~/.agent-orchestrator");
+}
+
+/** Get the portfolio directory (~/.agent-orchestrator/portfolio/) */
+export function getPortfolioDir(): string {
+  return join(getAoBaseDir(), "portfolio");
+}
+
+/** Get the portfolio preferences file path */
+export function getPreferencesPath(): string {
+  return join(getPortfolioDir(), "preferences.json");
+}
+
+/** Get the portfolio registered projects file path */
+export function getRegisteredPath(): string {
+  return join(getPortfolioDir(), "registered.json");
+}
+
 /**
  * Validate and store the .origin file for a project.
- * Throws if a hash collision is detected (different config, same hash).
+ *
+ * When the stored config path differs from the current one (e.g. after
+ * migrating from a local config to the global hybrid config), the .origin
+ * file is updated to the new path.  A true SHA-256 hash collision on 12 hex
+ * chars (1 in 2^48) is astronomically unlikely and not worth blocking a
+ * legitimate config migration.
  */
 export function validateAndStoreOrigin(configPath: string, projectPath: string): void {
   const originPath = getOriginFilePath(configPath, projectPath);
-  const resolvedConfigPath = realpathSync(configPath);
+  let resolvedConfigPath: string;
+  try {
+    resolvedConfigPath = realpathSync(configPath);
+  } catch {
+    resolvedConfigPath = resolve(configPath);
+  }
 
   if (existsSync(originPath)) {
     const stored = readFileSync(originPath, "utf-8").trim();
     if (stored !== resolvedConfigPath) {
-      throw new Error(
-        `Hash collision detected!\n` +
-          `Directory: ${getProjectBaseDir(configPath, projectPath)}\n` +
-          `Expected config: ${resolvedConfigPath}\n` +
-          `Actual config: ${stored}\n` +
-          `This is a rare hash collision. Please move one of the configs to a different directory.`,
-      );
+      // Config path changed (local → global migration). Update .origin.
+      writeFileSync(originPath, resolvedConfigPath, "utf-8");
     }
   } else {
     // Create project base directory and .origin file

--- a/packages/core/src/portfolio-projects.ts
+++ b/packages/core/src/portfolio-projects.ts
@@ -1,0 +1,30 @@
+/**
+ * Portfolio project config resolution with caching.
+ *
+ * Resolves a PortfolioProject to its full OrchestratorConfig + ProjectConfig.
+ * Caches loaded configs by configPath to avoid redundant YAML parsing.
+ */
+
+import type { PortfolioProject, OrchestratorConfig, ProjectConfig } from "./types.js";
+import { loadConfig } from "./config.js";
+
+const configCache = new Map<string, OrchestratorConfig>();
+
+export function resolveProjectConfig(entry: PortfolioProject): { config: OrchestratorConfig; project: ProjectConfig } | null {
+  try {
+    let config = configCache.get(entry.configPath);
+    if (!config) {
+      config = loadConfig(entry.configPath);
+      configCache.set(entry.configPath, config);
+    }
+    const project = config.projects[entry.configProjectKey];
+    if (!project) return null;
+    return { config, project };
+  } catch {
+    return null;
+  }
+}
+
+export function clearConfigCache(): void {
+  configCache.clear();
+}

--- a/packages/core/src/portfolio-projects.ts
+++ b/packages/core/src/portfolio-projects.ts
@@ -8,14 +8,18 @@
 import type { PortfolioProject, OrchestratorConfig, ProjectConfig } from "./types.js";
 import { loadConfig } from "./config.js";
 
-const configCache = new Map<string, OrchestratorConfig>();
+const CACHE_TTL_MS = 30_000;
+const configCache = new Map<string, { config: OrchestratorConfig; expiresAt: number }>();
 
 export function resolveProjectConfig(entry: PortfolioProject): { config: OrchestratorConfig; project: ProjectConfig } | null {
   try {
-    let config = configCache.get(entry.configPath);
-    if (!config) {
+    const cached = configCache.get(entry.configPath);
+    let config: OrchestratorConfig;
+    if (cached && Date.now() < cached.expiresAt) {
+      config = cached.config;
+    } else {
       config = loadConfig(entry.configPath);
-      configCache.set(entry.configPath, config);
+      configCache.set(entry.configPath, { config, expiresAt: Date.now() + CACHE_TTL_MS });
     }
     const project = config.projects[entry.configProjectKey];
     if (!project) return null;

--- a/packages/core/src/portfolio-registry.ts
+++ b/packages/core/src/portfolio-registry.ts
@@ -1,0 +1,410 @@
+/**
+ * Portfolio registry — discovery, registration, and preferences for cross-project aggregation.
+ *
+ * Discovery: scans ~/.agent-orchestrator/ for project directories matching {12hexchars}-{id}.
+ * Registration: explicit `ao project add` entries stored in registered.json.
+ * Preferences: user overlay (pinning, ordering, enabled) stored in preferences.json.
+ *
+ * getPortfolio() merges all three sources into a unified PortfolioProject[].
+ */
+
+import { existsSync, readdirSync, readFileSync, mkdirSync, statSync } from "node:fs";
+import { join, basename, resolve } from "node:path";
+import type {
+  PortfolioProject,
+  PortfolioPreferences,
+  PortfolioRegistered,
+  OrchestratorConfig,
+  ProjectConfig,
+} from "./types.js";
+import {
+  getAoBaseDir,
+  getPortfolioDir,
+  getPreferencesPath,
+  getRegisteredPath,
+  generateSessionPrefix,
+} from "./paths.js";
+import { loadConfig, findConfigFile } from "./config.js";
+import { getGlobalConfigPath } from "./global-config.js";
+import { atomicWriteFileSync } from "./atomic-write.js";
+import { derivePortfolioProjectId } from "./portfolio-routing.js";
+
+/** Pattern for AO project directories: 12 hex chars followed by a dash and an id */
+const DIR_PATTERN = /^[a-f0-9]{12}-.+$/;
+
+// =============================================================================
+// DISCOVERY — scan ~/.agent-orchestrator/ for project dirs
+// =============================================================================
+
+/**
+ * Discover projects by scanning ~/.agent-orchestrator/ directories.
+ * Each directory matching {12hexchars}-{projectId} with a .origin file is a candidate.
+ */
+export function discoverProjects(): PortfolioProject[] {
+  const baseDir = getAoBaseDir();
+  if (!existsSync(baseDir)) return [];
+
+  const entries = readdirSync(baseDir).sort();
+  const projects: PortfolioProject[] = [];
+
+  for (const entry of entries) {
+    if (!DIR_PATTERN.test(entry)) continue;
+
+    const entryPath = join(baseDir, entry);
+    try {
+      const stat = statSync(entryPath);
+      if (!stat.isDirectory()) continue;
+    } catch {
+      continue;
+    }
+
+    const originPath = join(entryPath, ".origin");
+    if (!existsSync(originPath)) continue;
+
+    let configPath: string;
+    try {
+      configPath = readFileSync(originPath, "utf-8").trim();
+    } catch {
+      continue;
+    }
+
+    // Extract projectId from directory name: everything after the first 13 chars (12 hex + dash)
+    const projectId = entry.slice(13);
+
+    let config: OrchestratorConfig | null = null;
+    let projectConfig: ProjectConfig | undefined;
+    let degraded = false;
+    let _degradedReason: string | undefined;
+
+    try {
+      config = loadConfig(configPath);
+      projectConfig = config.projects[projectId];
+      if (!projectConfig) {
+        // The config key may differ from the directory-level projectId.
+        // Try to find a matching project by path basename.
+        for (const [_key, pc] of Object.entries(config.projects)) {
+          if (basename(pc.path) === projectId) {
+            projectConfig = pc;
+            break;
+          }
+        }
+      }
+    } catch {
+      // .origin may point to a flat local config (post-migration to hybrid model).
+      // Fall back to the global config for project metadata while keeping the
+      // original configPath so the session-directory hash remains stable.
+      try {
+        const globalPath = getGlobalConfigPath();
+        if (existsSync(globalPath) && globalPath !== configPath) {
+          config = loadConfig(globalPath);
+          projectConfig = config.projects[projectId];
+          if (!projectConfig) {
+            for (const [_key, pc] of Object.entries(config.projects)) {
+              if (basename(pc.path) === projectId) {
+                projectConfig = pc;
+                break;
+              }
+            }
+          }
+        }
+      } catch {
+        // Global config also unavailable
+      }
+
+      if (!projectConfig) {
+        degraded = true;
+        _degradedReason = `Failed to load config at ${configPath}`;
+      }
+    }
+
+    // Skip directories whose config can't be resolved at all — these are
+    // stale test/dev artifacts, not real projects the user cares about.
+    if (degraded) continue;
+
+    const project: PortfolioProject = {
+      id: projectId,
+      name: projectConfig?.name || projectId,
+      configPath,
+      configProjectKey: projectConfig ? findConfigKey(config!, projectConfig) || projectId : projectId,
+      repoPath: projectConfig?.path || entryPath,
+      repo: projectConfig?.repo,
+      defaultBranch: projectConfig?.defaultBranch,
+      sessionPrefix: projectConfig?.sessionPrefix || generateSessionPrefix(projectId),
+      source: "discovered",
+      enabled: true,
+      pinned: false,
+      lastSeenAt: new Date().toISOString(),
+    };
+
+    projects.push(project);
+  }
+
+  // Deduplicate: after migration from local → global config, two directories
+  // may exist for the same project (one hashed from the local config path, one
+  // from the global config path). Keep the entry whose configPath is NOT the
+  // global config — it has the stable project-path-based hash and contains the
+  // legacy sessions. The global-config-based directory is an artefact of the
+  // migration period and typically only holds the orchestrator session.
+  const globalConfigPath = getGlobalConfigPath();
+  const byRepoPath = new Map<string, PortfolioProject[]>();
+  for (const project of projects) {
+    const key = project.repoPath;
+    const list = byRepoPath.get(key) ?? [];
+    list.push(project);
+    byRepoPath.set(key, list);
+  }
+
+  const deduped: PortfolioProject[] = [];
+  for (const candidates of byRepoPath.values()) {
+    if (candidates.length === 1) {
+      deduped.push(candidates[0]);
+    } else {
+      // Prefer the entry whose configPath is the local config (not global)
+      const local = candidates.find((c) => c.configPath !== globalConfigPath);
+      deduped.push(local ?? candidates[0]);
+    }
+  }
+
+  return deduped;
+}
+
+/** Find the config key for a given ProjectConfig within an OrchestratorConfig */
+function findConfigKey(config: OrchestratorConfig, projectConfig: ProjectConfig): string | undefined {
+  for (const [key, pc] of Object.entries(config.projects)) {
+    if (pc === projectConfig) return key;
+  }
+  return undefined;
+}
+
+// =============================================================================
+// REGISTERED — explicit project registration
+// =============================================================================
+
+/** Load registered projects from registered.json */
+export function loadRegistered(): PortfolioRegistered {
+  const path = getRegisteredPath();
+  if (!existsSync(path)) {
+    return { version: 1, projects: [] };
+  }
+  try {
+    const content = readFileSync(path, "utf-8");
+    return JSON.parse(content) as PortfolioRegistered;
+  } catch {
+    return { version: 1, projects: [] };
+  }
+}
+
+/** Save registered projects to registered.json */
+export function saveRegistered(reg: PortfolioRegistered): void {
+  const dir = getPortfolioDir();
+  mkdirSync(dir, { recursive: true });
+  atomicWriteFileSync(getRegisteredPath(), JSON.stringify(reg, null, 2));
+}
+
+// =============================================================================
+// PREFERENCES — user overlay
+// =============================================================================
+
+/** Load portfolio preferences from preferences.json */
+export function loadPreferences(): PortfolioPreferences {
+  const path = getPreferencesPath();
+  if (!existsSync(path)) {
+    return { version: 1 };
+  }
+  try {
+    const content = readFileSync(path, "utf-8");
+    return JSON.parse(content) as PortfolioPreferences;
+  } catch {
+    return { version: 1 };
+  }
+}
+
+/** Save portfolio preferences to preferences.json */
+export function savePreferences(prefs: PortfolioPreferences): void {
+  const dir = getPortfolioDir();
+  mkdirSync(dir, { recursive: true });
+  atomicWriteFileSync(getPreferencesPath(), JSON.stringify(prefs, null, 2));
+}
+
+// =============================================================================
+// PORTFOLIO — unified merge of discovered + registered + preferences
+// =============================================================================
+
+/**
+ * Build the unified portfolio by merging discovered projects, registered projects,
+ * and user preferences.
+ *
+ * Merge logic:
+ * 1. Start with discovered projects (keyed by id)
+ * 2. For each registered project not already discovered, resolve and add
+ * 3. Apply preferences overlay (pinning, ordering, enabled, displayName)
+ * 4. Sort: pinned first, then by preferences.projectOrder, then alphabetical
+ */
+export function getPortfolio(): PortfolioProject[] {
+  const discovered = discoverProjects();
+  const registered = loadRegistered();
+  const preferences = loadPreferences();
+
+  // Build map keyed by id
+  const projectMap = new Map<string, PortfolioProject>();
+  const existingIds = new Set<string>();
+
+  // Step 1: Add discovered projects
+  for (const project of discovered) {
+    const id = derivePortfolioProjectId(project.id, existingIds);
+    project.id = id;
+    existingIds.add(id);
+    projectMap.set(id, project);
+  }
+
+  // Step 2: Add registered projects not already discovered
+  for (const reg of registered.projects) {
+    // Try to find config directly at the registered path first, then fall back to findConfigFile.
+    // This avoids findConfigFile picking up a parent/CWD config that doesn't cover this project.
+    let configPath: string | null = null;
+    for (const filename of ["agent-orchestrator.yaml", "agent-orchestrator.yml"]) {
+      const candidate = resolve(reg.path, filename);
+      if (existsSync(candidate)) {
+        configPath = candidate;
+        break;
+      }
+    }
+    if (!configPath) {
+      configPath = findConfigFile(reg.path);
+    }
+    if (!configPath) continue;
+
+    let config: OrchestratorConfig;
+    try {
+      config = loadConfig(configPath);
+    } catch {
+      continue;
+    }
+
+    // Determine which project key to use
+    const projectKeys = reg.configProjectKey
+      ? [reg.configProjectKey]
+      : Object.keys(config.projects);
+
+    for (const key of projectKeys) {
+      const pc = config.projects[key];
+      if (!pc) continue;
+
+      // Check if already discovered (match by configPath + key)
+      const alreadyExists = Array.from(projectMap.values()).some(
+        (p) => p.configPath === configPath && p.configProjectKey === key,
+      );
+      if (alreadyExists) continue;
+
+      const id = derivePortfolioProjectId(key, existingIds);
+      existingIds.add(id);
+
+      const project: PortfolioProject = {
+        id,
+        name: pc.name || key,
+        configPath,
+        configProjectKey: key,
+        repoPath: pc.path,
+        repo: pc.repo,
+        defaultBranch: pc.defaultBranch,
+        sessionPrefix: pc.sessionPrefix || generateSessionPrefix(key),
+        source: "registered",
+        enabled: true,
+        pinned: false,
+        lastSeenAt: reg.addedAt,
+      };
+
+      projectMap.set(id, project);
+    }
+  }
+
+  // Step 3: Apply preferences overlay
+  if (preferences.projects) {
+    for (const [id, prefs] of Object.entries(preferences.projects)) {
+      const project = projectMap.get(id);
+      if (!project) continue;
+
+      if (prefs.pinned !== undefined) project.pinned = prefs.pinned;
+      if (prefs.enabled !== undefined) project.enabled = prefs.enabled;
+      if (prefs.displayName) project.name = prefs.displayName;
+    }
+  }
+
+  // Step 4: Sort — pinned first, then by projectOrder, then alphabetical
+  const orderMap = new Map<string, number>();
+  if (preferences.projectOrder) {
+    for (let i = 0; i < preferences.projectOrder.length; i++) {
+      orderMap.set(preferences.projectOrder[i], i);
+    }
+  }
+
+  const projects = Array.from(projectMap.values());
+  projects.sort((a, b) => {
+    // Pinned first
+    if (a.pinned && !b.pinned) return -1;
+    if (!a.pinned && b.pinned) return 1;
+
+    // Then by projectOrder
+    const orderA = orderMap.get(a.id) ?? Infinity;
+    const orderB = orderMap.get(b.id) ?? Infinity;
+    if (orderA !== orderB) return orderA - orderB;
+
+    // Then alphabetical
+    return a.name.localeCompare(b.name);
+  });
+
+  return projects;
+}
+
+// =============================================================================
+// MUTATION HELPERS
+// =============================================================================
+
+/** Register a project by repo path (and optional config project key) */
+export function registerProject(repoPath: string, configProjectKey?: string): void {
+  const reg = loadRegistered();
+
+  // Avoid duplicates
+  const exists = reg.projects.some(
+    (p) => p.path === repoPath && p.configProjectKey === configProjectKey,
+  );
+  if (exists) return;
+
+  reg.projects.push({
+    path: repoPath,
+    configProjectKey,
+    addedAt: new Date().toISOString(),
+  });
+
+  saveRegistered(reg);
+}
+
+/** Unregister a project by its portfolio ID */
+export function unregisterProject(projectId: string): void {
+  const portfolio = getPortfolio();
+  const project = portfolio.find((p) => p.id === projectId);
+  if (!project) return;
+
+  const reg = loadRegistered();
+  reg.projects = reg.projects.filter(
+    (p) => !(p.path === project.repoPath && (p.configProjectKey === project.configProjectKey || !p.configProjectKey)),
+  );
+
+  saveRegistered(reg);
+}
+
+/** Refresh a project's lastSeenAt timestamp */
+export function refreshProject(projectId: string, _configPath: string): void {
+  const reg = loadRegistered();
+  const portfolio = getPortfolio();
+  const project = portfolio.find((p) => p.id === projectId);
+  if (!project) return;
+
+  const entry = reg.projects.find(
+    (p) => p.path === project.repoPath && (p.configProjectKey === project.configProjectKey || !p.configProjectKey),
+  );
+  if (entry) {
+    entry.addedAt = new Date().toISOString();
+    saveRegistered(reg);
+  }
+}

--- a/packages/core/src/portfolio-registry.ts
+++ b/packages/core/src/portfolio-registry.ts
@@ -91,12 +91,13 @@ export function discoverProjects(): PortfolioProject[] {
       }
     } catch {
       // .origin may point to a flat local config (post-migration to hybrid model).
-      // Fall back to the global config for project metadata while keeping the
-      // original configPath so the session-directory hash remains stable.
+      // Fall back to the global config for project metadata and update configPath
+      // so PortfolioProject.configPath is resolvable by downstream callers.
       try {
         const globalPath = getGlobalConfigPath();
         if (existsSync(globalPath) && globalPath !== configPath) {
           config = loadConfig(globalPath);
+          configPath = globalPath;
           projectConfig = config.projects[projectId];
           if (!projectConfig) {
             for (const [_key, pc] of Object.entries(config.projects)) {
@@ -278,7 +279,15 @@ export function getPortfolio(): PortfolioProject[] {
     try {
       config = loadConfig(configPath);
     } catch {
-      continue;
+      // configPath may be a flat local config (post-migration). Try global config.
+      try {
+        const globalPath = getGlobalConfigPath();
+        if (!existsSync(globalPath)) continue;
+        config = loadConfig(globalPath);
+        configPath = globalPath;
+      } catch {
+        continue;
+      }
     }
 
     // Determine which project key to use

--- a/packages/core/src/portfolio-routing.ts
+++ b/packages/core/src/portfolio-routing.ts
@@ -1,0 +1,28 @@
+/**
+ * Portfolio routing — shared resolution helpers for cross-project navigation.
+ */
+
+import type { PortfolioProject, PortfolioSession } from "./types.js";
+import { listPortfolioSessions } from "./portfolio-session-service.js";
+
+export function resolvePortfolioProject(portfolio: PortfolioProject[], projectId: string): PortfolioProject | undefined {
+  return portfolio.find(p => p.id === projectId);
+}
+
+export async function resolvePortfolioSession(portfolio: PortfolioProject[], projectId: string, sessionId: string): Promise<PortfolioSession | undefined> {
+  const project = resolvePortfolioProject(portfolio, projectId);
+  if (!project) return undefined;
+
+  const sessions = await listPortfolioSessions([project]);
+  return sessions.find(s => s.session.id === sessionId);
+}
+
+export function derivePortfolioProjectId(configProjectKey: string, existingIds: Set<string>): string {
+  if (!existingIds.has(configProjectKey)) return configProjectKey;
+
+  let suffix = 2;
+  while (existingIds.has(`${configProjectKey}-${suffix}`)) {
+    suffix++;
+  }
+  return `${configProjectKey}-${suffix}`;
+}

--- a/packages/core/src/portfolio-session-service.ts
+++ b/packages/core/src/portfolio-session-service.ts
@@ -1,0 +1,169 @@
+/**
+ * Portfolio session service — lightweight cross-project session aggregation.
+ *
+ * Uses async I/O to avoid blocking the Node.js event loop in web server contexts.
+ * Reads session metadata files directly without constructing SessionManagers.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { PortfolioProject, PortfolioSession, Session, SessionMetadata } from "./types.js";
+import { getSessionsDir } from "./paths.js";
+import { parseKeyValueContent } from "./key-value.js";
+
+const DEFAULT_PER_PROJECT_TIMEOUT_MS = 3_000;
+const VALID_SESSION_ID = /^[a-zA-Z0-9_-]+$/;
+
+export async function listPortfolioSessions(
+  portfolio: PortfolioProject[],
+  opts?: { perProjectTimeoutMs?: number },
+): Promise<PortfolioSession[]> {
+  const timeout = opts?.perProjectTimeoutMs ?? DEFAULT_PER_PROJECT_TIMEOUT_MS;
+  const results: PortfolioSession[] = [];
+
+  for (const project of portfolio) {
+    if (!project.enabled || project.degraded) continue;
+
+    try {
+      const projectResults = await Promise.race([
+        loadProjectSessions(project),
+        new Promise<PortfolioSession[]>((resolve) =>
+          setTimeout(() => resolve([]), timeout),
+        ),
+      ]);
+      results.push(...projectResults);
+    } catch {
+      // Skip projects whose session dirs can't be read
+    }
+  }
+
+  return results;
+}
+
+async function loadProjectSessions(project: PortfolioProject): Promise<PortfolioSession[]> {
+  const results: PortfolioSession[] = [];
+  const sessionsDir = getSessionsDir(project.configPath, project.repoPath);
+
+  let entries: string[];
+  try {
+    entries = await readdir(sessionsDir);
+  } catch {
+    return results; // Dir doesn't exist
+  }
+
+  for (const name of entries) {
+    if (name === "archive" || name.startsWith(".")) continue;
+    if (!VALID_SESSION_ID.test(name)) continue;
+
+    try {
+      const filePath = join(sessionsDir, name);
+      const fileStat = await stat(filePath);
+      if (!fileStat.isFile()) continue;
+
+      const content = await readFile(filePath, "utf-8");
+      const raw = parseKeyValueContent(content);
+      const metadata = rawToMetadata(raw);
+
+      const session = metadataToSession(name, project, metadata);
+      results.push({ session, project });
+    } catch {
+      continue;
+    }
+  }
+
+  return results;
+}
+
+function rawToMetadata(raw: Record<string, string>): SessionMetadata {
+  return {
+    worktree: raw["worktree"] ?? "",
+    branch: raw["branch"] ?? "",
+    status: raw["status"] ?? "unknown",
+    tmuxName: raw["tmuxName"],
+    issue: raw["issue"],
+    pr: raw["pr"],
+    summary: raw["summary"],
+    project: raw["project"],
+    agent: raw["agent"],
+    createdAt: raw["createdAt"],
+    runtimeHandle: raw["runtimeHandle"],
+    restoredAt: raw["restoredAt"],
+    role: raw["role"],
+  };
+}
+
+/** Convert raw metadata to a Session object (lightweight, no plugin init) */
+function metadataToSession(sessionId: string, project: PortfolioProject, metadata: SessionMetadata): Session {
+  // Use the most recent timestamp available as lastActivityAt
+  const timestamps = [metadata.createdAt, metadata.restoredAt].filter(Boolean);
+  const lastActivity = timestamps.length > 0
+    ? new Date(Math.max(...timestamps.map(t => new Date(t!).getTime())))
+    : new Date();
+
+  return {
+    id: sessionId,
+    projectId: project.configProjectKey,
+    status: (metadata.status as Session["status"]) || "spawning",
+    activity: null, // Not available without agent plugin
+    branch: metadata.branch || null,
+    issueId: metadata.issue || null,
+    pr: metadata.pr ? { number: 0, url: metadata.pr, title: "", owner: "", repo: "", branch: "", baseBranch: "", isDraft: false } : null,
+    workspacePath: metadata.worktree || null,
+    runtimeHandle: metadata.runtimeHandle ? { id: metadata.runtimeHandle, runtimeName: "tmux", data: {} } : null,
+    agentInfo: metadata.summary ? { summary: metadata.summary, agentSessionId: null } : null,
+    createdAt: metadata.createdAt ? new Date(metadata.createdAt) : new Date(),
+    lastActivityAt: lastActivity,
+    restoredAt: metadata.restoredAt ? new Date(metadata.restoredAt) : undefined,
+    metadata: {} as Record<string, string>,
+  };
+}
+
+export async function getPortfolioSessionCounts(portfolio: PortfolioProject[]): Promise<Record<string, { total: number; active: number }>> {
+  const counts: Record<string, { total: number; active: number }> = {};
+  const TERMINAL = new Set(["killed", "terminated", "done", "cleanup", "errored", "merged"]);
+
+  for (const project of portfolio) {
+    if (!project.enabled || project.degraded) {
+      counts[project.id] = { total: 0, active: 0 };
+      continue;
+    }
+
+    try {
+      const sessionsDir = getSessionsDir(project.configPath, project.repoPath);
+      let entries: string[];
+      try {
+        entries = await readdir(sessionsDir);
+      } catch {
+        counts[project.id] = { total: 0, active: 0 };
+        continue;
+      }
+
+      let total = 0;
+      let active = 0;
+
+      for (const name of entries) {
+        if (name === "archive" || name.startsWith(".")) continue;
+        if (!VALID_SESSION_ID.test(name)) continue;
+
+        try {
+          const filePath = join(sessionsDir, name);
+          const fileStat = await stat(filePath);
+          if (!fileStat.isFile()) continue;
+
+          total++;
+          const content = await readFile(filePath, "utf-8");
+          const raw = parseKeyValueContent(content);
+          if (!TERMINAL.has(raw["status"] ?? "")) active++;
+        } catch {
+          continue;
+        }
+      }
+
+      counts[project.id] = { total, active };
+    } catch {
+      counts[project.id] = { total: 0, active: 0 };
+    }
+  }
+
+  return counts;
+}

--- a/packages/core/src/portfolio-session-service.ts
+++ b/packages/core/src/portfolio-session-service.ts
@@ -25,11 +25,14 @@ export async function listPortfolioSessions(
     if (!project.enabled || project.degraded) continue;
 
     try {
+      let timerId: ReturnType<typeof setTimeout> | undefined;
       const projectResults = await Promise.race([
-        loadProjectSessions(project),
-        new Promise<PortfolioSession[]>((resolve) =>
-          setTimeout(() => resolve([]), timeout),
-        ),
+        loadProjectSessions(project).finally(() => {
+          if (timerId !== undefined) clearTimeout(timerId);
+        }),
+        new Promise<PortfolioSession[]>((resolve) => {
+          timerId = setTimeout(() => resolve([]), timeout);
+        }),
       ]);
       results.push(...projectResults);
     } catch {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -60,7 +60,7 @@ import {
   getWorktreesDir,
   getProjectBaseDir,
   generateTmuxName,
-  generateConfigHash,
+  generateProjectHash,
   validateAndStoreOrigin,
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
@@ -685,8 +685,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
     for (let attempts = 0; attempts < 10_000; attempts++) {
       const sessionId = `${project.sessionPrefix}-${num}`;
-      const tmuxName = config.configPath
-        ? generateTmuxName(config.configPath, project.sessionPrefix, num)
+      const tmuxName = project.path
+        ? generateTmuxName(project.path, project.sessionPrefix, num)
         : undefined;
 
       if (!usedNumbers.has(num) && reserveSessionId(sessionsDir, sessionId)) {
@@ -1073,7 +1073,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           AO_CALLER_TYPE: "agent",
           AO_PROJECT_ID: spawnConfig.projectId,
           AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+          ...(config.port !== undefined &&
+            config.port !== null && { AO_PORT: String(config.port) }),
         },
       });
     } catch (err) {
@@ -1210,6 +1211,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       role: "orchestrator",
       project,
       defaults: config.defaults,
+      spawnAgentOverride: orchestratorConfig.agent,
     });
     const plugins = resolvePlugins(project, selection.agentName);
     if (!plugins.runtime) {
@@ -1226,8 +1228,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     // Generate tmux name if using new architecture
     let tmuxName: string | undefined;
-    if (config.configPath) {
-      const hash = generateConfigHash(config.configPath);
+    if (project.path) {
+      const hash = generateProjectHash(project.path);
       tmuxName = `${hash}-${sessionId}`;
     }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,3 @@
-import type { ObservabilityLevel } from "./observability.js";
-
 /**
  * Agent Orchestrator — Core Type Definitions
  *
@@ -201,6 +199,8 @@ export interface SessionSpawnConfig {
 export interface OrchestratorSpawnConfig {
   projectId: string;
   systemPrompt?: string;
+  /** Override the agent plugin for this orchestrator (e.g. "codex", "claude-code", "opencode") */
+  agent?: string;
 }
 
 // =============================================================================
@@ -594,21 +594,6 @@ export interface SCM {
 
   /** Check if PR is ready to merge */
   getMergeability(pr: PRInfo): Promise<MergeReadiness>;
-
-  /**
-   * Batch fetch PR data for multiple PRs in a single GraphQL query.
-   * Used by the orchestrator to poll all active sessions efficiently.
-   *
-   * This is an optimization method that, when implemented, can dramatically
-   * reduce API calls by fetching data for multiple PRs in one request
-   * instead of calling getPRState/getCISummary/getReviewDecision separately
-   * for each PR.
-   *
-   * @param prs - Array of PR information to fetch data for
-   * @param observer - Optional observer for batch operation metrics
-   * @returns Map keyed by "${owner}/${repo}#${number}" containing enrichment data
-   */
-  enrichSessionsPRBatch?(prs: PRInfo[], observer?: BatchObserver): Promise<Map<string, PREnrichmentData>>;
 }
 
 // --- PR Types ---
@@ -733,59 +718,6 @@ export interface MergeReadiness {
   approved: boolean;
   noConflicts: boolean;
   blockers: string[];
-}
-
-/**
- * Batch enrichment data returned by SCM plugins.
- * Contains all the information the orchestrator needs for status detection.
- */
-export interface PREnrichmentData {
-  /** Current PR state */
-  state: PRState;
-  /** Overall CI status */
-  ciStatus: CIStatus;
-  /** Review decision */
-  reviewDecision: ReviewDecision;
-  /** Whether the PR is mergeable based on CI, reviews, and merge state */
-  mergeable: boolean;
-  /** PR title */
-  title?: string;
-  /** Number of additions */
-  additions?: number;
-  /** Number of deletions */
-  deletions?: number;
-  /** Whether PR is a draft */
-  isDraft?: boolean;
-  /** Whether PR has merge conflicts */
-  hasConflicts?: boolean;
-  /** Whether PR is behind base branch */
-  isBehind?: boolean;
-  /** List of blockers preventing merge */
-  blockers?: string[];
-}
-
-/**
- * Observer for GraphQL batch PR enrichment operations.
- * Used by SCM plugins to report batch success/failure to the observability system.
- */
-export interface BatchObserver {
-  /** Record a successful batch enrichment */
-  recordSuccess(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    durationMs: number;
-  }): void;
-  /** Record a failed batch enrichment */
-  recordFailure(data: {
-    batchIndex: number;
-    totalBatches: number;
-    prCount: number;
-    error: string;
-    durationMs: number;
-  }): void;
-  /** Log a message at a specific level */
-  log(level: ObservabilityLevel, message: string): void;
 }
 
 // =============================================================================
@@ -1387,4 +1319,54 @@ export class ConfigNotFoundError extends Error {
     super(message ?? "No agent-orchestrator.yaml found. Run `ao start` to create one.");
     this.name = "ConfigNotFoundError";
   }
+}
+
+// =============================================================================
+// PORTFOLIO — Cross-project aggregation
+// =============================================================================
+
+/** A project entry in the portfolio index (merged from discovery + registration + preferences) */
+export interface PortfolioProject {
+  id: string;                          // Stable portfolio identity (configProjectKey, with collision suffix if needed)
+  name: string;                        // Human-readable display name
+  configPath: string;                  // Absolute path to agent-orchestrator.yaml
+  configProjectKey: string;            // Key in config.projects map
+  repoPath: string;                    // Absolute local filesystem path
+  repo?: string;                       // "owner/repo" for SCM
+  defaultBranch?: string;
+  sessionPrefix: string;
+  source: "discovered" | "registered" | "config"; // How this entry was found
+  enabled: boolean;                    // User can disable without removing
+  pinned: boolean;                     // User preference for ordering
+  lastSeenAt: string;                  // ISO timestamp
+  degraded?: boolean;                  // True if config can't be loaded
+  degradedReason?: string;             // Why it's degraded
+}
+
+/** User preferences overlay (canonical, small file) */
+export interface PortfolioPreferences {
+  version: 1;
+  defaultProjectId?: string;
+  projectOrder?: string[];             // Ordered project IDs for display
+  projects?: Record<string, {          // Per-project preferences
+    pinned?: boolean;
+    enabled?: boolean;
+    displayName?: string;
+  }>;
+}
+
+/** Registered projects (explicit `ao project add`) */
+export interface PortfolioRegistered {
+  version: 1;
+  projects: Array<{
+    path: string;                      // Repo path
+    configProjectKey?: string;         // Key in config if multi-project YAML
+    addedAt: string;                   // ISO timestamp
+  }>;
+}
+
+/** Aggregated portfolio session with project context */
+export interface PortfolioSession {
+  session: Session;
+  project: PortfolioProject;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,5 @@
+import type { ObservabilityLevel } from "./observability.js";
+
 /**
  * Agent Orchestrator — Core Type Definitions
  *
@@ -594,6 +596,74 @@ export interface SCM {
 
   /** Check if PR is ready to merge */
   getMergeability(pr: PRInfo): Promise<MergeReadiness>;
+
+  /**
+   * Batch fetch PR data for multiple PRs in a single GraphQL query.
+   * Used by the orchestrator to poll all active sessions efficiently.
+   *
+   * This is an optimization method that, when implemented, can dramatically
+   * reduce API calls by fetching data for multiple PRs in one request
+   * instead of calling getPRState/getCISummary/getReviewDecision separately
+   * for each PR.
+   *
+   * @param prs - Array of PR information to fetch data for
+   * @param observer - Optional observer for batch operation metrics
+   * @returns Map keyed by "${owner}/${repo}#${number}" containing enrichment data
+   */
+  enrichSessionsPRBatch?(prs: PRInfo[], observer?: BatchObserver): Promise<Map<string, PREnrichmentData>>;
+}
+
+/**
+ * Batch enrichment data returned by SCM plugins.
+ * Contains all the information the orchestrator needs for status detection.
+ */
+export interface PREnrichmentData {
+  /** Current PR state */
+  state: PRState;
+  /** Overall CI status */
+  ciStatus: CIStatus;
+  /** Review decision */
+  reviewDecision: ReviewDecision;
+  /** Whether the PR is mergeable based on CI, reviews, and merge state */
+  mergeable: boolean;
+  /** PR title */
+  title?: string;
+  /** Number of additions */
+  additions?: number;
+  /** Number of deletions */
+  deletions?: number;
+  /** Whether PR is a draft */
+  isDraft?: boolean;
+  /** Whether PR has merge conflicts */
+  hasConflicts?: boolean;
+  /** Whether PR is behind base branch */
+  isBehind?: boolean;
+  /** List of blockers preventing merge */
+  blockers?: string[];
+}
+
+/**
+ * Observer for GraphQL batch PR enrichment operations.
+ * Used by SCM plugins to report batch success/failure to the observability system.
+ */
+export interface BatchObserver {
+  /** Record a successful batch enrichment */
+  recordSuccess(data: {
+    batchIndex: number;
+    totalBatches: number;
+    prCount: number;
+    durationMs: number;
+  }): void;
+  /** Record a failed batch enrichment */
+  recordFailure(data: {
+    batchIndex: number;
+    totalBatches: number;
+    prCount: number;
+    error: string;
+    durationMs: number;
+  }): void;
+  /** Log a message at a specific level */
+  log(level: ObservabilityLevel, message: string): void;
 }
 
 // --- PR Types ---

--- a/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
+++ b/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
@@ -22,7 +22,7 @@ import {
   createSessionManager,
   createPluginRegistry,
   type OrchestratorConfig,
-  generateConfigHash,
+  generateProjectHash,
   getSessionsDir,
   generateTmuxName,
 } from "@composio/ao-core";
@@ -100,8 +100,8 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
   }, 30_000);
 
   it("sessions are stored in hash-based project-specific directory", () => {
-    // Calculate expected directory
-    const hash = generateConfigHash(configPath);
+    // Calculate expected directory — hash is based on project path, not config path
+    const hash = generateProjectHash(repoPath);
     const sessionsDir = getSessionsDir(configPath, repoPath);
 
     expect(sessionsDir).toMatch(new RegExp(`\\.agent-orchestrator/${hash}-test-repo/sessions$`));
@@ -112,7 +112,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
     mkdirSync(sessionsDir, { recursive: true });
 
     // Write metadata as CLI would do
-    const tmuxName = generateTmuxName(configPath, sessionPrefix, 1);
+    const tmuxName = generateTmuxName(repoPath, sessionPrefix, 1);
     const metadataPath = join(sessionsDir, sessionName);
     const metadata = [
       `worktree=${tmpDir}`,
@@ -139,7 +139,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
     mkdirSync(sessionsDir, { recursive: true });
 
     // Write metadata
-    const tmuxName = generateTmuxName(configPath, sessionPrefix, 1);
+    const tmuxName = generateTmuxName(repoPath, sessionPrefix, 1);
     const metadataPath = join(sessionsDir, sessionName);
     const metadata = [
       `worktree=${tmpDir}`,
@@ -199,8 +199,8 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
   });
 
   it("tmux name includes hash for global uniqueness", () => {
-    const hash = generateConfigHash(configPath);
-    const tmuxName = generateTmuxName(configPath, sessionPrefix, 1);
+    const hash = generateProjectHash(repoPath);
+    const tmuxName = generateTmuxName(repoPath, sessionPrefix, 1);
 
     expect(tmuxName).toMatch(new RegExp(`^${hash}-${sessionPrefix}-1$`));
     expect(tmuxName).not.toBe(sessionName); // User-facing name is different

--- a/packages/integration-tests/src/config-metadata-service.integration.test.ts
+++ b/packages/integration-tests/src/config-metadata-service.integration.test.ts
@@ -15,6 +15,7 @@ import {
   getSessionsDir,
   getProjectBaseDir,
   generateConfigHash,
+  generateProjectHash,
   writeMetadata,
   readMetadata,
   updateMetadata,
@@ -91,7 +92,7 @@ describe("config → metadata service integration (real filesystem)", () => {
     expect(sessionsDir).toContain("my-repo");
     expect(sessionsDir).toContain("sessions");
 
-    const hash = generateConfigHash(configPath);
+    const hash = generateProjectHash(repoPath);
     expect(sessionsDir).toContain(hash);
   });
 


### PR DESCRIPTION
## Summary

Part 1 of 3 for the dashboard unification feature. Core data model and services only — no CLI or UI changes.

- **Hybrid config architecture**: flat local `agent-orchestrator.yaml` (behavior) + global `~/.agent-orchestrator/config.yaml` (identity registry + shadow copies)
- **Stable session hashing**: `generateInstanceId` and `generateTmuxName` now both use `generateProjectHash(projectPath)` — hash is stable regardless of whether config is local or global
- **Portfolio registry**: `discoverProjects()` scans `~/.agent-orchestrator/` dirs, merges with `registered.json` + `preferences.json`; skips degraded (stale/test) entries
- **New types**: `PortfolioProject`, `PortfolioProjectSummary`, `AttentionLevel`, portfolio preferences/registered schemas
- **Helper modules**: `portfolio-routing`, `portfolio-session-service`, `portfolio-projects`

## Review order

1. `packages/core/src/types.ts` — new types
2. `packages/core/src/paths.ts` — hash change (root of the session-dir fix)
3. `packages/core/src/global-config.ts` — new global config load/save/sync/migrate
4. `packages/core/src/portfolio-registry.ts` — discovery + merge logic
5. `packages/core/src/session-manager.ts` — wired to new portfolio types
6. Integration tests

## Stack
- **[1/3] Core** ← you are here
- [2/3] CLI
- [3/3] Web dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)