### PR TITLE
feat(core): auto-resume worker sessions on respawn for same issue

### DIFF
--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -11,6 +11,7 @@ import {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  findArchivedSessionForIssue,
 } from "../metadata.js";
 
 let dataDir: string;
@@ -460,5 +461,128 @@ describe("listMetadata", () => {
     const list = listMetadata(emptyDir);
     expect(list).toEqual([]);
     // no cleanup needed since dir was never created
+  });
+});
+
+describe("findArchivedSessionForIssue", () => {
+  it("finds archived session matching issue and agent", () => {
+    writeMetadata(dataDir, "app-1", {
+      worktree: "/tmp/w",
+      branch: "feat/INT-100",
+      status: "killed",
+      issue: "INT-100",
+      agent: "claude-code",
+      createdAt: "2025-06-01T00:00:00.000Z",
+      summary: "Fixed the login bug",
+    });
+    deleteMetadata(dataDir, "app-1", true);
+
+    const result = findArchivedSessionForIssue(dataDir, "INT-100", "claude-code");
+    expect(result).not.toBeNull();
+    expect(result!.sessionId).toBe("app-1");
+    expect(result!.metadata["issue"]).toBe("INT-100");
+    expect(result!.metadata["agent"]).toBe("claude-code");
+    expect(result!.metadata["summary"]).toBe("Fixed the login bug");
+  });
+
+  it("returns null when no matching issue", () => {
+    writeMetadata(dataDir, "app-1", {
+      worktree: "/tmp/w",
+      branch: "feat/INT-100",
+      status: "killed",
+      issue: "INT-100",
+      agent: "claude-code",
+    });
+    deleteMetadata(dataDir, "app-1", true);
+
+    const result = findArchivedSessionForIssue(dataDir, "INT-999", "claude-code");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when agent doesn't match", () => {
+    writeMetadata(dataDir, "app-1", {
+      worktree: "/tmp/w",
+      branch: "feat/INT-100",
+      status: "killed",
+      issue: "INT-100",
+      agent: "claude-code",
+    });
+    deleteMetadata(dataDir, "app-1", true);
+
+    const result = findArchivedSessionForIssue(dataDir, "INT-100", "codex");
+    expect(result).toBeNull();
+  });
+
+  it("returns the most recent session when multiple exist", () => {
+    // Create first session
+    writeMetadata(dataDir, "app-1", {
+      worktree: "/tmp/w",
+      branch: "feat/INT-100",
+      status: "killed",
+      issue: "INT-100",
+      agent: "claude-code",
+      createdAt: "2025-06-01T00:00:00.000Z",
+      summary: "First attempt",
+    });
+    deleteMetadata(dataDir, "app-1", true);
+
+    // Create second session (more recent)
+    writeMetadata(dataDir, "app-2", {
+      worktree: "/tmp/w2",
+      branch: "feat/INT-100",
+      status: "killed",
+      issue: "INT-100",
+      agent: "claude-code",
+      createdAt: "2025-06-15T00:00:00.000Z",
+      summary: "Second attempt",
+    });
+    deleteMetadata(dataDir, "app-2", true);
+
+    const result = findArchivedSessionForIssue(dataDir, "INT-100", "claude-code");
+    expect(result).not.toBeNull();
+    expect(result!.metadata["summary"]).toBe("Second attempt");
+  });
+
+  it("returns null when archive directory doesn't exist", () => {
+    const result = findArchivedSessionForIssue(dataDir, "INT-100", "claude-code");
+    expect(result).toBeNull();
+  });
+});
+
+describe("resumedFrom persistence", () => {
+  it("roundtrips resumedFrom through writeMetadata and readMetadata", () => {
+    writeMetadata(dataDir, "app-2", {
+      worktree: "/tmp/w",
+      branch: "main",
+      status: "spawning",
+      resumedFrom: "app-1",
+    });
+
+    const meta = readMetadata(dataDir, "app-2");
+    expect(meta).not.toBeNull();
+    expect(meta!.resumedFrom).toBe("app-1");
+  });
+
+  it("resumedFrom is persisted in the key=value file", () => {
+    writeMetadata(dataDir, "app-2", {
+      worktree: "/tmp/w",
+      branch: "main",
+      status: "spawning",
+      resumedFrom: "app-1",
+    });
+
+    const content = readFileSync(join(dataDir, "app-2"), "utf-8");
+    expect(content).toContain("resumedFrom=app-1");
+  });
+
+  it("resumedFrom is undefined when not set", () => {
+    writeMetadata(dataDir, "app-3", {
+      worktree: "/tmp/w",
+      branch: "main",
+      status: "working",
+    });
+
+    const meta = readMetadata(dataDir, "app-3");
+    expect(meta!.resumedFrom).toBeUndefined();
   });
 });

--- a/packages/core/src/__tests__/session-context-builder.test.ts
+++ b/packages/core/src/__tests__/session-context-builder.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildPreviousSessionContext,
+  formatPreviousSessionContext,
+  type PreviousSessionContext,
+} from "../session-context-builder.js";
+
+describe("buildPreviousSessionContext", () => {
+  it("returns null when no useful context is available", async () => {
+    const result = await buildPreviousSessionContext(
+      "app-1",
+      { status: "killed" },
+      "/nonexistent/path",
+      "main",
+    );
+    expect(result).toBeNull();
+  });
+
+  it("returns context when summary is available", async () => {
+    const result = await buildPreviousSessionContext(
+      "app-1",
+      {
+        status: "killed",
+        summary: "Implemented login feature",
+        branch: "feat/login",
+      },
+      "/nonexistent/path",
+      "main",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.sourceSessionId).toBe("app-1");
+    expect(result!.summary).toBe("Implemented login feature");
+    expect(result!.previousStatus).toBe("killed");
+    expect(result!.branch).toBe("feat/login");
+  });
+
+  it("returns context when PR URL is available", async () => {
+    const result = await buildPreviousSessionContext(
+      "app-2",
+      {
+        status: "pr_open",
+        pr: "https://github.com/org/repo/pull/42",
+      },
+      "/nonexistent/path",
+      "main",
+    );
+    expect(result).not.toBeNull();
+    expect(result!.prUrl).toBe("https://github.com/org/repo/pull/42");
+  });
+
+  it("returns null when only status is available (no actionable context)", async () => {
+    const result = await buildPreviousSessionContext(
+      "app-3",
+      { status: "killed" },
+      "/nonexistent/path",
+      "main",
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("formatPreviousSessionContext", () => {
+  it("formats context with all fields", () => {
+    const context: PreviousSessionContext = {
+      sourceSessionId: "app-1",
+      summary: "Fixed login bug by updating auth middleware",
+      previousStatus: "killed",
+      prUrl: "https://github.com/org/repo/pull/42",
+      branch: "feat/login-fix",
+      recentCommits: "abc1234 fix: update auth middleware\ndef5678 chore: add tests",
+    };
+
+    const formatted = formatPreviousSessionContext(context);
+
+    expect(formatted).toContain("## Previous Session Context");
+    expect(formatted).toContain("`app-1`");
+    expect(formatted).toContain("Fixed login bug by updating auth middleware");
+    expect(formatted).toContain("`killed`");
+    expect(formatted).toContain("https://github.com/org/repo/pull/42");
+    expect(formatted).toContain("`feat/login-fix`");
+    expect(formatted).toContain("abc1234 fix: update auth middleware");
+    expect(formatted).toContain("Continue from where the previous session left off");
+  });
+
+  it("formats context with only summary", () => {
+    const context: PreviousSessionContext = {
+      sourceSessionId: "app-2",
+      summary: "Started implementing feature X",
+      previousStatus: "working",
+      prUrl: null,
+      branch: null,
+      recentCommits: null,
+    };
+
+    const formatted = formatPreviousSessionContext(context);
+
+    expect(formatted).toContain("## Previous Session Context");
+    expect(formatted).toContain("Started implementing feature X");
+    expect(formatted).not.toContain("### Pull Request");
+    expect(formatted).not.toContain("### Branch");
+    expect(formatted).not.toContain("### Commits");
+  });
+
+  it("includes PR continuation guidance", () => {
+    const context: PreviousSessionContext = {
+      sourceSessionId: "app-3",
+      summary: null,
+      previousStatus: "pr_open",
+      prUrl: "https://github.com/org/repo/pull/99",
+      branch: "feat/stuff",
+      recentCommits: null,
+    };
+
+    const formatted = formatPreviousSessionContext(context);
+
+    expect(formatted).toContain("Review the existing PR and continue from where it left off");
+  });
+});

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -2170,6 +2170,31 @@ describe("spawn", () => {
       const meta = readMetadataRaw(sessionsDir, session.id);
       expect(meta!["resumedFrom"]).toBeUndefined();
     });
+
+    it("does not set resumedFrom when archived session has no useful context", async () => {
+      // Archive a session with no summary, no PR, no commits — nothing to inject
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-600",
+        status: "killed",
+        issue: "INT-600",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        // No summary, no PR — buildPreviousSessionContext will return null
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app", issueId: "INT-600" });
+
+      // resumedFrom should NOT be set because no actual context was injected
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta!["resumedFrom"]).toBeUndefined();
+
+      // Prompt should NOT contain previous session context
+      const launchConfig = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(launchConfig?.prompt).not.toContain("Previous Session Context");
+    });
   });
 });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -2083,6 +2083,32 @@ describe("spawn", () => {
       expect(meta!["resumedFrom"]).toBe("app-1");
     });
 
+    it("skips post-launch prompt delivery when using native resume", async () => {
+      // Create and archive a previous session
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-350",
+        status: "killed",
+        issue: "INT-350",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Previous work",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      // Set agent to post-launch prompt delivery (like Claude Code)
+      Object.defineProperty(mockAgent, "promptDelivery", { value: "post-launch", configurable: true });
+      (mockAgent as Agent & { getRestoreCommand: ReturnType<typeof vi.fn> }).getRestoreCommand =
+        vi.fn().mockResolvedValue("mock-agent --resume abc123");
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await sm.spawn({ projectId: "my-app", issueId: "INT-350", prompt: "Work on this" });
+
+      // Runtime.sendMessage should NOT have been called — native resume means
+      // the agent already has its conversation history
+      expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    });
+
     it("falls back to context injection when getRestoreCommand returns null", async () => {
       // Create and archive a previous session
       writeMetadata(sessionsDir, "app-1", {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1995,5 +1995,181 @@ describe("spawn", () => {
       expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toEqual({});
     });
   });
+
+  describe("auto-resume on respawn", () => {
+    it("injects previous session context when archived session exists for the same issue", async () => {
+      // Create and archive a previous session for the same issue
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-100",
+        status: "killed",
+        issue: "INT-100",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Implemented the login flow",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app", issueId: "INT-100" });
+
+      // Session should be spawned with resumedFrom metadata
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta).not.toBeNull();
+      expect(meta!["resumedFrom"]).toBe("app-1");
+
+      // The launch command should have been called (context injection goes through prompt)
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalled();
+      const launchConfig = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      // The prompt should contain previous session context
+      expect(launchConfig?.prompt).toContain("Previous Session Context");
+      expect(launchConfig?.prompt).toContain("Implemented the login flow");
+    });
+
+    it("skips resume when workerRespawnStrategy is fresh", async () => {
+      // Create and archive a previous session
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-200",
+        status: "killed",
+        issue: "INT-200",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Previous work",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      // Set strategy to fresh
+      config.projects["my-app"]!.workerRespawnStrategy = "fresh";
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app", issueId: "INT-200" });
+
+      // Should NOT have resumedFrom metadata
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta!["resumedFrom"]).toBeUndefined();
+
+      // Prompt should NOT contain previous session context
+      const launchConfig = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(launchConfig?.prompt).not.toContain("Previous Session Context");
+    });
+
+    it("tries native resume when agent supports getRestoreCommand", async () => {
+      // Create and archive a previous session
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-300",
+        status: "killed",
+        issue: "INT-300",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Previous work",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      // Add getRestoreCommand to the mock agent
+      (mockAgent as Agent & { getRestoreCommand: ReturnType<typeof vi.fn> }).getRestoreCommand =
+        vi.fn().mockResolvedValue("mock-agent --resume abc123");
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app", issueId: "INT-300" });
+
+      // Should have used the restore command instead of getLaunchCommand's result
+      const runtimeCreateCall = (mockRuntime.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(runtimeCreateCall?.launchCommand).toBe("mock-agent --resume abc123");
+
+      // Should have resumedFrom metadata
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta!["resumedFrom"]).toBe("app-1");
+    });
+
+    it("falls back to context injection when getRestoreCommand returns null", async () => {
+      // Create and archive a previous session
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-400",
+        status: "killed",
+        issue: "INT-400",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Half-done work",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      // getRestoreCommand returns null (no session file found)
+      (mockAgent as Agent & { getRestoreCommand: ReturnType<typeof vi.fn> }).getRestoreCommand =
+        vi.fn().mockResolvedValue(null);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await sm.spawn({ projectId: "my-app", issueId: "INT-400" });
+
+      // Should fall back to regular launch with context injection
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalled();
+      const launchConfig = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(launchConfig?.prompt).toContain("Previous Session Context");
+      expect(launchConfig?.prompt).toContain("Half-done work");
+    });
+
+    it("uses context-inject strategy skipping native resume", async () => {
+      // Create and archive a previous session
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/INT-500",
+        status: "killed",
+        issue: "INT-500",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+        summary: "Work in progress",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      // Add getRestoreCommand but set strategy to context-inject
+      (mockAgent as Agent & { getRestoreCommand: ReturnType<typeof vi.fn> }).getRestoreCommand =
+        vi.fn().mockResolvedValue("mock-agent --resume abc123");
+      config.projects["my-app"]!.workerRespawnStrategy = "context-inject";
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await sm.spawn({ projectId: "my-app", issueId: "INT-500" });
+
+      // getRestoreCommand should NOT have been called (skipped by strategy)
+      expect(
+        (mockAgent as Agent & { getRestoreCommand: ReturnType<typeof vi.fn> }).getRestoreCommand,
+      ).not.toHaveBeenCalled();
+
+      // Should have context injected into prompt
+      const launchConfig = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+      expect(launchConfig?.prompt).toContain("Previous Session Context");
+    });
+
+    it("proceeds with fresh launch when no archived session exists", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app", issueId: "INT-999" });
+
+      // Should have no resumedFrom metadata
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta!["resumedFrom"]).toBeUndefined();
+
+      // Should use regular launch
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalled();
+    });
+
+    it("does not attempt resume when no issueId is provided", async () => {
+      // Create and archive a session (shouldn't matter without issueId)
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp/ws",
+        branch: "feat/test",
+        status: "killed",
+        agent: "mock-agent",
+        createdAt: "2025-06-01T00:00:00.000Z",
+      });
+      deleteMetadata(sessionsDir, "app-1", true);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const session = await sm.spawn({ projectId: "my-app" });
+
+      const meta = readMetadataRaw(sessionsDir, session.id);
+      expect(meta!["resumedFrom"]).toBeUndefined();
+    });
+  });
 });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -169,6 +169,7 @@ const ProjectConfigSchema = z.object({
     .enum(["reuse", "delete", "ignore", "delete-new", "ignore-new", "kill-previous"])
     .optional(),
   opencodeIssueSessionStrategy: z.enum(["reuse", "delete", "ignore"]).optional(),
+  workerRespawnStrategy: z.enum(["resume", "context-inject", "fresh"]).optional(),
   decomposer: DecomposerConfigSchema.optional(),
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export {
   updateMetadata,
   deleteMetadata,
   listMetadata,
+  findArchivedSessionForIssue,
 } from "./metadata.js";
 
 // tmux — command wrappers
@@ -54,6 +55,10 @@ export type { LifecycleManagerDeps } from "./lifecycle-manager.js";
 // Prompt builder — layered prompt composition
 export { buildPrompt, BASE_AGENT_PROMPT } from "./prompt-builder.js";
 export type { PromptBuildConfig } from "./prompt-builder.js";
+
+// Session context builder — context injection for respawned sessions
+export { buildPreviousSessionContext, formatPreviousSessionContext } from "./session-context-builder.js";
+export type { PreviousSessionContext } from "./session-context-builder.js";
 
 // Decomposer — LLM-driven task decomposition
 export {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -86,6 +86,7 @@ export function readMetadata(dataDir: string, sessionId: SessionId): SessionMeta
     createdAt: raw["createdAt"],
     runtimeHandle: raw["runtimeHandle"],
     restoredAt: raw["restoredAt"],
+    resumedFrom: raw["resumedFrom"],
     role: raw["role"],
     dashboardPort: raw["dashboardPort"] ? Number(raw["dashboardPort"]) : undefined,
     terminalWsPort: raw["terminalWsPort"] ? Number(raw["terminalWsPort"]) : undefined,
@@ -135,6 +136,7 @@ export function writeMetadata(
   if (metadata.createdAt) data["createdAt"] = metadata.createdAt;
   if (metadata.runtimeHandle) data["runtimeHandle"] = metadata.runtimeHandle;
   if (metadata.restoredAt) data["restoredAt"] = metadata.restoredAt;
+  if (metadata.resumedFrom) data["resumedFrom"] = metadata.resumedFrom;
   if (metadata.role) data["role"] = metadata.role;
   if (metadata.dashboardPort !== undefined) data["dashboardPort"] = String(metadata.dashboardPort);
   if (metadata.terminalWsPort !== undefined)
@@ -291,6 +293,46 @@ export function listMetadata(dataDir: string): SessionId[] {
       return false;
     }
   });
+}
+
+/**
+ * Search archived sessions for the most recent one matching a given issue ID and agent name.
+ * Searches both active and archived metadata, returning archived entries only.
+ * Returns the raw metadata of the most recent match, or null if none found.
+ */
+export function findArchivedSessionForIssue(
+  dataDir: string,
+  issueId: string,
+  agentName: string,
+): { sessionId: string; metadata: Record<string, string> } | null {
+  const archiveDir = join(dataDir, "archive");
+  if (!existsSync(archiveDir)) return null;
+
+  // Collect unique session IDs from archive
+  const sessionIds = new Set<string>();
+  for (const file of readdirSync(archiveDir)) {
+    const match = file.match(/^([a-zA-Z0-9_-]+)_\d/);
+    if (match?.[1]) sessionIds.add(match[1]);
+  }
+
+  // Find the most recent archived session matching issue + agent
+  let bestMatch: { sessionId: string; metadata: Record<string, string>; timestamp: string } | null =
+    null;
+
+  for (const sid of sessionIds) {
+    const raw = readArchivedMetadataRaw(dataDir, sid);
+    if (!raw) continue;
+    if (raw["issue"] !== issueId) continue;
+    if (raw["agent"] !== agentName) continue;
+
+    // Use createdAt as the comparison key (archived sessions are timestamped)
+    const timestamp = raw["createdAt"] ?? "";
+    if (!bestMatch || timestamp > bestMatch.timestamp) {
+      bestMatch = { sessionId: sid, metadata: raw, timestamp };
+    }
+  }
+
+  return bestMatch ? { sessionId: bestMatch.sessionId, metadata: bestMatch.metadata } : null;
 }
 
 /**

--- a/packages/core/src/session-context-builder.ts
+++ b/packages/core/src/session-context-builder.ts
@@ -1,0 +1,117 @@
+/**
+ * Session Context Builder — extracts context from a previous session's archived
+ * metadata and git history for injection into a new worker's prompt.
+ *
+ * Used when native agent resume isn't available (agent doesn't support it,
+ * session files are corrupted, or agent was switched between sessions).
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+export interface PreviousSessionContext {
+  /** The session ID this context was built from */
+  sourceSessionId: string;
+  /** Summary from the previous session's agent (if available) */
+  summary: string | null;
+  /** Status the previous session ended in */
+  previousStatus: string | null;
+  /** PR URL if one was created */
+  prUrl: string | null;
+  /** Branch the previous session was working on */
+  branch: string | null;
+  /** Git log of commits on the branch (if available) */
+  recentCommits: string | null;
+}
+
+/**
+ * Build context from a previous session's archived metadata and git history.
+ * Returns null if no useful context can be extracted.
+ */
+export async function buildPreviousSessionContext(
+  sourceSessionId: string,
+  archivedMetadata: Record<string, string>,
+  projectPath: string,
+  defaultBranch: string,
+): Promise<PreviousSessionContext | null> {
+  const summary = archivedMetadata["summary"] || null;
+  const previousStatus = archivedMetadata["status"] || null;
+  const prUrl = archivedMetadata["pr"] || null;
+  const branch = archivedMetadata["branch"] || null;
+
+  // Try to get recent commits from the branch
+  let recentCommits: string | null = null;
+  if (branch) {
+    try {
+      const { stdout } = await execFileAsync(
+        "git",
+        ["log", `${defaultBranch}..${branch}`, "--oneline", "--no-decorate", "-20"],
+        { cwd: projectPath, timeout: 5_000 },
+      );
+      const trimmed = stdout.trim();
+      if (trimmed) {
+        recentCommits = trimmed;
+      }
+    } catch {
+      // Branch may not exist locally or other git error — skip
+    }
+  }
+
+  // Only return context if we have at least something useful
+  if (!summary && !prUrl && !recentCommits) {
+    return null;
+  }
+
+  return {
+    sourceSessionId,
+    summary,
+    previousStatus,
+    prUrl,
+    branch,
+    recentCommits,
+  };
+}
+
+/**
+ * Format previous session context into a prompt section that can be
+ * prepended to a new worker's prompt.
+ */
+export function formatPreviousSessionContext(context: PreviousSessionContext): string {
+  const lines: string[] = [];
+
+  lines.push("## Previous Session Context");
+  lines.push(
+    `A previous worker session (\`${context.sourceSessionId}\`) worked on this same issue before. Here is what it accomplished:`,
+  );
+
+  if (context.summary) {
+    lines.push(`\n### Agent Summary\n${context.summary}`);
+  }
+
+  if (context.previousStatus) {
+    lines.push(`\n### Previous Status: \`${context.previousStatus}\``);
+  }
+
+  if (context.prUrl) {
+    lines.push(`\n### Pull Request\nA PR was already created: ${context.prUrl}`);
+    lines.push(
+      "Review the existing PR and continue from where it left off rather than creating a new one.",
+    );
+  }
+
+  if (context.branch) {
+    lines.push(`\n### Branch: \`${context.branch}\``);
+  }
+
+  if (context.recentCommits) {
+    lines.push(`\n### Commits from previous session:\n\`\`\`\n${context.recentCommits}\n\`\`\``);
+  }
+
+  lines.push(
+    "\n**Important:** Continue from where the previous session left off. Do not redo work that is already committed. Review the existing code changes and git history before making new changes.",
+  );
+
+  return lines.join("\n");
+}

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1078,6 +1078,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
               archivedSessionObj,
               project,
             );
+            if (nativeResumeCommand) {
+              resumedFromSessionId = archivedSession.sessionId;
+            }
           } catch {
             // getRestoreCommand failed — fall through to context injection
           }
@@ -1095,13 +1098,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             if (prevContext) {
               const contextSection = formatPreviousSessionContext(prevContext);
               composedPrompt = contextSection + "\n\n" + composedPrompt;
+              resumedFromSessionId = archivedSession.sessionId;
             }
           } catch {
             // Context building failed — proceed with fresh launch
           }
         }
-
-        resumedFromSessionId = archivedSession.sessionId;
       }
     }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1260,7 +1260,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     // exits after -p, so we send the prompt after it starts in interactive mode).
     // This is intentionally outside the try/catch above — a prompt delivery failure
     // should NOT destroy the session. The agent is running; user can retry with `ao send`.
-    if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+    // Skip when using native resume — the agent already has its full conversation history
+    // and sending the prompt would cause it to restart work from scratch.
+    if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt && !nativeResumeCommand) {
       try {
         // Wait for agent to start and be ready for input
         await new Promise((resolve) => setTimeout(resolve, 5_000));

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -53,8 +53,13 @@ import {
   deleteMetadata,
   listMetadata,
   reserveSessionId,
+  findArchivedSessionForIssue,
 } from "./metadata.js";
 import { buildPrompt } from "./prompt-builder.js";
+import {
+  buildPreviousSessionContext,
+  formatPreviousSessionContext,
+} from "./session-context-builder.js";
 import {
   getSessionsDir,
   getWorktreesDir,
@@ -1019,7 +1024,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    const composedPrompt = buildPrompt({
+    let composedPrompt = buildPrompt({
       project,
       projectId: spawnConfig.projectId,
       issueId: spawnConfig.issueId,
@@ -1028,6 +1033,77 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       lineage: spawnConfig.lineage,
       siblings: spawnConfig.siblings,
     });
+
+    // --- Auto-resume fallback chain ---
+    // When respawning for the same issue, try to resume from a previous session
+    // rather than starting from scratch. Fallback order:
+    //   1. workerRespawnStrategy == "fresh" → skip, launch fresh
+    //   2. No previous archived session → fresh
+    //   3. Agent implements getRestoreCommand() and strategy is "resume" → native resume
+    //   4. Build context from archived metadata + git history → context injection
+    const respawnStrategy = project.workerRespawnStrategy ?? "resume";
+    let resumedFromSessionId: string | undefined;
+    let nativeResumeCommand: string | null = null;
+
+    if (respawnStrategy !== "fresh" && spawnConfig.issueId) {
+      const archivedSession = findArchivedSessionForIssue(
+        sessionsDir,
+        spawnConfig.issueId,
+        selection.agentName,
+      );
+
+      if (archivedSession) {
+        // Step 1: Try native resume if strategy is "resume" and agent supports it
+        if (respawnStrategy === "resume" && plugins.agent.getRestoreCommand) {
+          try {
+            // Construct a minimal Session from archived metadata for getRestoreCommand
+            const archivedSessionObj: Session = {
+              id: archivedSession.sessionId,
+              projectId: spawnConfig.projectId,
+              status: (archivedSession.metadata["status"] ?? "killed") as Session["status"],
+              activity: null,
+              branch: archivedSession.metadata["branch"] || null,
+              issueId: archivedSession.metadata["issue"] || null,
+              pr: null,
+              workspacePath: archivedSession.metadata["worktree"] || null,
+              runtimeHandle: null,
+              agentInfo: null,
+              createdAt: archivedSession.metadata["createdAt"]
+                ? new Date(archivedSession.metadata["createdAt"])
+                : new Date(),
+              lastActivityAt: new Date(),
+              metadata: archivedSession.metadata,
+            };
+            nativeResumeCommand = await plugins.agent.getRestoreCommand(
+              archivedSessionObj,
+              project,
+            );
+          } catch {
+            // getRestoreCommand failed — fall through to context injection
+          }
+        }
+
+        // Step 2: If no native resume, try context injection
+        if (!nativeResumeCommand) {
+          try {
+            const prevContext = await buildPreviousSessionContext(
+              archivedSession.sessionId,
+              archivedSession.metadata,
+              workspacePath,
+              project.defaultBranch,
+            );
+            if (prevContext) {
+              const contextSection = formatPreviousSessionContext(prevContext);
+              composedPrompt = contextSection + "\n\n" + composedPrompt;
+            }
+          } catch {
+            // Context building failed — proceed with fresh launch
+          }
+        }
+
+        resumedFromSessionId = archivedSession.sessionId;
+      }
+    }
 
     // Get agent launch config and create runtime — clean up workspace on failure
     const opencodeIssueSessionStrategy = project.opencodeIssueSessionStrategy ?? "reuse";
@@ -1057,7 +1133,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     let handle: RuntimeHandle;
     try {
-      const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
+      // Use native resume command if available, otherwise fresh launch
+      const launchCommand = nativeResumeCommand ?? plugins.agent.getLaunchCommand(agentLaunchConfig);
       const environment = plugins.agent.getEnvironment(agentLaunchConfig);
 
       handle = await plugins.runtime.create({
@@ -1112,6 +1189,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       lastActivityAt: new Date(),
       metadata: {
         ...(reusedOpenCodeSessionId ? { opencodeSessionId: reusedOpenCodeSessionId } : {}),
+        ...(resumedFromSessionId ? { resumedFrom: resumedFromSessionId } : {}),
       },
     };
 
@@ -1127,6 +1205,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         createdAt: new Date().toISOString(),
         runtimeHandle: JSON.stringify(handle),
         opencodeSessionId: reusedOpenCodeSessionId,
+        resumedFrom: resumedFromSessionId,
       });
 
       if (plugins.agent.postLaunchSetup) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1068,6 +1068,14 @@ export interface ProjectConfig {
 
   opencodeIssueSessionStrategy?: "reuse" | "delete" | "ignore";
 
+  /**
+   * Strategy when respawning a worker for the same issue after a crash/kill.
+   * - "resume": attempt native agent resume (claude --resume, codex resume), then context injection, then fresh
+   * - "context-inject": skip native resume, inject context from previous session into prompt
+   * - "fresh": always start from scratch (current behavior)
+   */
+  workerRespawnStrategy?: "resume" | "context-inject" | "fresh";
+
   /** Task decomposition configuration */
   decomposer?: {
     /** Enable auto-decomposition for backlog issues (default: false) */
@@ -1223,6 +1231,7 @@ export interface SessionMetadata {
   createdAt?: string;
   runtimeHandle?: string;
   restoredAt?: string;
+  resumedFrom?: string; // Session ID this was resumed from (session lineage tracking)
   role?: string; // "orchestrator" for orchestrator sessions
   dashboardPort?: number;
   terminalWsPort?: number;


### PR DESCRIPTION
## Summary

Closes #816

When a worker session dies (crash, rate limit, OOM) and is respawned for the same issue, the new worker now attempts to resume from the previous session instead of starting from scratch. This eliminates wasted context-building time and prevents the new worker from repeating mistakes that caused the previous failure.

### Changes

- **`workerRespawnStrategy` config** (`types.ts`, `config.ts`): New per-project config with options `"resume"` (default), `"context-inject"`, or `"fresh"`
- **`resumedFrom` metadata field** (`types.ts`, `metadata.ts`): Tracks session lineage — which archived session a new session was resumed from
- **`findArchivedSessionForIssue()` helper** (`metadata.ts`): Searches archived metadata by issue ID + agent name, returns the most recent match
- **`session-context-builder.ts`** (new file): Builds context from archived metadata (summary, status, PR, branch) and git history (commits on branch), formats it as a prompt section
- **`spawn()` fallback chain** (`session-manager.ts`): Before launching fresh, checks for previous sessions and attempts resume:
  1. Strategy is `"fresh"` → skip (preserve current behavior)
  2. No previous archived session for this issue → fresh launch
  3. Agent supports `getRestoreCommand()` + strategy is `"resume"` → native resume (`claude --resume`, `codex resume`)
  4. Native resume unavailable/fails → inject context from previous session into prompt
  5. No context available → completely fresh launch

### Per-agent behavior

| Agent | Native Resume | Context Injection Fallback |
|---|---|---|
| Claude Code | `claude --resume <uuid>` | If JSONL file missing/corrupt |
| Codex | `codex resume <threadId>` | If session file missing |
| OpenCode | Not yet implemented | Primary path |
| Aider | Not available | Always gets context injection |

## Test plan

- [x] `findArchivedSessionForIssue` — finds matching archived sessions, filters by issue+agent, returns most recent
- [x] `buildPreviousSessionContext` — extracts context from metadata, returns null when no useful context
- [x] `formatPreviousSessionContext` — formats context into prompt section with all fields
- [x] Spawn with archived session → injects context into prompt, sets `resumedFrom` metadata
- [x] Spawn with `workerRespawnStrategy: "fresh"` → no resume attempted
- [x] Spawn with `getRestoreCommand` returning command → uses native resume command
- [x] Spawn with `getRestoreCommand` returning null → falls back to context injection
- [x] Spawn with `workerRespawnStrategy: "context-inject"` → skips native resume
- [x] Spawn without issueId → no resume attempted
- [x] Spawn without archived session → fresh launch
- [x] All existing tests continue to pass (507 tests)
- [x] Build, typecheck, lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)