### PR TITLE
feat(cli): hide orchestrator sessions from ao session ls by default

### DIFF
--- a/packages/cli/src/commands/session.ts
+++ b/packages/cli/src/commands/session.ts
@@ -35,8 +35,9 @@ export function registerSession(program: Command): void {
     .command("ls")
     .description("List all sessions")
     .option("-p, --project <id>", "Filter by project ID")
+    .option("-a, --all", "Include orchestrator sessions")
     .option("--json", "Output as JSON")
-    .action(async (opts: { project?: string; json?: boolean }) => {
+    .action(async (opts: { project?: string; all?: boolean; json?: boolean }) => {
       const config = loadConfig();
       if (opts.project && !config.projects[opts.project]) {
         console.error(chalk.red(`Unknown project: ${opts.project}`));
@@ -44,7 +45,14 @@ export function registerSession(program: Command): void {
       }
 
       const sm = await getSessionManager(config);
-      const sessions = await sm.list(opts.project);
+      const allSessions = await sm.list(opts.project);
+
+      // Filter out orchestrator sessions unless --all is passed
+      const sessions = opts.all
+        ? allSessions
+        : allSessions.filter(
+            (s) => !isOrchestratorSessionName(config, s.id, s.projectId),
+          );
 
       // Group sessions by project
       const byProject = new Map<string, typeof sessions>();


### PR DESCRIPTION
## Summary

- Filter out orchestrator sessions from `ao session ls` output by default using the existing `isOrchestratorSessionName()` helper
- Add `--all` / `-a` flag to include orchestrator sessions when needed

Closes #1088

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm test` passes (310/310)
- [x] Manual: `ao session ls` no longer shows orchestrator sessions
- [x] Manual: `ao session ls --all` shows orchestrator sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)