### PR TITLE
fix(web): filter out terminal orchestrator sessions from Dashboard

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -318,6 +318,62 @@ describe("API Routes", () => {
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
     });
 
+    it("returns enriched orchestrators when orchestratorOnly=true", async () => {
+      const orchestratorSessions: Session[] = [
+        makeSession({
+          id: "my-app-orchestrator",
+          projectId: "my-app",
+          status: "working",
+          activity: "active",
+          metadata: { role: "orchestrator" },
+        }),
+        makeSession({
+          id: "docs-orchestrator",
+          projectId: "docs-app",
+          status: "pr_open",
+          activity: "idle",
+          metadata: { role: "orchestrator" },
+        }),
+      ];
+      (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        orchestratorSessions,
+      );
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?orchestratorOnly=true"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      // orchestratorOnly returns empty sessions array
+      expect(data.sessions).toEqual([]);
+
+      // Enriched orchestrators should include activity/status fields
+      expect(data.orchestrators).toHaveLength(2);
+      expect(data.orchestrators[0]).toMatchObject({
+        id: expect.any(String),
+        projectId: expect.any(String),
+        projectName: expect.any(String),
+        activity: expect.any(String),
+        status: expect.any(String),
+        createdAt: expect.any(String),
+        lastActivityAt: expect.any(String),
+      });
+
+      // Verify activity state from sessions is included
+      const myAppOrchestrator = data.orchestrators.find(
+        (o: { projectId: string }) => o.projectId === "my-app",
+      );
+      expect(myAppOrchestrator.activity).toBe("active");
+      expect(myAppOrchestrator.status).toBe("working");
+
+      const docsOrchestrator = data.orchestrators.find(
+        (o: { projectId: string }) => o.projectId === "docs-app",
+      );
+      expect(docsOrchestrator.activity).toBe("idle");
+      expect(docsOrchestrator.status).toBe("pr_open");
+    });
+
     it("enriches all PRs concurrently, not sequentially", async () => {
       vi.useFakeTimers();
 

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -35,29 +35,35 @@ export async function GET(request: Request) {
     const orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
     const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
 
+    // Compute session prefixes once (used by both branches)
+    const allSessionPrefixes = Object.entries(config.projects).map(
+      ([projectId, p]) => p.sessionPrefix ?? projectId,
+    );
+
     if (orchestratorOnly) {
-      // Enrich orchestrator info with activity state
-      const allSessionPrefixes = Object.entries(config.projects).map(
-        ([projectId, p]) => p.sessionPrefix ?? projectId,
-      );
-      const enrichedOrchestrators = orchestrators.map((link) => {
-        const session = visibleSessions.find(
-          (s) =>
-            s.id === link.id &&
+      // Build a Map for O(1) session lookups
+      const orchestratorSessionsById = new Map(
+        visibleSessions
+          .filter((s) =>
             isOrchestratorSession(
               s,
               config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
               allSessionPrefixes,
             ),
-        );
+          )
+          .map((s) => [s.id, s] as const),
+      );
+
+      const enrichedOrchestrators = orchestrators.map((link) => {
+        const session = orchestratorSessionsById.get(link.id);
         return {
           id: link.id,
           projectId: link.projectId,
           projectName: link.projectName,
           activity: session?.activity ?? null,
-          status: session?.status ?? "unknown",
-          createdAt: session?.createdAt.toISOString() ?? new Date().toISOString(),
-          lastActivityAt: session?.lastActivityAt.toISOString() ?? new Date().toISOString(),
+          status: session?.status ?? null,
+          createdAt: session?.createdAt.toISOString() ?? null,
+          lastActivityAt: session?.lastActivityAt.toISOString() ?? null,
         };
       });
 
@@ -83,9 +89,6 @@ export async function GET(request: Request) {
       );
     }
 
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([projectId, p]) => p.sessionPrefix ?? projectId,
-    );
     let workerSessions = visibleSessions.filter(
       (session) =>
         !isOrchestratorSession(

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -36,6 +36,31 @@ export async function GET(request: Request) {
     const orchestratorId = orchestrators.length === 1 ? (orchestrators[0]?.id ?? null) : null;
 
     if (orchestratorOnly) {
+      // Enrich orchestrator info with activity state
+      const allSessionPrefixes = Object.entries(config.projects).map(
+        ([projectId, p]) => p.sessionPrefix ?? projectId,
+      );
+      const enrichedOrchestrators = orchestrators.map((link) => {
+        const session = visibleSessions.find(
+          (s) =>
+            s.id === link.id &&
+            isOrchestratorSession(
+              s,
+              config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
+              allSessionPrefixes,
+            ),
+        );
+        return {
+          id: link.id,
+          projectId: link.projectId,
+          projectName: link.projectName,
+          activity: session?.activity ?? null,
+          status: session?.status ?? "unknown",
+          createdAt: session?.createdAt.toISOString() ?? new Date().toISOString(),
+          lastActivityAt: session?.lastActivityAt.toISOString() ?? new Date().toISOString(),
+        };
+      });
+
       recordApiObservation({
         config,
         method: "GET",
@@ -50,7 +75,7 @@ export async function GET(request: Request) {
       return jsonWithCorrelation(
         {
           orchestratorId,
-          orchestrators,
+          orchestrators: enrichedOrchestrators,
           sessions: [],
         },
         { status: 200 },

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -8,6 +8,7 @@ import {
   computeStats,
   listDashboardOrchestrators,
 } from "@/lib/serialize";
+import type { EnrichedOrchestratorLink } from "@/lib/types";
 import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/lib/observability";
 import { filterProjectSessions } from "@/lib/project-utils";
 import { settlesWithin } from "@/lib/async-utils";
@@ -54,7 +55,7 @@ export async function GET(request: Request) {
           .map((s) => [s.id, s] as const),
       );
 
-      const enrichedOrchestrators = orchestrators.map((link) => {
+      const enrichedOrchestrators: EnrichedOrchestratorLink[] = orchestrators.map((link) => {
         const session = orchestratorSessionsById.get(link.id);
         return {
           id: link.id,

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -42,42 +42,45 @@ export async function GET(request: Request) {
     );
 
     if (orchestratorOnly) {
-      // Build a Map for O(1) session lookups
-      const orchestratorSessionsById = new Map(
-        visibleSessions
-          .filter((s) =>
-            isOrchestratorSession(
-              s,
-              config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
-              allSessionPrefixes,
-            ),
-          )
-          .map((s) => [s.id, s] as const),
-      );
+      let enrichedOrchestrators: EnrichedOrchestratorLink[] = [];
+      try {
+        // Build a Map for O(1) session lookups
+        const orchestratorSessionsById = new Map(
+          visibleSessions
+            .filter((s) =>
+              isOrchestratorSession(
+                s,
+                config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
+                allSessionPrefixes,
+              ),
+            )
+            .map((s) => [s.id, s] as const),
+        );
 
-      const enrichedOrchestrators: EnrichedOrchestratorLink[] = orchestrators.map((link) => {
-        const session = orchestratorSessionsById.get(link.id);
-        return {
-          id: link.id,
-          projectId: link.projectId,
-          projectName: link.projectName,
-          activity: session?.activity ?? null,
-          status: session?.status ?? null,
-          createdAt: session?.createdAt.toISOString() ?? null,
-          lastActivityAt: session?.lastActivityAt.toISOString() ?? null,
-        };
-      });
-
-      recordApiObservation({
-        config,
-        method: "GET",
-        path: "/api/sessions",
-        correlationId,
-        startedAt,
-        outcome: "success",
-        statusCode: 200,
-        data: { orchestratorOnly: true, orchestratorCount: orchestrators.length },
-      });
+        enrichedOrchestrators = orchestrators.map((link) => {
+          const session = orchestratorSessionsById.get(link.id);
+          return {
+            id: link.id,
+            projectId: link.projectId,
+            projectName: link.projectName,
+            activity: session?.activity ?? null,
+            status: session?.status ?? null,
+            createdAt: session ? session.createdAt.toISOString() : null,
+            lastActivityAt: session ? session.lastActivityAt.toISOString() : null,
+          };
+        });
+      } finally {
+        recordApiObservation({
+          config,
+          method: "GET",
+          path: "/api/sessions",
+          correlationId,
+          startedAt,
+          outcome: "success",
+          statusCode: 200,
+          data: { orchestratorOnly: true, orchestratorCount: orchestrators.length },
+        });
+      }
 
       return jsonWithCorrelation(
         {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -42,45 +42,42 @@ export async function GET(request: Request) {
     );
 
     if (orchestratorOnly) {
-      let enrichedOrchestrators: EnrichedOrchestratorLink[] = [];
-      try {
-        // Build a Map for O(1) session lookups
-        const orchestratorSessionsById = new Map(
-          visibleSessions
-            .filter((s) =>
-              isOrchestratorSession(
-                s,
-                config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
-                allSessionPrefixes,
-              ),
-            )
-            .map((s) => [s.id, s] as const),
-        );
+      // Build a Map for O(1) session lookups
+      const orchestratorSessionsById = new Map(
+        visibleSessions
+          .filter((s) =>
+            isOrchestratorSession(
+              s,
+              config.projects[s.projectId]?.sessionPrefix ?? s.projectId,
+              allSessionPrefixes,
+            ),
+          )
+          .map((s) => [s.id, s] as const),
+      );
 
-        enrichedOrchestrators = orchestrators.map((link) => {
-          const session = orchestratorSessionsById.get(link.id);
-          return {
-            id: link.id,
-            projectId: link.projectId,
-            projectName: link.projectName,
-            activity: session?.activity ?? null,
-            status: session?.status ?? null,
-            createdAt: session ? session.createdAt.toISOString() : null,
-            lastActivityAt: session ? session.lastActivityAt.toISOString() : null,
-          };
-        });
-      } finally {
-        recordApiObservation({
-          config,
-          method: "GET",
-          path: "/api/sessions",
-          correlationId,
-          startedAt,
-          outcome: "success",
-          statusCode: 200,
-          data: { orchestratorOnly: true, orchestratorCount: orchestrators.length },
-        });
-      }
+      const enrichedOrchestrators: EnrichedOrchestratorLink[] = orchestrators.map((link) => {
+        const session = orchestratorSessionsById.get(link.id);
+        return {
+          id: link.id,
+          projectId: link.projectId,
+          projectName: link.projectName,
+          activity: session?.activity ?? null,
+          status: session?.status ?? null,
+          createdAt: session ? session.createdAt.toISOString() : null,
+          lastActivityAt: session ? session.lastActivityAt.toISOString() : null,
+        };
+      });
+
+      recordApiObservation({
+        config,
+        method: "GET",
+        path: "/api/sessions",
+        correlationId,
+        startedAt,
+        outcome: "success",
+        statusCode: 200,
+        data: { orchestratorOnly: true, orchestratorCount: orchestrators.length },
+      });
 
       return jsonWithCorrelation(
         {

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -784,6 +784,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)] opacity-80" />
         orchestrators
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70"
           fill="none"
           stroke="currentColor"
@@ -806,6 +807,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
         orchestrator
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70"
           fill="none"
           stroke="currentColor"
@@ -825,6 +827,7 @@ function OrchestratorControl({
         <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)] opacity-80" />
         {orchestrators.length} orchestrators
         <svg
+          aria-hidden="true"
           className="h-3 w-3 opacity-70 transition-transform group-open:rotate-90"
           fill="none"
           stroke="currentColor"
@@ -848,6 +851,7 @@ function OrchestratorControl({
               <span className="truncate">{orchestrator.projectName}</span>
             </span>
             <svg
+              aria-hidden="true"
               className="h-3 w-3 shrink-0 opacity-60"
               fill="none"
               stroke="currentColor"

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -553,7 +553,7 @@ function DashboardInner({
                     PRs
                   </a>
                 ) : null}
-                {!allProjectsView && !isMobile ? (
+                {!allProjectsView && !isMobile && projectId ? (
                   <OrchestratorControl orchestrators={activeOrchestrators} projectId={projectId} />
                 ) : null}
                 <ThemeToggle />
@@ -767,12 +767,10 @@ function OrchestratorControl({
   projectId,
 }: {
   orchestrators: DashboardOrchestratorLink[];
-  projectId?: string;
+  projectId: string;
 }) {
   // Build the orchestrators picker URL
-  const orchestratorsHref = projectId
-    ? `/orchestrators?project=${encodeURIComponent(projectId)}`
-    : "/orchestrators";
+  const orchestratorsHref = `/orchestrators?project=${encodeURIComponent(projectId)}`;
 
   if (orchestrators.length === 0) {
     // Show "Orchestrators" button that links to picker even when no orchestrators running

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -554,7 +554,7 @@ function DashboardInner({
                   </a>
                 ) : null}
                 {!allProjectsView && !isMobile ? (
-                  <OrchestratorControl orchestrators={activeOrchestrators} />
+                  <OrchestratorControl orchestrators={activeOrchestrators} projectId={projectId} />
                 ) : null}
                 <ThemeToggle />
               </div>
@@ -762,8 +762,39 @@ export function Dashboard(props: DashboardProps) {
   );
 }
 
-function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrchestratorLink[] }) {
-  if (orchestrators.length === 0) return null;
+function OrchestratorControl({
+  orchestrators,
+  projectId,
+}: {
+  orchestrators: DashboardOrchestratorLink[];
+  projectId?: string;
+}) {
+  // Build the orchestrators picker URL
+  const orchestratorsHref = projectId
+    ? `/orchestrators?project=${encodeURIComponent(projectId)}`
+    : "/orchestrators";
+
+  if (orchestrators.length === 0) {
+    // Show "Orchestrators" button that links to picker even when no orchestrators running
+    return (
+      <a
+        href={orchestratorsHref}
+        className="orchestrator-btn flex items-center gap-2 px-4 py-2 text-[12px] font-semibold hover:no-underline"
+      >
+        <span className="h-1.5 w-1.5 rounded-full bg-[var(--color-text-tertiary)] opacity-80" />
+        orchestrators
+        <svg
+          className="h-3 w-3 opacity-70"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          viewBox="0 0 24 24"
+        >
+          <path d="m9 18 6-6-6-6" />
+        </svg>
+      </a>
+    );
+  }
 
   if (orchestrators.length === 1) {
     const orchestrator = orchestrators[0];
@@ -787,6 +818,7 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
     );
   }
 
+  // Multiple orchestrators: show dropdown with link to picker page
   return (
     <details className="group relative">
       <summary className="orchestrator-btn flex cursor-pointer list-none items-center gap-2 px-4 py-2 text-[12px] font-semibold hover:no-underline">
@@ -826,6 +858,12 @@ function OrchestratorControl({ orchestrators }: { orchestrators: DashboardOrches
             </svg>
           </a>
         ))}
+        <a
+          href={orchestratorsHref}
+          className="flex items-center justify-center gap-2 border-t border-[var(--color-border-subtle)] px-4 py-3 text-[11px] text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-hover)] hover:no-underline"
+        >
+          Manage all orchestrators
+        </a>
       </div>
     </details>
   );

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -165,3 +165,57 @@ describe("Dashboard project overview cards", () => {
     expect(screen.getAllByRole("button", { name: "Spawn Orchestrator" })).toHaveLength(2);
   });
 });
+
+describe("Dashboard OrchestratorControl in single-project view", () => {
+  beforeEach(() => {
+    global.EventSource = vi.fn(
+      () =>
+        ({
+          onmessage: null,
+          onerror: null,
+          close: vi.fn(),
+        }) as unknown as EventSource,
+    );
+    global.fetch = vi.fn();
+  });
+
+  it("shows orchestrators link to picker when no orchestrators are running", () => {
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[]}
+      />,
+    );
+
+    const orchestratorsLink = screen.getByRole("link", { name: /orchestrators/i });
+    expect(orchestratorsLink).toHaveAttribute("href", "/orchestrators?project=my-app");
+  });
+
+  it("shows dropdown with Manage all orchestrators link for multiple orchestrators", () => {
+    // Need orchestrators from different projects to avoid mergeOrchestrators deduplication
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[
+          { id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" },
+          { id: "other-orchestrator", projectId: "other-app", projectName: "Other App" },
+        ]}
+      />,
+    );
+
+    // Find the dropdown summary element
+    const dropdown = screen.getByText("2 orchestrators");
+    expect(dropdown).toBeInTheDocument();
+
+    // Click to open dropdown
+    fireEvent.click(dropdown);
+
+    // Check for the "Manage all orchestrators" link
+    const manageLink = screen.getByRole("link", { name: /Manage all orchestrators/i });
+    expect(manageLink).toHaveAttribute("href", "/orchestrators?project=my-app");
+  });
+});

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -179,6 +179,30 @@ describe("Dashboard OrchestratorControl in single-project view", () => {
     global.fetch = vi.fn();
   });
 
+  it("does not render OrchestratorControl when projectId is undefined (all-projects view)", () => {
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projects={[
+          { id: "my-app", name: "My App" },
+          { id: "docs-app", name: "Docs App" },
+        ]}
+        orchestrators={[{ id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" }]}
+      />,
+    );
+
+    // In all-projects view (no projectId), OrchestratorControl should not render
+    // OrchestratorControl shows links/buttons with text containing "orchestrator" (not "PRs")
+    // Check that no such element exists in the hero meta section
+    const heroMeta = document.querySelector(".dashboard-hero__meta");
+    expect(heroMeta).toBeInTheDocument();
+
+    // OrchestratorControl renders: "orchestrators" (empty), "orchestrator" (single), or "N orchestrators" (multiple)
+    // None of these should be present in all-projects view
+    const orchestratorTextInHero = heroMeta?.textContent?.match(/\borchestrator\b/i);
+    expect(orchestratorTextInHero).toBeNull();
+  });
+
   it("shows orchestrators link to picker when no orchestrators are running", () => {
     render(
       <Dashboard

--- a/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.projectOverview.test.tsx
@@ -193,6 +193,20 @@ describe("Dashboard OrchestratorControl in single-project view", () => {
     expect(orchestratorsLink).toHaveAttribute("href", "/orchestrators?project=my-app");
   });
 
+  it("shows direct link to session for single orchestrator", () => {
+    render(
+      <Dashboard
+        initialSessions={[makeSession({ projectId: "my-app" })]}
+        projectId="my-app"
+        projectName="My App"
+        orchestrators={[{ id: "my-app-orchestrator", projectId: "my-app", projectName: "My App" }]}
+      />,
+    );
+
+    const orchestratorLink = screen.getByRole("link", { name: /orchestrator/i });
+    expect(orchestratorLink).toHaveAttribute("href", "/sessions/my-app-orchestrator");
+  });
+
   it("shows dropdown with Manage all orchestrators link for multiple orchestrators", () => {
     // Need orchestrators from different projects to avoid mergeOrchestrators deduplication
     render(

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -22,6 +22,7 @@ import {
   enrichSessionsMetadata,
   enrichSessionsMetadataFast,
   computeStats,
+  listDashboardOrchestrators,
 } from "../serialize";
 import { prCache, prCacheKey } from "../cache";
 import type { DashboardSession } from "../types";
@@ -1129,5 +1130,144 @@ describe("basicPRToDashboard defaults", () => {
 
     expect(dashboard.pr?.enriched).toBe(false);
     expect(dashboard.pr?.mergeability.blockers).toEqual([]);
+  });
+});
+
+describe("listDashboardOrchestrators", () => {
+  const projects: Record<string, ProjectConfig> = {
+    myproject: {
+      name: "My Project",
+      sessionPrefix: "myproject",
+      repo: { owner: "test", name: "repo" },
+      branch: "main",
+    },
+  };
+
+  it("should include active orchestrator sessions", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator",
+        projectId: "myproject",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("myproject-orchestrator");
+    expect(result[0].projectName).toBe("My Project");
+  });
+
+  it("should exclude killed orchestrator sessions", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator",
+        projectId: "myproject",
+        status: "killed",
+        activity: null,
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should exclude terminated orchestrator sessions", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator",
+        projectId: "myproject",
+        status: "terminated",
+        activity: null,
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should exclude orchestrator sessions with exited activity", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator",
+        projectId: "myproject",
+        status: "working",
+        activity: "exited",
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should exclude done orchestrator sessions", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator",
+        projectId: "myproject",
+        status: "done",
+        activity: null,
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("should only include live orchestrators when mixed with dead ones", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-orchestrator-1",
+        projectId: "myproject",
+        status: "killed",
+        activity: null,
+        metadata: { role: "orchestrator" },
+      }),
+      createCoreSession({
+        id: "myproject-orchestrator-2",
+        projectId: "myproject",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+      }),
+      createCoreSession({
+        id: "myproject-orchestrator-3",
+        projectId: "myproject",
+        status: "terminated",
+        activity: null,
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("myproject-orchestrator-2");
+  });
+
+  it("should not include regular worker sessions", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "myproject-1",
+        projectId: "myproject",
+        status: "working",
+        activity: "active",
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(0);
   });
 });

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -16,8 +16,9 @@ import {
   type ProjectConfig,
   type OrchestratorConfig,
   type PluginRegistry,
+  isOrchestratorSession,
+  isTerminalSession,
 } from "@composio/ao-core";
-import { isOrchestratorSession, isTerminalSession } from "@composio/ao-core/types";
 import type {
   DashboardSession,
   DashboardPR,

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -6,7 +6,6 @@
  */
 
 import {
-  isOrchestratorSession,
   type Session,
   type Agent,
   type SCM,
@@ -16,6 +15,7 @@ import {
   type OrchestratorConfig,
   type PluginRegistry,
 } from "@composio/ao-core";
+import { isOrchestratorSession, isTerminalSession } from "@composio/ao-core/types";
 import type {
   DashboardSession,
   DashboardPR,
@@ -77,12 +77,13 @@ export function listDashboardOrchestrators(
     ([projectId, p]) => p.sessionPrefix ?? projectId,
   );
   return sessions
-    .filter((session) =>
-      isOrchestratorSession(
-        session,
-        projects[session.projectId]?.sessionPrefix ?? session.projectId,
-        allSessionPrefixes,
-      ),
+    .filter(
+      (session) =>
+        isOrchestratorSession(
+          session,
+          projects[session.projectId]?.sessionPrefix ?? session.projectId,
+          allSessionPrefixes,
+        ) && !isTerminalSession(session),
     )
     .map((session) => ({
       id: session.id,

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -136,6 +136,14 @@ export interface DashboardOrchestratorLink {
   projectName: string;
 }
 
+/** Enriched orchestrator data returned by /api/sessions?orchestratorOnly=true */
+export interface EnrichedOrchestratorLink extends DashboardOrchestratorLink {
+  activity: ActivityState | null;
+  status: SessionStatus | null;
+  createdAt: string | null;
+  lastActivityAt: string | null;
+}
+
 /** SSE snapshot event from /api/events */
 export interface SSESnapshotEvent {
   type: "snapshot";


### PR DESCRIPTION
## Summary
- Filters out terminal-based orchestrator sessions from the Dashboard view
- Various fixes and improvements across CLI, core, and web packages
- Added error boundaries and loading states for better UX
- New orchestrator selector page and dead session recovery
- Improved test coverage across multiple packages

## Changes
- **web**: Filter terminal orchestrator sessions, add OrchestratorSelector, error boundaries, loading states
- **cli**: Dashboard and session command improvements, preflight checks
- **core**: Lifecycle manager and session manager fixes
- **scm-github**: GraphQL batch improvements

## Test plan
- [ ] Verify Dashboard no longer shows terminal orchestrator sessions
- [ ] Test orchestrator selector page navigation
- [ ] Confirm error boundaries catch and display errors properly
- [ ] Run full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)