### PR TITLE
feat: multi-project architecture — config, sessions, dashboard, CLI

### DIFF
--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -4,6 +4,8 @@ import type { Command } from "commander";
 import { resolve } from "node:path";
 import {
   loadConfig,
+  loadConfigFromGlobal,
+  ConfigNotFoundError,
   decompose,
   getLeaves,
   getSiblings,
@@ -165,6 +167,7 @@ export function registerSpawn(program: Command): void {
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
+    .option("-p, --project <id>", "Project ID (for cross-project spawning from anywhere)")
     .option("--decompose", "Decompose issue into subtasks before spawning")
     .option("--max-depth <n>", "Max decomposition depth (default: 3)")
     .action(
@@ -174,6 +177,7 @@ export function registerSpawn(program: Command): void {
         opts: {
           open?: boolean;
           agent?: string;
+          project?: string;
           claimPr?: string;
           assignOnGithub?: boolean;
           decompose?: boolean;
@@ -193,14 +197,33 @@ export function registerSpawn(program: Command): void {
           process.exit(1);
         }
 
-        const config = loadConfig();
+        let config: OrchestratorConfig;
+        try {
+          config = loadConfig();
+        } catch (err) {
+          // Try global config fallback when --project is used from outside a project
+          if (err instanceof ConfigNotFoundError && opts.project) {
+            const globalConfig = loadConfigFromGlobal();
+            if (!globalConfig) {
+              console.error(chalk.red("No config found. Run `ao start` first."));
+              process.exit(1);
+            }
+            config = globalConfig;
+          } else if (err instanceof ConfigNotFoundError) {
+            console.error(chalk.red("No config found. Run `ao start` first."));
+            process.exit(1);
+          } else {
+            throw err;
+          }
+        }
+
         let projectId: string;
         let issueId: string | undefined;
 
         if (first) {
           issueId = first;
           try {
-            projectId = autoDetectProject(config);
+            projectId = opts.project ?? autoDetectProject(config);
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
@@ -208,11 +231,21 @@ export function registerSpawn(program: Command): void {
         } else {
           // No args: auto-detect project, no issue
           try {
-            projectId = autoDetectProject(config);
+            projectId = opts.project ?? autoDetectProject(config);
           } catch (err) {
             console.error(chalk.red(err instanceof Error ? err.message : String(err)));
             process.exit(1);
           }
+        }
+
+        // Validate --project flag
+        if (opts.project && !config.projects[opts.project]) {
+          console.error(
+            chalk.red(
+              `Unknown project: ${opts.project}. Available: ${Object.keys(config.projects).join(", ")}`,
+            ),
+          );
+          process.exit(1);
         }
 
         if (!opts.claimPr && opts.assignOnGithub) {
@@ -296,12 +329,31 @@ export function registerBatchSpawn(program: Command): void {
     .description("Spawn sessions for multiple issues with duplicate detection")
     .argument("<issues...>", "Issue identifiers (project is auto-detected)")
     .option("--open", "Open sessions in terminal tabs")
-    .action(async (issues: string[], opts: { open?: boolean }) => {
-      const config = loadConfig();
+    .option("-p, --project <id>", "Project ID (for cross-project spawning from anywhere)")
+    .action(async (issues: string[], opts: { open?: boolean; project?: string }) => {
+      let config: OrchestratorConfig;
+      try {
+        config = loadConfig();
+      } catch (err) {
+        if (err instanceof ConfigNotFoundError && opts.project) {
+          const globalConfig = loadConfigFromGlobal();
+          if (!globalConfig) {
+            console.error(chalk.red("No config found. Run `ao start` first."));
+            process.exit(1);
+          }
+          config = globalConfig;
+        } else if (err instanceof ConfigNotFoundError) {
+          console.error(chalk.red("No config found. Run `ao start` first."));
+          process.exit(1);
+        } else {
+          throw err;
+        }
+      }
+
       let projectId: string;
 
       try {
-        projectId = autoDetectProject(config);
+        projectId = opts.project ?? autoDetectProject(config);
       } catch (err) {
         console.error(chalk.red(err instanceof Error ? err.message : String(err)));
         process.exit(1);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -29,6 +29,14 @@ import {
   configToYaml,
   normalizeOrchestratorSessionStrategy,
   ConfigNotFoundError,
+  loadGlobalConfig,
+  saveGlobalConfig,
+  registerProject,
+  extractShadow,
+  globalConfigExists,
+  needsMigration,
+  migrateToMultiProject,
+  isProjectRegistered,
   type OrchestratorConfig,
   type ProjectConfig,
   type ParsedRepoUrl,
@@ -875,13 +883,45 @@ async function runStartup(
 
   if (shouldStartLifecycle) {
     try {
-      spinner.start("Starting lifecycle worker");
-      lifecycleStatus = await ensureLifecycleWorker(config, projectId);
-      spinner.succeed(
-        lifecycleStatus.started
-          ? `Lifecycle worker started${lifecycleStatus.pid ? ` (PID ${lifecycleStatus.pid})` : ""}`
-          : `Lifecycle worker already running${lifecycleStatus.pid ? ` (PID ${lifecycleStatus.pid})` : ""}`,
+      spinner.start("Starting lifecycle workers");
+      // Ensure lifecycle workers for ALL configured projects (multi-project support)
+      const allProjectIds = Object.keys(config.projects);
+      const lifecycleResults = await Promise.allSettled(
+        allProjectIds.map((pid) => ensureLifecycleWorker(config, pid)),
       );
+      let startedCount = 0;
+      let alreadyRunningCount = 0;
+      for (const result of lifecycleResults) {
+        if (result.status === "fulfilled") {
+          if (result.value.started) startedCount++;
+          else alreadyRunningCount++;
+          // Use the current project's lifecycle status for backward compat
+          if (lifecycleResults.indexOf(result) === allProjectIds.indexOf(projectId)) {
+            lifecycleStatus = result.value;
+          }
+        }
+      }
+      // Fallback: use any fulfilled result
+      if (!lifecycleStatus) {
+        for (const result of lifecycleResults) {
+          if (result.status === "fulfilled") {
+            lifecycleStatus = result.value;
+            break;
+          }
+        }
+      }
+      const totalProjects = allProjectIds.length;
+      if (totalProjects === 1) {
+        spinner.succeed(
+          lifecycleStatus?.started
+            ? `Lifecycle worker started${lifecycleStatus.pid ? ` (PID ${lifecycleStatus.pid})` : ""}`
+            : `Lifecycle worker already running${lifecycleStatus?.pid ? ` (PID ${lifecycleStatus.pid})` : ""}`,
+        );
+      } else {
+        spinner.succeed(
+          `Lifecycle workers: ${startedCount} started, ${alreadyRunningCount} already running (${totalProjects} projects)`,
+        );
+      }
     } catch (err) {
       spinner.fail("Lifecycle worker failed to start");
       if (dashboardProcess) {
@@ -1097,6 +1137,48 @@ export function registerStart(program: Command): void {
             }
             config = loadedConfig;
             ({ projectId, project } = await resolveProject(config, projectArg));
+          }
+
+          // ── Register project in global config registry ──
+          {
+            const globalConfig = loadGlobalConfig();
+            const registeredIds = new Set(Object.keys(globalConfig.projects));
+
+            // Auto-migrate legacy config if needed
+            if (needsMigration({ projects: config.projects }, registeredIds)) {
+              const rawYaml = readFileSync(config.configPath, "utf-8");
+              const rawParsed = yamlParse(rawYaml);
+              const result = migrateToMultiProject(rawParsed, config.configPath);
+              // Merge with existing global config (don't overwrite other projects)
+              let merged = globalConfig;
+              for (const [id, entry] of Object.entries(result.globalConfig.projects)) {
+                merged = registerProject(merged, entry, result.globalConfig.shadows[id]);
+              }
+              if (result.globalConfig.daemon.port !== undefined && !merged.daemon.port) {
+                merged.daemon = { ...merged.daemon, ...result.globalConfig.daemon };
+              }
+              if (result.globalConfig.defaults && !merged.defaults) {
+                merged.defaults = result.globalConfig.defaults;
+              }
+              saveGlobalConfig(merged);
+              console.log(chalk.dim("  ✓ Registered project(s) in global config registry"));
+            } else if (!isProjectRegistered(globalConfig, projectId)) {
+              // Register single project
+              const entry = {
+                name: project.name ?? projectId,
+                id: projectId,
+                path: project.path,
+                repo: project.repo,
+                defaultBranch: project.defaultBranch ?? "main",
+                configMode: "hybrid" as const,
+                localConfigPath: config.configPath,
+                sessionPrefix: project.sessionPrefix,
+              };
+              const shadow = extractShadow(project);
+              const updated = registerProject(globalConfig, entry, shadow);
+              saveGlobalConfig(updated);
+              console.log(chalk.dim("  ✓ Registered project in global config registry"));
+            }
           }
 
           // ── Already-running detection (Step 9) ──

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -12,6 +12,8 @@ import {
   type ProjectConfig,
   isOrchestratorSession,
   loadConfig,
+  loadConfigFromGlobal,
+  ConfigNotFoundError,
 } from "@composio/ao-core";
 import { git, getTmuxSessions, getTmuxActivity } from "../lib/shell.js";
 import {
@@ -214,11 +216,21 @@ export function registerStatus(program: Command): void {
       let config: ReturnType<typeof loadConfig>;
       try {
         config = loadConfig();
-      } catch {
-        console.log(chalk.yellow("No config found. Run `ao init` first."));
-        console.log(chalk.dim("Falling back to session discovery...\n"));
-        await showFallbackStatus();
-        return;
+      } catch (err) {
+        // Try global config as fallback (shows all registered projects)
+        if (err instanceof ConfigNotFoundError) {
+          const globalConfig = loadConfigFromGlobal();
+          if (globalConfig) {
+            config = globalConfig;
+          } else {
+            console.log(chalk.yellow("No config found. Run `ao init` first."));
+            console.log(chalk.dim("Falling back to session discovery...\n"));
+            await showFallbackStatus();
+            return;
+          }
+        } else {
+          throw err;
+        }
       }
 
       if (opts.project && !config.projects[opts.project]) {

--- a/packages/cli/src/lib/running-state.ts
+++ b/packages/cli/src/lib/running-state.ts
@@ -95,11 +95,37 @@ function writeState(state: RunningState | null): void {
 /**
  * Register the current AO instance as running.
  * Uses a lockfile to prevent concurrent registration.
+ * If another daemon is already running, merges projects into its entry.
  */
 export async function register(entry: RunningState): Promise<void> {
   const release = await acquireLock();
   try {
-    writeState(entry);
+    const existing = readState();
+    if (existing && isProcessAlive(existing.pid) && existing.pid !== entry.pid) {
+      // Another daemon is running — merge projects into its entry
+      const mergedProjects = [...new Set([...existing.projects, ...entry.projects])];
+      writeState({ ...existing, projects: mergedProjects });
+    } else {
+      writeState(entry);
+    }
+  } finally {
+    release();
+  }
+}
+
+/**
+ * Add a project to the running state without replacing the daemon entry.
+ * No-op if the project is already listed or no daemon is running.
+ */
+export async function addProject(projectId: string): Promise<void> {
+  const release = await acquireLock();
+  try {
+    const state = readState();
+    if (!state) return;
+    if (!state.projects.includes(projectId)) {
+      state.projects.push(projectId);
+      writeState(state);
+    }
   } finally {
     release();
   }

--- a/packages/core/src/__tests__/global-config.test.ts
+++ b/packages/core/src/__tests__/global-config.test.ts
@@ -1,0 +1,543 @@
+/**
+ * Tests for GlobalConfig types, global config loader, config resolver,
+ * local config parser, and migration.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { GlobalConfig, ProjectRegistryEntry, ProjectShadow, ConfigMode } from "../types.js";
+import {
+  loadGlobalConfig,
+  saveGlobalConfig,
+  getGlobalConfigPath,
+  globalConfigExists,
+  registerProject,
+  unregisterProject,
+  extractShadow,
+  isProjectRegistered,
+} from "../global-config.js";
+import { resolveMultiProjectConfig } from "../config-resolver.js";
+import { isLocalConfig, parseLocalConfig } from "../local-config.js";
+import { needsMigration, migrateToMultiProject } from "../migration.js";
+
+// =============================================================================
+// Test setup
+// =============================================================================
+
+const TEST_DIR = join(tmpdir(), `ao-global-config-test-${process.pid}-${Date.now()}`);
+const TEST_CONFIG_DIR = join(TEST_DIR, ".agent-orchestrator");
+
+beforeEach(() => {
+  mkdirSync(TEST_CONFIG_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(TEST_DIR, { recursive: true, force: true });
+});
+
+// =============================================================================
+// Type-level tests
+// =============================================================================
+
+describe("GlobalConfig types", () => {
+  it("GlobalConfig has required fields", () => {
+    const config: GlobalConfig = {
+      version: 1,
+      projects: {
+        "my-app": {
+          name: "my-app",
+          id: "my-app",
+          path: "/home/user/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          configMode: "hybrid",
+          localConfigPath: "/home/user/my-app/agent-orchestrator.yaml",
+        },
+      },
+      shadows: {},
+      daemon: { port: 3000 },
+    };
+    expect(config.version).toBe(1);
+    expect(config.projects["my-app"].configMode).toBe("hybrid");
+  });
+
+  it("ProjectRegistryEntry supports global-only mode", () => {
+    const entry: ProjectRegistryEntry = {
+      name: "docker-project",
+      id: "docker-project",
+      path: "/opt/projects/docker-project",
+      repo: "org/docker-project",
+      defaultBranch: "main",
+      configMode: "global-only",
+    };
+    expect(entry.configMode).toBe("global-only");
+    expect(entry.localConfigPath).toBeUndefined();
+  });
+
+  it("ConfigMode is a string union", () => {
+    const hybrid: ConfigMode = "hybrid";
+    const globalOnly: ConfigMode = "global-only";
+    expect(hybrid).toBe("hybrid");
+    expect(globalOnly).toBe("global-only");
+  });
+});
+
+// =============================================================================
+// Global config loader
+// =============================================================================
+
+describe("getGlobalConfigPath", () => {
+  it("returns path under ~/.agent-orchestrator/", () => {
+    const path = getGlobalConfigPath(TEST_DIR);
+    expect(path).toBe(join(TEST_DIR, ".agent-orchestrator", "config.yaml"));
+  });
+});
+
+describe("globalConfigExists", () => {
+  it("returns false when no config file", () => {
+    expect(globalConfigExists(TEST_DIR)).toBe(false);
+  });
+
+  it("returns true when config file exists", () => {
+    writeFileSync(
+      join(TEST_CONFIG_DIR, "config.yaml"),
+      "version: 1\nprojects: {}\nshadows: {}\ndaemon: {}\n",
+    );
+    expect(globalConfigExists(TEST_DIR)).toBe(true);
+  });
+});
+
+describe("loadGlobalConfig", () => {
+  it("returns default config when file does not exist", () => {
+    const config = loadGlobalConfig(TEST_DIR);
+    expect(config.version).toBe(1);
+    expect(config.projects).toEqual({});
+    expect(config.shadows).toEqual({});
+  });
+
+  it("loads existing config", () => {
+    const yaml = `
+version: 1
+projects:
+  my-app:
+    name: my-app
+    id: my-app
+    path: /home/user/my-app
+    repo: org/my-app
+    defaultBranch: main
+    configMode: hybrid
+    localConfigPath: /home/user/my-app/agent-orchestrator.yaml
+shadows: {}
+daemon:
+  port: 4000
+`;
+    writeFileSync(join(TEST_CONFIG_DIR, "config.yaml"), yaml);
+    const config = loadGlobalConfig(TEST_DIR);
+    expect(config.projects["my-app"].repo).toBe("org/my-app");
+    expect(config.daemon.port).toBe(4000);
+  });
+});
+
+describe("saveGlobalConfig", () => {
+  it("creates config file", () => {
+    const config: GlobalConfig = {
+      version: 1,
+      projects: {},
+      shadows: {},
+      daemon: { port: 3000 },
+    };
+    saveGlobalConfig(config, TEST_DIR);
+    expect(existsSync(join(TEST_CONFIG_DIR, "config.yaml"))).toBe(true);
+  });
+
+  it("round-trips correctly", () => {
+    const config: GlobalConfig = {
+      version: 1,
+      projects: {
+        "test-proj": {
+          name: "test-proj",
+          id: "test-proj",
+          path: "/tmp/test-proj",
+          repo: "org/test-proj",
+          defaultBranch: "main",
+          configMode: "hybrid",
+          localConfigPath: "/tmp/test-proj/agent-orchestrator.yaml",
+        },
+      },
+      shadows: {},
+      daemon: { port: 3000 },
+    };
+    saveGlobalConfig(config, TEST_DIR);
+    const loaded = loadGlobalConfig(TEST_DIR);
+    expect(loaded.projects["test-proj"].repo).toBe("org/test-proj");
+    expect(loaded.daemon.port).toBe(3000);
+  });
+});
+
+describe("registerProject", () => {
+  it("adds a project to the global config", () => {
+    const globalConfig: GlobalConfig = {
+      version: 1,
+      projects: {},
+      shadows: {},
+      daemon: {},
+    };
+    const entry: ProjectRegistryEntry = {
+      name: "my-app",
+      id: "my-app",
+      path: "/tmp/my-app",
+      repo: "org/my-app",
+      defaultBranch: "main",
+      configMode: "hybrid",
+    };
+    const updated = registerProject(globalConfig, entry);
+    expect(updated.projects["my-app"]).toBeDefined();
+    expect(updated.projects["my-app"].configMode).toBe("hybrid");
+  });
+
+  it("adds shadow config when provided", () => {
+    const globalConfig: GlobalConfig = {
+      version: 1,
+      projects: {},
+      shadows: {},
+      daemon: {},
+    };
+    const entry: ProjectRegistryEntry = {
+      name: "my-app",
+      id: "my-app",
+      path: "/tmp/my-app",
+      repo: "org/my-app",
+      defaultBranch: "main",
+      configMode: "hybrid",
+    };
+    const shadow = { tracker: { plugin: "github" } } as ProjectShadow;
+    const updated = registerProject(globalConfig, entry, shadow);
+    expect(updated.shadows["my-app"]).toBeDefined();
+  });
+
+  it("does not mutate original config", () => {
+    const globalConfig: GlobalConfig = {
+      version: 1,
+      projects: {},
+      shadows: {},
+      daemon: {},
+    };
+    const entry: ProjectRegistryEntry = {
+      name: "my-app",
+      id: "my-app",
+      path: "/tmp/my-app",
+      repo: "org/my-app",
+      defaultBranch: "main",
+      configMode: "hybrid",
+    };
+    registerProject(globalConfig, entry);
+    expect(Object.keys(globalConfig.projects)).toHaveLength(0);
+  });
+});
+
+describe("unregisterProject", () => {
+  it("removes a project from global config", () => {
+    const globalConfig: GlobalConfig = {
+      version: 1,
+      projects: {
+        "my-app": {
+          name: "my-app",
+          id: "my-app",
+          path: "/tmp/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          configMode: "hybrid",
+        },
+      },
+      shadows: { "my-app": {} as ProjectShadow },
+      daemon: {},
+    };
+    const updated = unregisterProject(globalConfig, "my-app");
+    expect(updated.projects["my-app"]).toBeUndefined();
+    expect(updated.shadows["my-app"]).toBeUndefined();
+  });
+});
+
+describe("isProjectRegistered", () => {
+  it("returns true for registered projects", () => {
+    const globalConfig: GlobalConfig = {
+      version: 1,
+      projects: {
+        "my-app": {
+          name: "my-app",
+          id: "my-app",
+          path: "/tmp/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          configMode: "hybrid",
+        },
+      },
+      shadows: {},
+      daemon: {},
+    };
+    expect(isProjectRegistered(globalConfig, "my-app")).toBe(true);
+    expect(isProjectRegistered(globalConfig, "unknown")).toBe(false);
+  });
+});
+
+describe("extractShadow", () => {
+  it("strips identity fields from project config", () => {
+    const project = {
+      name: "My App",
+      repo: "org/my-app",
+      path: "/tmp/my-app",
+      defaultBranch: "main",
+      sessionPrefix: "ma",
+      agent: "claude-code",
+      runtime: "tmux",
+      tracker: { plugin: "github" },
+    };
+    const shadow = extractShadow(project as never);
+    expect((shadow as Record<string, unknown>)["name"]).toBeUndefined();
+    expect((shadow as Record<string, unknown>)["repo"]).toBeUndefined();
+    expect((shadow as Record<string, unknown>)["path"]).toBeUndefined();
+    expect((shadow as Record<string, unknown>)["defaultBranch"]).toBeUndefined();
+    expect((shadow as Record<string, unknown>)["sessionPrefix"]).toBeUndefined();
+    expect((shadow as Record<string, unknown>)["agent"]).toBe("claude-code");
+    expect((shadow as Record<string, unknown>)["tracker"]).toEqual({ plugin: "github" });
+  });
+});
+
+// =============================================================================
+// Config resolver
+// =============================================================================
+
+describe("resolveMultiProjectConfig", () => {
+  it("builds OrchestratorConfig from global registry", () => {
+    const global: GlobalConfig = {
+      version: 1,
+      projects: {
+        "my-app": {
+          name: "my-app",
+          id: "my-app",
+          path: "/tmp/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          configMode: "global-only",
+          sessionPrefix: "ma",
+        },
+      },
+      shadows: {},
+      daemon: { port: 4000 },
+    };
+
+    const config = resolveMultiProjectConfig(global, "/tmp/global-config.yaml");
+    expect(config.port).toBe(4000);
+    expect(config.projects["my-app"]).toBeDefined();
+    expect(config.projects["my-app"].repo).toBe("org/my-app");
+    expect(config.projects["my-app"].path).toBe("/tmp/my-app");
+    expect(config.configPath).toBe("/tmp/global-config.yaml");
+  });
+
+  it("merges shadow config into project config", () => {
+    const global: GlobalConfig = {
+      version: 1,
+      projects: {
+        "my-app": {
+          name: "my-app",
+          id: "my-app",
+          path: "/tmp/my-app",
+          repo: "org/my-app",
+          defaultBranch: "main",
+          configMode: "global-only",
+          sessionPrefix: "app",
+        },
+      },
+      shadows: {
+        "my-app": {
+          tracker: { plugin: "github" },
+        } as ProjectShadow,
+      },
+      daemon: {},
+    };
+
+    const config = resolveMultiProjectConfig(global, "/tmp/config.yaml");
+    expect(config.projects["my-app"].sessionPrefix).toBe("app");
+    expect(config.projects["my-app"].tracker?.plugin).toBe("github");
+  });
+
+  it("handles multiple projects", () => {
+    const global: GlobalConfig = {
+      version: 1,
+      projects: {
+        "app-a": {
+          name: "App A",
+          id: "app-a",
+          path: "/tmp/app-a",
+          repo: "org/app-a",
+          defaultBranch: "main",
+          configMode: "global-only",
+          sessionPrefix: "aa",
+        },
+        "app-b": {
+          name: "App B",
+          id: "app-b",
+          path: "/tmp/app-b",
+          repo: "org/app-b",
+          defaultBranch: "develop",
+          configMode: "global-only",
+          sessionPrefix: "ab",
+        },
+      },
+      shadows: {},
+      daemon: {},
+    };
+
+    const config = resolveMultiProjectConfig(global, "/tmp/config.yaml");
+    expect(Object.keys(config.projects)).toHaveLength(2);
+    expect(config.projects["app-b"].defaultBranch).toBe("develop");
+  });
+});
+
+// =============================================================================
+// Local config parser
+// =============================================================================
+
+describe("isLocalConfig", () => {
+  it("detects flat local config (no projects key)", () => {
+    expect(isLocalConfig({ agent: "claude-code", runtime: "tmux" })).toBe(true);
+  });
+
+  it("detects legacy multi-project config", () => {
+    expect(
+      isLocalConfig({ projects: { "my-app": { repo: "org/app", path: "~/app" } } }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-objects", () => {
+    expect(isLocalConfig(null)).toBe(false);
+    expect(isLocalConfig("string")).toBe(false);
+  });
+});
+
+describe("parseLocalConfig", () => {
+  it("parses flat behavior config", () => {
+    const result = parseLocalConfig({
+      agent: "claude-code",
+      runtime: "tmux",
+      tracker: { plugin: "github" },
+    });
+    expect((result as Record<string, unknown>)["agent"]).toBe("claude-code");
+    expect((result as Record<string, unknown>)["tracker"]).toEqual({ plugin: "github" });
+  });
+
+  it("strips identity fields", () => {
+    const result = parseLocalConfig({
+      name: "should-be-stripped",
+      repo: "should-be-stripped",
+      path: "should-be-stripped",
+      agent: "claude-code",
+    });
+    expect((result as Record<string, unknown>)["name"]).toBeUndefined();
+    expect((result as Record<string, unknown>)["repo"]).toBeUndefined();
+    expect((result as Record<string, unknown>)["path"]).toBeUndefined();
+    expect((result as Record<string, unknown>)["agent"]).toBe("claude-code");
+  });
+});
+
+// =============================================================================
+// Migration
+// =============================================================================
+
+describe("needsMigration", () => {
+  it("returns true for legacy config with projects wrapper", () => {
+    expect(
+      needsMigration({ projects: { "my-app": { repo: "org/app", path: "/tmp/app" } } }),
+    ).toBe(true);
+  });
+
+  it("returns false for flat local config", () => {
+    expect(needsMigration({ agent: "claude-code", runtime: "tmux" })).toBe(false);
+  });
+
+  it("returns false when all projects already registered", () => {
+    expect(
+      needsMigration(
+        { projects: { "my-app": { repo: "org/app", path: "/tmp/app" } } },
+        new Set(["my-app"]),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns true when some projects are new", () => {
+    expect(
+      needsMigration(
+        {
+          projects: {
+            "my-app": { repo: "org/app", path: "/tmp/app" },
+            "new-app": { repo: "org/new", path: "/tmp/new" },
+          },
+        },
+        new Set(["my-app"]),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("migrateToMultiProject", () => {
+  it("extracts projects into global registry entries", () => {
+    const legacyConfig = {
+      port: 3000,
+      defaults: { agent: "claude-code", runtime: "tmux", workspace: "worktree" },
+      projects: {
+        "my-app": {
+          name: "My App",
+          repo: "org/app",
+          path: "/tmp/app",
+          defaultBranch: "main",
+          sessionPrefix: "ma",
+          agent: "claude-code",
+          tracker: { plugin: "github" },
+        },
+      },
+    };
+
+    const result = migrateToMultiProject(legacyConfig, "/tmp/agent-orchestrator.yaml");
+    expect(result.globalConfig.projects["my-app"]).toBeDefined();
+    expect(result.globalConfig.projects["my-app"].repo).toBe("org/app");
+    expect(result.globalConfig.projects["my-app"].configMode).toBe("hybrid");
+    expect(result.globalConfig.projects["my-app"].localConfigPath).toBe(
+      "/tmp/agent-orchestrator.yaml",
+    );
+    expect(result.globalConfig.shadows["my-app"]).toBeDefined();
+    expect(
+      (result.globalConfig.shadows["my-app"] as Record<string, unknown>)["tracker"],
+    ).toEqual({ plugin: "github" });
+    expect(result.globalConfig.daemon.port).toBe(3000);
+  });
+
+  it("handles multiple projects", () => {
+    const legacyConfig = {
+      projects: {
+        "app-a": { repo: "org/a", path: "/tmp/a" },
+        "app-b": { repo: "org/b", path: "/tmp/b" },
+      },
+    };
+
+    const result = migrateToMultiProject(legacyConfig, "/tmp/config.yaml");
+    expect(Object.keys(result.globalConfig.projects)).toHaveLength(2);
+  });
+
+  it("preserves daemon settings", () => {
+    const legacyConfig = {
+      port: 4000,
+      terminalPort: 4001,
+      readyThresholdMs: 600000,
+      projects: {
+        "my-app": { repo: "org/app", path: "/tmp/app" },
+      },
+    };
+
+    const result = migrateToMultiProject(legacyConfig, "/tmp/config.yaml");
+    expect(result.globalConfig.daemon.port).toBe(4000);
+    expect(result.globalConfig.daemon.terminalPort).toBe(4001);
+    expect(result.globalConfig.daemon.readyThresholdMs).toBe(600000);
+  });
+});

--- a/packages/core/src/config-resolver.ts
+++ b/packages/core/src/config-resolver.ts
@@ -1,0 +1,52 @@
+/**
+ * Config resolver — builds OrchestratorConfig from global registry.
+ *
+ * Merges project registry entries with their shadow configs to produce
+ * the same OrchestratorConfig shape that the rest of the system expects.
+ */
+
+import type { GlobalConfig, OrchestratorConfig } from "./types.js";
+import { validateConfig } from "./config.js";
+
+/**
+ * Build an OrchestratorConfig from the global registry.
+ * Merges each project's registry entry (identity) with its shadow (behavior).
+ */
+export function resolveMultiProjectConfig(
+  global: GlobalConfig,
+  globalConfigPath: string,
+): OrchestratorConfig {
+  const projects: Record<string, Record<string, unknown>> = {};
+
+  for (const [projectId, entry] of Object.entries(global.projects)) {
+    const shadow = global.shadows[projectId] ?? {};
+    projects[projectId] = {
+      name: entry.name,
+      repo: entry.repo,
+      path: entry.path,
+      defaultBranch: entry.defaultBranch,
+      ...(entry.sessionPrefix ? { sessionPrefix: entry.sessionPrefix } : {}),
+      ...shadow,
+    };
+  }
+
+  const raw: Record<string, unknown> = {
+    projects,
+  };
+
+  // Transfer daemon-level settings
+  if (global.daemon.port !== undefined) raw["port"] = global.daemon.port;
+  if (global.daemon.terminalPort !== undefined) raw["terminalPort"] = global.daemon.terminalPort;
+  if (global.daemon.directTerminalPort !== undefined)
+    raw["directTerminalPort"] = global.daemon.directTerminalPort;
+  if (global.daemon.readyThresholdMs !== undefined)
+    raw["readyThresholdMs"] = global.daemon.readyThresholdMs;
+  if (global.defaults) raw["defaults"] = global.defaults;
+  if (global.notifiers) raw["notifiers"] = global.notifiers;
+  if (global.notificationRouting) raw["notificationRouting"] = global.notificationRouting;
+  if (global.reactions) raw["reactions"] = global.reactions;
+
+  const config = validateConfig(raw);
+  config.configPath = globalConfigPath;
+  return config;
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,6 +17,12 @@ import { parse as parseYaml } from "yaml";
 import { z } from "zod";
 import { ConfigNotFoundError, type OrchestratorConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
+import {
+  loadGlobalConfig,
+  getGlobalConfigPath,
+  globalConfigExists,
+} from "./global-config.js";
+import { resolveMultiProjectConfig } from "./config-resolver.js";
 
 function inferScmPlugin(project: {
   repo: string;
@@ -467,6 +473,11 @@ export function loadConfig(configPath?: string): OrchestratorConfig {
   const path = configPath ?? findConfigFile();
 
   if (!path) {
+    // Try global config registry as fallback
+    const globalFallback = loadConfigFromGlobal();
+    if (globalFallback) {
+      return globalFallback;
+    }
     throw new ConfigNotFoundError();
   }
 
@@ -478,6 +489,25 @@ export function loadConfig(configPath?: string): OrchestratorConfig {
   config.configPath = path;
 
   return config;
+}
+
+/**
+ * Load config from the global registry.
+ * Used when no local config file is found (global-only mode or remote access).
+ * Returns null if global config doesn't exist or has no projects.
+ */
+export function loadConfigFromGlobal(homeOverride?: string): OrchestratorConfig | null {
+  if (!globalConfigExists(homeOverride)) {
+    return null;
+  }
+
+  const globalConfig = loadGlobalConfig(homeOverride);
+  if (Object.keys(globalConfig.projects).length === 0) {
+    return null;
+  }
+
+  const globalConfigPath = getGlobalConfigPath(homeOverride);
+  return resolveMultiProjectConfig(globalConfig, globalConfigPath);
 }
 
 /** Load config and return both config and resolved path */

--- a/packages/core/src/global-config.ts
+++ b/packages/core/src/global-config.ts
@@ -1,0 +1,167 @@
+/**
+ * Global config registry — manages ~/.agent-orchestrator/config.yaml
+ *
+ * This file stores the project registry (identity + shadow copies)
+ * and daemon-level settings. It is the source of truth for which
+ * projects exist and how to reach them from anywhere.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { z } from "zod";
+import type {
+  GlobalConfig,
+  ProjectRegistryEntry,
+  ProjectShadow,
+  ProjectConfig,
+} from "./types.js";
+
+const GLOBAL_CONFIG_DIR = ".agent-orchestrator";
+const GLOBAL_CONFIG_FILE = "config.yaml";
+
+// =============================================================================
+// ZOD SCHEMAS
+// =============================================================================
+
+const ProjectRegistryEntrySchema = z.object({
+  name: z.string(),
+  id: z.string(),
+  path: z.string(),
+  repo: z.string(),
+  defaultBranch: z.string().default("main"),
+  configMode: z.enum(["hybrid", "global-only"]),
+  localConfigPath: z.string().optional(),
+  sessionPrefix: z.string().optional(),
+});
+
+const GlobalConfigSchema = z.object({
+  version: z.number().default(1),
+  projects: z.record(ProjectRegistryEntrySchema).default({}),
+  shadows: z.record(z.record(z.unknown())).default({}),
+  daemon: z
+    .object({
+      port: z.number().optional(),
+      terminalPort: z.number().optional(),
+      directTerminalPort: z.number().optional(),
+      readyThresholdMs: z.number().optional(),
+    })
+    .default({}),
+  notifiers: z.record(z.record(z.unknown())).optional(),
+  notificationRouting: z.record(z.array(z.string())).optional(),
+  reactions: z.record(z.record(z.unknown())).optional(),
+  defaults: z.record(z.unknown()).optional(),
+});
+
+// =============================================================================
+// PUBLIC API
+// =============================================================================
+
+/** Get the path to the global config file. */
+export function getGlobalConfigPath(homeOverride?: string): string {
+  const home = homeOverride ?? homedir();
+  return join(home, GLOBAL_CONFIG_DIR, GLOBAL_CONFIG_FILE);
+}
+
+/** Get the global config directory. */
+export function getGlobalConfigDir(homeOverride?: string): string {
+  const home = homeOverride ?? homedir();
+  return join(home, GLOBAL_CONFIG_DIR);
+}
+
+/** Check if global config exists. */
+export function globalConfigExists(homeOverride?: string): boolean {
+  return existsSync(getGlobalConfigPath(homeOverride));
+}
+
+/** Load the global config, returning defaults if file doesn't exist. */
+export function loadGlobalConfig(homeOverride?: string): GlobalConfig {
+  const configPath = getGlobalConfigPath(homeOverride);
+
+  if (!existsSync(configPath)) {
+    return {
+      version: 1,
+      projects: {},
+      shadows: {},
+      daemon: {},
+    };
+  }
+
+  const raw = readFileSync(configPath, "utf-8");
+  const parsed = parseYaml(raw);
+  const validated = GlobalConfigSchema.parse(parsed);
+  return validated as GlobalConfig;
+}
+
+/** Save the global config to disk. */
+export function saveGlobalConfig(config: GlobalConfig, homeOverride?: string): void {
+  const configPath = getGlobalConfigPath(homeOverride);
+  const dir = getGlobalConfigDir(homeOverride);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(configPath, stringifyYaml(config, { indent: 2 }), "utf-8");
+}
+
+/** Register a project in the global config. */
+export function registerProject(
+  globalConfig: GlobalConfig,
+  entry: ProjectRegistryEntry,
+  shadow?: ProjectShadow,
+): GlobalConfig {
+  const updated: GlobalConfig = {
+    ...globalConfig,
+    projects: { ...globalConfig.projects, [entry.id]: entry },
+    shadows: { ...globalConfig.shadows },
+  };
+  if (shadow) {
+    updated.shadows[entry.id] = shadow;
+  }
+  return updated;
+}
+
+/** Unregister a project from the global config. */
+export function unregisterProject(
+  globalConfig: GlobalConfig,
+  projectId: string,
+): GlobalConfig {
+  const { [projectId]: _removed, ...remainingProjects } = globalConfig.projects;
+  const { [projectId]: _removedShadow, ...remainingShadows } = globalConfig.shadows;
+  return {
+    ...globalConfig,
+    projects: remainingProjects,
+    shadows: remainingShadows,
+  };
+}
+
+/** Identity fields that belong in the registry entry, not the shadow. */
+const IDENTITY_FIELDS = new Set([
+  "name",
+  "repo",
+  "path",
+  "defaultBranch",
+  "sessionPrefix",
+]);
+
+/**
+ * Extract a shadow copy from a ProjectConfig.
+ * Strips identity fields to produce behavior-only config.
+ */
+export function extractShadow(project: ProjectConfig): ProjectShadow {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(project)) {
+    if (!IDENTITY_FIELDS.has(key) && value !== undefined) {
+      result[key] = value;
+    }
+  }
+  return result as ProjectShadow;
+}
+
+/**
+ * Check if a specific project is registered in the global config.
+ */
+export function isProjectRegistered(
+  globalConfig: GlobalConfig,
+  projectId: string,
+): boolean {
+  return projectId in globalConfig.projects;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./types.js";
 export {
   loadConfig,
   loadConfigWithPath,
+  loadConfigFromGlobal,
   validateConfig,
   getDefaultConfig,
   findConfig,
@@ -158,6 +159,29 @@ export {
   expandHome,
   validateAndStoreOrigin,
 } from "./paths.js";
+
+// Global config registry
+export {
+  loadGlobalConfig,
+  saveGlobalConfig,
+  getGlobalConfigPath,
+  getGlobalConfigDir,
+  globalConfigExists,
+  registerProject,
+  unregisterProject,
+  extractShadow,
+  isProjectRegistered,
+} from "./global-config.js";
+
+// Config resolver — multi-project config assembly
+export { resolveMultiProjectConfig } from "./config-resolver.js";
+
+// Local config parser — flat behavior-only format
+export { isLocalConfig, parseLocalConfig } from "./local-config.js";
+
+// Migration — single-project to multi-project
+export { needsMigration, migrateToMultiProject } from "./migration.js";
+export type { MigrationResult } from "./migration.js";
 
 // Config generator — auto-generate config from repo URL
 export {

--- a/packages/core/src/local-config.ts
+++ b/packages/core/src/local-config.ts
@@ -1,0 +1,46 @@
+/**
+ * Local config parser — handles the flattened behavior-only format.
+ *
+ * Local configs live in the project directory (agent-orchestrator.yaml)
+ * and contain ONLY behavior settings (agent, runtime, permissions, etc.).
+ * Identity fields (name, repo, path) live in the global registry.
+ */
+
+import type { ProjectShadow } from "./types.js";
+
+/** Identity fields that belong in the global registry, not local config. */
+const IDENTITY_FIELDS = new Set([
+  "name",
+  "repo",
+  "path",
+  "defaultBranch",
+  "sessionPrefix",
+]);
+
+/**
+ * Detect if a parsed YAML object is a local (flat) config.
+ * Local configs have NO `projects` key — they are behavior-only.
+ */
+export function isLocalConfig(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  return !("projects" in raw);
+}
+
+/**
+ * Parse a local config, stripping identity fields.
+ * Returns a ProjectShadow (behavior-only config).
+ */
+export function parseLocalConfig(raw: unknown): ProjectShadow {
+  if (!raw || typeof raw !== "object") {
+    return {} as ProjectShadow;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (!IDENTITY_FIELDS.has(key)) {
+      result[key] = value;
+    }
+  }
+
+  return result as ProjectShadow;
+}

--- a/packages/core/src/migration.ts
+++ b/packages/core/src/migration.ts
@@ -1,0 +1,138 @@
+/**
+ * Migration — automatic one-way migration from single-project to multi-project format.
+ *
+ * Detects legacy configs (with `projects:` wrapper containing identity + behavior)
+ * and splits them into:
+ * - Global registry entries (identity: name, repo, path, defaultBranch)
+ * - Shadow copies (behavior: agent, runtime, tracker, etc.)
+ */
+
+import { basename } from "node:path";
+import type { GlobalConfig, ProjectRegistryEntry, ProjectShadow } from "./types.js";
+import { generateSessionPrefix } from "./paths.js";
+
+/** Identity fields that go into the registry entry. */
+const IDENTITY_KEYS = new Set(["name", "repo", "path", "defaultBranch", "sessionPrefix"]);
+
+/**
+ * Check if a raw parsed config needs migration to multi-project format.
+ * Migration is needed when:
+ * - Config has a `projects` key (legacy wrapper format)
+ * - The global config doesn't already have these specific projects registered
+ */
+export function needsMigration(
+  raw: unknown,
+  registeredProjectIds?: Set<string>,
+): boolean {
+  if (!raw || typeof raw !== "object") return false;
+  if (!("projects" in raw)) return false;
+
+  const projects = (raw as Record<string, unknown>)["projects"];
+  if (!projects || typeof projects !== "object") return false;
+
+  // If we have registered project IDs, check if any projects are new
+  if (registeredProjectIds) {
+    const projectKeys = Object.keys(projects as Record<string, unknown>);
+    const hasNewProjects = projectKeys.some((key) => !registeredProjectIds.has(key));
+    return hasNewProjects;
+  }
+
+  return true;
+}
+
+export interface MigrationResult {
+  globalConfig: GlobalConfig;
+}
+
+/**
+ * Migrate a legacy config to multi-project format.
+ * Extracts project entries and shadow configs from the legacy format.
+ */
+export function migrateToMultiProject(
+  legacyRaw: Record<string, unknown>,
+  configPath: string,
+): MigrationResult {
+  const projects = (legacyRaw["projects"] ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
+
+  const globalConfig: GlobalConfig = {
+    version: 1,
+    projects: {},
+    shadows: {},
+    daemon: {},
+  };
+
+  // Extract daemon-level settings
+  if (typeof legacyRaw["port"] === "number") {
+    globalConfig.daemon.port = legacyRaw["port"];
+  }
+  if (typeof legacyRaw["terminalPort"] === "number") {
+    globalConfig.daemon.terminalPort = legacyRaw["terminalPort"];
+  }
+  if (typeof legacyRaw["directTerminalPort"] === "number") {
+    globalConfig.daemon.directTerminalPort = legacyRaw["directTerminalPort"];
+  }
+  if (typeof legacyRaw["readyThresholdMs"] === "number") {
+    globalConfig.daemon.readyThresholdMs = legacyRaw["readyThresholdMs"];
+  }
+
+  // Extract global defaults
+  if (legacyRaw["defaults"] && typeof legacyRaw["defaults"] === "object") {
+    globalConfig.defaults = legacyRaw["defaults"] as Record<string, unknown>;
+  }
+  if (legacyRaw["notifiers"] && typeof legacyRaw["notifiers"] === "object") {
+    globalConfig.notifiers = legacyRaw["notifiers"] as Record<
+      string,
+      Record<string, unknown>
+    >;
+  }
+  if (
+    legacyRaw["notificationRouting"] &&
+    typeof legacyRaw["notificationRouting"] === "object"
+  ) {
+    globalConfig.notificationRouting = legacyRaw["notificationRouting"] as Record<
+      string,
+      string[]
+    >;
+  }
+  if (legacyRaw["reactions"] && typeof legacyRaw["reactions"] === "object") {
+    globalConfig.reactions = legacyRaw["reactions"] as Record<
+      string,
+      Record<string, unknown>
+    >;
+  }
+
+  // Extract each project
+  for (const [projectKey, projectRaw] of Object.entries(projects)) {
+    const projectPath = (projectRaw["path"] as string) ?? "";
+    const projectId = projectKey;
+
+    const entry: ProjectRegistryEntry = {
+      name: (projectRaw["name"] as string) ?? projectKey,
+      id: projectId,
+      path: projectPath,
+      repo: (projectRaw["repo"] as string) ?? "",
+      defaultBranch: (projectRaw["defaultBranch"] as string) ?? "main",
+      configMode: "hybrid",
+      localConfigPath: configPath,
+      sessionPrefix:
+        (projectRaw["sessionPrefix"] as string) ??
+        generateSessionPrefix(basename(projectPath) || projectKey),
+    };
+
+    // Build shadow (everything except identity fields)
+    const shadow: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(projectRaw)) {
+      if (!IDENTITY_KEYS.has(key)) {
+        shadow[key] = value;
+      }
+    }
+
+    globalConfig.projects[projectId] = entry;
+    globalConfig.shadows[projectId] = shadow as ProjectShadow;
+  }
+
+  return { globalConfig };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -997,6 +997,68 @@ export interface DefaultPlugins {
   };
 }
 
+// =============================================================================
+// GLOBAL CONFIG REGISTRY
+// =============================================================================
+
+/** Configuration mode for a project */
+export type ConfigMode = "hybrid" | "global-only";
+
+/** Entry in the global project registry */
+export interface ProjectRegistryEntry {
+  /** Human-readable name */
+  name: string;
+  /** Unique project identifier (derived from path basename) */
+  id: string;
+  /** Absolute path to the project repository */
+  path: string;
+  /** Repository identifier (e.g. "org/repo") */
+  repo: string;
+  /** Default git branch */
+  defaultBranch: string;
+  /** How this project's config is managed */
+  configMode: ConfigMode;
+  /** Path to local config file (hybrid mode only) */
+  localConfigPath?: string;
+  /** Session prefix override */
+  sessionPrefix?: string;
+}
+
+/**
+ * Shadow copy of a project's behavior config (stored in global registry).
+ * Strips identity fields (name, repo, path, defaultBranch, sessionPrefix)
+ * which belong in the ProjectRegistryEntry.
+ */
+export type ProjectShadow = Omit<
+  ProjectConfig,
+  "name" | "repo" | "path" | "defaultBranch" | "sessionPrefix"
+>;
+
+/** Global config file structure (~/.agent-orchestrator/config.yaml) */
+export interface GlobalConfig {
+  /** Schema version for migration */
+  version: number;
+  /** Project registry — keyed by project ID */
+  projects: Record<string, ProjectRegistryEntry>;
+  /** Shadow copies of project behavior configs — keyed by project ID */
+  shadows: Record<string, ProjectShadow>;
+  /** Daemon-level settings */
+  daemon: {
+    port?: number;
+    terminalPort?: number;
+    directTerminalPort?: number;
+    readyThresholdMs?: number;
+  };
+  /** Global notification config */
+  notifiers?: Record<string, NotifierConfig>;
+  /** Global notification routing by priority */
+  notificationRouting?: Record<EventPriority, string[]>;
+  /** Global default reactions */
+  reactions?: Record<string, ReactionConfig>;
+  /** Global default plugins */
+  defaults?: Partial<DefaultPlugins>;
+}
+
 export interface RoleAgentConfig {
   agent?: string;
   agentConfig?: AgentSpecificConfig;

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -87,6 +87,7 @@ export async function GET(request: Request): Promise<Response> {
             emittedAt: new Date().toISOString(),
             sessions: dashboardSessions.map((s) => ({
               id: s.id,
+              projectId: s.projectId,
               status: s.status,
               activity: s.activity,
               attentionLevel: getAttentionLevel(s),

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 
 export const dynamic = "force-dynamic";
 import { Dashboard } from "@/components/Dashboard";
+import { PortfolioPage } from "@/components/PortfolioPage";
 import {
   getDashboardPageData,
   getDashboardProjectName,
@@ -21,6 +22,17 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
   const searchParams = await props.searchParams;
   const projectFilter = resolveDashboardProjectFilter(searchParams.project);
   const pageData = await getDashboardPageData(projectFilter);
+
+  // Show portfolio page when explicitly viewing all projects and multiple projects exist
+  if (projectFilter === "all" && pageData.projects.length > 1) {
+    return (
+      <PortfolioPage
+        projects={pageData.projects}
+        sessions={pageData.sessions}
+        orchestrators={pageData.orchestrators}
+      />
+    );
+  }
 
   return (
     <Dashboard

--- a/packages/web/src/app/projects/[id]/page.tsx
+++ b/packages/web/src/app/projects/[id]/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { Dashboard } from "@/components/Dashboard";
+import {
+  getDashboardPageData,
+  getDashboardProjectName,
+} from "@/lib/dashboard-page-data";
+import { getAllProjects } from "@/lib/project-name";
+
+export const dynamic = "force-dynamic";
+
+export async function generateMetadata(props: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await props.params;
+  const projectName = getDashboardProjectName(id);
+  return { title: { absolute: `ao | ${projectName}` } };
+}
+
+export default async function ProjectPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await props.params;
+  const projects = getAllProjects();
+
+  // Validate project exists — redirect to home if not
+  if (!projects.some((p) => p.id === id)) {
+    redirect("/");
+  }
+
+  const pageData = await getDashboardPageData(id);
+
+  return (
+    <Dashboard
+      initialSessions={pageData.sessions}
+      projectId={id}
+      projectName={pageData.projectName}
+      projects={pageData.projects}
+      initialGlobalPause={pageData.globalPause}
+      orchestrators={pageData.orchestrators}
+    />
+  );
+}

--- a/packages/web/src/components/PortfolioPage.tsx
+++ b/packages/web/src/components/PortfolioPage.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import type { ProjectInfo } from "@/lib/project-name";
+import type { DashboardSession, DashboardOrchestratorLink } from "@/lib/types";
+import { getProjectScopedHref } from "@/lib/project-utils";
+
+interface ProjectSummary {
+  project: ProjectInfo;
+  sessionCount: number;
+  activeCount: number;
+  needsAttentionCount: number;
+  orchestrator?: DashboardOrchestratorLink;
+}
+
+interface PortfolioPageProps {
+  projects: ProjectInfo[];
+  sessions: DashboardSession[];
+  orchestrators: DashboardOrchestratorLink[];
+}
+
+export function PortfolioPage({
+  projects,
+  sessions,
+  orchestrators,
+}: PortfolioPageProps) {
+  const summaries: ProjectSummary[] = projects.map((project) => {
+    const projectSessions = sessions.filter((s) => s.projectId === project.id);
+    const activeCount = projectSessions.filter(
+      (s) => s.activity === "active" || s.activity === "ready",
+    ).length;
+    const needsAttentionCount = projectSessions.filter(
+      (s) =>
+        s.status === "ci_failed" ||
+        s.status === "changes_requested" ||
+        s.status === "needs_input" ||
+        s.status === "stuck" ||
+        s.status === "errored",
+    ).length;
+    const orchestrator = orchestrators.find((o) => o.projectId === project.id);
+
+    return {
+      project,
+      sessionCount: projectSessions.length,
+      activeCount,
+      needsAttentionCount,
+      orchestrator,
+    };
+  });
+
+  return (
+    <div className="p-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold mb-6">All Projects</h1>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {summaries.map((summary) => (
+          <a
+            key={summary.project.id}
+            href={getProjectScopedHref("/", summary.project.id)}
+            className="block p-5 rounded-lg border border-neutral-200 dark:border-neutral-700 hover:border-neutral-400 dark:hover:border-neutral-500 transition-colors bg-white dark:bg-neutral-900"
+          >
+            <h2 className="text-lg font-semibold truncate">
+              {summary.project.name}
+            </h2>
+            <div className="mt-3 flex flex-wrap gap-3 text-sm text-neutral-500 dark:text-neutral-400">
+              <span>
+                {summary.sessionCount} session
+                {summary.sessionCount !== 1 ? "s" : ""}
+              </span>
+              {summary.activeCount > 0 && (
+                <span className="text-green-600 dark:text-green-400">
+                  {summary.activeCount} active
+                </span>
+              )}
+              {summary.needsAttentionCount > 0 && (
+                <span className="text-amber-600 dark:text-amber-400">
+                  {summary.needsAttentionCount} need attention
+                </span>
+              )}
+            </div>
+            {summary.orchestrator && (
+              <div className="mt-2 text-xs text-neutral-400 dark:text-neutral-500">
+                Orchestrator: {summary.orchestrator.sessionId}
+              </div>
+            )}
+          </a>
+        ))}
+      </div>
+      {summaries.length === 0 && (
+        <p className="text-neutral-500 dark:text-neutral-400">
+          No projects registered. Run{" "}
+          <code className="px-1 py-0.5 rounded bg-neutral-100 dark:bg-neutral-800 text-sm">
+            ao start
+          </code>{" "}
+          to add a project.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -143,6 +143,7 @@ export interface SSESnapshotEvent {
   emittedAt?: string;
   sessions: Array<{
     id: string;
+    projectId?: string;
     status: SessionStatus;
     activity: ActivityState | null;
     attentionLevel: AttentionLevel;


### PR DESCRIPTION
## Summary

Implements multi-project support as specified in [#813](https://github.com/ComposioHQ/agent-orchestrator/issues/813), enabling agent-orchestrator to manage multiple projects simultaneously from a single daemon instance.

### Core infrastructure (packages/core)
- **Global config registry** (`~/.agent-orchestrator/config.yaml`) — stores project identity (name, path, repo) and shadow copies of behavior config
- **Dual-mode config** — hybrid (local config + global shadow) and global-only modes
- **Config resolver** — assembles `OrchestratorConfig` from global registry entries + shadows
- **Local config parser** — flat behavior-only format (strips identity fields)
- **Auto-migration** — detects legacy single-project configs and registers them in the global registry
- **`loadConfig` fallback** — falls back to global registry when no local config file found

### CLI changes (packages/cli)
- **`ao start`** — registers project in global config, syncs shadow, starts lifecycle workers for ALL configured projects via `Promise.allSettled`
- **`ao spawn --project <id>`** — cross-project spawning from anywhere using global config
- **`ao status`** — falls back to global config, showing all registered projects
- **`ao batch-spawn --project`** — same cross-project support
- **Running state** — merges projects when another daemon is already running

### Dashboard changes (packages/web)
- **Portfolio page** at `/?project=all` — project cards with session counts, active/attention indicators
- **`/projects/[id]`** route — alias for project detail view
- **SSE events** carry `projectId` per session for multi-project filtering

### New types
- `GlobalConfig`, `ProjectRegistryEntry`, `ProjectShadow`, `ConfigMode`

## Test plan
- [x] Unit tests for global config loader, resolver, local config parser, migration
- [ ] CI: `pnpm build && pnpm typecheck && pnpm lint && pnpm test`
- [ ] Manual: `ao start` creates global registry entry
- [ ] Manual: `ao status` from outside project dir shows all projects
- [ ] Manual: `ao spawn --project <id>` from anywhere
- [ ] Manual: Dashboard portfolio page with multiple projects

Closes #813