### PR TITLE
docs: expand TypeScript rules with async, organization, and type guidelines

### DIFF
--- a/packages/cli/templates/rules/typescript.md
+++ b/packages/cli/templates/rules/typescript.md
@@ -1,28 +1,39 @@
-Use TypeScript strict mode.
-Use ESM modules with .js extensions in imports (e.g., import { foo } from "./bar.js").
-Use node: prefix for built-in modules (e.g., import { readFile } from "node:fs").
-Prefer const over let, never use var.
-Use type imports for type-only imports: import type { Foo } from "./bar.js".
-No any types - use unknown with type guards instead.
+# TypeScript Conventions
+
+Use TypeScript strict mode. Use ESM modules with `.js` extensions in imports
+(e.g., `import { foo } from "./bar.js"`). Use the `node:` prefix for built-in
+modules (e.g., `import { readFile } from "node:fs"`). Prefer `const` over
+`let`, never use `var`. Use type imports for type-only imports:
+`import type { Foo } from "./bar.js"`. No `any` types — use `unknown` with
+type guards instead.
 
 ## Async & Error Handling
 
-- Use async/await over raw Promises.
-- Always handle errors explicitly - don't suppress them.
-- Use proper error types: create custom Error classes for domain-specific errors.
-- Use try/catch for synchronous error handling, but prefer async error handling patterns for promises.
+- Use `async`/`await` over raw Promises.
+- Always handle errors explicitly — don't suppress them.
+- Use `try/catch` with `async`/`await` consistently. Avoid mixing `.catch()`
+  chains with `await` in the same flow.
+- Use proper error types: create custom `Error` classes for domain-specific
+  errors (e.g., `ConfigNotFoundError`, `SessionNotFoundError`).
 
 ## Code Organization
 
-- Keep files small and focused - aim for one primary export per file.
-- Use meaningful variable and function names (avoid single letters except in loops).
-- Prefer composition over inheritance; use utility types (Pick, Omit, Partial, Record, etc.) for type composition.
-- Group related functionality into modules with clear boundaries.
+- Group related exports into focused modules with clear boundaries. Utility
+  modules (e.g., `types.ts`, `metadata.ts`) may export multiple related items —
+  prefer cohesion over arbitrary single-export splitting.
+- Always use the `node:` prefix for Node.js built-in module imports.
+- Use meaningful variable and function names (avoid single letters except in
+  loops).
+- Prefer composition over inheritance; use utility types (`Pick`, `Omit`,
+  `Partial`, `Record`, etc.) for type composition.
 
 ## Interfaces & Types
 
-- Use interfaces for public APIs and extensible contracts.
-- Use type aliases for unions, tuples, and primitive compositions.
-- Always fully type function parameters and return values - no implicit any.
-- Use generics with constraints rather than loose typing (e.g., <T extends { id: string }>).
+- Use `interface` for public APIs and extensible contracts where declaration
+  merging may be useful. Use `type` aliases for unions, tuples, and primitive
+  compositions. In practice, `type` and `interface` are often interchangeable —
+  consistency within a module matters more than a strict rule.
+- Always fully type function parameters and return values — no implicit `any`.
+- Use generics with constraints rather than loose typing
+  (e.g., `<T extends { id: string }>` instead of bare `<T>`).
 - Avoid deeply nested types; extract complex types into named type aliases.

--- a/packages/cli/templates/rules/typescript.md
+++ b/packages/cli/templates/rules/typescript.md
@@ -4,3 +4,25 @@ Use node: prefix for built-in modules (e.g., import { readFile } from "node:fs")
 Prefer const over let, never use var.
 Use type imports for type-only imports: import type { Foo } from "./bar.js".
 No any types - use unknown with type guards instead.
+
+## Async & Error Handling
+
+- Use async/await over raw Promises.
+- Always handle errors explicitly - don't suppress them.
+- Use proper error types: create custom Error classes for domain-specific errors.
+- Use try/catch for synchronous error handling, but prefer async error handling patterns for promises.
+
+## Code Organization
+
+- Keep files small and focused - aim for one primary export per file.
+- Use meaningful variable and function names (avoid single letters except in loops).
+- Prefer composition over inheritance; use utility types (Pick, Omit, Partial, Record, etc.) for type composition.
+- Group related functionality into modules with clear boundaries.
+
+## Interfaces & Types
+
+- Use interfaces for public APIs and extensible contracts.
+- Use type aliases for unions, tuples, and primitive compositions.
+- Always fully type function parameters and return values - no implicit any.
+- Use generics with constraints rather than loose typing (e.g., <T extends { id: string }>).
+- Avoid deeply nested types; extract complex types into named type aliases.


### PR DESCRIPTION
Extends `packages/cli/templates/rules/typescript.md` with three new sections
that align with existing codebase conventions:

### Async & Error Handling
- Prefer async/await over raw Promises
- Avoid mixing .catch() chains with await
- Use custom Error classes for domain errors (matches existing patterns like
  ConfigNotFoundError, SessionNotFoundError)
  ### Code Organization
- Group related exports into cohesive modules rather than enforcing one-export-per-file
- Reinforces node: prefix convention for built-in imports
- Prefer composition over inheritance with utility types

### Interfaces & Types
- Pragmatic interface vs type guidance — consistency within a module over strict rules
- Require explicit typing on function parameters and return values
- Use constrained generics over loose <T>

These rules are injected into agent prompts via the template system, so agents
spawned by AO will follow these conventions automatically.