### PR TITLE
feat(cli): add --preview-prompt to ao spawn

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -4,7 +4,13 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { type Session, type SessionManager, getProjectBaseDir } from "@aoagents/ao-core";
 
-const { mockExec, mockConfigRef, mockSessionManager, mockEnsureLifecycleWorker } = vi.hoisted(
+const {
+  mockExec,
+  mockConfigRef,
+  mockSessionManager,
+  mockEnsureLifecycleWorker,
+  mockDecompose,
+} = vi.hoisted(
   () => ({
     mockExec: vi.fn(),
     mockConfigRef: { current: null as Record<string, unknown> | null },
@@ -19,6 +25,7 @@ const { mockExec, mockConfigRef, mockSessionManager, mockEnsureLifecycleWorker }
       claimPR: vi.fn(),
     },
     mockEnsureLifecycleWorker: vi.fn(),
+    mockDecompose: vi.fn(),
   }),
 );
 
@@ -49,6 +56,7 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
   return {
     ...actual,
     loadConfig: () => mockConfigRef.current,
+    decompose: (...args: Parameters<typeof actual.decompose>) => mockDecompose(...args),
   };
 });
 
@@ -122,6 +130,7 @@ beforeEach(() => {
   mockSessionManager.claimPR.mockReset();
   mockExec.mockReset();
   mockEnsureLifecycleWorker.mockReset();
+  mockDecompose.mockReset();
   mockEnsureLifecycleWorker.mockResolvedValue({
     running: true,
     started: true,
@@ -367,6 +376,69 @@ describe("spawn command", () => {
       issueId: "INT-42",
       agent: "codex",
     });
+  });
+
+  it("prints prompt preview without starting lifecycle or spawning", async () => {
+    await program.parseAsync(["node", "test", "spawn", "INT-42", "--preview-prompt"]);
+
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Prompt Preview");
+    expect(output).toContain("Tracker issue context is not fetched in preview mode");
+    expect(output).toContain("Work on issue: INT-42");
+    expect(output).toContain("Repository: org/my-app");
+  });
+
+  it("prints decomposed leaf prompts in preview mode", async () => {
+    mockDecompose.mockResolvedValue({
+      id: "plan-1",
+      rootTask: "INT-42",
+      maxDepth: 3,
+      phase: "review",
+      createdAt: new Date().toISOString(),
+      tree: {
+        id: "1",
+        depth: 0,
+        description: "INT-42",
+        kind: "composite",
+        status: "ready",
+        lineage: [],
+        children: [
+          {
+            id: "1.1",
+            depth: 1,
+            description: "Build API",
+            kind: "atomic",
+            status: "ready",
+            lineage: ["INT-42"],
+            children: [],
+          },
+          {
+            id: "1.2",
+            depth: 1,
+            description: "Build UI",
+            kind: "atomic",
+            status: "ready",
+            lineage: ["INT-42"],
+            children: [],
+          },
+        ],
+      },
+    });
+
+    await program.parseAsync(["node", "test", "spawn", "INT-42", "--decompose", "--preview-prompt"]);
+
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockSessionManager.spawn).not.toHaveBeenCalled();
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(output).toContain("Leaf 1: Build API");
+    expect(output).toContain("Leaf 2: Build UI");
+    expect(output).toContain("## Task Hierarchy");
+    expect(output).toContain("## Parallel Work");
+    expect(output).toContain("Build UI");
   });
 
   it("warns and exits when two positional args given (old syntax)", async () => {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -9,8 +9,10 @@ import {
   getSiblings,
   formatPlanTree,
   TERMINAL_STATUSES,
+  buildPrompt,
   type OrchestratorConfig,
   type DecomposerConfig,
+  type ProjectConfig,
   DEFAULT_DECOMPOSER_CONFIG,
 } from "@aoagents/ao-core";
 import { DEFAULT_PORT } from "../lib/constants.js";
@@ -58,6 +60,57 @@ function autoDetectProject(config: OrchestratorConfig): string {
 interface SpawnClaimOptions {
   claimPr?: string;
   assignOnGithub?: boolean;
+}
+
+interface PromptPreviewOptions {
+  issueId?: string;
+  lineage?: string[];
+  siblings?: string[];
+}
+
+function getDecomposerConfig(
+  config: OrchestratorConfig,
+  projectId: string,
+  maxDepth?: string,
+): DecomposerConfig {
+  const project = config.projects[projectId];
+  return {
+    ...DEFAULT_DECOMPOSER_CONFIG,
+    ...(project.decomposer ?? {}),
+    maxDepth: maxDepth ? parseInt(maxDepth, 10) : (project.decomposer?.maxDepth ?? 3),
+  };
+}
+
+function printPromptPreviewHeader(projectId: string, issueId?: string): void {
+  console.log(chalk.bold("Prompt Preview"));
+  console.log(chalk.dim(`Project: ${projectId}`));
+  if (issueId) {
+    console.log(chalk.dim(`Issue:   ${issueId}`));
+    console.log(
+      chalk.yellow(
+        "Tracker issue context is not fetched in preview mode because it requires a network call.",
+      ),
+    );
+  }
+  console.log(
+    chalk.dim("Preview mode only prints the composed prompt. No session or lifecycle worker is started."),
+  );
+  console.log();
+}
+
+function printPromptPreview(
+  project: ProjectConfig,
+  projectId: string,
+  options: PromptPreviewOptions,
+): void {
+  const prompt = buildPrompt({
+    project,
+    projectId,
+    issueId: options.issueId,
+    lineage: options.lineage,
+    siblings: options.siblings,
+  });
+  console.log(prompt);
 }
 
 /**
@@ -169,6 +222,7 @@ export function registerSpawn(program: Command): void {
     .option("--claim-pr <pr>", "Immediately claim an existing PR for the spawned session")
     .option("--assign-on-github", "Assign the claimed PR to the authenticated GitHub user")
     .option("--decompose", "Decompose issue into subtasks before spawning")
+    .option("--preview-prompt", "Print the composed prompt without creating a session")
     .option("--max-depth <n>", "Max decomposition depth (default: 3)")
     .action(
       async (
@@ -180,6 +234,7 @@ export function registerSpawn(program: Command): void {
           claimPr?: string;
           assignOnGithub?: boolean;
           decompose?: boolean;
+          previewPrompt?: boolean;
           maxDepth?: string;
         },
       ) => {
@@ -228,20 +283,58 @@ export function registerSpawn(program: Command): void {
           assignOnGithub: opts.assignOnGithub,
         };
 
+        const project = config.projects[projectId];
+
+        if (opts.previewPrompt) {
+          try {
+            printPromptPreviewHeader(projectId, issueId);
+
+            if (opts.decompose && issueId) {
+              const spinner = ora("Decomposing task for prompt preview...").start();
+              const plan = await decompose(issueId, getDecomposerConfig(config, projectId, opts.maxDepth));
+              const leaves = getLeaves(plan.tree);
+              spinner.succeed(`Decomposed into ${chalk.bold(String(leaves.length))} subtasks`);
+
+              console.log();
+              console.log(chalk.dim(formatPlanTree(plan.tree)));
+              console.log();
+
+              if (leaves.length <= 1) {
+                printPromptPreview(project, projectId, { issueId });
+              } else {
+                for (const [index, leaf] of leaves.entries()) {
+                  const siblings = getSiblings(plan.tree, leaf.id);
+                  console.log(chalk.bold(`Leaf ${index + 1}: ${leaf.description}`));
+                  console.log();
+                  printPromptPreview(project, projectId, {
+                    issueId,
+                    lineage: leaf.lineage,
+                    siblings,
+                  });
+                  if (index < leaves.length - 1) {
+                    console.log();
+                    console.log(chalk.dim("=".repeat(80)));
+                    console.log();
+                  }
+                }
+              }
+            } else {
+              printPromptPreview(project, projectId, { issueId });
+            }
+            return;
+          } catch (err) {
+            console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+            process.exit(1);
+          }
+        }
+
         try {
           await runSpawnPreflight(config, projectId, claimOptions);
           await ensureLifecycleWorker(config, projectId);
 
           if (opts.decompose && issueId) {
             // Decompose the issue before spawning
-            const project = config.projects[projectId];
-            const decompConfig: DecomposerConfig = {
-              ...DEFAULT_DECOMPOSER_CONFIG,
-              ...(project.decomposer ?? {}),
-              maxDepth: opts.maxDepth
-                ? parseInt(opts.maxDepth, 10)
-                : (project.decomposer?.maxDepth ?? 3),
-            };
+            const decompConfig = getDecomposerConfig(config, projectId, opts.maxDepth);
 
             const spinner = ora("Decomposing task...").start();
             const issueTitle = issueId;


### PR DESCRIPTION
## Summary
- add `--preview-prompt` to `ao spawn` so the composed agent prompt can be printed without creating a session
- support preview output for decomposed spawns so lineage and sibling context are visible per leaf task
- add CLI tests covering plain preview mode and decomposed preview mode

## Why
Developers need a way to inspect the exact prompt layering from project context, rules, and decomposition metadata before committing to a live spawn.

Closes #1077

## Validation
- `pnpm --filter @aoagents/ao-cli test -- --run __tests__/commands/spawn.test.ts`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test` *(fails in unrelated existing `packages/core` suites: `plugin-registry.test.ts` and `plugin-integration.test.ts`)*