### PR TITLE
fix(windows): agent isProcessRunning PID check for process runtime (PR 3/6)

### DIFF
--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -279,6 +279,31 @@ describe("isProcessRunning", () => {
   });
 });
 
+describe("isProcessRunning with process runtime", () => {
+  it("returns true for a live PID", async () => {
+    const handle = {
+      id: "test-session",
+      runtimeName: "process",
+      data: { pid: process.pid }, // current process — known alive
+    };
+    const agent = create();
+    const result = await agent.isProcessRunning(handle as unknown as RuntimeHandle);
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a dead PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+      throw err;
+    });
+    const handle = { id: "test", runtimeName: "process", data: { pid: 999999 } };
+    const agent = create();
+    const result = await agent.isProcessRunning(handle as any);
+    expect(result).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
 // =========================================================================
 // detectActivity — terminal output classification
 // =========================================================================

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -520,6 +520,31 @@ describe("isProcessRunning", () => {
   });
 });
 
+describe("isProcessRunning with process runtime", () => {
+  it("returns true for a live PID", async () => {
+    const handle = {
+      id: "test-session",
+      runtimeName: "process",
+      data: { pid: process.pid }, // current process — known alive
+    };
+    const agent = create();
+    const result = await agent.isProcessRunning(handle as unknown as RuntimeHandle);
+    expect(result).toBe(true);
+  });
+
+  it("returns false for a dead PID", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementationOnce(() => {
+      const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+      throw err;
+    });
+    const handle = { id: "test", runtimeName: "process", data: { pid: 999999 } };
+    const agent = create();
+    const result = await agent.isProcessRunning(handle as any);
+    expect(result).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
 describe("detectActivity — terminal output classification", () => {
   const agent = create();
 


### PR DESCRIPTION
## Summary

Verifies all 4 agent plugins have PID-based `isProcessRunning` for `runtime: process`. Claude Code and Codex already had this — adds tests for Aider and OpenCode confirming the same.

## Blockers addressed

- **B13**: All agent plugins check `process.kill(pid, 0)` directly when `runtimeName !== "tmux"` instead of relying on `ps -eo` tmux TTY scanning. Handles `EPERM` correctly (process exists, no permission → return `true`).

## Test plan

- [x] Live PID (`process.pid`) returns `true` for Aider and OpenCode
- [x] Dead PID mock (`ESRCH`) returns `false` (uses `vi.spyOn` — deterministic, no real signal sent)
- [x] Zero behavior change on Linux/macOS — tmux path unchanged

Closes #999

🤖 Generated with [Claude Code](https://claude.com/claude-code)