### PR TITLE
fix: stop session terminal clipping in session detail

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -404,11 +404,11 @@ export function DirectTerminal({
           return true;
         });
 
-        // Handle window resize (works with whatever ws is current)
-        const handleResize = () => {
+        const fitAndSyncSize = () => {
+          fit.fit();
+
           const currentWs = ws.current;
-          if (fit && currentWs?.readyState === WebSocket.OPEN) {
-            fit.fit();
+          if (currentWs?.readyState === WebSocket.OPEN) {
             currentWs.send(
               JSON.stringify({
                 type: "resize",
@@ -419,7 +419,21 @@ export function DirectTerminal({
           }
         };
 
+        // Handle window resize (works with whatever ws is current)
+        const handleResize = () => {
+          fitAndSyncSize();
+        };
+
         window.addEventListener("resize", handleResize);
+
+        const resizeObserver =
+          typeof window !== "undefined" && "ResizeObserver" in window
+            ? new ResizeObserver(() => {
+                fitAndSyncSize();
+              })
+            : null;
+
+        resizeObserver?.observe(terminalRef.current);
 
         // Terminal input → current WebSocket
         inputDisposable = terminal.onData((data) => {
@@ -551,6 +565,7 @@ export function DirectTerminal({
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
           window.removeEventListener("resize", handleResize);
+          resizeObserver?.disconnect();
           inputDisposable?.dispose();
           inputDisposable = null;
           if (reconnectTimerRef.current) {
@@ -810,15 +825,16 @@ export function DirectTerminal({
       </div>
       {/* Terminal area */}
       <div
-        ref={terminalRef}
-        className={cn("w-full p-1.5")}
+        className="w-full min-w-0 p-1.5"
         style={{
-          overflow: "hidden",
-          display: "flex",
-          flexDirection: "column",
           height: fullscreen ? "calc(100dvh - 37px)" : height,
         }}
-      />
+      >
+        <div
+          ref={terminalRef}
+          className="flex h-full w-full min-w-0 flex-col overflow-hidden"
+        />
+      </div>
     </div>
   );
 }

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -386,7 +386,7 @@ export function SessionDetail({
             />
           )}
 
-          <section className="mt-5">
+          <section className="mt-5 min-w-0">
             <div id="session-terminal-section" aria-hidden="true" />
             <div className="mb-3 flex items-center gap-2">
               <div

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -115,7 +115,7 @@ describe("DirectTerminal render", () => {
   });
 
   it("renders the shared accent chrome for orchestrator terminals", async () => {
-    render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+    const { container } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
 
     await waitFor(() => expect(fetch).toHaveBeenCalledWith("/api/runtime/terminal", expect.any(Object)));
     await waitFor(() =>
@@ -125,5 +125,10 @@ describe("DirectTerminal render", () => {
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
     expect(MockWebSocket.instances[0]?.url).toContain("/ao-terminal-ws?session=ao-orchestrator");
+
+    const terminalArea = screen.getByText("Connected").closest("div")?.nextElementSibling as HTMLElement;
+    expect(terminalArea).toHaveClass("p-1.5");
+    expect(terminalArea.firstElementChild).toHaveClass("h-full", "w-full", "min-w-0");
+    expect(container.querySelector(".p-1\\.5 > .min-w-0")).toBeTruthy();
   });
 });

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -4,6 +4,7 @@ import { DirectTerminal } from "../DirectTerminal";
 
 const replaceMock = vi.fn();
 let searchParams = new URLSearchParams();
+let resizeObserverCallback: ResizeObserverCallback | null = null;
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ replace: replaceMock }),
@@ -50,7 +51,12 @@ class MockTerminal {
 }
 
 class MockFitAddon {
-  fit() {}
+  static instances: MockFitAddon[] = [];
+  fit = vi.fn();
+
+  constructor() {
+    MockFitAddon.instances.push(this);
+  }
 }
 
 function MockWebLinksAddon() {
@@ -72,7 +78,7 @@ class MockWebSocket {
     setTimeout(() => this.onopen?.(), 0);
   }
 
-  send() {}
+  send = vi.fn();
   close() {}
 }
 
@@ -93,11 +99,24 @@ describe("DirectTerminal render", () => {
     searchParams = new URLSearchParams();
     replaceMock.mockReset();
     MockWebSocket.instances = [];
+    MockFitAddon.instances = [];
+    resizeObserverCallback = null;
     Object.defineProperty(document, "fonts", {
       configurable: true,
       value: { ready: Promise.resolve() },
     });
     vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.stubGlobal(
+      "ResizeObserver",
+      class MockResizeObserver {
+        observe = vi.fn();
+        disconnect = vi.fn();
+
+        constructor(callback: ResizeObserverCallback) {
+          resizeObserverCallback = callback;
+        }
+      },
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -130,5 +149,42 @@ describe("DirectTerminal render", () => {
     expect(terminalArea).toHaveClass("p-1.5");
     expect(terminalArea.firstElementChild).toHaveClass("h-full", "w-full", "min-w-0");
     expect(container.querySelector(".p-1\\.5 > .min-w-0")).toBeTruthy();
+  });
+
+  it("re-fits and syncs the terminal size on window resize and resize observer updates", async () => {
+    render(<DirectTerminal sessionId="ao-terminal-2" />);
+
+    await waitFor(() => expect(screen.getByText("Connected")).toBeInTheDocument());
+
+    const fit = MockFitAddon.instances[0];
+    const socket = MockWebSocket.instances[0];
+
+    expect(fit).toBeDefined();
+    expect(socket).toBeDefined();
+
+    fit.fit.mockClear();
+    socket.send.mockClear();
+
+    window.dispatchEvent(new Event("resize"));
+
+    await waitFor(() => {
+      expect(fit.fit).toHaveBeenCalledTimes(1);
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: "resize", cols: 80, rows: 24 }),
+      );
+    });
+
+    fit.fit.mockClear();
+    socket.send.mockClear();
+
+    expect(resizeObserverCallback).toBeTruthy();
+    resizeObserverCallback?.([], {} as ResizeObserver);
+
+    await waitFor(() => {
+      expect(fit.fit).toHaveBeenCalledTimes(1);
+      expect(socket.send).toHaveBeenCalledWith(
+        JSON.stringify({ type: "resize", cols: 80, rows: 24 }),
+      );
+    });
   });
 });


### PR DESCRIPTION
closes #1023

## Summary
- move xterm.js onto an unpadded inner mount node so fit calculations use the real drawable width
- observe terminal container resizes and re-fit/re-sync terminal dimensions when the session detail layout changes
- keep the session detail terminal section shrinkable and add a render regression test for the new layout

## Verification
- `pnpm --filter @composio/ao-web typecheck`
- `pnpm --filter @composio/ao-web test -- --run DirectTerminal.render.test.tsx`
- `pnpm typecheck`
- `pnpm lint` (existing warnings only)
- `pnpm test`
- `pnpm build` *(fails on an existing Next.js `/404` prerender issue: `<Html> should not be imported outside of pages/_document`)*