### PR TITLE
feat(core): support external tracker, scm, and notifier plugins from config

### DIFF
--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -343,7 +343,9 @@ async function sendTestNotifications(
   const targets = new Map<string, NotifierTarget>();
 
   for (const [name, notifierConfig] of configuredNotifiers) {
-    targets.set(notifierConfig.plugin, { label: name, pluginName: notifierConfig.plugin });
+    if (notifierConfig.plugin) {
+      targets.set(notifierConfig.plugin, { label: name, pluginName: notifierConfig.plugin });
+    }
   }
 
   for (const name of activeNotifierNames) {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -386,7 +386,7 @@ export function registerStatus(program: Command): void {
             let unverifiedTotal = 0;
             for (const projectId of projectIds) {
               const project: ProjectConfig | undefined = config.projects[projectId];
-              if (!project?.tracker) continue;
+              if (!project?.tracker?.plugin) continue;
               const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
               if (!tracker?.listIssues) continue;
               try {

--- a/packages/cli/src/commands/verify.ts
+++ b/packages/cli/src/commands/verify.ts
@@ -60,6 +60,10 @@ async function getTracker(
   const registry = createPluginRegistry();
   await registry.loadFromConfig(config, importPluginModuleFromSource);
 
+  if (!project.tracker.plugin) {
+    console.error(chalk.red("Project tracker plugin not configured."));
+    process.exit(1);
+  }
   const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
   if (!tracker) {
     console.error(chalk.red(`Tracker plugin "${project.tracker.plugin}" not found.`));

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -1,9 +1,9 @@
 /**
- * Unit tests for config validation (project uniqueness, prefix collisions).
+ * Unit tests for config validation (project uniqueness, prefix collisions, external plugins).
  */
 
 import { describe, it, expect } from "vitest";
-import { validateConfig } from "../config.js";
+import { validateConfig, collectExternalPluginConfigs } from "../config.js";
 
 describe("Config Validation - Project Uniqueness", () => {
   it("rejects duplicate project IDs (same basename)", () => {
@@ -580,5 +580,442 @@ describe("Config Defaults", () => {
     const validated = validateConfig(config);
     expect(validated.projects.proj1.tracker).toEqual({ plugin: "gitlab", host: "gitlab.com" });
     expect(validated.projects.proj1.scm).toEqual({ plugin: "gitlab" });
+  });
+});
+
+describe("Config Validation - External Plugin Schema", () => {
+  it("accepts tracker with plugin only (built-in)", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "github",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.tracker?.plugin).toBe("github");
+  });
+
+  it("accepts tracker with package only (external npm)", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+            teamId: "TEAM-123",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    // Plugin name should be auto-generated from package
+    expect(validated.projects.proj1.tracker?.plugin).toBe("jira");
+    expect(validated.projects.proj1.tracker?.package).toBe("@acme/ao-plugin-tracker-jira");
+  });
+
+  it("accepts tracker with path only (local plugin)", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            path: "./plugins/my-tracker",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    // Plugin name should be auto-generated from path
+    expect(validated.projects.proj1.tracker?.plugin).toBe("my-tracker");
+    expect(validated.projects.proj1.tracker?.path).toBe("./plugins/my-tracker");
+  });
+
+  it("accepts tracker with both plugin and package (explicit naming)", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "jira",
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.tracker?.plugin).toBe("jira");
+    expect(validated.projects.proj1.tracker?.package).toBe("@acme/ao-plugin-tracker-jira");
+  });
+
+  it("rejects tracker with neither plugin nor package/path", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            teamId: "TEAM-123",
+          },
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow(/plugin.*package.*path/i);
+  });
+
+  it("rejects tracker with both package and path", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+            path: "./plugins/my-tracker",
+          },
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow(/cannot have both/i);
+  });
+
+  it("accepts scm with package only", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          scm: {
+            package: "@acme/ao-plugin-scm-bitbucket",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.scm?.plugin).toBe("bitbucket");
+  });
+
+  it("accepts notifier with package only", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+      notifiers: {
+        teams: {
+          package: "@acme/ao-plugin-notifier-teams",
+          webhookUrl: "https://teams.webhook.url",
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.notifiers["teams"]?.plugin).toBe("teams");
+    expect(validated.notifiers["teams"]?.package).toBe("@acme/ao-plugin-notifier-teams");
+  });
+
+  it("preserves plugin-specific config alongside package", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+            host: "https://jira.company.com",
+            teamId: "TEAM-123",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.tracker?.host).toBe("https://jira.company.com");
+    expect(validated.projects.proj1.tracker?.teamId).toBe("TEAM-123");
+  });
+});
+
+describe("collectExternalPluginConfigs", () => {
+  it("collects tracker with package", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "jira",
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    const entries = collectExternalPluginConfigs(config);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      source: "projects.proj1.tracker",
+      slot: "tracker",
+      package: "@acme/ao-plugin-tracker-jira",
+      expectedPluginName: "jira",
+    });
+  });
+
+  it("collects scm with path", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          scm: {
+            path: "./plugins/my-scm",
+          },
+        },
+      },
+    });
+
+    const entries = collectExternalPluginConfigs(config);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      source: "projects.proj1.scm",
+      slot: "scm",
+      path: "./plugins/my-scm",
+      expectedPluginName: "my-scm", // auto-generated
+    });
+  });
+
+  it("collects notifier with package", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+      notifiers: {
+        teams: {
+          package: "@acme/ao-plugin-notifier-teams",
+        },
+      },
+    });
+
+    const entries = collectExternalPluginConfigs(config);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      source: "notifiers.teams",
+      slot: "notifier",
+      package: "@acme/ao-plugin-notifier-teams",
+      expectedPluginName: "teams", // auto-generated
+    });
+  });
+
+  it("collects multiple external plugins", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+          scm: {
+            path: "./plugins/my-scm",
+          },
+        },
+      },
+      notifiers: {
+        teams: {
+          package: "@acme/ao-plugin-notifier-teams",
+        },
+      },
+    });
+
+    const entries = collectExternalPluginConfigs(config);
+    expect(entries).toHaveLength(3);
+  });
+
+  it("ignores built-in plugins (plugin only)", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "github",
+          },
+          scm: {
+            plugin: "github",
+          },
+        },
+      },
+    });
+
+    const entries = collectExternalPluginConfigs(config);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("auto-generates plugins array entries from external plugin configs", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    // plugins array should be auto-populated
+    expect(config.plugins).toBeDefined();
+    expect(config.plugins).toContainEqual(
+      expect.objectContaining({
+        source: "npm",
+        package: "@acme/ao-plugin-tracker-jira",
+        enabled: true,
+      }),
+    );
+  });
+
+  it("stores external plugin entries on config for validation", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "jira",
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    expect(config._externalPluginEntries).toBeDefined();
+    expect(config._externalPluginEntries).toHaveLength(1);
+    expect(config._externalPluginEntries?.[0]).toMatchObject({
+      source: "projects.proj1.tracker",
+      expectedPluginName: "jira",
+    });
+  });
+});
+
+describe("External Plugin Name Generation", () => {
+  it("extracts plugin name from scoped npm package", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.tracker?.plugin).toBe("jira");
+  });
+
+  it("extracts plugin name from unscoped npm package", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            package: "ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.tracker?.plugin).toBe("jira");
+  });
+
+  it("extracts plugin name from local path", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            path: "./plugins/my-custom-tracker",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.tracker?.plugin).toBe("my-custom-tracker");
+  });
+
+  it("extracts plugin name from absolute path", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            path: "/home/user/plugins/custom-tracker",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.tracker?.plugin).toBe("custom-tracker");
+  });
+
+  it("does not override explicit plugin name", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          tracker: {
+            plugin: "my-custom-name",
+            package: "@acme/ao-plugin-tracker-jira",
+          },
+        },
+      },
+    });
+
+    expect(config.projects.proj1.tracker?.plugin).toBe("my-custom-name");
   });
 });

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -455,3 +455,223 @@ describe("loadFromConfig", () => {
     expect(registry.get("agent", "goose")).toBeNull();
   });
 });
+
+describe("External plugin manifest validation", () => {
+  it("accepts matching manifest.name and expectedPluginName", async () => {
+    const registry = createPluginRegistry();
+
+    const mockPlugin = {
+      manifest: { name: "jira", slot: "tracker" as const, version: "1.0.0", description: "Jira tracker" },
+      create: vi.fn(() => ({})),
+    };
+
+    const importFn = vi.fn(async () => mockPlugin);
+
+    const config = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      plugins: [
+        { name: "jira", source: "npm", package: "@acme/ao-plugin-tracker-jira", enabled: true },
+      ],
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          name: "proj1",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+          tracker: { plugin: "jira", package: "@acme/ao-plugin-tracker-jira" },
+        },
+      },
+      _externalPluginEntries: [
+        {
+          source: "projects.proj1.tracker",
+          slot: "tracker",
+          package: "@acme/ao-plugin-tracker-jira",
+          expectedPluginName: "jira",
+        },
+      ],
+    });
+
+    // Should not throw
+    await registry.loadFromConfig(config, importFn);
+    expect(registry.get("tracker", "jira")).not.toBeNull();
+  });
+
+  it("warns when manifest.name does not match expectedPluginName", async () => {
+    const registry = createPluginRegistry();
+
+    const mockPlugin = {
+      manifest: { name: "jira-enterprise", slot: "tracker" as const, version: "1.0.0", description: "Jira Enterprise" },
+      create: vi.fn(() => ({})),
+    };
+
+    const importFn = vi.fn(async () => mockPlugin);
+
+    const config = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      plugins: [
+        { name: "jira", source: "npm", package: "@acme/ao-plugin-tracker-jira", enabled: true },
+      ],
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          name: "proj1",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+          tracker: { plugin: "jira", package: "@acme/ao-plugin-tracker-jira" },
+        },
+      },
+      _externalPluginEntries: [
+        {
+          source: "projects.proj1.tracker",
+          slot: "tracker",
+          package: "@acme/ao-plugin-tracker-jira",
+          expectedPluginName: "jira",
+        },
+      ],
+    });
+
+    // Should warn but not throw (error is caught and logged)
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await registry.loadFromConfig(config, importFn);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load plugin"),
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("infers plugin name when expectedPluginName is not specified", async () => {
+    const registry = createPluginRegistry();
+
+    const mockPlugin = {
+      manifest: { name: "jira", slot: "tracker" as const, version: "1.0.0", description: "Jira tracker" },
+      create: vi.fn(() => ({})),
+    };
+
+    const importFn = vi.fn(async () => mockPlugin);
+
+    const config = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      plugins: [
+        { name: "jira", source: "npm", package: "@acme/ao-plugin-tracker-jira", enabled: true },
+      ],
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          name: "proj1",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+          // Plugin field will be updated with manifest.name
+          tracker: { plugin: "jira", package: "@acme/ao-plugin-tracker-jira" },
+        },
+      },
+      _externalPluginEntries: [
+        {
+          source: "projects.proj1.tracker",
+          slot: "tracker",
+          package: "@acme/ao-plugin-tracker-jira",
+          // No expectedPluginName - should accept any manifest.name
+        },
+      ],
+    });
+
+    await registry.loadFromConfig(config, importFn);
+
+    // Plugin should be registered under manifest.name
+    expect(registry.get("tracker", "jira")).not.toBeNull();
+    // Config should be updated with actual manifest.name
+    expect(config.projects.proj1.tracker?.plugin).toBe("jira");
+  });
+
+  it("updates config with actual manifest.name for notifiers", async () => {
+    const registry = createPluginRegistry();
+
+    const mockPlugin = {
+      manifest: { name: "ms-teams", slot: "notifier" as const, version: "1.0.0", description: "Teams notifier" },
+      create: vi.fn(() => ({})),
+    };
+
+    const importFn = vi.fn(async () => mockPlugin);
+
+    const config = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      plugins: [
+        { name: "teams", source: "npm", package: "@acme/ao-plugin-notifier-teams", enabled: true },
+      ],
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          name: "proj1",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+        },
+      },
+      notifiers: {
+        myteams: { plugin: "teams", package: "@acme/ao-plugin-notifier-teams" },
+      },
+      _externalPluginEntries: [
+        {
+          source: "notifiers.myteams",
+          slot: "notifier",
+          package: "@acme/ao-plugin-notifier-teams",
+          // No expectedPluginName
+        },
+      ],
+    });
+
+    await registry.loadFromConfig(config, importFn);
+
+    // Config should be updated with actual manifest.name
+    expect(config.notifiers?.myteams?.plugin).toBe("ms-teams");
+    // Plugin should be registered under manifest.name
+    expect(registry.get("notifier", "ms-teams")).not.toBeNull();
+  });
+
+  it("warns when plugin slot does not match config slot", async () => {
+    const registry = createPluginRegistry();
+
+    const mockPlugin = {
+      manifest: { name: "jira", slot: "notifier" as const, version: "1.0.0", description: "Wrong slot!" },
+      create: vi.fn(() => ({})),
+    };
+
+    const importFn = vi.fn(async () => mockPlugin);
+
+    const config = makeOrchestratorConfig({
+      configPath: "/test/config.yaml",
+      plugins: [
+        { name: "jira", source: "npm", package: "@acme/ao-plugin-tracker-jira", enabled: true },
+      ],
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          name: "proj1",
+          defaultBranch: "main",
+          sessionPrefix: "test",
+          tracker: { plugin: "jira", package: "@acme/ao-plugin-tracker-jira" },
+        },
+      },
+      _externalPluginEntries: [
+        {
+          source: "projects.proj1.tracker",
+          slot: "tracker", // Expected tracker
+          package: "@acme/ao-plugin-tracker-jira",
+        },
+      ],
+    });
+
+    const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await registry.loadFromConfig(config, importFn);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("has slot \"notifier\" but was configured as \"tracker\""),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -15,7 +15,7 @@ import { resolve, join, basename } from "node:path";
 import { homedir } from "node:os";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-import { ConfigNotFoundError, type OrchestratorConfig } from "./types.js";
+import { ConfigNotFoundError, type ExternalPluginEntryRef, type OrchestratorConfig } from "./types.js";
 import { generateSessionPrefix } from "./paths.js";
 
 function inferScmPlugin(project: {
@@ -63,13 +63,33 @@ const ReactionConfigSchema = z.object({
 
 const TrackerConfigSchema = z
   .object({
-    plugin: z.string(),
+    plugin: z.string().optional(),
+    package: z.string().optional(),
+    path: z.string().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((value, ctx) => {
+    // Must have either plugin or package/path
+    if (!value.plugin && !value.package && !value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tracker config requires either 'plugin' (for built-ins) or 'package'/'path' (for external plugins)",
+      });
+    }
+    // Cannot have both package and path
+    if (value.package && value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Tracker config cannot have both 'package' and 'path' - use one or the other",
+      });
+    }
+  });
 
 const SCMConfigSchema = z
   .object({
-    plugin: z.string(),
+    plugin: z.string().optional(),
+    package: z.string().optional(),
+    path: z.string().optional(),
     webhook: z
       .object({
         enabled: z.boolean().default(true),
@@ -82,13 +102,47 @@ const SCMConfigSchema = z
       })
       .optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((value, ctx) => {
+    // Must have either plugin or package/path
+    if (!value.plugin && !value.package && !value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "SCM config requires either 'plugin' (for built-ins) or 'package'/'path' (for external plugins)",
+      });
+    }
+    // Cannot have both package and path
+    if (value.package && value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "SCM config cannot have both 'package' and 'path' - use one or the other",
+      });
+    }
+  });
 
 const NotifierConfigSchema = z
   .object({
-    plugin: z.string(),
+    plugin: z.string().optional(),
+    package: z.string().optional(),
+    path: z.string().optional(),
   })
-  .passthrough();
+  .passthrough()
+  .superRefine((value, ctx) => {
+    // Must have either plugin or package/path
+    if (!value.plugin && !value.package && !value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Notifier config requires either 'plugin' (for built-ins) or 'package'/'path' (for external plugins)",
+      });
+    }
+    // Cannot have both package and path
+    if (value.package && value.path) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Notifier config cannot have both 'package' and 'path' - use one or the other",
+      });
+    }
+  });
 
 const AgentPermissionSchema = z
   .enum(["permissionless", "default", "auto-edit", "suggest", "skip"])
@@ -251,6 +305,135 @@ function expandPaths(config: OrchestratorConfig): OrchestratorConfig {
   }
 
   return config;
+}
+
+/**
+ * Generate a temporary plugin name from a package or path specifier.
+ * This name is used until the actual manifest.name is discovered during plugin loading.
+ * Format: extract the last segment from the package/path, removing common prefixes.
+ * e.g., "@acme/ao-plugin-tracker-jira" -> "jira"
+ * e.g., "./plugins/my-tracker" -> "my-tracker"
+ */
+function generateTempPluginName(pkg?: string, path?: string): string {
+  const specifier = pkg ?? path ?? "unknown";
+
+  // For npm packages, extract the last part after the last hyphen or slash
+  // @acme/ao-plugin-tracker-jira -> jira
+  // @composio/ao-plugin-scm-gitlab -> gitlab
+  if (specifier.startsWith("@") || !specifier.includes("/")) {
+    const parts = specifier.split(/[-/]/);
+    return parts[parts.length - 1] ?? specifier;
+  }
+
+  // For local paths, use the basename
+  // ./plugins/my-tracker -> my-tracker
+  const segments = specifier.split("/").filter((s) => s && s !== "." && s !== "..");
+  return segments[segments.length - 1] ?? specifier;
+}
+
+/**
+ * Collect external plugin configs from tracker, scm, and notifier inline configs.
+ * These will be auto-added to config.plugins for loading.
+ *
+ * Also sets a temporary plugin name on configs that only have package/path,
+ * so that resolvePlugins() can look up the plugin by name.
+ */
+export function collectExternalPluginConfigs(config: OrchestratorConfig): ExternalPluginEntryRef[] {
+  const entries: ExternalPluginEntryRef[] = [];
+
+  // Collect from project tracker configs
+  for (const [projectId, project] of Object.entries(config.projects)) {
+    if (project.tracker && (project.tracker.package || project.tracker.path)) {
+      // If plugin name not specified, generate a temporary one from package/path
+      if (!project.tracker.plugin) {
+        project.tracker.plugin = generateTempPluginName(
+          project.tracker.package,
+          project.tracker.path,
+        );
+      }
+      entries.push({
+        source: `projects.${projectId}.tracker`,
+        slot: "tracker",
+        package: project.tracker.package,
+        path: project.tracker.path,
+        expectedPluginName: project.tracker.plugin,
+      });
+    }
+
+    if (project.scm && (project.scm.package || project.scm.path)) {
+      // If plugin name not specified, generate a temporary one from package/path
+      if (!project.scm.plugin) {
+        project.scm.plugin = generateTempPluginName(project.scm.package, project.scm.path);
+      }
+      entries.push({
+        source: `projects.${projectId}.scm`,
+        slot: "scm",
+        package: project.scm.package,
+        path: project.scm.path,
+        expectedPluginName: project.scm.plugin,
+      });
+    }
+  }
+
+  // Collect from global notifier configs
+  for (const [notifierId, notifierConfig] of Object.entries(config.notifiers ?? {})) {
+    if (notifierConfig && (notifierConfig.package || notifierConfig.path)) {
+      // If plugin name not specified, generate a temporary one from package/path
+      if (!notifierConfig.plugin) {
+        notifierConfig.plugin = generateTempPluginName(
+          notifierConfig.package,
+          notifierConfig.path,
+        );
+      }
+      entries.push({
+        source: `notifiers.${notifierId}`,
+        slot: "notifier",
+        package: notifierConfig.package,
+        path: notifierConfig.path,
+        expectedPluginName: notifierConfig.plugin,
+      });
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Generate InstalledPluginConfig entries from external plugin entries.
+ * Merges with existing plugins, avoiding duplicates by package/path.
+ */
+function mergeExternalPlugins(
+  existingPlugins: OrchestratorConfig["plugins"],
+  externalEntries: ExternalPluginEntryRef[],
+): OrchestratorConfig["plugins"] {
+  const plugins = [...(existingPlugins ?? [])];
+  const seen = new Set<string>();
+
+  // Track existing plugins by package/path
+  for (const plugin of plugins) {
+    if (plugin.package) seen.add(`package:${plugin.package}`);
+    if (plugin.path) seen.add(`path:${plugin.path}`);
+  }
+
+  // Add external entries that aren't already present
+  for (const entry of externalEntries) {
+    const key = entry.package ? `package:${entry.package}` : `path:${entry.path}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    // Generate a temporary name - will be replaced with manifest.name during loading
+    const tempName = entry.expectedPluginName ?? entry.package ?? entry.path ?? "unknown";
+
+    plugins.push({
+      name: tempName,
+      source: entry.package ? "npm" : "local",
+      package: entry.package,
+      path: entry.path,
+      enabled: true,
+    });
+  }
+
+  return plugins;
 }
 
 /** Apply defaults to project configs */
@@ -543,6 +726,15 @@ export function validateConfig(raw: unknown): OrchestratorConfig {
   config = expandPaths(config);
   config = applyProjectDefaults(config);
   config = applyDefaultReactions(config);
+
+  // Collect external plugin configs from inline tracker/scm/notifier configs
+  // and merge them into config.plugins for loading
+  const externalPluginEntries = collectExternalPluginConfigs(config);
+  if (externalPluginEntries.length > 0) {
+    config.plugins = mergeExternalPlugins(config.plugins, externalPluginEntries);
+    // Store entries for manifest validation during plugin loading
+    config._externalPluginEntries = externalPluginEntries;
+  }
 
   // Validate project uniqueness and prefix collisions
   validateProjectUniqueness(config);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,6 +16,7 @@ export {
   getDefaultConfig,
   findConfig,
   findConfigFile,
+  collectExternalPluginConfigs,
 } from "./config.js";
 
 // Plugin registry

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -235,7 +235,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const [owner, repo] = p.repo.split("/");
         return owner === pr.owner && repo === pr.repo;
       });
-      if (!project?.scm) continue;
+      if (!project?.scm?.plugin) continue;
 
       const pluginKey = project.scm.plugin;
       if (!prsByPlugin.has(pluginKey)) {
@@ -350,7 +350,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       persistedAgent: session.metadata["agent"],
     }).agentName;
     const agent = registry.get<Agent>("agent", agentName);
-    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
 
     // Track activity state across steps so stuck detection can run after PR checks
     let detectedIdleTimestamp: Date | null = null;
@@ -726,7 +726,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const project = config.projects[session.projectId];
     if (!project || !session.pr) return;
 
-    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
     if (!scm) return;
 
     const humanReactionKey = "changes-requested";
@@ -903,7 +903,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const project = config.projects[session.projectId];
     if (!project || !session.pr) return;
 
-    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
     if (!scm) return;
 
     const ciReactionKey = "ci-failed";
@@ -1025,7 +1025,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const project = config.projects[session.projectId];
     if (!project || !session.pr) return;
 
-    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
     if (!scm) return;
 
     const conflictReactionKey = "merge-conflicts";

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -11,6 +11,7 @@ import { existsSync, readFileSync, statSync } from "node:fs";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import type {
+  ExternalPluginEntryRef,
   InstalledPluginConfig,
   PluginSlot,
   PluginManifest,
@@ -82,6 +83,81 @@ function extractPluginConfig(
   }
 
   return undefined;
+}
+
+/**
+ * Find the external plugin entry that matches a given plugin config.
+ * Used for manifest.name validation when loading inline tracker/scm/notifier plugins.
+ */
+function findExternalPluginEntry(
+  plugin: InstalledPluginConfig,
+  externalEntries: ExternalPluginEntryRef[] | undefined,
+): ExternalPluginEntryRef | undefined {
+  if (!externalEntries) return undefined;
+
+  return externalEntries.find((entry) => {
+    if (plugin.package && entry.package === plugin.package) return true;
+    if (plugin.path && entry.path === plugin.path) return true;
+    return false;
+  });
+}
+
+/**
+ * Validate that a plugin's manifest.name matches the expected name (if specified).
+ * Throws an error if there's a mismatch.
+ */
+function validateManifestName(
+  manifest: PluginManifest,
+  entry: ExternalPluginEntryRef,
+  specifier: string,
+): void {
+  // If the user specified an explicit plugin name, validate it matches the manifest
+  if (entry.expectedPluginName && entry.expectedPluginName !== manifest.name) {
+    throw new Error(
+      `Plugin manifest.name mismatch at ${entry.source}: ` +
+        `expected "${entry.expectedPluginName}" but package "${specifier}" has manifest.name "${manifest.name}". ` +
+        `Either update the 'plugin' field to match the actual manifest.name, or remove it to auto-infer.`,
+    );
+  }
+}
+
+/**
+ * Update the config with the actual plugin name after loading an external plugin.
+ * This ensures resolvePlugins() can look up the plugin by its manifest.name.
+ */
+function updateConfigWithManifestName(
+  manifest: PluginManifest,
+  entry: ExternalPluginEntryRef,
+  config: OrchestratorConfig,
+): void {
+  const { source, slot } = entry;
+
+  // Parse the source to find the config location
+  // Format: "projects.<projectId>.tracker" or "projects.<projectId>.scm" or "notifiers.<notifierId>"
+  const parts = source.split(".");
+
+  if (parts[0] === "projects" && parts.length === 3) {
+    const projectId = parts[1];
+    const configType = parts[2] as "tracker" | "scm";
+    const project = config.projects[projectId];
+    if (project?.[configType]) {
+      project[configType]!.plugin = manifest.name;
+    }
+  } else if (parts[0] === "notifiers" && parts.length === 2) {
+    const notifierId = parts[1];
+    const notifierConfig = config.notifiers[notifierId];
+    if (notifierConfig) {
+      notifierConfig.plugin = manifest.name;
+    }
+  }
+
+  // Also validate slot matches
+  if (manifest.slot !== slot) {
+    console.warn(
+      `[plugin-registry] Plugin at ${source} has slot "${manifest.slot}" but was configured as "${slot}". ` +
+        `The plugin will be registered under its declared slot "${manifest.slot}".`,
+    );
+  }
 }
 
 export function isPluginModule(value: unknown): value is PluginModule {
@@ -261,6 +337,7 @@ export function createPluginRegistry(): PluginRegistry {
       await this.loadBuiltins(config, importFn);
 
       const doImport = importFn ?? ((pkg: string) => import(pkg));
+      const externalEntries = config._externalPluginEntries;
 
       for (const plugin of config.plugins ?? []) {
         if (plugin.enabled === false) continue;
@@ -274,6 +351,15 @@ export function createPluginRegistry(): PluginRegistry {
         try {
           const mod = normalizeImportedPluginModule(await doImport(specifier));
           if (!mod) continue;
+
+          // Check if this plugin was auto-added from inline tracker/scm/notifier config
+          const externalEntry = findExternalPluginEntry(plugin, externalEntries);
+          if (externalEntry) {
+            // Validate manifest.name matches expectedPluginName (if specified)
+            validateManifestName(mod.manifest, externalEntry, specifier);
+            // Update the config with the actual manifest.name
+            updateConfigWithManifestName(mod.manifest, externalEntry, config);
+          }
 
           const pluginConfig = extractPluginConfig(mod.manifest.slot, mod.manifest.name, config);
           this.register(mod, pluginConfig);

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -710,10 +710,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       "workspace",
       project.workspace ?? config.defaults.workspace,
     );
-    const tracker = project.tracker
-      ? registry.get<Tracker>("tracker", project.tracker.plugin)
-      : null;
-    const scm = project.scm ? registry.get<SCM>("scm", project.scm.plugin) : null;
+    // After config validation, plugin is always set if tracker/scm exists
+    // (either from user config or auto-generated from package/path)
+    const tracker =
+      project.tracker?.plugin ? registry.get<Tracker>("tracker", project.tracker.plugin) : null;
+    const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
 
     return { runtime, agent, workspace, tracker, scm };
   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1013,6 +1013,29 @@ export interface OrchestratorConfig {
 
   /** Default reaction configs */
   reactions: Record<string, ReactionConfig>;
+
+  /**
+   * Internal: External plugin entries collected from inline tracker/scm/notifier configs.
+   * Used by plugin-registry for manifest validation. Set automatically during config validation.
+   */
+  _externalPluginEntries?: ExternalPluginEntryRef[];
+}
+
+/**
+ * Reference to an external plugin config (from inline tracker/scm/notifier configs).
+ * Used for manifest.name validation during plugin loading.
+ */
+export interface ExternalPluginEntryRef {
+  /** Where this config came from (for error messages) */
+  source: string;
+  /** The slot this plugin fills */
+  slot: "tracker" | "scm" | "notifier";
+  /** npm package name (if specified) */
+  package?: string;
+  /** Local path (if specified) */
+  path?: string;
+  /** Expected plugin name (manifest.name), if specified */
+  expectedPluginName?: string;
 }
 
 export interface DefaultPlugins {
@@ -1135,13 +1158,31 @@ export interface ProjectConfig {
 }
 
 export interface TrackerConfig {
-  plugin: string;
+  /**
+   * Plugin name (manifest.name). Required when using built-in plugins.
+   * Optional when `package` or `path` is specified (will be inferred from manifest).
+   * When both plugin and package/path are specified, manifest.name must match plugin.
+   */
+  plugin?: string;
+  /** npm package name for external plugins (e.g. "@acme/ao-plugin-tracker-jira") */
+  package?: string;
+  /** Local filesystem path for external plugins (relative to config file or absolute) */
+  path?: string;
   /** Plugin-specific config (e.g. teamId for Linear) */
   [key: string]: unknown;
 }
 
 export interface SCMConfig {
-  plugin: string;
+  /**
+   * Plugin name (manifest.name). Required when using built-in plugins.
+   * Optional when `package` or `path` is specified (will be inferred from manifest).
+   * When both plugin and package/path are specified, manifest.name must match plugin.
+   */
+  plugin?: string;
+  /** npm package name for external plugins (e.g. "@acme/ao-plugin-scm-bitbucket") */
+  package?: string;
+  /** Local filesystem path for external plugins (relative to config file or absolute) */
+  path?: string;
   webhook?: SCMWebhookConfig;
   [key: string]: unknown;
 }
@@ -1157,7 +1198,16 @@ export interface SCMWebhookConfig {
 }
 
 export interface NotifierConfig {
-  plugin: string;
+  /**
+   * Plugin name (manifest.name). Required when using built-in plugins.
+   * Optional when `package` or `path` is specified (will be inferred from manifest).
+   * When both plugin and package/path are specified, manifest.name must match plugin.
+   */
+  plugin?: string;
+  /** npm package name for external plugins (e.g. "@acme/ao-plugin-notifier-teams") */
+  package?: string;
+  /** Local filesystem path for external plugins (relative to config file or absolute) */
+  path?: string;
   [key: string]: unknown;
 }
 

--- a/packages/web/src/app/api/issues/route.ts
+++ b/packages/web/src/app/api/issues/route.ts
@@ -21,7 +21,7 @@ export async function GET(request: NextRequest) {
 
     for (const [projectId, project] of Object.entries(config.projects)) {
       if (projectFilter && projectId !== projectFilter) continue;
-      if (!project.tracker) continue;
+      if (!project.tracker?.plugin) continue;
 
       const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
       if (!tracker?.listIssues) continue;
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
     }
     const project = config.projects[projectId];
 
-    if (!project.tracker) {
+    if (!project.tracker?.plugin) {
       return NextResponse.json({ error: "No tracker configured for this project" }, { status: 422 });
     }
 

--- a/packages/web/src/app/api/verify/route.ts
+++ b/packages/web/src/app/api/verify/route.ts
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: projectErr }, { status: 404 });
     }
     const project = config.projects[projectId];
-    if (!project.tracker) {
+    if (!project.tracker?.plugin) {
       return NextResponse.json({ error: `Project ${projectId} has no tracker` }, { status: 422 });
     }
 

--- a/packages/web/src/lib/scm-webhooks.ts
+++ b/packages/web/src/lib/scm-webhooks.ts
@@ -34,7 +34,7 @@ export function findWebhookProjects(
   pathname: string,
 ): WebhookProjectMatch[] {
   return Object.entries(config.projects).flatMap(([projectId, project]) => {
-    if (!project.scm) return [];
+    if (!project.scm?.plugin) return [];
     const webhookPath = getProjectWebhookPath(project);
     if (!webhookPath || webhookPath !== pathname) return [];
     const scm = registry.get<SCM>("scm", project.scm.plugin);

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -364,7 +364,7 @@ export async function enrichSessionsMetadata(
 
   // Enrich issue labels (synchronous — must run before async title enrichment)
   projects.forEach((project, i) => {
-    if (!dashboardSessions[i].issueUrl || !project?.tracker) return;
+    if (!dashboardSessions[i].issueUrl || !project?.tracker?.plugin) return;
     const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
     if (!tracker) return;
     enrichSessionIssue(dashboardSessions[i], tracker, project);
@@ -385,7 +385,7 @@ export async function enrichSessionsMetadata(
     if (!dashboardSessions[i].issueUrl || !dashboardSessions[i].issueLabel) {
       return Promise.resolve();
     }
-    if (!project?.tracker) return Promise.resolve();
+    if (!project?.tracker?.plugin) return Promise.resolve();
     const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
     if (!tracker) return Promise.resolve();
     return enrichSessionIssueTitle(dashboardSessions[i], tracker, project);

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -137,7 +137,7 @@ async function labelIssuesForVerification(
   for (const session of mergedSessions) {
     const key = `${session.projectId}:${session.issueId}`;
     const project = config.projects[session.projectId];
-    if (!project?.tracker) {
+    if (!project?.tracker?.plugin) {
       processedIssues.add(key);
       continue;
     }
@@ -180,7 +180,7 @@ async function relabelReopenedIssues(
   registry: PluginRegistry,
 ): Promise<void> {
   for (const [, project] of Object.entries(config.projects)) {
-    if (!project.tracker) continue;
+    if (!project.tracker?.plugin) continue;
     const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
     if (!tracker?.listIssues || !tracker.updateIssue) continue;
 
@@ -240,7 +240,7 @@ export async function pollBacklog(): Promise<void> {
 
     for (const [projectId, project] of Object.entries(config.projects)) {
       if (availableSlots <= 0) break;
-      if (!project.tracker) continue;
+      if (!project.tracker?.plugin) continue;
 
       const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
       if (!tracker?.listIssues) continue;
@@ -352,7 +352,7 @@ export async function getBacklogIssues(): Promise<Array<Issue & { projectId: str
   try {
     const { config, registry } = await getServices();
     for (const [projectId, project] of Object.entries(config.projects)) {
-      if (!project.tracker) continue;
+      if (!project.tracker?.plugin) continue;
       const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
       if (!tracker?.listIssues) continue;
 
@@ -380,7 +380,7 @@ export async function getVerifyIssues(): Promise<Array<Issue & { projectId: stri
   try {
     const { config, registry } = await getServices();
     for (const [projectId, project] of Object.entries(config.projects)) {
-      if (!project.tracker) continue;
+      if (!project.tracker?.plugin) continue;
       const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
       if (!tracker?.listIssues) continue;
 
@@ -404,6 +404,6 @@ export async function getVerifyIssues(): Promise<Array<Issue & { projectId: stri
 
 /** Resolve the SCM plugin for a project. Returns null if not configured. */
 export function getSCM(registry: PluginRegistry, project: ProjectConfig | undefined): SCM | null {
-  if (!project?.scm) return null;
+  if (!project?.scm?.plugin) return null;
   return registry.get<SCM>("scm", project.scm.plugin);
 }


### PR DESCRIPTION
## Summary

- Add support for specifying external plugins inline in tracker, scm, and notifier configs using optional `package` (npm) or `path` (local) fields
- Auto-infer plugin name from package/path when not explicitly specified
- Validate that `manifest.name` matches the declared `plugin` field when both are specified
- Auto-generate `InstalledPluginConfig` entries merged into `config.plugins` during config validation

## Example Usage

```yaml
projects:
  my-app:
    tracker:
      plugin: jira  # optional - validates against manifest.name
      package: "@acme/ao-plugin-tracker-jira"
      teamId: "TEAM-123"
    scm:
      path: ./plugins/my-scm  # local plugin

notifiers:
  teams:
    package: "@acme/ao-plugin-notifier-teams"
```

## Changes

### Schema (`types.ts`, `config.ts`)
- TrackerConfig, SCMConfig, NotifierConfig now accept optional `package` and `path` fields
- Added `ExternalPluginEntryRef` type for tracking external plugin configs
- Added Zod validation to ensure either `plugin` or `package`/`path` is specified

### Config Loading (`config.ts`)
- Added `collectExternalPluginConfigs()` to extract external plugin entries
- Added `mergeExternalPlugins()` to auto-generate InstalledPluginConfig entries
- Added `generateTempPluginName()` to infer plugin name from package/path

### Plugin Registry (`plugin-registry.ts`)
- Added manifest.name validation when loading external plugins
- Updates config with actual manifest.name after loading
- Warns when plugin slot doesn't match configured slot

### Session Manager / Lifecycle Manager
- Updated plugin resolution to handle optional `plugin` field

## Test plan
- [x] Config validation tests for new schema fields
- [x] collectExternalPluginConfigs tests
- [x] Plugin registry manifest validation tests
- [x] Plugin name generation tests
- [x] All existing tests pass

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)