### PR TITLE
fix(core): skip opencode session list spawn for terminal sessions

### DIFF
--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -408,6 +408,166 @@ describe("list", () => {
     // lastActivityAt should NOT be downgraded to the older detection timestamp
     expect(sessions[0].lastActivityAt.getTime()).toBeGreaterThan(olderTimestamp.getTime());
   });
+
+  // Regression tests for issue #1120: terminal opencode sessions must not
+  // trigger `opencode session list` subprocess spawns on every refresh.
+  describe("opencode session list spawning (issue #1120)", () => {
+    function makeOpenCodeListLogPath(): string {
+      return join(tmpDir, `opencode-list-${Math.random().toString(36).slice(2)}.log`);
+    }
+
+    function readListInvocations(listLogPath: string): string[] {
+      try {
+        return readFileSync(listLogPath, "utf-8").trim().split("\n").filter(Boolean);
+      } catch {
+        return [];
+      }
+    }
+
+    it("does not spawn opencode session list when all opencode sessions are killed", async () => {
+      const listLogPath = makeOpenCodeListLogPath();
+      const deleteLogPath = join(tmpDir, "opencode-delete-killed.log");
+      const mockBin = installMockOpencode(
+        tmpDir,
+        JSON.stringify([{ id: "ses_orphan", title: "AO:app-1" }]),
+        deleteLogPath,
+        0,
+        listLogPath,
+      );
+      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp",
+        branch: "a",
+        status: "killed",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+      });
+      writeMetadata(sessionsDir, "app-2", {
+        worktree: "/tmp",
+        branch: "b",
+        status: "merged",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-2")),
+      });
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sessions = await sm.list();
+
+      expect(sessions).toHaveLength(2);
+      expect(readListInvocations(listLogPath)).toHaveLength(0);
+    });
+
+    it("does not spawn opencode session list when there are zero opencode sessions", async () => {
+      const listLogPath = makeOpenCodeListLogPath();
+      const deleteLogPath = join(tmpDir, "opencode-delete-none.log");
+      const mockBin = installMockOpencode(
+        tmpDir,
+        JSON.stringify([]),
+        deleteLogPath,
+        0,
+        listLogPath,
+      );
+      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp",
+        branch: "a",
+        status: "working",
+        project: "my-app",
+        agent: "claude-code",
+        runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+      });
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sessions = await sm.list();
+
+      expect(sessions).toHaveLength(1);
+      expect(readListInvocations(listLogPath)).toHaveLength(0);
+    });
+
+    it(
+      "spawns opencode session list exactly once when at least one opencode session is non-terminal, " +
+        "regardless of how many terminal opencode sessions exist",
+      async () => {
+        const listLogPath = makeOpenCodeListLogPath();
+        const deleteLogPath = join(tmpDir, "opencode-delete-mixed.log");
+        const mockBin = installMockOpencode(
+          tmpDir,
+          JSON.stringify([{ id: "ses_live", title: "AO:app-live" }]),
+          deleteLogPath,
+          0,
+          listLogPath,
+        );
+        process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+        // Two killed opencode sessions...
+        writeMetadata(sessionsDir, "app-killed-1", {
+          worktree: "/tmp",
+          branch: "a",
+          status: "killed",
+          project: "my-app",
+          agent: "opencode",
+          runtimeHandle: JSON.stringify(makeHandle("rt-killed-1")),
+        });
+        writeMetadata(sessionsDir, "app-killed-2", {
+          worktree: "/tmp",
+          branch: "b",
+          status: "merged",
+          project: "my-app",
+          agent: "opencode",
+          runtimeHandle: JSON.stringify(makeHandle("rt-killed-2")),
+        });
+        // ...plus one live opencode session that needs mapping discovery.
+        writeMetadata(sessionsDir, "app-live", {
+          worktree: "/tmp",
+          branch: "c",
+          status: "working",
+          project: "my-app",
+          agent: "opencode",
+          runtimeHandle: JSON.stringify(makeHandle("rt-live")),
+        });
+
+        const sm = createSessionManager({ config, registry: mockRegistry });
+        const sessions = await sm.list();
+
+        expect(sessions).toHaveLength(3);
+        expect(readListInvocations(listLogPath)).toHaveLength(1);
+        expect(readMetadataRaw(sessionsDir, "app-live")?.["opencodeSessionId"]).toBe("ses_live");
+      },
+    );
+
+    it("does not spawn opencode session list when the only opencode session is already mapped", async () => {
+      const listLogPath = makeOpenCodeListLogPath();
+      const deleteLogPath = join(tmpDir, "opencode-delete-mapped.log");
+      const mockBin = installMockOpencode(
+        tmpDir,
+        JSON.stringify([{ id: "ses_existing", title: "AO:app-1" }]),
+        deleteLogPath,
+        0,
+        listLogPath,
+      );
+      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: "/tmp",
+        branch: "a",
+        status: "working",
+        project: "my-app",
+        agent: "opencode",
+        opencodeSessionId: "ses_existing",
+        runtimeHandle: JSON.stringify(makeHandle("rt-1")),
+      });
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sessions = await sm.list();
+
+      expect(sessions).toHaveLength(1);
+      expect(readListInvocations(listLogPath)).toHaveLength(0);
+    });
+  });
 });
 
 describe("get", () => {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -194,6 +194,14 @@ function getSessionNumber(sessionId: string, prefix: string): number | undefined
   return Number.isNaN(parsed) ? undefined : parsed;
 }
 
+const TERMINAL_SESSION_STATUSES: ReadonlySet<string> = new Set([
+  "killed",
+  "done",
+  "merged",
+  "terminated",
+  "cleanup",
+]);
+
 const PR_TRACKING_STATUSES: ReadonlySet<string> = new Set([
   "pr_open",
   "ci_failed",
@@ -779,11 +787,18 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionName: string,
     sessionsDir: string,
     effectiveAgentName: string,
-    sessionListPromise?: Promise<OpenCodeSessionListEntry[]>,
+    sessionListGetter?: () => Promise<OpenCodeSessionListEntry[]>,
   ): Promise<void> {
     if (effectiveAgentName !== "opencode") return;
+    // Skip subprocess work for sessions already known to be terminal — there is
+    // nothing to discover and the agent's opencode session is irrelevant.
+    if (TERMINAL_SESSION_STATUSES.has(session.status)) return;
     if (asValidOpenCodeSessionId(session.metadata["opencodeSessionId"])) return;
 
+    // Only materialize the (memoized) session list promise after the early
+    // returns above — otherwise we spawn `opencode session list` for terminal
+    // and already-mapped sessions on every refresh. See issue #1120.
+    const sessionListPromise = sessionListGetter?.();
     const discovered = await discoverOpenCodeSessionIdByTitle(
       sessionName,
       OPENCODE_DISCOVERY_TIMEOUT_MS,
@@ -839,14 +854,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     project: ProjectConfig,
     effectiveAgentName: string,
     plugins: ReturnType<typeof resolvePlugins>,
-    sessionListPromise?: Promise<OpenCodeSessionListEntry[]>,
+    sessionListGetter?: () => Promise<OpenCodeSessionListEntry[]>,
   ): Promise<void> {
     await ensureOpenCodeSessionMapping(
       session,
       sessionName,
       sessionsDir,
       effectiveAgentName,
-      sessionListPromise,
+      sessionListGetter,
     );
 
     const tmuxNameFromMetadata = session.metadata["tmuxName"]?.trim();
@@ -873,8 +888,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
    * Enrich session with live runtime state (alive/exited) and activity detection.
    * Mutates the session object in place.
    */
-  const TERMINAL_SESSION_STATUSES = new Set(["killed", "done", "merged", "terminated", "cleanup"]);
-
   async function enrichSessionWithRuntimeState(
     session: Session,
     plugins: ReturnType<typeof resolvePlugins>,
@@ -1521,7 +1534,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         raw: record.raw,
       }));
     });
+    // Lazily fetch the OpenCode session list at most once per list() call, and
+    // only when we actually need it. The thunk is passed all the way down to
+    // ensureOpenCodeSessionMapping, which only invokes it after its early
+    // returns (wrong agent / terminal status / already-mapped). This prevents
+    // spawning `opencode session list` for refreshes that have nothing live to
+    // resolve. See issue #1120.
     let openCodeSessionListPromise: Promise<OpenCodeSessionListEntry[]> | undefined;
+    const getOpenCodeSessionList = (): Promise<OpenCodeSessionListEntry[]> =>
+      (openCodeSessionListPromise ??= fetchOpenCodeSessionList());
 
     const tasks = allSessions.map(async ({ sessionName, projectId: sessionProjectId, raw }) => {
       const project = config.projects[sessionProjectId];
@@ -1544,10 +1565,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const selection = resolveSelectionForSession(project, sessionName, raw);
       const effectiveAgentName = selection.agentName;
       const plugins = resolvePlugins(project, effectiveAgentName);
-      const sessionListPromise =
-        effectiveAgentName === "opencode"
-          ? (openCodeSessionListPromise ??= fetchOpenCodeSessionList())
-          : undefined;
+      const sessionListGetter =
+        effectiveAgentName === "opencode" ? getOpenCodeSessionList : undefined;
 
       let enrichTimeoutId: ReturnType<typeof setTimeout> | null = null;
       const enrichTimeout = new Promise<void>((resolve) => {
@@ -1560,7 +1579,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         project,
         effectiveAgentName,
         plugins,
-        sessionListPromise,
+        sessionListGetter,
       ).catch(() => {});
       try {
         await Promise.race([enrichPromise, enrichTimeout]);


### PR DESCRIPTION
## Summary

Fixes ComposioHQ/agent-orchestrator#1120 — killed/done/merged OpenCode sessions still spawned `opencode session list --format json` on every dashboard refresh.

- Convert the per-`list()` memoized OpenCode session list promise from an eager `Promise` to a lazy thunk. The subprocess is now only started when `ensureOpenCodeSessionMapping` actually needs it — i.e. for an OpenCode session that is non-terminal and does not already have a mapped `opencodeSessionId`.
- Add a `TERMINAL_SESSION_STATUSES` early return inside `ensureOpenCodeSessionMapping` so terminal sessions cannot trigger discovery even via `get()`.
- Promote `TERMINAL_SESSION_STATUSES` to module scope so it is shared by `enrichSessionWithRuntimeState`, `ensureOpenCodeSessionMapping`, and any future call sites.

Net effect: with N killed and 0 live OpenCode sessions, `list()` produces **zero** `opencode` subprocess spawns; with 1 live and N killed, exactly **one** spawn per call (down from N+1 today and 1 forever after #1118).

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` — 589 tests pass across 28 files
- [x] New `query.test.ts` cases (under `describe("opencode session list spawning (issue #1120)")`):
  - [x] all-killed → 0 spawns
  - [x] zero-opencode → 0 spawns
  - [x] mixed killed + 1 live → exactly 1 spawn, mapping persisted
  - [x] already-mapped live → 0 spawns
- [ ] Manual: spawn 1 opencode session, kill it, leave dashboard idle 60s, watch `pgrep -afc 'opencode session list'` stays at 0