### PR TITLE
feat: add ping command to CLI

### DIFF
--- a/packages/cli/src/commands/ping.ts
+++ b/packages/cli/src/commands/ping.ts
@@ -1,0 +1,10 @@
+import type { Command } from "commander";
+
+export function registerPing(program: Command): void {
+  program
+    .command("ping")
+    .description("Print the word ping")
+    .action(() => {
+      console.log("ping");
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,7 @@ import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
+import { registerPing } from "./commands/ping.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -42,6 +43,7 @@ export function createProgram(): Command {
   registerUpdate(program);
   registerSetup(program);
   registerPlugin(program);
+  registerPing(program);
 
   program
     .command("config-help")


### PR DESCRIPTION
## Summary
- Adds `ao ping` CLI command that prints the word "ping"
- Registers the command in the main program

## Test plan
- [ ] Run `ao ping` and verify it outputs "ping"
- [ ] All existing tests pass (`pnpm test`)
- [ ] Build passes (`pnpm build`)
- [ ] Type check passes (`pnpm typecheck`)
- [ ] Lint passes (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)