### PR TITLE
feat(cli): interactive prompt for spawn multiple projects

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -4,23 +4,30 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { type Session, type SessionManager, getProjectBaseDir } from "@composio/ao-core";
 
-const { mockExec, mockConfigRef, mockSessionManager, mockEnsureLifecycleWorker } = vi.hoisted(
-  () => ({
-    mockExec: vi.fn(),
-    mockConfigRef: { current: null as Record<string, unknown> | null },
-    mockSessionManager: {
-      list: vi.fn(),
-      kill: vi.fn(),
-      cleanup: vi.fn(),
-      get: vi.fn(),
-      spawn: vi.fn(),
-      spawnOrchestrator: vi.fn(),
-      send: vi.fn(),
-      claimPR: vi.fn(),
-    },
-    mockEnsureLifecycleWorker: vi.fn(),
-  }),
-);
+const {
+  mockExec,
+  mockConfigRef,
+  mockSessionManager,
+  mockEnsureLifecycleWorker,
+  mockPromptSelect,
+  mockIsHumanCaller,
+} = vi.hoisted(() => ({
+  mockExec: vi.fn(),
+  mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockSessionManager: {
+    list: vi.fn(),
+    kill: vi.fn(),
+    cleanup: vi.fn(),
+    get: vi.fn(),
+    spawn: vi.fn(),
+    spawnOrchestrator: vi.fn(),
+    send: vi.fn(),
+    claimPR: vi.fn(),
+  },
+  mockEnsureLifecycleWorker: vi.fn(),
+  mockPromptSelect: vi.fn(),
+  mockIsHumanCaller: vi.fn().mockReturnValue(true),
+}));
 
 vi.mock("../../src/lib/shell.js", () => ({
   tmux: vi.fn(),
@@ -57,6 +64,15 @@ vi.mock("../../src/lib/create-session-manager.js", () => ({
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({
   ensureLifecycleWorker: (...args: unknown[]) => mockEnsureLifecycleWorker(...args),
+}));
+
+vi.mock("../../src/lib/prompts.js", () => ({
+  promptConfirm: vi.fn(),
+  promptSelect: (...args: unknown[]) => mockPromptSelect(...args),
+}));
+
+vi.mock("../../src/lib/caller-context.js", () => ({
+  isHumanCaller: (...args: unknown[]) => mockIsHumanCaller(...args),
 }));
 
 vi.mock("../../src/lib/metadata.js", () => ({
@@ -116,6 +132,9 @@ beforeEach(() => {
   mockSessionManager.claimPR.mockReset();
   mockExec.mockReset();
   mockEnsureLifecycleWorker.mockReset();
+  mockPromptSelect.mockReset();
+  mockIsHumanCaller.mockReset();
+  mockIsHumanCaller.mockReturnValue(true);
   mockEnsureLifecycleWorker.mockResolvedValue({
     running: true,
     started: true,
@@ -226,6 +245,64 @@ describe("spawn command", () => {
     });
   });
 
+  it("prompts for a project when multiple are configured and spawn is ambiguous", async () => {
+    const fakeSession: Session = {
+      id: "api-1",
+      projectId: "backend",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-100",
+      issueId: "INT-100",
+      pr: null,
+      workspacePath: "/tmp/api-wt",
+      runtimeHandle: { id: "hash-api-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      frontend: {
+        name: "Frontend",
+        repo: "org/frontend",
+        path: join(tmpDir, "frontend-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "fe",
+      },
+      backend: {
+        name: "Backend",
+        repo: "org/backend",
+        path: join(tmpDir, "backend-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "api",
+      },
+    };
+    mkdirSync(join(tmpDir, "frontend-repo"), { recursive: true });
+    mkdirSync(join(tmpDir, "backend-repo"), { recursive: true });
+
+    mockPromptSelect.mockResolvedValue("backend");
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "INT-100"]);
+
+    expect(mockPromptSelect).toHaveBeenCalledWith(
+      "Choose project to spawn for:",
+      expect.arrayContaining([
+        expect.objectContaining({ value: "frontend", label: "Frontend", hint: "frontend" }),
+        expect.objectContaining({ value: "backend", label: "Backend", hint: "backend" }),
+      ]),
+    );
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: expect.any(String) }),
+      "backend",
+    );
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "backend",
+      issueId: "INT-100",
+    });
+  });
+
   it("shows tmux attach command using runtimeHandle.id (hash-based name)", async () => {
     const fakeSession: Session = {
       id: "app-7",
@@ -326,6 +403,41 @@ describe("spawn command", () => {
     await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
       "process.exit(1)",
     );
+  });
+
+  it("shows a non-interactive inference error when multiple projects are configured", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      frontend: {
+        name: "Frontend",
+        repo: "org/frontend",
+        path: join(tmpDir, "frontend-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "fe",
+      },
+      backend: {
+        name: "Backend",
+        repo: "org/backend",
+        path: join(tmpDir, "backend-repo"),
+        defaultBranch: "main",
+        sessionPrefix: "api",
+      },
+    };
+    mkdirSync(join(tmpDir, "frontend-repo"), { recursive: true });
+    mkdirSync(join(tmpDir, "backend-repo"), { recursive: true });
+    mockIsHumanCaller.mockReturnValue(false);
+
+    await expect(program.parseAsync(["node", "test", "spawn"])).rejects.toThrow(
+      "process.exit(1)",
+    );
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => String(c[0]))
+      .join("\n");
+    expect(errors).toContain("Unable to infer which project to spawn for");
+    expect(errors).toContain("AO_PROJECT_ID");
+    expect(mockPromptSelect).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
   });
 
   it("claims a PR for the spawned session when --claim-pr is provided", async () => {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -19,14 +19,17 @@ import { banner } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
+import { isHumanCaller } from "../lib/caller-context.js";
+import { promptSelect } from "../lib/prompts.js";
 
 /**
  * Auto-detect the project ID from the config.
  * - If only one project exists, use it.
+ * - If multiple projects exist and the caller is interactive, prompt to choose.
  * - If multiple projects exist, match cwd against project paths.
  * - Falls back to AO_PROJECT_ID env var (set when called from an agent session).
  */
-function autoDetectProject(config: OrchestratorConfig): string {
+async function autoDetectProject(config: OrchestratorConfig): Promise<string> {
   const projectIds = Object.keys(config.projects);
   if (projectIds.length === 0) {
     throw new Error("No projects configured. Run 'ao start' first.");
@@ -49,9 +52,21 @@ function autoDetectProject(config: OrchestratorConfig): string {
     }
   }
 
+  if (isHumanCaller()) {
+    return await promptSelect(
+      "Choose project to spawn for:",
+      projectIds.map((id) => ({
+        value: id,
+        label: config.projects[id].name ?? id,
+        hint: id,
+      })),
+    );
+  }
+
   throw new Error(
-    `Multiple projects configured. Specify one: ${projectIds.join(", ")}\n` +
-      `Or run from within a project directory.`,
+    `Multiple projects configured. Unable to infer which project to spawn for.\n` +
+      `Available projects: ${projectIds.join(", ")}\n` +
+      `Run this command from within a project directory, set AO_PROJECT_ID, or use an interactive terminal to choose a project.`,
   );
 }
 
@@ -200,7 +215,7 @@ export function registerSpawn(program: Command): void {
         if (first) {
           issueId = first;
           try {
-            projectId = autoDetectProject(config);
+            projectId = await autoDetectProject(config);
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
@@ -208,7 +223,7 @@ export function registerSpawn(program: Command): void {
         } else {
           // No args: auto-detect project, no issue
           try {
-            projectId = autoDetectProject(config);
+            projectId = await autoDetectProject(config);
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
@@ -301,7 +316,7 @@ export function registerBatchSpawn(program: Command): void {
       let projectId: string;
 
       try {
-        projectId = autoDetectProject(config);
+        projectId = await autoDetectProject(config);
       } catch (err) {
         console.error(chalk.red(err instanceof Error ? err.message : String(err)));
         process.exit(1);


### PR DESCRIPTION
# Summary

If the user runs `ao spawn` and the project cannot be inferred, the CLI now shows an interactive project picker instead of throwing error and telling the user to pass the project manually.

# Changes

- add interactive project selection to `ao spawn` when multiple projects are configured
- keep non-interactive callers on an explicit error path
- add tests for interactive and non-interactive behavior