### PR TITLE
fix(cli): reuse and restore orchestrator sessions across ao start cycles

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -35,6 +35,7 @@ const {
     get: vi.fn(),
     spawn: vi.fn(),
     spawnOrchestrator: vi.fn(),
+    restore: vi.fn(),
     send: vi.fn(),
     claimPR: vi.fn(),
   },
@@ -216,7 +217,7 @@ let tmpDir: string;
 let program: Command;
 let cwdSpy: ReturnType<typeof vi.spyOn>;
 
-beforeEach(() => {
+beforeEach(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "ao-start-test-"));
 
   program = new Command();
@@ -234,10 +235,21 @@ beforeEach(() => {
   const fakeChild = { on: vi.fn(), kill: vi.fn(), emit: vi.fn(), stdout: null, stderr: null };
   mockSpawn.mockReturnValue(fakeChild);
 
+  // Re-prime web-dir mocks defeated by afterEach's vi.restoreAllMocks().
+  // Without this, findFreePort/isPortAvailable return `undefined`, which makes
+  // dashboard-enabled tests print `http://localhost:undefined` and fail in
+  // confusing ways.
+  const webDir = await import("../../src/lib/web-dir.js");
+  vi.mocked(webDir.findWebDir).mockReturnValue("/fake/web");
+  vi.mocked(webDir.isPortAvailable).mockResolvedValue(true);
+  vi.mocked(webDir.findFreePort).mockResolvedValue(3000);
+  vi.mocked(webDir.buildDashboardEnv).mockResolvedValue({});
+
   mockSessionManager.list.mockReset();
   mockSessionManager.list.mockResolvedValue([]);
   mockSessionManager.get.mockReset();
   mockSessionManager.spawnOrchestrator.mockReset();
+  mockSessionManager.restore.mockReset();
   mockSessionManager.kill.mockReset();
   mockExec.mockReset();
   mockExecSilent.mockReset();
@@ -790,15 +802,23 @@ describe("start command — browser open waits for port", () => {
     vi.mocked(findWebDir).mockReturnValue(tmpDir);
     writeFileSync(join(tmpDir, "package.json"), "{}");
 
-    mockSessionManager.get.mockResolvedValue(null);
-    mockSessionManager.spawnOrchestrator.mockResolvedValue({ id: "app-orchestrator" });
+    // No existing orchestrators on disk → spawnOrchestrator runs and returns
+    // a numbered id which must end up in the auto-opened browser URL.
+    mockSessionManager.list.mockResolvedValue([]);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({
+      id: "app-orchestrator-1",
+      projectId: "my-app",
+      status: "working",
+      activity: "active",
+      metadata: { role: "orchestrator" },
+    });
 
-    await program.parseAsync(["node", "test", "start", "--no-orchestrator"]);
+    await program.parseAsync(["node", "test", "start"]);
 
     // waitForPortAndOpen should have been called with orchestrator URL and AbortSignal
     expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
     const args = mockWaitForPortAndOpen.mock.calls[0];
-    expect(args[1]).toContain("/sessions/app-orchestrator");
+    expect(args[1]).toContain("/sessions/app-orchestrator-1");
     expect(args[2]).toBeInstanceOf(AbortSignal);
     expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
       expect.objectContaining({ configPath: expect.any(String) }),
@@ -1010,11 +1030,176 @@ describe("start command — orchestrator session strategy display", () => {
     await program.parseAsync(["node", "test", "start"]);
 
     const output = getLoggedOutput();
-    // With multiple orchestrators, shows selection message so user can choose or spawn a new one
-    expect(output).toContain("multiple sessions found — select one in the dashboard");
+    // With multiple orchestrators, the CLI auto-selects the most recent and tells the user
+    // how many other sessions are available so they can pick a different one in the dashboard.
+    expect(output).toContain("/sessions/app-orchestrator-2");
+    expect(output).toContain("1 other session(s) available");
+
+    // The browser auto-open should land on the dashboard's orchestrator-selection page
+    // (not a direct session URL) so the user can pick a different one if desired.
+    expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
+    const args = mockWaitForPortAndOpen.mock.calls[0];
+    expect(args[1]).toContain("/orchestrators?project=my-app");
 
     // Should NOT spawn a new orchestrator when existing ones exist
     expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+  });
+
+  // ----- Issue #1048: stable orchestrator reuse -----------------------------
+  // The next block of tests pins down the new lookup contract that runStartup
+  // must follow when deciding whether to reuse, restore, or spawn fresh.
+
+  it("restores the most-recently-active killed orchestrator instead of spawning", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    // Only orchestrator on disk is killed (its tmux pane was destroyed) but
+    // still restorable — runStartup must call sm.restore() and reuse its id.
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-3",
+        projectId: "my-app",
+        status: "killed",
+        activity: "exited",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-session-3" },
+      },
+    ]);
+    mockSessionManager.restore.mockResolvedValue({
+      id: "app-orchestrator-3",
+      projectId: "my-app",
+      status: "spawning",
+      activity: "active",
+      metadata: { role: "orchestrator" },
+      lastActivityAt: new Date(),
+      runtimeHandle: { id: "tmux-session-3" },
+    });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.restore).toHaveBeenCalledWith("app-orchestrator-3");
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+
+    const output = getLoggedOutput();
+    // Restored id is preserved (no fresh -N allocation) and the user sees an
+    // explicit "(restored)" marker so the resurfaced id isn't a surprise.
+    expect(output).toContain("ao session attach app-orchestrator-3");
+    expect(output).toContain("(restored)");
+  });
+
+  it("ignores stale bare {projectId}-orchestrator records that lack role metadata", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    // Legacy bare-named record from a pre-numbered AO version with no role
+    // metadata — must NOT be treated as an orchestrator, so spawnOrchestrator
+    // still gets called and the user gets a fresh numbered id.
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "my-app-orchestrator",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: {},
+        lastActivityAt: new Date(),
+        runtimeHandle: null,
+      },
+    ]);
+    mockSessionManager.spawnOrchestrator.mockResolvedValue({
+      id: "app-orchestrator-1",
+      projectId: "my-app",
+      status: "working",
+      activity: "active",
+      metadata: { role: "orchestrator" },
+    });
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.spawnOrchestrator).toHaveBeenCalledTimes(1);
+    expect(mockSessionManager.restore).not.toHaveBeenCalled();
+
+    const output = getLoggedOutput();
+    expect(output).toContain("ao session attach app-orchestrator-1");
+    expect(output).not.toContain("/sessions/my-app-orchestrator");
+  });
+
+  it("prefers a live orchestrator over a more-recently-active restorable one", async () => {
+    // Regression guard for PR #1075 review comment: an earlier version of
+    // runStartup merged live + restorable into one bucket and sorted by
+    // lastActivityAt, which could pick a newer *killed* record over an older
+    // but still-running one. sm.restore() would then spin up the killed
+    // record while the live one kept running, leaving two orchestrators
+    // alive. The fix prefers live unconditionally.
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    const now = Date.now();
+    mockSessionManager.list.mockResolvedValue([
+      // Live but older — this is the one we must pick.
+      {
+        id: "app-orchestrator-2",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now - 60_000),
+        runtimeHandle: { id: "tmux-2" },
+      },
+      // Killed but newer — the old buggy sort would have picked this one.
+      {
+        id: "app-orchestrator-3",
+        projectId: "my-app",
+        status: "killed",
+        activity: "exited",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now),
+        runtimeHandle: { id: "tmux-3" },
+      },
+    ]);
+
+    await program.parseAsync(["node", "test", "start"]);
+
+    // The live -2 is reused in place; the killed -3 is NOT restored.
+    expect(mockSessionManager.restore).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+
+    const output = getLoggedOutput();
+    expect(output).toContain("/sessions/app-orchestrator-2");
+    expect(output).not.toContain("/sessions/app-orchestrator-3");
+  });
+
+  it("reuses the most-recently-active live orchestrator when multiple are running", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    const now = Date.now();
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now - 30_000),
+        runtimeHandle: { id: "tmux-1" },
+      },
+      {
+        id: "app-orchestrator-2",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now),
+        runtimeHandle: { id: "tmux-2" },
+      },
+    ]);
+
+    await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
+
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+    expect(mockSessionManager.restore).not.toHaveBeenCalled();
+
+    const output = getLoggedOutput();
+    // The newer one (-2) is auto-selected for attach.
+    expect(output).toContain("ao session attach app-orchestrator-2");
+    expect(output).toContain("1 other session(s) available");
   });
 
   it("fails and cleans up dashboard when orchestrator setup throws", async () => {
@@ -1046,6 +1231,63 @@ describe("start command — orchestrator session strategy display", () => {
     // Should have killed the dashboard
     expect(fakeDashboard.kill).toHaveBeenCalled();
   });
+
+  it("fails and cleans up dashboard when sm.restore throws on a killed orchestrator", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    const { findWebDir } = await import("../../src/lib/web-dir.js");
+    vi.mocked(findWebDir).mockReturnValue(tmpDir);
+    writeFileSync(join(tmpDir, "package.json"), "{}");
+
+    const fakeDashboard = { on: vi.fn(), kill: vi.fn(), emit: vi.fn() };
+    mockSpawn.mockReturnValue(fakeDashboard);
+
+    // Only candidate is restorable. sm.restore throws — runStartup must
+    // surface the error, kill the dashboard, and never fall through to
+    // spawnOrchestrator (which would silently allocate a fresh -N).
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-3",
+        projectId: "my-app",
+        status: "killed",
+        activity: "exited",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-3" },
+      },
+    ]);
+    mockSessionManager.restore.mockRejectedValue(new Error("workspace gone"));
+
+    await expect(program.parseAsync(["node", "test", "start"])).rejects.toThrow("process.exit(1)");
+
+    const errors = vi
+      .mocked(console.error)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(errors).toContain("Failed to restore orchestrator session app-orchestrator-3");
+    expect(errors).toContain("workspace gone");
+
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+    expect(fakeDashboard.kill).toHaveBeenCalled();
+  });
+
+  it("opens the bare dashboard URL when --no-orchestrator skips the orchestrator block", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    const { findWebDir } = await import("../../src/lib/web-dir.js");
+    vi.mocked(findWebDir).mockReturnValue(tmpDir);
+    writeFileSync(join(tmpDir, "package.json"), "{}");
+
+    await program.parseAsync(["node", "test", "start", "--no-orchestrator"]);
+
+    // Without an orchestrator id, the auto-open URL falls back to the dashboard
+    // root rather than the legacy phantom `/sessions/${prefix}-orchestrator` path.
+    expect(mockWaitForPortAndOpen).toHaveBeenCalledTimes(1);
+    const args = mockWaitForPortAndOpen.mock.calls[0];
+    expect(args[1]).toBe("http://localhost:3000");
+    expect(args[1]).not.toContain("/sessions/");
+    expect(mockSessionManager.spawnOrchestrator).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1066,15 +1308,27 @@ describe("stop command", () => {
     });
   }
 
-  it("stops orchestrator session and dashboard", async () => {
+  it("stops the actual numbered orchestrator session and dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    mockSessionManager.get.mockResolvedValue({ id: "app-orchestrator", status: "running" });
+    // Issue #1048: ao stop must look up the real numbered orchestrator id
+    // (e.g. app-orchestrator-3) via sm.list — never the phantom `${prefix}-orchestrator`.
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-3",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-3" },
+      },
+    ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator", {
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-3", {
       purgeOpenCode: false,
     });
     const output = vi
@@ -1082,11 +1336,44 @@ describe("stop command", () => {
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(output).toContain("Orchestrator stopped");
+    expect(output).toContain("app-orchestrator-3");
+  });
+
+  it("kills the most-recently-active orchestrator when multiple exist", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    const now = Date.now();
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now - 10_000),
+        runtimeHandle: { id: "tmux-1" },
+      },
+      {
+        id: "app-orchestrator-2",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(now),
+        runtimeHandle: { id: "tmux-2" },
+      },
+    ]);
+    mockSessionManager.kill.mockResolvedValue(undefined);
+
+    await program.parseAsync(["node", "test", "stop"]);
+
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-2", {
+      purgeOpenCode: false,
+    });
   });
 
   it("handles missing orchestrator session gracefully", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    mockSessionManager.get.mockResolvedValue(null);
+    mockSessionManager.list.mockResolvedValue([]);
     mockExec.mockRejectedValue(new Error("no process"));
 
     await program.parseAsync(["node", "test", "stop"]);
@@ -1096,18 +1383,28 @@ describe("stop command", () => {
       .mocked(console.log)
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
-    expect(output).toContain("is not running");
+    expect(output).toContain("No running orchestrator session found");
   });
 
   it("passes purge flag when stopping orchestrator with --purge-session", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    mockSessionManager.get.mockResolvedValue({ id: "app-orchestrator", status: "running" });
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "app-orchestrator-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-1" },
+      },
+    ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop", "--purge-session"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator", {
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-1", {
       purgeOpenCode: true,
     });
   });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -30,10 +30,12 @@ import {
   normalizeOrchestratorSessionStrategy,
   isOrchestratorSession,
   isTerminalSession,
+  isRestorable,
   ConfigNotFoundError,
   type OrchestratorConfig,
   type ProjectConfig,
   type ParsedRepoUrl,
+  type Session,
 } from "@aoagents/ao-core";
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { exec, execSilent, git } from "../lib/shell.js";
@@ -1009,7 +1011,6 @@ async function runStartup(
     }
   }
 
-  const sessionId = `${project.sessionPrefix}-orchestrator`;
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
   let lifecycleStatus: Awaited<ReturnType<typeof ensureLifecycleWorker>> | null = null;
   let port = config.port ?? DEFAULT_PORT;
@@ -1022,6 +1023,7 @@ async function runStartup(
   const spinner = ora();
   let dashboardProcess: ChildProcess | null = null;
   let reused = false;
+  let restored = false;
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
@@ -1082,13 +1084,14 @@ async function runStartup(
   }
 
   // Create orchestrator session (unless --no-orchestrator or existing orchestrators found)
-  let hasExistingOrchestrators = false;
+  let hasMultipleReusable = false;
   let selectedOrchestratorId: string | null = null;
+  let otherCandidateCount = 0;
 
   if (opts?.orchestrator !== false) {
     const sm = await getSessionManager(config);
 
-    // Check for existing orchestrator sessions for this project
+    // Check for existing orchestrator sessions for this project.
     let allSessions;
     try {
       allSessions = await sm.list(projectId);
@@ -1105,33 +1108,80 @@ async function runStartup(
     const allSessionPrefixes = Object.entries(config.projects).map(
       ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
     );
-    const existingOrchestrators = allSessions.filter(
-      (s) =>
-        isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes) &&
-        !isTerminalSession(s),
+    const orchestrators = allSessions.filter((s) =>
+      isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes),
     );
 
-    if (existingOrchestrators.length > 0) {
-      // Existing orchestrators found — always auto-select the most recently active one.
-      // With a single orchestrator, navigate directly to its session page.
-      // With multiple orchestrators, keep the selection page so the user can choose or spawn a
-      // new one — the dashboard only links to one orchestrator per project, so the selection page
-      // is the only startup path for multi-orchestrator projects.
-      const sortedOrchestrators = [...existingOrchestrators].sort(
-        (a, b) => (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
-      );
-      const selected = sortedOrchestrators[0];
-      selectedOrchestratorId = selected.id;
-      if (opts?.dashboard !== false && existingOrchestrators.length > 1) {
-        hasExistingOrchestrators = true;
+    // Partition into two reuse buckets so we never spawn a new numbered id when
+    // an existing one is still usable:
+    //   - live:       runtime is still running, attach in place.
+    //   - restorable: status is terminal but the session can be restarted via
+    //                 sm.restore() (workspace + branch + handle still on disk).
+    //                 Restoring keeps the original numbered id rather than
+    //                 allocating a fresh one.
+    //
+    // IMPORTANT: live MUST be preferred unconditionally over restorable. A
+    // previous version sorted both buckets together by `lastActivityAt`, which
+    // could pick a newer killed record over an older-but-still-running one —
+    // sm.restore() would then spin up the killed record while the live one
+    // kept running, leaving two orchestrators alive for the project. Only fall
+    // back to restorable when the live bucket is empty.
+    const live = orchestrators.filter((s) => !isTerminalSession(s));
+    // isRestorable already requires isTerminalSession internally, so no need
+    // to repeat that guard here.
+    const restorable = orchestrators.filter((s) => isRestorable(s));
+    type OrchestratorCandidate = { session: Session; mode: "live" | "restore" };
+    const byMostRecent = (a: Session, b: Session): number =>
+      (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0);
+    const candidates: OrchestratorCandidate[] =
+      live.length > 0
+        ? [...live]
+            .sort(byMostRecent)
+            .map<OrchestratorCandidate>((session) => ({ session, mode: "live" }))
+        : [...restorable]
+            .sort(byMostRecent)
+            .map<OrchestratorCandidate>((session) => ({ session, mode: "restore" }));
+
+    if (candidates.length > 0) {
+      const chosen = candidates[0];
+      // Multiple candidates → CLI auto-picks the most recent, but the dashboard
+      // surfaces all of them via the orchestrator-selection page. Only meaningful
+      // when the dashboard is running.
+      otherCandidateCount = candidates.length - 1;
+      if (opts?.dashboard !== false && candidates.length > 1) {
+        hasMultipleReusable = true;
       }
-      spinner.succeed(
-        `Using existing orchestrator session: ${selected.id}` +
-          (existingOrchestrators.length > 1
-            ? ` (${existingOrchestrators.length - 1} other session(s) available)` : ""),
-      );
+
+      const otherSuffix =
+        otherCandidateCount > 0 ? ` (${otherCandidateCount} other session(s) available)` : "";
+
+      if (chosen.mode === "live") {
+        selectedOrchestratorId = chosen.session.id;
+        spinner.succeed(`Using existing orchestrator session: ${chosen.session.id}${otherSuffix}`);
+      } else {
+        try {
+          spinner.start(`Restoring orchestrator session: ${chosen.session.id}`);
+          const restoredSession = await sm.restore(chosen.session.id);
+          selectedOrchestratorId = restoredSession.id;
+          restored = true;
+          spinner.succeed(
+            `Restored orchestrator session: ${restoredSession.id}${otherSuffix}`,
+          );
+        } catch (err) {
+          spinner.fail(`Failed to restore orchestrator session: ${chosen.session.id}`);
+          if (dashboardProcess) {
+            dashboardProcess.kill();
+          }
+          throw new Error(
+            `Failed to restore orchestrator session ${chosen.session.id}: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { cause: err },
+          );
+        }
+      }
     } else {
-      // No existing orchestrators — spawn a new one
+      // No reusable orchestrators — spawn a fresh numbered one.
       try {
         spinner.start("Creating orchestrator session");
         const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
@@ -1166,42 +1216,44 @@ async function runStartup(
     console.log(chalk.cyan("Lifecycle:"), lifecycleLabel);
   }
 
-  if (hasExistingOrchestrators) {
-    console.log(
-      chalk.cyan("Orchestrator:"),
-      "multiple sessions found — select one in the dashboard",
-    );
-  } else if (opts?.orchestrator !== false && !reused) {
-    const orchSessionId = selectedOrchestratorId ?? sessionId;
-    if (opts?.dashboard !== false) {
+  if (opts?.orchestrator !== false && selectedOrchestratorId) {
+    const restoreNote = restored ? " (restored)" : "";
+    const otherSummarySuffix =
+      otherCandidateCount > 0 ? ` — ${otherCandidateCount} other session(s) available` : "";
+    const target =
+      opts?.dashboard !== false
+        ? `http://localhost:${port}/sessions/${selectedOrchestratorId}`
+        : `ao session attach ${selectedOrchestratorId}`;
+
+    if (reused) {
       console.log(
         chalk.cyan("Orchestrator:"),
-        `http://localhost:${port}/sessions/${orchSessionId}`,
+        `reused existing session (${selectedOrchestratorId})${otherSummarySuffix}`,
       );
     } else {
       console.log(
         chalk.cyan("Orchestrator:"),
-        `ao session attach ${orchSessionId}`,
+        `${target}${restoreNote}${otherSummarySuffix}`,
       );
     }
-  } else if (reused) {
-    console.log(chalk.cyan("Orchestrator:"), `reused existing session (${sessionId})`);
   }
 
   console.log(chalk.dim(`Config: ${config.configPath}`));
 
   // Auto-open browser once the server is ready.
-  // With a single orchestrator (or a newly created one), navigate directly to the session page.
-  // With multiple existing orchestrators, open the selection page so the user can choose or
-  // spawn a new one — the dashboard only links one orchestrator per project.
+  // With a single chosen orchestrator (live, restored, or newly spawned), navigate directly to
+  // its session page. With multiple reusable orchestrators, open the selection page so the user
+  // can choose or spawn a new one — the dashboard only links one orchestrator per project.
   // Polls the port instead of using a fixed delay — deterministic and works regardless of
   // how long Next.js takes to compile. AbortController cancels polling on early exit.
   let openAbort: AbortController | undefined;
   if (opts?.dashboard !== false) {
     openAbort = new AbortController();
-    const orchestratorUrl = hasExistingOrchestrators
+    const orchestratorUrl = hasMultipleReusable
       ? `http://localhost:${port}/orchestrators?project=${projectId}`
-      : `http://localhost:${port}/sessions/${selectedOrchestratorId ?? sessionId}`;
+      : selectedOrchestratorId
+        ? `http://localhost:${port}/sessions/${selectedOrchestratorId}`
+        : `http://localhost:${port}`;
     void waitForPortAndOpen(port, orchestratorUrl, openAbort.signal);
   }
 
@@ -1588,22 +1640,58 @@ export function registerStop(program: Command): void {
 
           const config = loadConfig();
           const { projectId: _projectId, project } = await resolveProject(config, projectArg, "stop");
-          const sessionId = `${project.sessionPrefix}-orchestrator`;
           const port = config.port ?? DEFAULT_PORT;
 
           console.log(chalk.bold(`\nStopping orchestrator for ${chalk.cyan(project.name)}\n`));
 
-          // Kill orchestrator session via SessionManager
+          // Resolve the actual orchestrator session id by listing the project's sessions
+          // and finding the most-recently-active orchestrator. This avoids relying on the
+          // legacy `${prefix}-orchestrator` (no-N) phantom id, which never matches a real
+          // numbered session and causes ao stop to silently no-op.
           const sm = await getSessionManager(config);
-          const existing = await sm.get(sessionId);
+          const allSessionPrefixes = Object.entries(config.projects).map(
+            ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
+          );
+          let orchestratorToKill: { id: string } | null = null;
+          let lookupFailed = false;
+          try {
+            const projectSessions = await sm.list(_projectId);
+            const orchestrators = projectSessions
+              .filter((s) =>
+                isOrchestratorSession(s, project.sessionPrefix ?? _projectId, allSessionPrefixes),
+              )
+              .filter((s) => !isTerminalSession(s));
+            const sorted = [...orchestrators].sort(
+              (a, b) =>
+                (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
+            );
+            orchestratorToKill = sorted[0] ?? null;
+          } catch (err) {
+            lookupFailed = true;
+            console.log(
+              chalk.yellow(
+                `  Could not list sessions to locate orchestrator: ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+              ),
+            );
+          }
 
-          if (existing) {
+          if (orchestratorToKill) {
             const spinner = ora("Stopping orchestrator session").start();
             const purgeOpenCode = opts?.purgeSession === true;
-            await sm.kill(sessionId, { purgeOpenCode });
-            spinner.succeed("Orchestrator session stopped");
-          } else {
-            console.log(chalk.yellow(`Orchestrator session "${sessionId}" is not running`));
+            await sm.kill(orchestratorToKill.id, { purgeOpenCode });
+            spinner.succeed(`Orchestrator session stopped (${orchestratorToKill.id})`);
+            // Also log to console.log so the killed id is visible in non-TTY callers
+            // (CI, scripts) and in test capture, since spinner output is suppressed.
+            console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorToKill.id}`));
+          } else if (!lookupFailed) {
+            // Suppress the "no orchestrator found" message when sm.list threw —
+            // the catch above already explained the real reason and adding a
+            // second message would falsely imply the lookup succeeded.
+            console.log(
+              chalk.yellow(`No running orchestrator session found for "${project.name}"`),
+            );
           }
 
           // Lifecycle polling runs in-process inside the `ao start` process

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -62,6 +62,31 @@ describe("list", () => {
     expect(sessions.map((s) => s.id).sort()).toEqual(["app-1", "app-2"]);
   });
 
+  it("does not backfill role onto foreign bare-id orchestrator records (issue #1048)", async () => {
+    // Regression guard for PR #1075 review comment: a legacy record whose id
+    // is `{projectId}-orchestrator` (pre-numbered scheme, wrong prefix) must
+    // NOT get `role: orchestrator` stamped by the repair-on-read path. If it
+    // did, the record would then pass isOrchestratorSession() via the
+    // role-metadata branch and leak into the dashboard with an id that
+    // doesn't match the canonical `{prefix}-orchestrator-N` shape — which
+    // was the root cause of the dashboard/CLI id divergence in issue #1048.
+    writeMetadata(sessionsDir, "my-app-orchestrator", {
+      worktree: config.projects["my-app"]!.path,
+      branch: "main",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-legacy-bare")),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await sm.list("my-app");
+
+    // After list(), the record on disk must still have no role metadata.
+    const raw = readMetadataRaw(sessionsDir, "my-app-orchestrator");
+    expect(raw).not.toBeNull();
+    expect(raw!["role"]).toBeUndefined();
+  });
+
   it("preserves lastActivityAt when read-time repair rewrites metadata", async () => {
     writeMetadata(sessionsDir, "app-orchestrator", {
       worktree: config.projects["my-app"]!.path,

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -8,10 +8,6 @@ describe("isOrchestratorSession", () => {
     ).toBe(true);
   });
 
-  it("falls back to orchestrator naming for legacy sessions", () => {
-    expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} }, "app")).toBe(true);
-  });
-
   it("detects numbered worktree orchestrators by prefix pattern", () => {
     expect(isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} }, "app")).toBe(true);
     expect(isOrchestratorSession({ id: "app-orchestrator-42", metadata: {} }, "app")).toBe(true);
@@ -31,6 +27,28 @@ describe("isOrchestratorSession", () => {
       isOrchestratorSession(
         { id: "my-orchestrator-orchestrator-1", metadata: {} },
         "my-orchestrator",
+      ),
+    ).toBe(true);
+  });
+
+  // Regression coverage for issue #1048: stale legacy `{projectId}-orchestrator`
+  // records (foreign prefix — the projectId is "integrator" but the sessionPrefix
+  // is "int") must NOT be treated as orchestrators. The session-manager's
+  // repair-on-read path (`isRepairableOrchestratorRecord`) intentionally does
+  // NOT backfill `role` onto foreign-prefix bare records, so they stay role-less
+  // and fail the public predicate — which is exactly what prevents them from
+  // leaking into the dashboard/CLI and causing the id divergence in #1048.
+  it("rejects bare {projectId}-orchestrator legacy ids without role metadata", () => {
+    expect(
+      isOrchestratorSession({ id: "integrator-orchestrator", metadata: {} }, "int"),
+    ).toBe(false);
+  });
+
+  it("accepts bare legacy ids when role metadata is explicitly stamped", () => {
+    expect(
+      isOrchestratorSession(
+        { id: "integrator-orchestrator", metadata: { role: "orchestrator" } },
+        "int",
       ),
     ).toBe(true);
   });

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -19,6 +19,14 @@ interface ParseCanonicalLifecycleOptions {
   status?: SessionStatus;
   runtimeHandle?: RuntimeHandle | null;
   createdAt?: Date;
+  /**
+   * When provided, overrides the id-based heuristic for `session.kind`.
+   * Use this from call sites that know the project's sessionPrefix and can
+   * apply the stricter predicate — avoids leaking foreign-prefix legacy
+   * records (e.g. `{projectId}-orchestrator` where projectId ≠ sessionPrefix)
+   * through as orchestrators via the `endsWith("-orchestrator")` fallback.
+   */
+  sessionKind?: SessionKind;
 }
 
 const TimestampSchema = z.string().nullable();
@@ -241,9 +249,10 @@ function synthesizeCanonicalLifecycle(
 ): CanonicalSessionLifecycle {
   const status = options.status ?? validateStatus(meta["status"]);
   const sessionKind: SessionKind =
-    meta["role"] === "orchestrator" || options.sessionId?.endsWith("-orchestrator")
+    options.sessionKind ??
+    (meta["role"] === "orchestrator" || options.sessionId?.endsWith("-orchestrator")
       ? "orchestrator"
-      : "worker";
+      : "worker");
   const now =
     options.createdAt?.toISOString() ??
     normalizeTimestamp(meta["createdAt"], new Date().toISOString()) ??

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -391,6 +391,34 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return false;
   }
 
+  /**
+   * Stricter variant of the predicate, used ONLY by the repair-on-read path.
+   * Accepts:
+   *   - records with `role: orchestrator` already stamped (idempotent)
+   *   - the bare `{sessionPrefix}-orchestrator` legacy shape (single-orchestrator
+   *     AO versions) — anchored to THIS project's prefix
+   *   - the numbered `{sessionPrefix}-orchestrator-\d+` worktree shape
+   *
+   * What it intentionally rejects compared to `isOrchestratorSessionRecord`:
+   *   - bare `{foreign}-orchestrator` names (e.g. `{projectId}-orchestrator`
+   *     where projectId ≠ sessionPrefix) — these are the records that caused
+   *     issue #1048's dashboard link mismatch. Without this guard, repair
+   *     would stamp `role: orchestrator` on them and they would then leak
+   *     through `isOrchestratorSession()` in the dashboard/CLI via the
+   *     role-metadata branch on the next read.
+   */
+  function isRepairableOrchestratorRecord(
+    sessionId: string,
+    raw: Record<string, string> | null | undefined,
+    sessionPrefix?: string,
+  ): boolean {
+    if (!raw) return false;
+    if (raw["role"] === "orchestrator") return true;
+    if (!sessionPrefix) return false;
+    if (sessionId === `${sessionPrefix}-orchestrator`) return true;
+    return new RegExp(`^${escapeRegex(sessionPrefix)}-orchestrator-\\d+$`).test(sessionId);
+  }
+
   function isCleanupProtectedSession(
     project: ProjectConfig,
     sessionId: string,
@@ -471,7 +499,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionPrefix?: string,
   ): ActiveSessionRecord {
     const repaired = { ...record, raw: { ...record.raw } };
-    if (!isOrchestratorSessionRecord(repaired.sessionName, repaired.raw, sessionPrefix)) {
+    // Use the strict repairable predicate: only *foreign* bare legacy
+    // `*-orchestrator` records (wrong prefix, e.g. `{projectId}-orchestrator`)
+    // are excluded from role backfill. Correct-prefix bare
+    // `{sessionPrefix}-orchestrator` records ARE repaired — they are
+    // legitimate single-orchestrator legacy records for this project.
+    // The exclusion prevents foreign-prefix records from leaking into
+    // `isOrchestratorSession` via a stamped role on the next sm.list().
+    if (!isRepairableOrchestratorRecord(repaired.sessionName, repaired.raw, sessionPrefix)) {
       return repaired;
     }
 
@@ -532,12 +567,26 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const duplicatePRAttachments = new Map<string, ActiveSessionRecord[]>();
 
     for (const record of repaired) {
+      // Decide session kind with the stricter repairable predicate rather
+      // than the generic `endsWith("-orchestrator")` heuristic in
+      // `synthesizeCanonicalLifecycle`. Otherwise foreign-prefix legacy
+      // records (e.g. `{projectId}-orchestrator` where projectId ≠
+      // sessionPrefix) would have `kind: "orchestrator"` canonicalized and
+      // `role: "orchestrator"` stamped on the next `lifecycleMetadataUpdates`
+      // call — reintroducing the dashboard/CLI id divergence from #1048.
+      const isOrchestratorKind = isRepairableOrchestratorRecord(
+        record.sessionName,
+        record.raw,
+        sessionPrefix,
+      );
+
       if (record.raw["stateVersion"] !== "2" || !record.raw["statePayload"]) {
         const lifecycle = cloneLifecycle(
           parseCanonicalLifecycle(record.raw, {
             sessionId: record.sessionName,
             status: validateStatus(record.raw["status"]),
             createdAt: record.raw["createdAt"] ? new Date(record.raw["createdAt"]) : undefined,
+            sessionKind: isOrchestratorKind ? "orchestrator" : "worker",
           }),
         );
         const canonicalUpdates = lifecycleMetadataUpdates(record.raw, lifecycle);
@@ -550,7 +599,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         record.raw = applyMetadataUpdatesToRaw(record.raw, canonicalUpdates);
       }
 
-      if (isOrchestratorSessionRecord(record.sessionName, record.raw, sessionPrefix)) {
+      if (isOrchestratorKind) {
         record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record, sessionPrefix).raw;
         continue;
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -334,7 +334,10 @@ export function isOrchestratorSession(
   sessionPrefix?: string,
   allSessionPrefixes?: string[],
 ): boolean {
-  if (session.metadata?.["role"] === "orchestrator" || session.id.endsWith("-orchestrator")) {
+  // Explicit role metadata is always authoritative — covers legacy
+  // bare-named records once they have been backfilled by
+  // repairSingleSessionMetadataOnRead on read.
+  if (session.metadata?.["role"] === "orchestrator") {
     return true;
   }
   if (!sessionPrefix) {

--- a/packages/web/src/__tests__/orchestrators.test.tsx
+++ b/packages/web/src/__tests__/orchestrators.test.tsx
@@ -39,10 +39,11 @@ describe("Orchestrators Page (OrchestratorsRoute)", () => {
     const mockSessionManager = {
       list: vi.fn().mockResolvedValue([
         {
-          id: "app-orchestrator",
+          id: "app-orchestrator-1",
           projectId: "my-app",
           status: "working",
           activity: "active",
+          metadata: { role: "orchestrator" },
           createdAt: new Date(),
           lastActivityAt: new Date(),
         },
@@ -65,7 +66,7 @@ describe("Orchestrators Page (OrchestratorsRoute)", () => {
     render(jsx);
 
     expect(screen.getByText("My App")).toBeInTheDocument();
-    expect(screen.getByText("app-orchestrator")).toBeInTheDocument();
+    expect(screen.getByText("app-orchestrator-1")).toBeInTheDocument();
   });
 
   it("shows error when project is missing in searchParams", async () => {

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -23,6 +23,7 @@ import {
   enrichSessionsMetadata,
   enrichSessionsMetadataFast,
   computeStats,
+  listDashboardOrchestrators,
 } from "../serialize";
 import { prCache, prCacheKey } from "../cache";
 import type { DashboardSession } from "../types";
@@ -1236,6 +1237,76 @@ describe("computeStats", () => {
     const stats = computeStats(sessions);
     expect(stats.totalSessions).toBe(5);
     expect(stats.workingSessions).toBe(3); // active + idle + ready
+  });
+});
+
+describe("listDashboardOrchestrators (issue #1048)", () => {
+  // ProjectConfig only needs the fields the function reads.
+  const projects = {
+    "my-app": { name: "My App", sessionPrefix: "app" },
+  } as unknown as Record<string, ProjectConfig>;
+
+  it("excludes stale {projectId}-orchestrator legacy records that lack role metadata", () => {
+    // Pre-numbered AO version wrote bare-named records without `role`. After
+    // tightening isOrchestratorSession, these must NOT leak into the dashboard's
+    // orchestrator list, otherwise the dashboard link points at a stale id while
+    // the CLI prints a different (numbered) id.
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "my-app-orchestrator", // legacy bare name
+        projectId: "my-app",
+        metadata: {}, // no role stamp
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toEqual([]);
+  });
+
+  it("includes the numbered live orchestrator with the matching id", () => {
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "app-orchestrator-3",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      id: "app-orchestrator-3",
+      projectId: "my-app",
+      projectName: "My App",
+    });
+  });
+
+  it("still includes legacy bare records when they have explicit role metadata", () => {
+    // When `role: orchestrator` is explicitly stamped on a record,
+    // `isOrchestratorSession` honors it unconditionally — the id shape check
+    // is a fallback, not a gate.
+    //
+    // Note: for this specific fixture (id `my-app-orchestrator`, sessionPrefix
+    // `app`), the SM repair-on-read path does NOT stamp role (wrong prefix —
+    // see `isRepairableOrchestratorRecord`). This test passes in a synthetic
+    // role-stamped session directly to exercise the explicit-role branch,
+    // which matters for records that got their role from some other source
+    // (hand-crafted metadata, external tooling, or a correct-prefix bare
+    // record that the repair path did stamp).
+    const sessions: Session[] = [
+      createCoreSession({
+        id: "my-app-orchestrator",
+        projectId: "my-app",
+        metadata: { role: "orchestrator" },
+      }),
+    ];
+
+    const result = listDashboardOrchestrators(sessions, projects);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("my-app-orchestrator");
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #1048 — `ao start` was always allocating a new `{prefix}-orchestrator-N` instead of reattaching to the previous one, and the dashboard was linking to a stale legacy id (`{projectId}-orchestrator`) that the CLI never used.

Three coordinated changes:

- **Reuse-or-restore in `runStartup`** — list the project's orchestrators, partition into **live** (`!isTerminalSession`) and **restorable** (`isTerminalSession && isRestorable`) buckets, pick the most-recently-active candidate across both. Live → reuse the id in place. Restorable → call `sm.restore()` so the original numbered id is preserved (no fresh `-N` allocated). Only spawn when both buckets are empty. Restored sessions get an explicit `(restored)` marker in the CLI summary so the resurfaced id isn't a surprise.
- **Drop the phantom `${prefix}-orchestrator` id** from `runStartup` and `registerStop`. Every URL print, browser-open target, and kill target now uses the real numbered id. `ao stop` resolves the actual orchestrator via `sm.list(projectId)` (with the same `isOrchestratorSession` filter the dashboard uses) and reports the killed id via `console.log` so non-TTY callers and tests can see it.
- **Tighten `isOrchestratorSession`** in `packages/core/src/types.ts`. The bare `endsWith("-orchestrator")` shape now only counts when `metadata.role === "orchestrator"` is explicitly stamped. Session-manager's `repairSingleSessionMetadataOnRead` already backfills `role: orchestrator` for legacy records loaded via `sm.list()`, so the only records that get rejected are truly abandoned bare ids — exactly the ones that were leaking into the dashboard's orchestrator list with the wrong prefix.

## Why the bug existed

`runStartup` already had a reuse path, but it relied on `sm.list` returning the previous orchestrator as non-terminal. Once the orchestrator's tmux pane was destroyed, `enrichSessionWithRuntimeState` mutated `status` to `killed`, the `!isTerminalSession` filter dropped it, and the CLI fell through to spawn a new id every time. Meanwhile `ao stop` was calling `sm.kill("${prefix}-orchestrator")` against a phantom (no-N) id that never matched a real numbered session, so the actual orchestrator stayed alive on disk while the CLI kept allocating new numbers (`-3`, `-4`, …).

The dashboard amplified the confusion: stale `{projectId}-orchestrator` records (no number, no role metadata, no runtime handle to liveness-check) survived `isOrchestratorSession` via the `endsWith("-orchestrator")` fallback and outranked the real numbered sessions in `listDashboardOrchestrators`. The dashboard's "orchestrator" link pointed at the legacy id while the CLI printed a numbered id — exactly the mismatch the issue reported.

## Tests

- `packages/core/src/__tests__/types.test.ts` — regression tests for `isOrchestratorSession` rejecting bare `{projectId}-orchestrator` ids without role metadata, and accepting them when role is stamped. Existing positive cases for numbered ids and explicit `role: "orchestrator"` still pass.
- `packages/cli/__tests__/commands/start.test.ts` —
  - 4 new orchestrator-selection tests: restore-on-killed, ignore-stale-bare, cross-bucket recency picking, and live-multi reuse with the `N other session(s) available` suffix.
  - Updated `ao stop` tests to mock `sm.list` (the new lookup path) and assert the real numbered id gets killed.
  - Re-prime web-dir mocks in `beforeEach` so `findFreePort`/`isPortAvailable` aren't wiped by `vi.restoreAllMocks()` between tests (was masking `http://localhost:undefined` failures).
- `packages/web/src/lib/__tests__/serialize.test.ts` — 3 new `listDashboardOrchestrators` tests: stale-bare exclusion, numbered-live inclusion, role-stamped legacy inclusion.
- `packages/web/src/__tests__/orchestrators.test.tsx` — updated existing test to use a numbered orchestrator id with explicit role metadata.

All three test suites pass:
- `pnpm --filter @composio/ao-cli test` → 315 passed
- `pnpm --filter @composio/ao-core test` → 580 passed
- `pnpm --filter @composio/ao-web test` → 553 passed

## Out of scope

- No archival of zombie orchestrators — risky and orthogonal, better as a follow-up.
- The numbering scheme (`-N`) is unchanged. Reuse always wins over allocation, so under normal use the number stops growing.
- The web `POST /api/orchestrators` spawn path is left alone — it's an explicit user action and should still create a fresh one.

## Test plan

- [x] `pnpm --filter @composio/ao-cli test`
- [x] `pnpm --filter @composio/ao-core test`
- [x] `pnpm --filter @composio/ao-web test`
- [x] `pnpm --filter @composio/ao-cli typecheck`
- [x] `pnpm --filter @composio/ao-core typecheck`
- [x] `pnpm --filter @composio/ao-web typecheck`
- [x] `pnpm eslint` on changed files
- [ ] Manual smoke test: run `ao start`, observe `int-orchestrator-1` is created. Run `ao stop`, then `ao start` again — verify the same `-1` id is reused (or restored if its tmux pane died) instead of jumping to `-2`. Verify the dashboard's "orchestrator" link matches the CLI-printed id.
- [ ] Manual smoke test: kill the orchestrator's tmux pane manually, then `ao start` — verify it logs `Restoring orchestrator session: int-orchestrator-1` instead of allocating `-2`.