### PR TITLE
fix(agent-claude-code): auto-accept bypass permissions prompt in tmux sessions

### DIFF
--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -173,6 +173,7 @@ describe("getLaunchCommand", () => {
   it("includes --dangerously-skip-permissions when permissions=permissionless", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("$TMUX");
     expect(cmd).toContain("tmux send-keys");
   });
 
@@ -181,12 +182,14 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
     );
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("$TMUX");
     expect(cmd).toContain("tmux send-keys");
   });
 
   it("maps permissions=auto-edit to no-prompt mode on Claude", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("$TMUX");
     expect(cmd).toContain("tmux send-keys");
   });
 
@@ -206,6 +209,7 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ permissions: "permissionless", model: "opus", prompt: "Hello" }),
     );
     expect(cmd).toContain("claude --dangerously-skip-permissions --model 'opus'");
+    expect(cmd).toContain("$TMUX");
     expect(cmd).toContain("tmux send-keys");
   });
 

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -173,6 +173,7 @@ describe("getLaunchCommand", () => {
   it("includes --dangerously-skip-permissions when permissions=permissionless", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "permissionless" }));
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("tmux send-keys");
   });
 
   it("treats legacy permissions=skip as permissionless", () => {
@@ -180,11 +181,13 @@ describe("getLaunchCommand", () => {
       makeLaunchConfig({ permissions: "skip" as unknown as AgentLaunchConfig["permissions"] }),
     );
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("tmux send-keys");
   });
 
   it("maps permissions=auto-edit to no-prompt mode on Claude", () => {
     const cmd = agent.getLaunchCommand(makeLaunchConfig({ permissions: "auto-edit" }));
     expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("tmux send-keys");
   });
 
   it("shell-escapes model argument", () => {
@@ -202,7 +205,8 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ permissions: "permissionless", model: "opus", prompt: "Hello" }),
     );
-    expect(cmd).toBe("claude --dangerously-skip-permissions --model 'opus'");
+    expect(cmd).toContain("claude --dangerously-skip-permissions --model 'opus'");
+    expect(cmd).toContain("tmux send-keys");
   });
 
   it("omits --dangerously-skip-permissions when permissions=default", () => {
@@ -264,6 +268,7 @@ describe("getEnvironment", () => {
     const env = agent.getEnvironment(makeLaunchConfig());
     expect(env["AO_ISSUE_ID"]).toBeUndefined();
   });
+
 });
 
 // =========================================================================

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -228,6 +228,18 @@ export function toClaudeProjectPath(workspacePath: string): string {
   return normalized.replace(/:/g, "").replace(/[/.]/g, "-");
 }
 
+/**
+ * Wrap a claude command with a background auto-accept for the bypass permissions
+ * confirmation prompt. Only applies when running inside tmux ($TMUX is set).
+ * Claude Code's --dangerously-skip-permissions shows an interactive prompt that
+ * blocks non-interactive sessions. This sends Down + Enter via tmux send-keys
+ * after a short delay to auto-accept it.
+ */
+function wrapWithBypassAutoAccept(cmd: string, isBypassMode: boolean): string {
+  if (!isBypassMode) return cmd;
+  return `([ -n "\$TMUX" ] && sleep 3 && tmux send-keys -t "\${AO_TMUX_NAME:-\${AO_SESSION_NAME}}" Down Enter 2>/dev/null) & ${cmd}`;
+}
+
 /** Find the most recently modified .jsonl session file in a directory */
 async function findLatestSessionFile(projectDir: string): Promise<string | null> {
   let entries: string[];
@@ -658,7 +670,8 @@ function createClaudeCodeAgent(): Agent {
 
     getLaunchCommand(config: AgentLaunchConfig): string {
       // Note: CLAUDECODE is unset via getEnvironment() (set to ""), not here.
-      // This command must be safe for both shell and execFile contexts.
+      // In bypass mode, the command uses shell syntax (subshell + background job)
+      // and requires a shell runtime (e.g. tmux). Non-bypass commands remain execFile-safe.
       const parts: string[] = ["claude"];
 
       const permissionMode = normalizePermissionMode(config.permissions);
@@ -684,17 +697,7 @@ function createClaudeCodeAgent(): Agent {
       // runtime.sendMessage() to keep Claude in interactive mode.
       // Using -p causes one-shot mode (Claude exits after responding).
 
-      const cmd = parts.join(" ");
-
-      // Claude Code's --dangerously-skip-permissions shows an interactive confirmation
-      // prompt that blocks non-interactive (tmux) sessions. Auto-accept it by sending
-      // Down + Enter keystrokes via tmux after a short delay. Uses $AO_TMUX_NAME
-      // (set by session manager) to target the correct tmux pane.
-      if (isBypassMode) {
-        return `(sleep 3 && tmux send-keys -t "\${AO_TMUX_NAME:-\${AO_SESSION_NAME}}" Down Enter 2>/dev/null) & ${cmd}`;
-      }
-
-      return cmd;
+      return wrapWithBypassAutoAccept(parts.join(" "), isBypassMode);
     },
 
     getEnvironment(config: AgentLaunchConfig): Record<string, string> {
@@ -833,7 +836,8 @@ function createClaudeCodeAgent(): Agent {
       const parts: string[] = ["claude", "--resume", shellEscape(sessionUuid)];
 
       const permissionMode = normalizePermissionMode(project.agentConfig?.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      const isBypassMode = permissionMode === "permissionless" || permissionMode === "auto-edit";
+      if (isBypassMode) {
         parts.push("--dangerously-skip-permissions");
       }
 
@@ -841,7 +845,7 @@ function createClaudeCodeAgent(): Agent {
         parts.push("--model", shellEscape(project.agentConfig.model as string));
       }
 
-      return parts.join(" ");
+      return wrapWithBypassAutoAccept(parts.join(" "), isBypassMode);
     },
 
     async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -662,7 +662,8 @@ function createClaudeCodeAgent(): Agent {
       const parts: string[] = ["claude"];
 
       const permissionMode = normalizePermissionMode(config.permissions);
-      if (permissionMode === "permissionless" || permissionMode === "auto-edit") {
+      const isBypassMode = permissionMode === "permissionless" || permissionMode === "auto-edit";
+      if (isBypassMode) {
         parts.push("--dangerously-skip-permissions");
       }
 
@@ -683,7 +684,17 @@ function createClaudeCodeAgent(): Agent {
       // runtime.sendMessage() to keep Claude in interactive mode.
       // Using -p causes one-shot mode (Claude exits after responding).
 
-      return parts.join(" ");
+      const cmd = parts.join(" ");
+
+      // Claude Code's --dangerously-skip-permissions shows an interactive confirmation
+      // prompt that blocks non-interactive (tmux) sessions. Auto-accept it by sending
+      // Down + Enter keystrokes via tmux after a short delay. Uses $AO_TMUX_NAME
+      // (set by session manager) to target the correct tmux pane.
+      if (isBypassMode) {
+        return `(sleep 3 && tmux send-keys -t "\${AO_TMUX_NAME:-\${AO_SESSION_NAME}}" Down Enter 2>/dev/null) & ${cmd}`;
+      }
+
+      return cmd;
     },
 
     getEnvironment(config: AgentLaunchConfig): Record<string, string> {


### PR DESCRIPTION
## Summary
- Claude Code's `--dangerously-skip-permissions` now shows an interactive confirmation prompt that blocks non-interactive tmux sessions, causing all AO workers in bypass mode to hang and exit
- Fix wraps the launch command with a background subshell that auto-accepts the prompt via `tmux send-keys` (Down + Enter) after a 3-second delay
- Uses existing `$AO_TMUX_NAME` / `$AO_SESSION_NAME` env vars to target the correct pane

Fixes #817

## Test plan
- [x] All 149 unit tests pass (`pnpm --filter @composio/ao-plugin-agent-claude-code test`)
- [x] Live tested: spawned worker session `ao-114`, successfully auto-accepted the prompt and started working
- [ ] Verify with `permissions: "auto-edit"` mode
- [ ] Verify non-bypass modes (`permissions: "default"`) are unaffected (no wrapper added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)