### PR TITLE
feat(web): extract sidebar UI for session detail

### DIFF
--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
 
 const sessionDetailSpy = vi.fn();
+const projectSidebarSpy = vi.fn();
 const notFoundError = new Error("NEXT_NOT_FOUND");
 const notFoundSpy = vi.fn(() => {
   throw notFoundError;
@@ -21,6 +22,13 @@ vi.mock("@/components/SessionDetail", () => ({
   },
 }));
 
+vi.mock("@/components/ProjectSidebar", () => ({
+  ProjectSidebar: (props: unknown) => {
+    projectSidebarSpy(props);
+    return <div data-testid="project-sidebar" />;
+  },
+}));
+
 function makeWorkerSession(): DashboardSession {
   return {
     id: "worker-1",
@@ -31,6 +39,7 @@ function makeWorkerSession(): DashboardSession {
     issueId: "https://linear.app/test/issue/INT-100",
     issueUrl: "https://linear.app/test/issue/INT-100",
     issueLabel: "INT-100",
+    issueTitle: null,
     summary: "Test worker session",
     summaryIsFallback: false,
     createdAt: new Date().toISOString(),
@@ -71,6 +80,7 @@ describe("SessionPage project polling", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     sessionDetailSpy.mockClear();
+    projectSidebarSpy.mockClear();
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     const eventSourceMock = {
@@ -103,6 +113,27 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [
+              { id: "my-app", name: "My App", sessionPrefix: "my-app" },
+              { id: "docs", name: "Docs", sessionPrefix: "docs" },
+            ],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [workerSession] }),
+        } as Response;
+      }
+
       if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
         return {
           ok: true,
@@ -129,6 +160,13 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(fetch).toHaveBeenCalledWith("/api/sessions/worker-1");
+    expect(screen.getByTestId("project-sidebar")).toBeInTheDocument();
+    expect(projectSidebarSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        activeProjectId: "my-app",
+        activeSessionId: "worker-1",
+      }),
+    );
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_000);
@@ -166,6 +204,14 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [] }),
+        } as Response;
+      }
+
       if (url === "/api/sessions/worker-1") {
         return {
           ok: false,
@@ -194,6 +240,14 @@ describe("SessionPage project polling", () => {
           ok: true,
           status: 200,
           json: async () => ({ projects: [] }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [] }),
         } as Response;
       }
 

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { notFound, useParams } from "next/navigation";
 import { isOrchestratorSession } from "@composio/ao-core/types";
+import { ProjectSidebar } from "@/components/ProjectSidebar";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, type ActivityState, getAttentionLevel, type AttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
@@ -62,6 +63,10 @@ export default function SessionPage() {
   const [session, setSession] = useState<DashboardSession | null>(null);
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[]>([]);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
@@ -83,18 +88,34 @@ export default function SessionPage() {
   }, [prefixByProject]);
 
   // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
-  useEffect(() => {
-    fetch("/api/projects")
-      .then((res) => res.ok ? res.json() : null)
-      .then((data: { projects?: ProjectInfo[] } | null) => {
-        if (data?.projects) {
-          setPrefixByProject(
-            new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
-          );
-        }
-      })
-      .catch(() => {/* non-critical — falls back to role metadata check */});
+  const fetchProjects = useCallback(async () => {
+    try {
+      const res = await fetch("/api/projects");
+      if (!res.ok) return;
+      const data = (await res.json()) as { projects?: ProjectInfo[] } | null;
+      if (!data?.projects) return;
+      setProjects(data.projects);
+      setPrefixByProject(new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])));
+    } catch {
+      // Non-critical - sidebar just won't render if projects fail to load.
+    }
   }, []);
+
+  const fetchSidebarSessions = useCallback(async () => {
+    try {
+      const res = await fetch("/api/sessions");
+      if (!res.ok) return;
+      const data = (await res.json()) as { sessions?: DashboardSession[] } | null;
+      setSidebarSessions(data?.sessions ?? []);
+    } catch {
+      // Non-critical - session page still works without sidebar data.
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchProjects();
+    void fetchSidebarSessions();
+  }, [fetchProjects, fetchSidebarSessions]);
 
   // Subscribe to SSE for real-time activity updates (title emoji)
   const sseActivity = useSSESessionActivity(id);
@@ -207,9 +228,10 @@ export default function SessionPage() {
     const interval = setInterval(() => {
       fetchSession();
       fetchProjectSessions();
+      fetchSidebarSessions();
     }, 5000);
     return () => clearInterval(interval);
-  }, [fetchSession, fetchProjectSessions]);
+  }, [fetchSession, fetchProjectSessions, fetchSidebarSessions]);
 
   if (loading) {
     return (
@@ -233,11 +255,51 @@ export default function SessionPage() {
   }
 
   return (
-    <SessionDetail
-      session={session}
-      isOrchestrator={sessionIsOrchestrator}
-      orchestratorZones={zoneCounts ?? undefined}
-      projectOrchestratorId={projectOrchestratorId}
-    />
+    <div className="dashboard-shell flex h-screen">
+      {projects.length > 1 ? (
+        <ProjectSidebar
+          projects={projects}
+          sessions={sidebarSessions}
+          activeProjectId={session.projectId}
+          activeSessionId={session.id}
+          projectHrefBuilder={(projectId) => `/?project=${encodeURIComponent(projectId ?? "all")}`}
+          sessionHrefBuilder={(_projectId, sessionId) =>
+            `/sessions/${encodeURIComponent(sessionId)}`
+          }
+          collapsed={sidebarCollapsed}
+          onToggleCollapsed={() => setSidebarCollapsed((current) => !current)}
+          mobileOpen={mobileMenuOpen}
+          onMobileClose={() => setMobileMenuOpen(false)}
+        />
+      ) : null}
+      <div className="dashboard-main flex-1 overflow-y-auto">
+        {projects.length > 1 ? (
+          <div className="mb-3 flex md:hidden">
+            <button
+              type="button"
+              className="mobile-menu-toggle"
+              onClick={() => setMobileMenuOpen(true)}
+              aria-label="Open menu"
+            >
+              <svg
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                className="h-5 w-5"
+              >
+                <path d="M4 6h16M4 12h16M4 18h16" />
+              </svg>
+            </button>
+          </div>
+        ) : null}
+        <SessionDetail
+          session={session}
+          isOrchestrator={sessionIsOrchestrator}
+          orchestratorZones={zoneCounts ?? undefined}
+          projectOrchestratorId={projectOrchestratorId}
+        />
+      </div>
+    </div>
   );
 }

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -13,6 +13,8 @@ interface ProjectSidebarProps {
   sessions: DashboardSession[];
   activeProjectId: string | undefined;
   activeSessionId: string | undefined;
+  projectHrefBuilder?: (projectId?: string) => string;
+  sessionHrefBuilder?: (projectId: string, sessionId: string) => string;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
   mobileOpen?: boolean;
@@ -102,6 +104,8 @@ function ProjectSidebarInner({
   sessions,
   activeProjectId,
   activeSessionId,
+  projectHrefBuilder,
+  sessionHrefBuilder,
   collapsed = false,
   onToggleCollapsed,
   mobileOpen = false,
@@ -109,6 +113,14 @@ function ProjectSidebarInner({
 }: ProjectSidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const buildProjectHref = (projectId?: string) =>
+    projectHrefBuilder?.(projectId) ??
+    `${pathname}?project=${encodeURIComponent(projectId ?? "all")}`;
+  const buildSessionSelectionHref = (projectId: string, sessionId: string) =>
+    sessionHrefBuilder?.(projectId, sessionId) ??
+    `${pathname}?project=${encodeURIComponent(projectId)}&session=${encodeURIComponent(sessionId)}`;
+  const buildSessionDetailHref = (projectId: string, sessionId: string) =>
+    sessionHrefBuilder?.(projectId, sessionId) ?? `/sessions/${encodeURIComponent(sessionId)}`;
 
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
     () => new Set(activeProjectId && activeProjectId !== "all" ? [activeProjectId] : []),
@@ -134,7 +146,7 @@ function ProjectSidebarInner({
 
   const handleProjectHeaderClick = (projectId: string) => {
     toggleExpand(projectId);
-    router.push(pathname + `?project=${encodeURIComponent(projectId)}`);
+    router.push(buildProjectHref(projectId));
   };
 
   const prefixByProject = useMemo(
@@ -191,7 +203,7 @@ function ProjectSidebarInner({
                 <button
                   key={project.id}
                   type="button"
-                  onClick={() => router.push(pathname + `?project=${encodeURIComponent(project.id)}`)}
+                  onClick={() => router.push(buildProjectHref(project.id))}
                   className={cn(
                     "project-sidebar__collapsed-project",
                     isActive && "project-sidebar__collapsed-project--active",
@@ -277,7 +289,7 @@ function ProjectSidebarInner({
 
       <nav className="flex-1 overflow-y-auto px-2 pb-3">
         <button
-          onClick={() => router.push(pathname + "?project=all")}
+          onClick={() => router.push(buildProjectHref())}
           className={cn(
             "project-sidebar__item mb-1 flex w-full items-center gap-2 px-2.5 py-[9px] text-left text-[12px] font-medium transition-colors",
             activeProjectId === undefined || activeProjectId === "all"
@@ -351,16 +363,10 @@ function ProjectSidebarInner({
                         key={session.id}
                         role="button"
                         tabIndex={0}
-                        onClick={() =>
-                          router.push(
-                            `${pathname}?project=${encodeURIComponent(project.id)}&session=${encodeURIComponent(session.id)}`,
-                          )
-                        }
+                        onClick={() => router.push(buildSessionSelectionHref(project.id, session.id))}
                         onKeyDown={(e) => {
                           if (e.key === "Enter" || e.key === " ") {
-                            router.push(
-                              `${pathname}?project=${encodeURIComponent(project.id)}&session=${encodeURIComponent(session.id)}`,
-                            );
+                            router.push(buildSessionSelectionHref(project.id, session.id));
                           }
                         }}
                         className={cn(
@@ -376,7 +382,7 @@ function ProjectSidebarInner({
                           {sessionToneLabel[level]}
                         </span>
                         <a
-                          href={`/sessions/${encodeURIComponent(session.id)}`}
+                          href={buildSessionDetailHref(project.id, session.id)}
                           onClick={(e) => e.stopPropagation()}
                           className="project-sidebar__session-id shrink-0 font-mono text-[9px] hover:underline"
                           title={session.id}

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ProjectSidebar } from "@/components/ProjectSidebar";
+import { makeSession } from "@/__tests__/helpers";
 
 const mockPush = vi.fn();
 const mockPathname = "/";
@@ -74,5 +75,31 @@ describe("ProjectSidebar", () => {
     render(<ProjectSidebar projects={projectsWithSpecialChars} sessions={[]} activeProjectId="my-app" activeSessionId={undefined} />);
     fireEvent.click(screen.getByRole("button", { name: "Other Project" }));
     expect(mockPush).toHaveBeenCalledWith("/?project=other-project");
+  });
+
+  it("uses custom href builders when provided", () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[
+          makeSession({
+            id: "worker-1",
+            projectId: "project-1",
+            summary: "Investigate failing test",
+          }),
+        ]}
+        activeProjectId="project-1"
+        activeSessionId="worker-1"
+        projectHrefBuilder={(projectId) => `/projects/${projectId ?? "all"}`}
+        sessionHrefBuilder={(projectId, sessionId) => `/projects/${projectId}/sessions/${sessionId}`}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Project Two" }));
+    expect(mockPush).toHaveBeenCalledWith("/projects/project-2");
+    expect(screen.getByRole("link", { name: "worker-1" })).toHaveAttribute(
+      "href",
+      "/projects/project-1/sessions/worker-1",
+    );
   });
 });


### PR DESCRIPTION
This extracts the existing sidebar UI into a reusable form without bringing over the multi-dashboard routing stack from #892.
It mounts the sidebar on the current `/sessions/[id]` page and lets `ProjectSidebar` accept route builders so the same UI can work across legacy routes.
It also adds focused tests for the reusable sidebar links and session-detail sidebar mounting.
Tests were not run in this workspace because `node_modules` are missing and `vitest` is unavailable.