### PR TITLE
Honor Linear branchName as single source of truth for spawn worktree branches

### DIFF
--- a/.changeset/linear-spawn-branch-name.md
+++ b/.changeset/linear-spawn-branch-name.md
@@ -1,0 +1,6 @@
+---
+"@composio/ao-core": patch
+"@composio/ao-plugin-tracker-linear": patch
+---
+
+Honor Linear issue `branchName` when spawning worktrees; fall back to `feat/<id>`. Query `branchName` in the Linear tracker plugin. Document branch format in SETUP and examples.

--- a/SETUP.md
+++ b/SETUP.md
@@ -344,6 +344,8 @@ gh auth status
          teamId: "your-team-id"
    ```
 
+**Branch names:** On `ao spawn <issue>` with the Linear tracker, AO **prefers** Linear’s branch name (same as **Copy git branch name**, API field `branchName`). If that value is missing, it **falls back** to the previous convention: `feat/<ISSUE-ID>` (e.g. `feat/INT-123`). To change how Linear generates `branchName`, use **Linear → Settings → Integrations → GitHub → Branch format**.
+
 **Verification:**
 
 ```bash

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,8 @@ Use this if:
 
 Integrates with Linear for issue tracking. Requires `LINEAR_API_KEY` environment variable.
 
+Spawns prefer Linear’s **Copy git branch name** (API `branchName`); if absent, AO uses `feat/<issue-id>` as before. To change Linear’s pattern, use **Linear → Settings → Integrations → GitHub → Branch format**.
+
 Use this if:
 
 - Your team uses Linear for project management

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -107,6 +107,36 @@ describe("spawn", () => {
     expect(session.issueId).toBe("INT-100");
   });
 
+  it("prefers tracker-provided Issue.branchName over tracker.branchName()", async () => {
+    const mockTracker: Tracker = {
+      name: "mock-tracker",
+      getIssue: vi.fn().mockResolvedValue({ branchName: "ABC-1234" }),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockReturnValue(""),
+      branchName: vi.fn().mockReturnValue("custom/INT-100-my-feature"),
+      generatePrompt: vi.fn().mockResolvedValue(""),
+    };
+
+    const registryWithTracker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return mockTracker;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker,
+    });
+
+    const session = await sm.spawn({ projectId: "my-app", issueId: "INT-100" });
+    expect(session.branch).toBe("ABC-1234");
+  });
+
   it("sanitizes free-text issueId into a valid branch slug", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -137,6 +137,82 @@ describe("spawn", () => {
     expect(session.branch).toBe("ABC-1234");
   });
 
+  it("uses tracker.branchName when Issue omits branchName", async () => {
+    const mockTracker: Tracker = {
+      name: "mock-tracker",
+      getIssue: vi.fn().mockResolvedValue({
+        id: "INT-100",
+        title: "T",
+        description: "",
+        url: "https://tracker.test/INT-100",
+        state: "open",
+        labels: [],
+      }),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockReturnValue(""),
+      branchName: vi.fn().mockReturnValue("custom/INT-100-my-feature"),
+      generatePrompt: vi.fn().mockResolvedValue(""),
+    };
+
+    const registryWithTracker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return mockTracker;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker,
+    });
+
+    const session = await sm.spawn({ projectId: "my-app", issueId: "INT-100" });
+    expect(session.branch).toBe("custom/INT-100-my-feature");
+    expect(mockTracker.branchName).toHaveBeenCalledWith("INT-100", expect.anything());
+  });
+
+  it("falls back to tracker.branchName when Issue.branchName is not git-safe", async () => {
+    const mockTracker: Tracker = {
+      name: "mock-tracker",
+      getIssue: vi.fn().mockResolvedValue({
+        id: "INT-100",
+        title: "T",
+        description: "",
+        url: "https://tracker.test/INT-100",
+        state: "open",
+        labels: [],
+        branchName: "bad branch with spaces",
+      }),
+      isCompleted: vi.fn().mockResolvedValue(false),
+      issueUrl: vi.fn().mockReturnValue(""),
+      branchName: vi.fn().mockReturnValue("feat/INT-100"),
+      generatePrompt: vi.fn().mockResolvedValue(""),
+    };
+
+    const registryWithTracker: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return mockAgent;
+        if (slot === "workspace") return mockWorkspace;
+        if (slot === "tracker") return mockTracker;
+        return null;
+      }),
+    };
+
+    const sm = createSessionManager({
+      config,
+      registry: registryWithTracker,
+    });
+
+    const session = await sm.spawn({ projectId: "my-app", issueId: "INT-100" });
+    expect(session.branch).toBe("feat/INT-100");
+  });
+
   it("sanitizes free-text issueId into a valid branch slug", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -2,7 +2,12 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { isRetryableHttpStatus, normalizeRetryConfig, readLastJsonlEntry } from "../utils.js";
+import {
+  isGitBranchNameSafe,
+  isRetryableHttpStatus,
+  normalizeRetryConfig,
+  readLastJsonlEntry,
+} from "../utils.js";
 import { parsePrFromUrl } from "../utils/pr.js";
 
 describe("readLastJsonlEntry", () => {
@@ -84,6 +89,30 @@ describe("readLastJsonlEntry", () => {
     const path = setup('{"type":"test"}\n');
     const result = await readLastJsonlEntry(path);
     expect(result!.modifiedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("isGitBranchNameSafe", () => {
+  it("accepts typical Linear-style branch names", () => {
+    expect(isGitBranchNameSafe("feature/foo-bar-123")).toBe(true);
+    expect(isGitBranchNameSafe("feat/INT-123")).toBe(true);
+  });
+
+  it("rejects empty, @, lock suffix, double dots, and leading dot", () => {
+    expect(isGitBranchNameSafe("")).toBe(false);
+    expect(isGitBranchNameSafe("@")).toBe(false);
+    expect(isGitBranchNameSafe("foo.lock")).toBe(false);
+    expect(isGitBranchNameSafe("a..b")).toBe(false);
+    expect(isGitBranchNameSafe(".hidden")).toBe(false);
+  });
+
+  it("rejects characters invalid in git refs", () => {
+    expect(isGitBranchNameSafe("bad branch")).toBe(false);
+    expect(isGitBranchNameSafe("x:y")).toBe(false);
+    expect(isGitBranchNameSafe("x~y")).toBe(false);
+    expect(isGitBranchNameSafe("x?y")).toBe(false);
+    expect(isGitBranchNameSafe("x[y]")).toBe(false);
+    expect(isGitBranchNameSafe("a\nb")).toBe(false);
   });
 });
 

--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -106,6 +106,11 @@ describe("isGitBranchNameSafe", () => {
     expect(isGitBranchNameSafe(".hidden")).toBe(false);
   });
 
+  it("rejects consecutive slashes and dot-prefixed components", () => {
+    expect(isGitBranchNameSafe("feat//bar")).toBe(false);
+    expect(isGitBranchNameSafe("feat/.hidden")).toBe(false);
+  });
+
   it("rejects characters invalid in git refs", () => {
     expect(isGitBranchNameSafe("bad branch")).toBe(false);
     expect(isGitBranchNameSafe("x:y")).toBe(false);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -98,6 +98,7 @@ export {
   shellEscape,
   escapeAppleScript,
   validateUrl,
+  isGitBranchNameSafe,
   isRetryableHttpStatus,
   normalizeRetryConfig,
   readLastJsonlEntry,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -952,7 +952,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (spawnConfig.branch) {
       branch = spawnConfig.branch;
     } else if (spawnConfig.issueId && plugins.tracker && resolvedIssue) {
-      branch = plugins.tracker.branchName(spawnConfig.issueId, project);
+      branch = resolvedIssue.branchName
+        ? resolvedIssue.branchName
+        : plugins.tracker.branchName(spawnConfig.issueId, project);
     } else if (spawnConfig.issueId) {
       // If the issueId is already branch-safe (e.g. "INT-9999"), use as-is.
       // Otherwise sanitize free-text (e.g. "fix login bug") into a valid slug.

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -73,6 +73,7 @@ import {
 } from "./global-pause.js";
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse } from "./utils/validation.js";
+import { isGitBranchNameSafe } from "./utils.js";
 import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
 
 const execFileAsync = promisify(execFile);
@@ -952,9 +953,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (spawnConfig.branch) {
       branch = spawnConfig.branch;
     } else if (spawnConfig.issueId && plugins.tracker && resolvedIssue) {
-      branch = resolvedIssue.branchName
-        ? resolvedIssue.branchName
-        : plugins.tracker.branchName(spawnConfig.issueId, project);
+      const fromIssue = resolvedIssue.branchName;
+      branch =
+        fromIssue && isGitBranchNameSafe(fromIssue)
+          ? fromIssue
+          : plugins.tracker.branchName(spawnConfig.issueId, project);
     } else if (spawnConfig.issueId) {
       // If the issueId is already branch-safe (e.g. "INT-9999"), use as-is.
       // Otherwise sanitize free-text (e.g. "fix login bug") into a valid slug.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -519,6 +519,7 @@ export interface Issue {
   labels: string[];
   assignee?: string;
   priority?: number;
+  branchName?: string;
 }
 
 export interface IssueFilters {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -34,6 +34,28 @@ export function validateUrl(url: string, label: string): void {
 }
 
 /**
+ * Conservative subset of git `check-ref-format` rules for branch-like names.
+ * Used before passing tracker-supplied names to `git worktree` / `checkout -b`.
+ *
+ * Slashes are allowed (e.g. `feature/foo-bar`).
+ */
+export function isGitBranchNameSafe(name: string): boolean {
+  if (!name) return false;
+  if (name === "@" || name.startsWith(".") || name.endsWith(".") || name.endsWith("/")) return false;
+  if (name.endsWith(".lock")) return false;
+  if (name.includes("..")) return false;
+  if (name.includes("@{")) return false;
+  if (name.startsWith("/")) return false;
+  for (let i = 0; i < name.length; i++) {
+    const c = name.charCodeAt(i);
+    if (c <= 0x1f || c === 0x7f) return false;
+  }
+  // Space and git-forbidden punctuation (see git-check-ref-format)
+  if (/[\s~^:?*[\\]/.test(name)) return false;
+  return true;
+}
+
+/**
  * Returns true if an HTTP status code should be retried.
  * Retry only 429 (rate-limit) and 5xx (server) failures.
  */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -44,6 +44,8 @@ export function isGitBranchNameSafe(name: string): boolean {
   if (name === "@" || name.startsWith(".") || name.endsWith(".") || name.endsWith("/")) return false;
   if (name.endsWith(".lock")) return false;
   if (name.includes("..")) return false;
+  if (name.includes("//")) return false;
+  if (name.includes("/.")) return false;
   if (name.includes("@{")) return false;
   if (name.startsWith("/")) return false;
   for (let i = 0; i < name.length; i++) {

--- a/packages/integration-tests/src/tracker-linear.integration.test.ts
+++ b/packages/integration-tests/src/tracker-linear.integration.test.ts
@@ -217,6 +217,10 @@ describe.skipIf(!canRun)("tracker-linear (integration)", () => {
     expect(issue.state).toBe("open");
     expect(Array.isArray(issue.labels)).toBe(true);
     expect(issue.priority).toBe(4);
+
+    expect(issue.branchName).toBeDefined();
+    expect(typeof issue.branchName).toBe("string");
+    expect(issue.branchName).toContain(issueIdentifier);
   });
 
   it("isCompleted returns false for an open issue", async () => {

--- a/packages/integration-tests/src/tracker-linear.integration.test.ts
+++ b/packages/integration-tests/src/tracker-linear.integration.test.ts
@@ -220,7 +220,7 @@ describe.skipIf(!canRun)("tracker-linear (integration)", () => {
 
     expect(issue.branchName).toBeDefined();
     expect(typeof issue.branchName).toBe("string");
-    expect(issue.branchName).toContain(issueIdentifier);
+    expect(issue.branchName!.length).toBeGreaterThan(0);
   });
 
   it("isCompleted returns false for an open issue", async () => {

--- a/packages/plugins/tracker-linear/src/index.ts
+++ b/packages/plugins/tracker-linear/src/index.ts
@@ -296,7 +296,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
-        ...(node.branchName ? { branchName: node.branchName } : {}),
+        branchName: node.branchName ?? undefined,
       };
     },
 
@@ -429,7 +429,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
-        ...(node.branchName ? { branchName: node.branchName } : {}),
+        branchName: node.branchName ?? undefined,
       }));
     },
 
@@ -622,7 +622,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
-        ...(node.branchName ? { branchName: node.branchName } : {}),
+        branchName: node.branchName ?? undefined,
       };
 
       // Assign after creation (Linear's issueCreate uses assigneeId, not display name)

--- a/packages/plugins/tracker-linear/src/index.ts
+++ b/packages/plugins/tracker-linear/src/index.ts
@@ -215,6 +215,7 @@ interface LinearIssueNode {
   description: string | null;
   url: string;
   priority: number;
+  branchName?: string | null;
   state: {
     name: string;
     type: string; // "triage" | "backlog" | "unstarted" | "started" | "completed" | "canceled"
@@ -260,6 +261,7 @@ const ISSUE_FIELDS = `
   description
   url
   priority
+  branchName
   state { name type }
   labels { nodes { name } }
   assignee { name displayName }
@@ -294,6 +296,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
+        ...(node.branchName ? { branchName: node.branchName } : {}),
       };
     },
 
@@ -426,6 +429,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
+        ...(node.branchName ? { branchName: node.branchName } : {}),
       }));
     },
 

--- a/packages/plugins/tracker-linear/src/index.ts
+++ b/packages/plugins/tracker-linear/src/index.ts
@@ -622,6 +622,7 @@ function createLinearTracker(query: GraphQLTransport): Tracker {
         labels: node.labels.nodes.map((l) => l.name),
         assignee: node.assignee?.displayName ?? node.assignee?.name,
         priority: node.priority,
+        ...(node.branchName ? { branchName: node.branchName } : {}),
       };
 
       // Assign after creation (Linear's issueCreate uses assigneeId, not display name)

--- a/packages/plugins/tracker-linear/test/index.test.ts
+++ b/packages/plugins/tracker-linear/test/index.test.ts
@@ -43,6 +43,7 @@ const sampleIssueNode = {
   description: "Users can't log in with SSO",
   url: "https://linear.app/acme/issue/INT-123",
   priority: 2,
+  branchName: "feat/INT-123",
   state: { name: "In Progress", type: "started" },
   labels: { nodes: [{ name: "bug" }, { name: "high-priority" }] },
   assignee: { name: "Alice Smith", displayName: "Alice" },
@@ -189,6 +190,7 @@ describe("tracker-linear plugin", () => {
         labels: ["bug", "high-priority"],
         assignee: "Alice",
         priority: 2,
+        branchName: "feat/INT-123",
       });
     });
 

--- a/packages/plugins/tracker-linear/test/index.test.ts
+++ b/packages/plugins/tracker-linear/test/index.test.ts
@@ -641,6 +641,7 @@ describe("tracker-linear plugin", () => {
         id: "INT-123",
         title: "Fix login bug",
         state: "in_progress",
+        branchName: "feat/INT-123",
       });
     });
 

--- a/scripts/claude-batch-spawn
+++ b/scripts/claude-batch-spawn
@@ -136,9 +136,9 @@ for ISSUE in "${ISSUES[@]}"; do
 
     # Build initial prompt
     if [ "$SESSION_PREFIX" = "splitly" ]; then
-        INITIAL_PROMPT="Please start working on GitHub issue #$ISSUE_NUM. First, fetch the issue details using: gh issue view $ISSUE_NUM --repo $GITHUB_REPO. Then implement the solution in the branch already prepared for this session."
+        INITIAL_PROMPT="Please start working on GitHub issue #$ISSUE_NUM. First, fetch the issue details using: gh issue view $ISSUE_NUM --repo $GITHUB_REPO. Then implement the solution in the branch already prepared for this session (confirm with \`git branch --show-current\` in the worktree if needed)."
     else
-        INITIAL_PROMPT="Please start working on $ISSUE, fetch ticket info, and implement the task in the branch already prepared for this session."
+        INITIAL_PROMPT="Please start working on $ISSUE, fetch ticket info, and implement the task in the branch already prepared for this session (confirm with \`git branch --show-current\` in the worktree if needed)."
     fi
 
     # Send prompt to the running Claude session

--- a/scripts/claude-batch-spawn
+++ b/scripts/claude-batch-spawn
@@ -136,9 +136,9 @@ for ISSUE in "${ISSUES[@]}"; do
 
     # Build initial prompt
     if [ "$SESSION_PREFIX" = "splitly" ]; then
-        INITIAL_PROMPT="Please start working on GitHub issue #$ISSUE_NUM. First, fetch the issue details using: gh issue view $ISSUE_NUM --repo $GITHUB_REPO. Then create an appropriate feature branch (e.g., fix/issue-$ISSUE_NUM-short-description or feat/issue-$ISSUE_NUM-short-description), and start implementing the solution."
+        INITIAL_PROMPT="Please start working on GitHub issue #$ISSUE_NUM. First, fetch the issue details using: gh issue view $ISSUE_NUM --repo $GITHUB_REPO. Then implement the solution in the branch already prepared for this session."
     else
-        INITIAL_PROMPT="Please start working on $ISSUE, fetch ticket info, create the appropriate branch so that github auto links to linear, and start working on the task"
+        INITIAL_PROMPT="Please start working on $ISSUE, fetch ticket info, and implement the task in the branch already prepared for this session."
     fi
 
     # Send prompt to the running Claude session


### PR DESCRIPTION
## Summary
When spawning from a Linear issue, AO now uses Linear’s `branchName` field (same string as **Copy git branch name** in the UI) as the single source of truth for the git branch on the new worktree. If Linear does not return branchName, behavior falls back to the previous Linear tracker convention (`feat/<issue-id>`), so existing flows keep working.

## Why
Branch names were sometimes out of sync between Linear and AO, which makes reviews and handoffs harder. Aligning the worktree branch with Linear removes that mismatch.

## What changed
`Issue`: optional branchName on the core type.
`tracker-linear`: GraphQL requests branchName and maps it on `getIssue` / list paths.
`session-manager`: after resolving the issue, prefers `resolvedIssue.branchName`, else `tracker.branchName(...)`.
Tests: spawn unit test for the preference; Linear plugin tests; integration assertion when Linear credentials are present.
Docs: `SETUP.md` and `examples/README.md` — SSOT, fallback, and **Linear → Settings → Integrations → GitHub → Branch format** for changing the pattern.
`scripts/claude-batch-spawn`: prompts tell workers to use the branch AO already prepared (avoid conflicting git/branch instructions).
**Changeset**: patch for `@composio/ao-core` and `@composio/ao-plugin-tracker-linear`.

## How to test
1. Configure a project with **tracker linear** and `LINEAR_API_KEY` (and team config as today).
1. Pick an issue that shows **Copy git branch name** in Linear.
1. Run `ao spawn <ISSUE-ID>` from the project directory.
1. Confirm the printed Branch matches that Linear string (SSOT).
1. (Optional) Run `pnpm lint`, `pnpm typecheck`, and `pnpm test` — matches [CONTRIBUTING.md](https://github.com/ComposioHQ/agent-orchestrator/blob/main/CONTRIBUTING.md) / CI expectations.

## Checklist

- [x] Focused change set (Linear branch naming + related tests/docs/script)
- [x] Changeset added for published packages
- [x] CI green