### PR TITLE
feat(power): prevent macOS idle sleep while AO is running

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,22 @@ CI fails → agent gets the logs and fixes it. Reviewer requests changes → age
 
 See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the full reference, or run `ao config-help` for the complete schema.
 
+## Remote Access
+
+AO keeps your Mac awake while running, so you can access the dashboard remotely (e.g., via Tailscale from your phone) without the machine going to sleep.
+
+**How it works:** On macOS, AO automatically holds an idle-sleep prevention assertion using `caffeinate`. When AO exits, the assertion is released.
+
+```yaml
+# agent-orchestrator.yaml
+power:
+  preventIdleSleep: true  # Default on macOS, no-op on Linux
+```
+
+Set to `false` if you want to allow idle sleep while AO runs.
+
+**Lid-close limitation:** macOS enforces lid-close sleep at the hardware level — no userspace assertion can override it. If you need remote access while traveling with the lid closed, use [clamshell mode](https://support.apple.com/en-us/102505) (external power + display + input device).
+
 ## Plugin Architecture
 
 Seven plugin slots. Lifecycle stays in core.

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -13,6 +13,13 @@ port: 3000
 # terminalPort: 14800
 # directTerminalPort: 14801
 
+# Power management — controls system sleep while AO is running
+# power:
+#   preventIdleSleep: true  # Default on macOS, no-op on Linux
+#                           # Keeps Mac awake for remote dashboard access (e.g., via Tailscale)
+#                           # Uses caffeinate -i -w <pid> — auto-releases when AO exits
+#                           # Note: lid-close sleep is enforced by hardware and cannot be prevented
+
 # Default plugins (these are the defaults — you can omit this section)
 defaults:
   runtime: tmux           # tmux | process

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ChildProcess } from "node:child_process";
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+
+vi.mock("node:child_process", () => ({
+  spawn: mockSpawn,
+}));
+
+import { preventIdleSleep } from "../../src/lib/prevent-sleep.js";
+
+// Store original platform
+const originalPlatform = process.platform;
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, "platform", { value: platform });
+}
+
+function restorePlatform(): void {
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+}
+
+beforeEach(() => {
+  mockSpawn.mockReset();
+});
+
+afterEach(() => {
+  restorePlatform();
+});
+
+describe("preventIdleSleep", () => {
+  describe("on macOS", () => {
+    beforeEach(() => {
+      setPlatform("darwin");
+    });
+
+    it("spawns caffeinate with correct arguments", () => {
+      const mockChild = {
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "caffeinate",
+        ["-i", "-w", String(process.pid)],
+        { stdio: "ignore", detached: true },
+      );
+      expect(mockChild.unref).toHaveBeenCalled();
+      expect(handle).not.toBeNull();
+    });
+
+    it("spawns caffeinate with custom pid", () => {
+      const mockChild = {
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const customPid = 12345;
+      preventIdleSleep(customPid);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "caffeinate",
+        ["-i", "-w", String(customPid)],
+        { stdio: "ignore", detached: true },
+      );
+    });
+
+    it("returns handle with release function", () => {
+      const mockChild = {
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      expect(handle).not.toBeNull();
+      expect(handle?.release).toBeInstanceOf(Function);
+    });
+
+    it("release function kills the caffeinate process", () => {
+      const mockChild = {
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+      handle?.release();
+
+      expect(mockChild.kill).toHaveBeenCalled();
+    });
+
+    it("release function handles errors silently", () => {
+      const mockChild = {
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn().mockImplementation(() => {
+          throw new Error("Process already dead");
+        }),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      // Should not throw
+      expect(() => handle?.release()).not.toThrow();
+    });
+
+    it("registers error handler for spawn failures", () => {
+      const onMock = vi.fn();
+      const mockChild = {
+        unref: vi.fn(),
+        on: onMock,
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      preventIdleSleep();
+
+      expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+  });
+
+  describe("on non-macOS platforms", () => {
+    it("returns null on Linux", () => {
+      setPlatform("linux");
+
+      const handle = preventIdleSleep();
+
+      expect(handle).toBeNull();
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it("returns null on Windows", () => {
+      setPlatform("win32");
+
+      const handle = preventIdleSleep();
+
+      expect(handle).toBeNull();
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/cli/__tests__/lib/prevent-sleep.test.ts
+++ b/packages/cli/__tests__/lib/prevent-sleep.test.ts
@@ -9,15 +9,23 @@ vi.mock("node:child_process", () => ({
 
 import { preventIdleSleep } from "../../src/lib/prevent-sleep.js";
 
-// Store original platform
-const originalPlatform = process.platform;
+// Store original platform descriptor for safe restoration
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(
+  process,
+  "platform",
+);
 
 function setPlatform(platform: string): void {
-  Object.defineProperty(process, "platform", { value: platform });
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
 }
 
 function restorePlatform(): void {
-  Object.defineProperty(process, "platform", { value: originalPlatform });
+  if (originalPlatformDescriptor) {
+    Object.defineProperty(process, "platform", originalPlatformDescriptor);
+  }
 }
 
 beforeEach(() => {
@@ -36,6 +44,7 @@ describe("preventIdleSleep", () => {
 
     it("spawns caffeinate with correct arguments", () => {
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: vi.fn(),
         kill: vi.fn(),
@@ -55,6 +64,7 @@ describe("preventIdleSleep", () => {
 
     it("spawns caffeinate with custom pid", () => {
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: vi.fn(),
         kill: vi.fn(),
@@ -73,6 +83,7 @@ describe("preventIdleSleep", () => {
 
     it("returns handle with release function", () => {
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: vi.fn(),
         kill: vi.fn(),
@@ -87,6 +98,7 @@ describe("preventIdleSleep", () => {
 
     it("release function kills the caffeinate process", () => {
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: vi.fn(),
         kill: vi.fn(),
@@ -101,6 +113,7 @@ describe("preventIdleSleep", () => {
 
     it("release function handles errors silently", () => {
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: vi.fn(),
         kill: vi.fn().mockImplementation(() => {
@@ -118,6 +131,7 @@ describe("preventIdleSleep", () => {
     it("registers error handler for spawn failures", () => {
       const onMock = vi.fn();
       const mockChild = {
+        pid: 9999,
         unref: vi.fn(),
         on: onMock,
         kill: vi.fn(),
@@ -127,6 +141,21 @@ describe("preventIdleSleep", () => {
       preventIdleSleep();
 
       expect(onMock).toHaveBeenCalledWith("error", expect.any(Function));
+    });
+
+    it("returns null when spawn fails synchronously (no pid)", () => {
+      const mockChild = {
+        pid: undefined,
+        unref: vi.fn(),
+        on: vi.fn(),
+        kill: vi.fn(),
+      } as unknown as ChildProcess;
+      mockSpawn.mockReturnValue(mockChild);
+
+      const handle = preventIdleSleep();
+
+      expect(handle).toBeNull();
+      expect(mockChild.unref).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -51,6 +51,7 @@ import {
 import { rebuildDashboardProductionArtifacts } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
 import { register, unregister, isAlreadyRunning, getRunning, waitForExit } from "../lib/running-state.js";
+import { preventIdleSleep } from "../lib/prevent-sleep.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
 import { detectAgentRuntime, detectAvailableAgents, type DetectedAgent } from "../lib/detect-agent.js";
@@ -921,6 +922,16 @@ async function runStartup(
     await ensureTmux();
   }
   await warnAboutOpenClawStatus(config);
+
+  // Prevent macOS idle sleep while AO is running (if enabled in config)
+  // Uses caffeinate -i -w <pid> to hold an assertion tied to this process lifetime.
+  // No-op on non-macOS platforms.
+  if (config.power?.preventIdleSleep !== false) {
+    const sleepHandle = preventIdleSleep();
+    if (sleepHandle) {
+      console.log(chalk.dim("  Preventing macOS idle sleep while AO is running"));
+    }
+  }
 
   // Only inject OpenClaw credentials when the project actually uses OpenClaw.
   // This avoids exposing API keys to projects/plugins that don't need them.

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -1,0 +1,70 @@
+/**
+ * Idle sleep prevention for macOS.
+ *
+ * Spawns `caffeinate -i -w <pid>` to hold an idle-sleep prevention assertion
+ * for the duration of the AO process. The assertion is automatically released
+ * when the watched process exits (cleanly, on crash, or via kill -9).
+ *
+ * No-op on non-macOS platforms.
+ *
+ * @see https://github.com/ComposioHQ/agent-orchestrator/issues/1072
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+
+export interface SleepPreventionHandle {
+  /** Release the sleep prevention assertion early (optional — auto-releases on process exit) */
+  release: () => void;
+}
+
+/**
+ * Prevent macOS idle sleep for the lifetime of a process.
+ *
+ * @param pid - The process ID to watch. When this process exits, the assertion is released.
+ *              Defaults to the current process.
+ * @returns A handle to release the assertion early, or null if not on macOS.
+ *
+ * @example
+ * ```ts
+ * // Prevent sleep for the current process
+ * const handle = preventIdleSleep();
+ *
+ * // Prevent sleep while a child process runs
+ * const child = spawn("node", ["server.js"]);
+ * const handle = preventIdleSleep(child.pid);
+ * ```
+ */
+export function preventIdleSleep(pid?: number): SleepPreventionHandle | null {
+  // Only supported on macOS
+  if (process.platform !== "darwin") {
+    return null;
+  }
+
+  const targetPid = pid ?? process.pid;
+
+  // Spawn caffeinate:
+  // -i: Create an assertion to prevent idle sleep (works on battery)
+  // -w <pid>: Wait for the specified process to exit, then release the assertion
+  const child: ChildProcess = spawn("caffeinate", ["-i", "-w", String(targetPid)], {
+    stdio: "ignore",
+    detached: true,
+  });
+
+  // Don't keep the Node event loop alive for this child
+  child.unref();
+
+  // Handle spawn errors silently — caffeinate might not exist on old macOS versions
+  child.on("error", () => {
+    // caffeinate not available — silently ignore
+  });
+
+  return {
+    release: () => {
+      try {
+        child.kill();
+      } catch {
+        // Already dead or not killable — ignore
+      }
+    },
+  };
+}

--- a/packages/cli/src/lib/prevent-sleep.ts
+++ b/packages/cli/src/lib/prevent-sleep.ts
@@ -50,6 +50,12 @@ export function preventIdleSleep(pid?: number): SleepPreventionHandle | null {
     detached: true,
   });
 
+  // Check if spawn succeeded — child.pid is undefined if spawn failed synchronously
+  // (e.g., ENOENT when caffeinate doesn't exist)
+  if (child.pid === undefined) {
+    return null;
+  }
+
   // Don't keep the Node event loop alive for this child
   child.unref();
 

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -1087,3 +1087,72 @@ describe("External Plugin Name Generation", () => {
     expect(config.projects.proj1.scm?.plugin).toBe("azure-devops");
   });
 });
+
+describe("Config Validation - Power Config", () => {
+  it("applies default power config with preventIdleSleep based on platform", () => {
+    const config = validateConfig({
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    // Default is true on darwin, false elsewhere
+    expect(config.power).toBeDefined();
+    expect(config.power.preventIdleSleep).toBe(process.platform === "darwin");
+  });
+
+  it("accepts explicit power.preventIdleSleep: true", () => {
+    const config = validateConfig({
+      power: {
+        preventIdleSleep: true,
+      },
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    expect(config.power.preventIdleSleep).toBe(true);
+  });
+
+  it("accepts explicit power.preventIdleSleep: false", () => {
+    const config = validateConfig({
+      power: {
+        preventIdleSleep: false,
+      },
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+        },
+      },
+    });
+
+    expect(config.power.preventIdleSleep).toBe(false);
+  });
+
+  it("rejects invalid power.preventIdleSleep type", () => {
+    expect(() =>
+      validateConfig({
+        power: {
+          preventIdleSleep: "yes", // Invalid: should be boolean
+        },
+        projects: {
+          proj1: {
+            path: "/repos/test",
+            repo: "org/test",
+            defaultBranch: "main",
+          },
+        },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -1102,7 +1102,7 @@ describe("Config Validation - Power Config", () => {
 
     // Default is true on darwin, false elsewhere
     expect(config.power).toBeDefined();
-    expect(config.power.preventIdleSleep).toBe(process.platform === "darwin");
+    expect(config.power!.preventIdleSleep).toBe(process.platform === "darwin");
   });
 
   it("accepts explicit power.preventIdleSleep: true", () => {
@@ -1119,7 +1119,7 @@ describe("Config Validation - Power Config", () => {
       },
     });
 
-    expect(config.power.preventIdleSleep).toBe(true);
+    expect(config.power!.preventIdleSleep).toBe(true);
   });
 
   it("accepts explicit power.preventIdleSleep: false", () => {
@@ -1136,7 +1136,7 @@ describe("Config Validation - Power Config", () => {
       },
     });
 
-    expect(config.power.preventIdleSleep).toBe(false);
+    expect(config.power!.preventIdleSleep).toBe(false);
   });
 
   it("rejects invalid power.preventIdleSleep type", () => {

--- a/packages/core/src/__tests__/observability.test.ts
+++ b/packages/core/src/__tests__/observability.test.ts
@@ -23,6 +23,7 @@ beforeEach(() => {
     configPath,
     port: 3000,
     readyThresholdMs: 300_000,
+    power: { preventIdleSleep: false },
     defaults: {
       runtime: "tmux",
       agent: "claude-code",

--- a/packages/core/src/__tests__/orchestrator-prompt.test.ts
+++ b/packages/core/src/__tests__/orchestrator-prompt.test.ts
@@ -5,6 +5,7 @@ import type { OrchestratorConfig } from "../types.js";
 const config: OrchestratorConfig = {
   configPath: "/tmp/agent-orchestrator.yaml",
   port: 3000,
+  power: { preventIdleSleep: false },
   defaults: {
     runtime: "tmux",
     agent: "claude-code",

--- a/packages/core/src/__tests__/recovery-actions.test.ts
+++ b/packages/core/src/__tests__/recovery-actions.test.ts
@@ -20,6 +20,7 @@ function makeConfig(rootDir: string): OrchestratorConfig {
     configPath: join(rootDir, "agent-orchestrator.yaml"),
     port: 3000,
     readyThresholdMs: 300_000,
+    power: { preventIdleSleep: false },
     defaults: {
       runtime: "tmux",
       agent: "claude-code",

--- a/packages/core/src/__tests__/recovery-validator.test.ts
+++ b/packages/core/src/__tests__/recovery-validator.test.ts
@@ -74,6 +74,7 @@ describe("recovery validator", () => {
       configPath: join(rootDir, "agent-orchestrator.yaml"),
       port: 3000,
       readyThresholdMs: 300_000,
+      power: { preventIdleSleep: false },
       defaults: {
         runtime: "tmux",
         agent: "mock-agent",
@@ -170,6 +171,7 @@ describe("recovery validator", () => {
       configPath: join(rootDir, "agent-orchestrator.yaml"),
       port: 3000,
       readyThresholdMs: 300_000,
+      power: { preventIdleSleep: false },
       defaults: {
         runtime: "tmux",
         agent: "mock-agent",

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -207,6 +207,7 @@ export function createTestEnvironment(): TestEnvironment {
   const config: OrchestratorConfig = {
     configPath,
     port: 3000,
+    power: { preventIdleSleep: false },
     defaults: {
       runtime: "mock",
       agent: "mock-agent",
@@ -278,6 +279,7 @@ export function setupTestContext(): TestContext {
   const config: OrchestratorConfig = {
     configPath,
     port: 3000,
+    power: { preventIdleSleep: false },
     defaults: {
       runtime: "mock",
       agent: "mock-agent",

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -243,11 +243,23 @@ const InstalledPluginConfigSchema = z
     }
   });
 
+const PowerConfigSchema = z
+  .object({
+    /**
+     * Prevent macOS idle sleep while AO is running.
+     * Uses `caffeinate -i -w <pid>` to hold an assertion.
+     * Defaults to true on macOS, no-op on other platforms.
+     */
+    preventIdleSleep: z.boolean().default(process.platform === "darwin"),
+  })
+  .default({});
+
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),
   terminalPort: z.number().optional(),
   directTerminalPort: z.number().optional(),
   readyThresholdMs: z.number().nonnegative().default(300_000),
+  power: PowerConfigSchema,
   defaults: DefaultPluginsSchema.default({}),
   plugins: z.array(InstalledPluginConfigSchema).default([]),
   projects: z.record(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1003,6 +1003,19 @@ export interface ReactionResult {
 // CONFIGURATION
 // =============================================================================
 
+/**
+ * Power management configuration.
+ * Controls system sleep behavior while AO is running.
+ */
+export interface PowerConfig {
+  /**
+   * Prevent macOS idle sleep while AO is running.
+   * Uses `caffeinate -i -w <pid>` to hold an assertion.
+   * Defaults to true on macOS, no-op on other platforms.
+   */
+  preventIdleSleep: boolean;
+}
+
 /** Top-level orchestrator configuration (from agent-orchestrator.yaml) */
 export interface OrchestratorConfig {
   /**
@@ -1023,6 +1036,9 @@ export interface OrchestratorConfig {
 
   /** Milliseconds before a "ready" session becomes "idle" (default: 300000 = 5 min) */
   readyThresholdMs: number;
+
+  /** Power management settings (idle sleep prevention, etc.) */
+  power: PowerConfig;
 
   /** Default plugin selections */
   defaults: DefaultPlugins;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1037,8 +1037,8 @@ export interface OrchestratorConfig {
   /** Milliseconds before a "ready" session becomes "idle" (default: 300000 = 5 min) */
   readyThresholdMs: number;
 
-  /** Power management settings (idle sleep prevention, etc.) */
-  power: PowerConfig;
+  /** Power management settings (idle sleep prevention, etc.). Populated with defaults post-validation. */
+  power?: PowerConfig;
 
   /** Default plugin selections */
   defaults: DefaultPlugins;

--- a/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
+++ b/packages/integration-tests/src/cli-spawn-core-read-new.integration.test.ts
@@ -157,6 +157,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
       configPath, // This enables hash-based architecture
       port: 3000,
       readyThresholdMs: 300_000,
+      power: { preventIdleSleep: false },
       defaults: {
         runtime: "tmux",
         agent: "claude-code",
@@ -217,6 +218,7 @@ describe.skipIf(!tmuxOk)("CLI-Core integration (hash-based architecture)", () =>
       configPath,
       port: 3000,
       readyThresholdMs: 300_000,
+      power: { preventIdleSleep: false },
       defaults: {
         runtime: "tmux",
         agent: "claude-code",


### PR DESCRIPTION
## Summary
- Add `preventIdleSleep()` helper using `caffeinate -i -w <pid>` on macOS
- Add `power.preventIdleSleep` config option (defaults to true on darwin)
- Wire sleep prevention into `ao start` command to keep Mac awake for remote dashboard access
- Document the feature in README and example config

## Test plan
- [ ] Verify `preventIdleSleep()` spawns caffeinate on macOS
- [ ] Verify `preventIdleSleep()` returns null on Linux
- [ ] Verify config validation accepts/rejects power settings
- [ ] Verify `ao start` shows "Preventing macOS idle sleep" message on macOS
- [ ] Verify assertion releases when AO exits

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)