### PR TITLE
fix(ao): rebuild node-pty when prebuilt binary is incompatible

### DIFF
--- a/packages/ao/bin/postinstall.js
+++ b/packages/ao/bin/postinstall.js
@@ -2,14 +2,18 @@
 /**
  * Postinstall script for @aoagents/ao (npm/yarn global installs).
  *
- * Fixes node-pty's spawn-helper binary missing the execute bit.
- * node-pty@1.1.0 ships spawn-helper without +x; the monorepo works around
- * this via scripts/rebuild-node-pty.js, but that never runs for global installs.
+ * 1. Fixes node-pty's spawn-helper binary missing the execute bit.
+ *    node-pty@1.1.0 ships spawn-helper without +x; the monorepo works around
+ *    this via scripts/rebuild-node-pty.js, but that never runs for global installs.
+ *    Upstream fix: microsoft/node-pty#866 (only in 1.2.0-beta, not stable yet).
  *
- * Upstream fix: microsoft/node-pty#866 (only in 1.2.0-beta, not stable yet).
+ * 2. Verifies the prebuilt binary is compatible with the current Node.js version.
+ *    If not (common with nvm/fnm/volta), rebuilds from source via npx node-gyp.
+ *    See: https://github.com/ComposioHQ/agent-orchestrator/issues/987
  */
 
 import { chmodSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -33,6 +37,7 @@ function findPackageUp(startDir, ...segments) {
 const nodePtyDir = findPackageUp(__dirname, "node-pty");
 if (!nodePtyDir) process.exit(0);
 
+// Step 1: Fix spawn-helper permissions
 const spawnHelper = resolve(
   nodePtyDir,
   "prebuilds",
@@ -40,11 +45,34 @@ const spawnHelper = resolve(
   "spawn-helper",
 );
 
-if (!existsSync(spawnHelper)) process.exit(0);
+if (existsSync(spawnHelper)) {
+  try {
+    chmodSync(spawnHelper, 0o755);
+    console.log("\u2713 node-pty spawn-helper permissions set");
+  } catch {
+    console.warn("\u26a0\ufe0f  Could not set spawn-helper permissions (non-critical)");
+  }
+}
 
+// Step 2: Verify the prebuilt binary actually works with this Node.js version.
+// If it doesn't (ABI mismatch from nvm/fnm/volta version switching), rebuild.
 try {
-  chmodSync(spawnHelper, 0o755);
-  console.log("\u2713 node-pty spawn-helper permissions set");
+  execSync("node -e \"require('node-pty')\"", {
+    cwd: resolve(nodePtyDir, ".."),
+    stdio: "ignore",
+    timeout: 10000,
+  });
 } catch {
-  console.warn("\u26a0\ufe0f  Could not set spawn-helper permissions (non-critical)");
+  console.log("\u26a0\ufe0f  node-pty prebuilt binary incompatible with Node.js " + process.version + ", rebuilding...");
+  try {
+    execSync("npx --yes node-gyp rebuild", {
+      cwd: nodePtyDir,
+      stdio: "inherit",
+      timeout: 120000,
+    });
+    console.log("\u2713 node-pty rebuilt successfully");
+  } catch {
+    console.warn("\u26a0\ufe0f  node-pty rebuild failed — web terminal may not work");
+    console.warn("  Manual fix: cd " + nodePtyDir + " && npx node-gyp rebuild");
+  }
 }

--- a/packages/ao/bin/postinstall.js
+++ b/packages/ao/bin/postinstall.js
@@ -60,7 +60,7 @@ if (existsSync(spawnHelper)) {
 // failure only surfaces when the helper binary is actually executed.
 try {
   execSync(
-    "node -e \"var p=require('node-pty');var t=p.spawn('/bin/sh',['-c','exit 0'],{});t.kill();\"",
+    "node -e \"var p=require('node-pty');var t=p.spawn('/bin/sh',['-c','exit 0'],{});t.kill();process.exit(0);\"",
     {
       cwd: resolve(nodePtyDir, ".."),
       stdio: "ignore",

--- a/packages/ao/bin/postinstall.js
+++ b/packages/ao/bin/postinstall.js
@@ -56,12 +56,17 @@ if (existsSync(spawnHelper)) {
 
 // Step 2: Verify the prebuilt binary actually works with this Node.js version.
 // If it doesn't (ABI mismatch from nvm/fnm/volta version switching), rebuild.
+// We exercise pty.spawn() — not just require() — because the posix_spawnp
+// failure only surfaces when the helper binary is actually executed.
 try {
-  execSync("node -e \"require('node-pty')\"", {
-    cwd: resolve(nodePtyDir, ".."),
-    stdio: "ignore",
-    timeout: 10000,
-  });
+  execSync(
+    "node -e \"var p=require('node-pty');var t=p.spawn('/bin/sh',['-c','exit 0'],{});t.kill();\"",
+    {
+      cwd: resolve(nodePtyDir, ".."),
+      stdio: "ignore",
+      timeout: 10000,
+    },
+  );
 } catch {
   console.log("\u26a0\ufe0f  node-pty prebuilt binary incompatible with Node.js " + process.version + ", rebuilding...");
   try {


### PR DESCRIPTION
## Summary

- Fixes #987 — `posix_spawnp` failure on `npm install -g @composio/ao` when node-pty's prebuilt binary doesn't match the user's Node.js version
- The existing postinstall only did `chmod +x` on spawn-helper. Now it also verifies node-pty loads correctly, and if it doesn't (ABI mismatch from nvm/fnm/volta), rebuilds from source via `npx --yes node-gyp rebuild`
- Uses `npx --yes` so node-gyp doesn't need to be a direct dependency of the published package

## Test plan

- [ ] `npm install -g @composio/ao` on a machine with nvm where Node version differs from prebuilt target
- [ ] Verify postinstall outputs "node-pty rebuilt successfully" instead of silently leaving a broken binary
- [ ] Verify normal case (matching Node version) still works — postinstall should not attempt rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)