### PR TITLE
ci: fix deploy by using correct RSA SSH host fingerprint

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -36,6 +36,7 @@ jobs:
           host: ${{ secrets.VPS_HOST }}
           username: root
           key: ${{ secrets.VPS_SSH_KEY }}
+          fingerprint: SHA256:Yat7fObKrTBZGxr0HGlN40oWhC/LlLN9SpjzPifsLzw
           script: |
             set -e
             DEPLOY_SHA="${{ github.event.workflow_run.head_sha }}"


### PR DESCRIPTION
## What's an SSH fingerprint?

When GitHub Actions SSHs into the VPS, the server presents its public host key to prove its identity. A fingerprint is just a short hash of that public key — it's how you verify you're talking to the right server and not an impostor.

Without a pinned fingerprint, the SSH client connects with `StrictHostKeyChecking=no`, meaning it'll accept any server claiming to be your VPS (MITM risk).

## Why it was failing

We originally pinned the ED25519 fingerprint (`SHA256:mlWd4p7TXI...`), but `appleboy/ssh-action` negotiates RSA. Fingerprints are per key type, so it compared the RSA host key against the ED25519 fingerprint — mismatch, deploy failed.

## Fix

Replace ED25519 fingerprint with the RSA fingerprint. These are both from the same VPS — just different key types.

**Verify independently:**
```bash
ssh-keyscan 91.107.194.138 2>/dev/null | ssh-keygen -lf -
# Should include: SHA256:Yat7fObKrTBZGxr0HGlN40oWhC/LlLN9SpjzPifsLzw (RSA)
```