### PR TITLE
fix: handle unknown flag error from older gh in getCIChecks

### DIFF
--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -123,7 +123,11 @@ function prInfoFromView(
 
 function isUnsupportedPrChecksJsonError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  return /pr checks/i.test(err.message) && /unknown json field/i.test(err.message);
+  if (!/pr checks/i.test(err.message)) return false;
+  // Older gh versions (< 2.49) don't support --json for `pr checks` and return
+  // "unknown flag: --json" instead of "unknown json field". Both patterns indicate
+  // that we should fall back to the statusCheckRollup API.
+  return /unknown json field/i.test(err.message) || /unknown flag/i.test(err.message);
 }
 
 function mapRawCheckStateToStatus(rawState: string | undefined): CICheck["status"] {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -634,6 +634,30 @@ describe("scm-github plugin", () => {
       expect(checks).toHaveLength(1);
       expect(checks[0]).toMatchObject({ name: "build", status: "passed" });
     });
+
+    it("falls back to statusCheckRollup when older gh returns unknown flag: --json", async () => {
+      mockGhError("gh pr checks 814 failed: Command failed: gh pr checks 814 --repo owner/repo --json name,state\nunknown flag: --json\n");
+      mockGh({
+        statusCheckRollup: [
+          {
+            name: "Diff Coverage (80% on changed code)",
+            conclusion: "FAILURE",
+            detailsUrl: "https://github.com/org/repo/actions/runs/123/job/456",
+            startedAt: "2025-01-01T00:00:00Z",
+            completedAt: "2025-01-01T00:02:00Z",
+            status: "COMPLETED",
+          },
+        ],
+      });
+
+      const checks = await scm.getCIChecks(pr);
+      expect(checks).toHaveLength(1);
+      expect(checks[0]).toMatchObject({
+        name: "Diff Coverage (80% on changed code)",
+        status: "failed",
+        conclusion: "FAILURE",
+      });
+    });
   });
 
   // ---- getCISummary ------------------------------------------------------


### PR DESCRIPTION
## Summary

- `gh` v2.45.0 (and older versions) don't support `--json` for `pr checks`, returning `"unknown flag: --json"` 
- `isUnsupportedPrChecksJsonError` only matched `"unknown json field"` errors, so the `"unknown flag"` error propagated as `"Failed to fetch CI checks"`
- `maybeDispatchCIFailureDetails` caught this and silently returned early — `lastCIFailureFingerprint` was never written and no CI failure details were ever sent to agents

The fix extends the error detection in `isUnsupportedPrChecksJsonError` to also match `"unknown flag"` errors, triggering the existing `statusCheckRollup` fallback that works on all `gh` versions.

**Root cause confirmed**: Session ao-112 (PR #814, status=ci_failed) never received CI failure details because `gh pr checks 814 --json ...` fails on this host's `gh` v2.45.0 — all other checks (`getCISummary` via fail-closed, PR enrichment via GraphQL) worked correctly, masking the bug in `getCIChecks`.

## Test plan

- [x] Added test: `"falls back to statusCheckRollup when older gh returns unknown flag: --json"` in `scm-github/test/index.test.ts`
- [x] All existing `getCIChecks` tests still pass
- [x] All 535 core tests pass
- [x] All 127 scm-github tests pass

Closes #850 (CI failure details not dispatched)