### PR TITLE
fix(web): resolve @composio/core build warning in tracker-linear

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -11,6 +11,18 @@ const nextConfig = {
     "@aoagents/ao-plugin-tracker-linear",
     "@aoagents/ao-plugin-workspace-worktree",
   ],
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      // @composio/core is an optional peer dep of tracker-linear (the Composio SDK,
+      // not our internal @aoagents/ao-core). It's dynamically imported with a try/catch
+      // at runtime, but webpack still tries to resolve it at build time since
+      // tracker-linear is in transpilePackages. Mark it as external so webpack
+      // skips resolution entirely.
+      config.externals = config.externals || [];
+      config.externals.push("@composio/core");
+    }
+    return config;
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

- Adds webpack `externals` entry for `@composio/core` on server builds in `next.config.js`, so webpack skips resolution of the optional Composio SDK during transpilation of `tracker-linear`
- Eliminates the `Module not found: Can't resolve '@composio/core'` build warning without affecting runtime behavior
- The dynamic `import("@composio/core")` in tracker-linear's try/catch continues to work correctly at runtime

## Why not the other approaches?

- **`serverExternalPackages`** — `@composio/core` is already listed there, but it doesn't prevent resolution during transpilation of pnpm workspace-linked packages
- **`IgnorePlugin`** — would break runtime if `@composio/core` is actually installed, since it replaces the module entirely rather than deferring to Node.js

## Test plan

- [x] `pnpm --filter @aoagents/ao-web build` completes with no `@composio/core` warnings
- [x] Remaining warnings are only the pre-existing `plugin-registry.js` "Critical dependency" (unrelated)
- [ ] Verify Linear tracker still works at runtime with and without `@composio/core` installed

Closes #1057

🤖 Generated with [Claude Code](https://claude.com/claude-code)