### PR TITLE
fix: resolve @composio/core module not found in dev server

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverExternalPackages: ["@composio/core"],
   transpilePackages: [
     "@composio/ao-core",
     "@composio/ao-plugin-agent-claude-code",


### PR DESCRIPTION
## Summary
- `tracker-linear` dynamically imports `@composio/core` (Composio SDK) as an optional dependency for the Composio transport path
- Since `tracker-linear` is listed in Next.js `transpilePackages`, the bundler tries to resolve the import at build time and fails when the SDK isn't installed
- Add `@composio/core` to `serverExternalPackages` so Next.js skips bundling it and leaves it as a runtime import

The plugin already handles the missing SDK gracefully at runtime — if `COMPOSIO_API_KEY` is not set, the Composio transport is never used. If it is set but the SDK isn't installed, a clear error message is thrown telling the user to install it.

Closes #866

## Test plan
- [x] `pnpm --filter @composio/ao-web build` succeeds without `@composio/core` module errors
- [x] `pnpm dev` starts without the reported error — Next.js ready in ~1.6s with no module resolution failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)