### PR TITLE
fix: use pnpm dev in monorepo for dashboard terminal

### DIFF
--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@composio/ao-core";
@@ -58,11 +60,21 @@ export function registerDashboard(program: Command): void {
         config.directTerminalPort,
       );
 
-      const child = spawn("npx", ["next", "dev", "-p", String(port)], {
-        cwd: webDir,
-        stdio: ["inherit", "inherit", "pipe"],
-        env,
-      });
+      // In dev mode (monorepo), use `pnpm run dev` which starts Next.js AND
+      // the terminal WebSocket servers via concurrently. Without the WS servers,
+      // the live terminal in the dashboard won't work.
+      const isDevMode = existsSync(resolve(webDir, "server"));
+      const child = isDevMode
+        ? spawn("pnpm", ["run", "dev"], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          })
+        : spawn("npx", ["next", "dev", "-p", String(port)], {
+            cwd: webDir,
+            stdio: ["inherit", "inherit", "pipe"],
+            env,
+          });
 
       const stderrChunks: string[] = [];
 


### PR DESCRIPTION
## Summary

- In dev mode (monorepo), `npx next dev` only starts Next.js without the terminal WebSocket servers
- Detects monorepo by checking for `server/` dir and uses `pnpm run dev` which starts both Next.js and WS servers via concurrently
- Fixes live terminal not working in the dashboard during local development

## Test plan

- [ ] `ao dashboard` in monorepo starts both Next.js and terminal WS servers
- [ ] `ao dashboard` in production install still uses `npx next dev`
- [ ] Live terminal in dashboard works in dev mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)