### PR TITLE
fix: preserve live session activity after PR merge

### DIFF
--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -171,6 +171,78 @@ describe("list", () => {
     expect(sessions[0].activity).toBe("exited");
   });
 
+  it("preserves activity for merged sessions when the runtime is still alive", async () => {
+    const runtimeWithSpy: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const agentWithState: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue({ state: "ready" }),
+    };
+    const registryWithLiveTerminalSession: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return runtimeWithSpy;
+        if (slot === "agent") return agentWithState;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-merged", {
+      worktree: "/tmp/w-merged",
+      branch: "feat/merged",
+      status: "merged",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-merged")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithLiveTerminalSession });
+    const sessions = await sm.list();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].status).toBe("merged");
+    expect(sessions[0].activity).toBe("ready");
+    expect(runtimeWithSpy.isAlive).toHaveBeenCalledWith(makeHandle("rt-merged"));
+    expect(agentWithState.getActivityState).toHaveBeenCalled();
+  });
+
+  it("marks merged sessions exited when the runtime probe confirms the process is dead", async () => {
+    const deadRuntime: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(false),
+    };
+    const agentWithSpy: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue({ state: "ready" }),
+    };
+    const registryWithDeadTerminalSession: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return deadRuntime;
+        if (slot === "agent") return agentWithSpy;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-merged", {
+      worktree: "/tmp/w-merged",
+      branch: "feat/merged",
+      status: "merged",
+      project: "my-app",
+      runtimeHandle: JSON.stringify(makeHandle("rt-merged")),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithDeadTerminalSession });
+    const sessions = await sm.list();
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].status).toBe("merged");
+    expect(sessions[0].activity).toBe("exited");
+    expect(deadRuntime.isAlive).toHaveBeenCalledWith(makeHandle("rt-merged"));
+    expect(agentWithSpy.getActivityState).not.toHaveBeenCalled();
+  });
+
   it("detects activity using agent-native mechanism", async () => {
     const agentWithState: Agent = {
       ...mockAgent,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -880,11 +880,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
   ): Promise<void> {
-    // Skip all subprocess/IO work for sessions already known to be terminal.
-    if (TERMINAL_SESSION_STATUSES.has(session.status)) {
-      session.activity = "exited";
-      return;
-    }
+    const hasTerminalStatus = TERMINAL_SESSION_STATUSES.has(session.status);
 
     // Check runtime liveness — but only if the handle came from metadata.
     // Fabricated handles (constructed as fallback for external sessions) should
@@ -892,9 +888,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     // a tmux session, and we'd clobber meaningful statuses like "pr_open".
     if (handleFromMetadata && session.runtimeHandle && plugins.runtime) {
       try {
-        const alive = await plugins.runtime.isAlive(session.runtimeHandle);
-        if (!alive) {
-          session.status = "killed";
+        const isRuntimeAlive = await plugins.runtime.isAlive(session.runtimeHandle);
+        if (!isRuntimeAlive) {
+          if (!hasTerminalStatus) {
+            session.status = "killed";
+          }
           session.activity = "exited";
           return;
         }


### PR DESCRIPTION
## Summary
- probe runtime liveness before forcing `activity = "exited"` in `enrichSessionWithRuntimeState()`
- keep terminal-status sessions such as `merged` eligible for agent activity detection when the runtime is still alive
- add regression coverage for merged sessions with both live and dead runtimes

## Why
Closes #1081.

The bug was reproducible from the current `session-manager` flow: terminal statuses short-circuited directly to `activity = "exited"`, so a merged PR always looked dead even when the tmux-backed agent process was still alive. The fix makes activity reflect runtime truth instead of PR state.

## Lifecycle reasoning
Session `status` and process `activity` are orthogonal signals. A session can be terminal from a workflow perspective (`merged`) while the agent is still alive and interactive. This change preserves that distinction:
- if the runtime probe says the process is dead, activity becomes `exited`
- if the runtime probe says the process is alive, terminal sessions still use agent activity detection
- when a non-terminal session is confirmed dead, we still repair status to `killed`
- when a terminal session is confirmed dead, we keep its terminal status instead of rewriting it to `killed`

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/query.test.ts`
- `pnpm test` *(fails in unrelated existing `packages/core/src/__tests__/plugin-registry.test.ts` cases: "registers alias-specific notifier instances for the same plugin" and "prefers the notifier id matching the plugin name for direct plugin lookups")*