### PR TITLE
fix(web): display PR details card above terminal in session detail

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -393,7 +393,13 @@ export function SessionDetail({
             />
           )}
 
-          <section className="mt-5">
+          {pr ? (
+            <section id="session-pr-section" className="mt-5">
+              <SessionDetailPRCard pr={pr} sessionId={session.id} metadata={session.metadata} />
+            </section>
+          ) : null}
+
+          <section className={pr ? "mt-6" : "mt-5"}>
             <div id="session-terminal-section" aria-hidden="true" />
             <div className="mb-3 flex items-center gap-2">
               <div
@@ -413,12 +419,6 @@ export function SessionDetail({
               reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
             />
           </section>
-
-          {pr ? (
-            <section id="session-pr-section" className="mt-6">
-              <SessionDetailPRCard pr={pr} sessionId={session.id} metadata={session.metadata} />
-            </section>
-          ) : null}
         </main>
       </div>
       {isMobile ? (


### PR DESCRIPTION
## Summary

- Moves the PR details card above the live terminal section in the session detail page, so users see PR status (CI, reviews, merge readiness) before the terminal
- Adjusts spacing: terminal section gets `mt-6` when a PR card is present, `mt-5` otherwise, preserving the original visual rhythm

Closes #1024