### PR TITLE
fix: detect nested project directories in CLI auto-resolution

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -66,6 +66,7 @@ vi.mock("../../src/lib/metadata.js", () => ({
 
 let tmpDir: string;
 let configPath: string;
+let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 import { Command } from "commander";
 import { registerSpawn } from "../../src/commands/spawn.js";
@@ -126,6 +127,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  cwdSpy?.mockRestore();
+  cwdSpy = undefined;
   const projectBaseDir = getProjectBaseDir(configPath, join(tmpDir, "main-repo"));
   if (projectBaseDir) {
     rmSync(projectBaseDir, { recursive: true, force: true });
@@ -195,6 +198,58 @@ describe("spawn command", () => {
     expect(mockSessionManager.spawn).toHaveBeenCalledWith({
       projectId: "my-app",
       issueId: "42",
+    });
+  });
+
+  it("auto-detects the project from a nested cwd in multi-project configs", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      frontend: {
+        name: "Frontend",
+        repo: "org/frontend",
+        path: join(tmpDir, "frontend"),
+        defaultBranch: "main",
+        sessionPrefix: "fe",
+      },
+      backend: {
+        name: "Backend",
+        repo: "org/backend",
+        path: join(tmpDir, "backend"),
+        defaultBranch: "main",
+        sessionPrefix: "be",
+      },
+    };
+
+    const backendSubdir = join(tmpDir, "backend", "packages", "api");
+    mkdirSync(backendSubdir, { recursive: true });
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(backendSubdir);
+
+    const fakeSession: Session = {
+      id: "be-1",
+      projectId: "backend",
+      status: "spawning",
+      activity: null,
+      branch: "feat/INT-42",
+      issueId: "INT-42",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-be-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "INT-42"]);
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: expect.any(String) }),
+      "backend",
+    );
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "backend",
+      issueId: "INT-42",
     });
   });
 

--- a/packages/cli/__tests__/lib/project-resolution.test.ts
+++ b/packages/cli/__tests__/lib/project-resolution.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { findProjectForDirectory } from "../../src/lib/project-resolution.js";
+
+describe("findProjectForDirectory", () => {
+  it("returns a project when cwd is inside a project subdirectory", () => {
+    const projectId = findProjectForDirectory(
+      {
+        frontend: { path: "/repos/frontend" },
+        backend: { path: "/repos/backend" },
+      },
+      "/repos/backend/packages/api",
+    );
+
+    expect(projectId).toBe("backend");
+  });
+
+  it("prefers the deepest matching project path", () => {
+    const projectId = findProjectForDirectory(
+      {
+        monorepo: { path: "/repos/mono" },
+        docs: { path: "/repos/mono/docs" },
+      },
+      "/repos/mono/docs/guides",
+    );
+
+    expect(projectId).toBe("docs");
+  });
+
+  it("returns null when cwd is outside every configured project", () => {
+    const projectId = findProjectForDirectory(
+      {
+        frontend: { path: "/repos/frontend" },
+      },
+      "/repos/backend",
+    );
+
+    expect(projectId).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -9,7 +9,6 @@ import {
   getSiblings,
   formatPlanTree,
   TERMINAL_STATUSES,
-  expandHome,
   type OrchestratorConfig,
   type DecomposerConfig,
   DEFAULT_DECOMPOSER_CONFIG,
@@ -19,6 +18,7 @@ import { banner } from "../lib/format.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
 import { ensureLifecycleWorker } from "../lib/lifecycle-service.js";
 import { preflight } from "../lib/preflight.js";
+import { findProjectForDirectory } from "../lib/project-resolution.js";
 
 /**
  * Auto-detect the project ID from the config.
@@ -43,10 +43,9 @@ function autoDetectProject(config: OrchestratorConfig): string {
 
   // Try matching cwd to a project path
   const cwd = resolve(process.cwd());
-  for (const [id, project] of Object.entries(config.projects)) {
-    if (project.path && resolve(expandHome(project.path)) === cwd) {
-      return id;
-    }
+  const matchedProjectId = findProjectForDirectory(config.projects, cwd);
+  if (matchedProjectId) {
+    return matchedProjectId;
   }
 
   throw new Error(

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -58,6 +58,7 @@ import {
   generateRulesFromTemplates,
   formatProjectTypeForDisplay,
 } from "../lib/project-detection.js";
+import { findProjectForDirectory } from "../lib/project-resolution.js";
 
 const DEFAULT_PORT = 3000;
 const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
@@ -102,10 +103,9 @@ async function resolveProject(
   // Multiple projects — try matching cwd to a project path
   // Note: loadConfig() already expands ~ in project paths via expandPaths()
   const currentDir = resolve(cwd());
-  for (const [id, proj] of Object.entries(config.projects)) {
-    if (resolve(proj.path) === currentDir) {
-      return { projectId: id, project: proj };
-    }
+  const matchedProjectId = findProjectForDirectory(config.projects, currentDir);
+  if (matchedProjectId) {
+    return { projectId: matchedProjectId, project: config.projects[matchedProjectId] };
   }
 
   // No match — prompt if interactive, otherwise error

--- a/packages/cli/src/lib/project-resolution.ts
+++ b/packages/cli/src/lib/project-resolution.ts
@@ -1,0 +1,27 @@
+import { isAbsolute, relative, resolve } from "node:path";
+
+interface ProjectWithPath {
+  path: string;
+}
+
+function isWithinProject(projectPath: string, currentDir: string): boolean {
+  const relativePath = relative(projectPath, currentDir);
+  return relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath));
+}
+
+/**
+ * Find the best matching project for the current directory.
+ * When multiple project paths contain the cwd, prefer the deepest match.
+ */
+export function findProjectForDirectory<T extends ProjectWithPath>(
+  projects: Record<string, T>,
+  currentDir: string,
+): string | null {
+  const resolvedCurrentDir = resolve(currentDir);
+
+  const matches = Object.entries(projects)
+    .filter(([, project]) => isWithinProject(resolve(project.path), resolvedCurrentDir))
+    .sort(([, a], [, b]) => resolve(b.path).length - resolve(a.path).length);
+
+  return matches[0]?.[0] ?? null;
+}


### PR DESCRIPTION
## Summary
- fix project auto-detection for `ao start` and `ao spawn` when they are run from a nested directory inside a configured project
- share the path-matching logic in a small CLI helper so both commands resolve projects the same way
- prefer the deepest matching project path when configured project roots overlap

## Why
In a multi-project config, auto-detection was only checking for an exact cwd match against the configured project path. That works from the repo root, but it falls over in common monorepo workflows where commands are run from a nested package or app directory.

This change makes the resolution logic treat any cwd inside a configured project as a match, which feels closer to what users expect from the CLI.

## Testing
- `corepack pnpm -r build`
- `corepack pnpm lint`
- `corepack pnpm -r typecheck`
- `corepack pnpm -r --filter '!@composio/ao-web' test`

Lint completed with the repo's existing warnings, but no new errors were introduced.
