### PR TITLE
fix(cli): update stale ao-core imports

### DIFF
--- a/packages/cli/__tests__/index.test.ts
+++ b/packages/cli/__tests__/index.test.ts
@@ -21,7 +21,7 @@ describe("cli entrypoint", () => {
   });
 
   it("prints a clean message and exits 1 on ConfigNotFoundError", async () => {
-    const { ConfigNotFoundError } = await import("@composio/ao-core");
+    const { ConfigNotFoundError } = await import("@aoagents/ao-core");
     const error = new ConfigNotFoundError();
     let rejectionHandler:
       | ((reason: unknown) => unknown)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { ConfigNotFoundError } from "@composio/ao-core";
+import { ConfigNotFoundError } from "@aoagents/ao-core";
 import { createProgram } from "./program.js";
 
 createProgram()


### PR DESCRIPTION
Fixes #1143

## What Changed

- Updated the stale `@composio/ao-core` import in `packages/cli/src/index.ts` to `@aoagents/ao-core`
- Updated the matching CLI entrypoint test import in `packages/cli/__tests__/index.test.ts`
