### PR TITLE
Improve base agent prompt for AO-managed branches

### DIFF
--- a/packages/core/src/__tests__/prompt-builder.test.ts
+++ b/packages/core/src/__tests__/prompt-builder.test.ts
@@ -62,7 +62,8 @@ describe("buildPrompt", () => {
       issueId: "INT-1343",
     });
     expect(result).toContain("Work on issue: INT-1343");
-    expect(result).toContain("feat/INT-1343");
+    expect(result).toContain("AO has already provisioned the issue-linked branch for this session.");
+    expect(result).not.toContain("Create a branch named");
   });
 
   it("includes issue context when provided", () => {
@@ -215,5 +216,7 @@ describe("BASE_AGENT_PROMPT", () => {
     expect(BASE_AGENT_PROMPT).toContain("Git Workflow");
     expect(BASE_AGENT_PROMPT).toContain("PR Best Practices");
     expect(BASE_AGENT_PROMPT).toContain("ao session claim-pr");
+    expect(BASE_AGENT_PROMPT).toContain("AO has already prepared for this session");
+    expect(BASE_AGENT_PROMPT).not.toContain("Always create a feature branch");
   });
 });

--- a/packages/core/src/prompt-builder.ts
+++ b/packages/core/src/prompt-builder.ts
@@ -28,7 +28,7 @@ export const BASE_AGENT_PROMPT = `You are an AI coding agent managed by the Agen
 - If reviewers request changes, the orchestrator will forward their comments — address each one, push fixes, and reply to the comments.
 
 ## Git Workflow
-- Always create a feature branch from the default branch (never commit directly to it).
+- Use the feature branch that AO has already prepared for this session.
 - Use conventional commit messages (feat:, fix:, chore:, etc.).
 - Push your branch and create a PR when the implementation is ready.
 - Keep PRs focused — one issue per PR.
@@ -86,9 +86,7 @@ function buildConfigLayer(config: PromptBuildConfig): string {
   if (issueId) {
     lines.push(`\n## Task`);
     lines.push(`Work on issue: ${issueId}`);
-    lines.push(
-      `Create a branch named so that it auto-links to the issue tracker (e.g. feat/${issueId}).`,
-    );
+    lines.push("AO has already provisioned the issue-linked branch for this session.");
   }
 
   if (issueContext) {


### PR DESCRIPTION
## Summary
- remove the redundant instruction telling agents to create a feature branch
- replace the issue task wording with a note that AO already provisions the issue-linked branch
- update prompt-builder tests to lock in the new branch guidance

Closes #1037