### PR TITLE
fix: start terminal WebSocket servers in ao dashboard dev mode

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
@@ -58,11 +60,21 @@ export function registerDashboard(program: Command): void {
         config.directTerminalPort,
       );
 
-      const child = spawn("npx", ["next", "dev", "-p", String(port)], {
-        cwd: webDir,
-        stdio: ["inherit", "inherit", "pipe"],
-        env,
-      });
+      // In dev mode (monorepo), use `pnpm run dev` which starts Next.js AND
+      // the terminal WebSocket servers via concurrently. Without the WS servers,
+      // the live terminal in the dashboard won't work.
+      const isDevMode = existsSync(resolve(webDir, "server"));
+      const child = isDevMode
+        ? spawn("pnpm", ["run", "dev"], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          })
+        : spawn("npx", ["next", "dev", "-p", String(port)], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          });
 
       const stderrChunks: string[] = [];
 


### PR DESCRIPTION
## Summary

- `ao dashboard` only spawned `next dev`, missing the terminal and direct-terminal WebSocket servers
- The live terminal in the dashboard silently failed to connect — no error shown to the user
- `ao start` didn't have this bug because it uses `pnpm run dev` (which runs all three servers via concurrently)
- Fix: detect dev mode (monorepo has `server/` dir) and use `pnpm run dev` instead of bare `next dev`, matching `ao start` behavior
- Production mode (installed from npm) is unchanged — continues using `npx next dev`

## Test plan

- [ ] Run `ao dashboard` in the monorepo — verify terminal WS servers start on ports 14800/14801
- [ ] Open a session detail page — verify live terminal connects and shows output
- [ ] Run `ao start` — verify behavior unchanged (already uses `pnpm run dev`)