### PR TITLE
fix(core): derive activity from runtime probe, not terminal status

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -880,13 +880,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     plugins: ReturnType<typeof resolvePlugins>,
     handleFromMetadata: boolean,
   ): Promise<void> {
-    // Skip all subprocess/IO work for sessions already known to be terminal.
-    if (TERMINAL_SESSION_STATUSES.has(session.status)) {
-      session.activity = "exited";
-      return;
-    }
-
-    // Check runtime liveness — but only if the handle came from metadata.
+    // Check runtime liveness first — regardless of session status.
+    // This fixes #1081: terminal statuses (merged, done, etc.) should not force
+    // activity to "exited" if the agent process is still alive.
     // Fabricated handles (constructed as fallback for external sessions) should
     // NOT override status to "killed" — we don't know if the session ever had
     // a tmux session, and we'd clobber meaningful statuses like "pr_open".
@@ -894,7 +890,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       try {
         const alive = await plugins.runtime.isAlive(session.runtimeHandle);
         if (!alive) {
-          session.status = "killed";
+          // Process is confirmed dead — set activity to exited.
+          // Only update status to "killed" if not already in a terminal state.
+          if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
+            session.status = "killed";
+          }
           session.activity = "exited";
           return;
         }
@@ -903,10 +903,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    // Detect activity independently of runtime handle.
+    // Detect activity independently of runtime handle and session status.
     // Activity detection reads JSONL files on disk — it only needs workspacePath,
     // not a runtime handle. Gating on runtimeHandle caused sessions created by
     // external scripts (which don't store runtimeHandle) to always show "unknown".
+    // This now runs for ALL sessions, including terminal statuses, so a merged
+    // session with a live agent shows accurate activity (ready/idle/waiting_input).
     if (plugins.agent) {
       try {
         const detected = await plugins.agent.getActivityState(session, config.readyThresholdMs);


### PR DESCRIPTION
## Summary

Fixes #1081 — session activity was forced to `exited` when PR merged, even if the agent process was still alive.

## Problem

In `enrichSessionWithRuntimeState()`, terminal statuses (`merged`, `done`, `killed`, `terminated`, `cleanup`) caused an early return that set `activity = "exited"` without checking if the agent process was actually running:

```typescript
// OLD (buggy)
if (TERMINAL_SESSION_STATUSES.has(session.status)) {
  session.activity = "exited";  // ← forced without liveness check
  return;
}
```

This meant:
- **Dashboard lies** — shows `exited` when agent is alive in tmux
- **Stuck-detection misfires** — may kill healthy agents
- **Post-merge work lost** — users can't continue interacting with agent after PR merges

## Root Cause

`status` and `activity` are two independent dimensions:

| Dimension | Source | Meaning |
|-----------|--------|---------|
| `status` | Lifecycle manager polling SCM (PR state, CI checks) | "Where is this session in the workflow?" |
| `activity` | Runtime probe (`isAlive`) + Agent probe (`getActivityState`) | "What is the agent process doing right now?" |

The bug conflated them — terminal status was incorrectly forcing activity state.

## Solution

Reorder the logic so the runtime liveness check runs **first**, regardless of session status:

```typescript
// NEW (fixed)
// 1. Check liveness first — for ALL statuses
if (handleFromMetadata && session.runtimeHandle && plugins.runtime) {
  const alive = await plugins.runtime.isAlive(session.runtimeHandle);
  if (!alive) {
    if (!TERMINAL_SESSION_STATUSES.has(session.status)) {
      session.status = "killed";
    }
    session.activity = "exited";
    return;
  }
}

// 2. Derive activity from agent (same for all statuses)
const detected = await plugins.agent.getActivityState(session);
session.activity = detected?.state;
```

Now:
- Dead process → `activity = "exited"` (regardless of status)
- Alive process → `activity` from `getActivityState()` (regardless of status)
- Terminal status no longer forces `exited`

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| `status=merged`, process alive | `activity=exited` | `activity=ready/idle/active` |
| `status=merged`, process dead | `activity=exited` | `activity=exited` |
| `status=working`, process alive | `activity` from probe | `activity` from probe (unchanged) |
| `status=working`, process dead | `activity=exited` | `activity=exited` (unchanged) |

## Test plan

- [x] All 162 session-manager tests pass
- [ ] Manual test: spawn session → merge PR → verify agent still shows correct activity in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)