### PR TITLE
fix(web): stop treating idle ad hoc sessions as working

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -12,6 +12,7 @@
 
 import { randomUUID } from "node:crypto";
 import {
+  ACTIVITY_STATE,
   SESSION_STATUS,
   PR_STATE,
   CI_STATUS,
@@ -20,6 +21,7 @@ import {
   type SessionManager,
   type SessionId,
   type SessionStatus,
+  type ActivityState,
   type EventType,
   type OrchestratorEvent,
   type OrchestratorConfig,
@@ -369,7 +371,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
 
     // Track activity state across steps so stuck detection can run after PR checks
+    // and the dashboard can distinguish actively-working sessions from agents
+    // that have already returned to the prompt.
     let detectedIdleTimestamp: Date | null = null;
+    let detectedActivityState: ActivityState | null = null;
 
     // 1. Check if runtime is alive
     if (session.runtimeHandle) {
@@ -405,6 +410,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // Try JSONL-based activity detection first (reads agent's session files directly)
         const activityState = await agent.getActivityState(session, config.readyThresholdMs);
         if (activityState) {
+          detectedActivityState = activityState.state;
           if (activityState.state === "waiting_input") return "needs_input";
           if (activityState.state === "exited") return "killed";
 
@@ -426,6 +432,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const terminalOutput = runtime ? await runtime.getOutput(session.runtimeHandle, 10) : "";
           if (terminalOutput) {
             const activity = agent.detectActivity(terminalOutput);
+            detectedActivityState = activity;
             if (activity === "waiting_input") return "needs_input";
 
             const processAlive = await agent.isProcessRunning(session.runtimeHandle);
@@ -552,6 +559,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // still check stuck threshold. This handles agents that finish without creating a PR.
     if (detectedIdleTimestamp && isIdleBeyondThreshold(session, detectedIdleTimestamp)) {
       return "stuck";
+    }
+
+    // 5b. Non-PR sessions that are back at the prompt should not remain in the
+    // generic "working" bucket forever. Mark them idle so downstream surfaces
+    // can classify them as waiting rather than actively progressing.
+    if (
+      !session.pr &&
+      (detectedActivityState === ACTIVITY_STATE.READY ||
+        detectedActivityState === ACTIVITY_STATE.IDLE)
+    ) {
+      return SESSION_STATUS.IDLE;
     }
 
     // 6. Default: if agent is active, it's working

--- a/packages/core/src/utils/validation.ts
+++ b/packages/core/src/utils/validation.ts
@@ -8,6 +8,7 @@ import type { SessionStatus } from "../types.js";
 const VALID_STATUSES: ReadonlySet<string> = new Set([
   "spawning",
   "working",
+  "idle",
   "pr_open",
   "ci_failed",
   "review_pending",

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -261,6 +261,15 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
     }
   }
 
+  // ── Pending: idle/ready sessions are not actively being worked on ──
+  if (
+    session.status === SESSION_STATUS.IDLE ||
+    session.activity === ACTIVITY_STATE.READY ||
+    session.activity === ACTIVITY_STATE.IDLE
+  ) {
+    return "pending";
+  }
+
   // ── Working: agents doing their thing ─────────────────────────────
   return "working";
 }


### PR DESCRIPTION
Fixes #1089

## Summary
- preserve `idle` as a valid persisted session status
- mark non-PR sessions that have returned to the prompt as `idle` in lifecycle resolution
- classify `idle` / `ready` ad hoc sessions into the existing `Pending` dashboard bucket instead of `Working`

## Why
Ad hoc workers that already finished their current task and returned to the prompt were still shown under the dashboard's `Working` column, even though `ao status` showed them as `ready` / `idle`.

This made research / brainstorm / one-shot task sessions look actively in progress when they were really waiting for the next instruction.

## Validation
- `pnpm build`
