### PR TITLE
fix(cli): prevent duplicate YAML entry on already-running `ao start`

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -51,6 +51,21 @@ const { mockProcessCwd } = vi.hoisted(() => ({
   mockProcessCwd: vi.fn<[], string>(),
 }));
 
+const { mockPromptSelect, mockPromptConfirm } = vi.hoisted(() => ({
+  mockPromptSelect: vi.fn(),
+  mockPromptConfirm: vi.fn().mockResolvedValue(true),
+}));
+
+const { mockIsAlreadyRunning, mockUnregister, mockWaitForExit } = vi.hoisted(() => ({
+  mockIsAlreadyRunning: vi.fn().mockReturnValue(null),
+  mockUnregister: vi.fn(),
+  mockWaitForExit: vi.fn().mockReturnValue(true),
+}));
+
+const { mockIsHumanCaller } = vi.hoisted(() => ({
+  mockIsHumanCaller: vi.fn().mockReturnValue(true),
+}));
+
 vi.mock("../../src/lib/shell.js", () => ({
   tmux: vi.fn(),
   exec: mockExec,
@@ -126,14 +141,14 @@ vi.mock("../../src/lib/preflight.js", () => ({
 
 vi.mock("../../src/lib/running-state.js", () => ({
   register: vi.fn(),
-  unregister: vi.fn(),
-  isAlreadyRunning: vi.fn().mockReturnValue(null),
+  unregister: (...args: unknown[]) => mockUnregister(...args),
+  isAlreadyRunning: (...args: unknown[]) => mockIsAlreadyRunning(...args),
   getRunning: vi.fn().mockReturnValue(null),
-  waitForExit: vi.fn().mockReturnValue(true),
+  waitForExit: (...args: unknown[]) => mockWaitForExit(...args),
 }));
 
 vi.mock("../../src/lib/caller-context.js", () => ({
-  isHumanCaller: vi.fn().mockReturnValue(true),
+  isHumanCaller: (...args: unknown[]) => mockIsHumanCaller(...args),
   getCallerType: vi.fn().mockReturnValue("human"),
 }));
 
@@ -158,6 +173,11 @@ vi.mock("../../src/lib/project-detection.js", () => ({
 
 vi.mock("../../src/lib/openclaw-probe.js", () => ({
   detectOpenClawInstallation: (...args: unknown[]) => mockDetectOpenClawInstallation(...args),
+}));
+
+vi.mock("../../src/lib/prompts.js", () => ({
+  promptSelect: (...args: unknown[]) => mockPromptSelect(...args),
+  promptConfirm: (...args: unknown[]) => mockPromptConfirm(...args),
 }));
 
 // Mock node:child_process — start.ts imports spawn for dashboard + browser open
@@ -245,6 +265,16 @@ beforeEach(() => {
   });
   mockSpawn.mockClear();
   mockProcessCwd.mockReset();
+  mockPromptSelect.mockReset();
+  mockPromptConfirm.mockReset();
+  mockPromptConfirm.mockResolvedValue(true);
+  mockIsAlreadyRunning.mockReset();
+  mockIsAlreadyRunning.mockResolvedValue(null);
+  mockUnregister.mockReset();
+  mockWaitForExit.mockReset();
+  mockWaitForExit.mockResolvedValue(true);
+  mockIsHumanCaller.mockReset();
+  mockIsHumanCaller.mockReturnValue(true);
 });
 
 afterEach(() => {
@@ -690,8 +720,7 @@ describe("start command — non-interactive install safety", () => {
   }
 
   it("does not auto-install tmux when missing in non-interactive mode", async () => {
-    const { isHumanCaller } = await import("../../src/lib/caller-context.js");
-    vi.mocked(isHumanCaller).mockReturnValue(false);
+    mockIsHumanCaller.mockReturnValue(false);
 
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     mockExecSilent.mockImplementation(async (cmd: string, args: string[] = []) => {
@@ -711,8 +740,7 @@ describe("start command — non-interactive install safety", () => {
   });
 
   it("does not auto-install git when missing in non-interactive URL start", async () => {
-    const { isHumanCaller } = await import("../../src/lib/caller-context.js");
-    vi.mocked(isHumanCaller).mockReturnValue(false);
+    mockIsHumanCaller.mockReturnValue(false);
 
     mockCwd(tmpDir);
     mockExecSilent.mockImplementation(async (cmd: string, args: string[] = []) => {
@@ -1109,5 +1137,289 @@ describe("start command — autoCreateConfig", () => {
     const content = readFileSync(configPath, "utf-8");
     const parsed = parseYaml(content) as { defaults?: { notifiers?: unknown[] } };
     expect(parsed.defaults?.notifiers).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Already-running detection (moved before config mutation)
+// ---------------------------------------------------------------------------
+
+describe("start command — already-running detection", () => {
+  it("exits immediately for non-TTY caller when AO is already running", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockIsHumanCaller.mockReturnValue(false);
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    // process.exit(0) throws in tests, caught by the action's catch block which calls exit(1)
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    // Verify the already-running message was printed (not a config error)
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("AO is already running");
+    expect(output).toContain("PID: 9999");
+  });
+
+  it("exits when human caller selects 'quit'", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockPromptSelect.mockResolvedValue("quit");
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("AO is already running");
+  });
+
+  it("exits when human caller selects 'open'", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockPromptSelect.mockResolvedValue("open");
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("AO is already running");
+  });
+
+  it("kills existing process and continues when human caller selects 'restart'", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockWaitForExit.mockResolvedValue(true);
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    mockPromptSelect.mockResolvedValue("restart");
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    // After restart the startup flow continues — it may succeed or fail
+    // depending on infrastructure mocks, so we just verify the restart actions
+    try {
+      await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+    } catch {
+      // Startup after restart may throw — that's OK for this test
+    }
+
+    expect(killSpy).toHaveBeenCalledWith(9999, "SIGTERM");
+    expect(mockUnregister).toHaveBeenCalled();
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("Stopped existing instance");
+
+    killSpy.mockRestore();
+  });
+
+  it("creates new orchestrator entry when human caller selects 'new'", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockPromptSelect.mockResolvedValue("new");
+
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+    writeFileSync(
+      configPath,
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            "my-app": {
+              name: "My App",
+              repo: "org/my-app",
+              path: join(tmpDir, "main-repo"),
+              defaultBranch: "main",
+              sessionPrefix: "app",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    (mockConfigRef.current as Record<string, unknown>).configPath = configPath;
+
+    // After "new" the startup flow continues — it may fail on infrastructure
+    try {
+      await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+    } catch {
+      // Startup may throw — that's OK for this test
+    }
+
+    // Verify a new orchestrator entry was added to the YAML
+    const updatedContent = readFileSync(configPath, "utf-8");
+    const updatedConfig = parseYaml(updatedContent) as { projects: Record<string, unknown> };
+    const projectKeys = Object.keys(updatedConfig.projects);
+    expect(projectKeys.length).toBe(2);
+    expect(projectKeys).toContain("my-app");
+    // The new entry should have a suffix like "my-app-xxxx"
+    const newKey = projectKeys.find((k) => k !== "my-app");
+    expect(newKey).toMatch(/^my-app-/);
+  });
+
+  it("does not mutate YAML when non-TTY caller detects already running (path arg)", async () => {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/fake/config.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["my-app"],
+    });
+
+    mockIsHumanCaller.mockReturnValue(false);
+
+    const repoDir = join(tmpDir, "some-project");
+    createFakeRepo(repoDir, "https://github.com/org/some-project.git");
+
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+    const originalYaml = yamlStringify(
+      {
+        defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+        projects: {
+          "my-app": {
+            name: "My App",
+            repo: "org/my-app",
+            path: join(tmpDir, "main-repo"),
+            defaultBranch: "main",
+            sessionPrefix: "app",
+          },
+        },
+      },
+      { indent: 2 },
+    );
+    writeFileSync(configPath, originalYaml);
+
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockCwd(tmpDir);
+
+    // process.exit(0) throws, caught by catch block which calls exit(1)
+    await expect(
+      program.parseAsync(["node", "test", "start", repoDir, "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    // Verify the already-running message was printed
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("AO is already running");
+
+    // YAML should be unchanged — no duplicate entry added
+    const afterYaml = readFileSync(configPath, "utf-8");
+    expect(afterYaml).toBe(originalYaml);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// addProjectToConfig — path-based deduplication
+// ---------------------------------------------------------------------------
+
+describe("start command — path-based deduplication in addProjectToConfig", () => {
+  it("returns existing project ID when path is already configured", async () => {
+    // This test verifies that addProjectToConfig() detects an existing project
+    // by path (not just name) and returns the existing ID without creating a duplicate.
+    // We use createConfigOnly + path arg flow through ao-core's real loadConfig.
+    const repoDir = join(tmpDir, "my-app");
+    createFakeRepo(repoDir, "https://github.com/org/my-app.git");
+
+    // Create a config file that already has this path registered
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+    const yamlContent = {
+      defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+      projects: {
+        "my-app": {
+          name: "My App",
+          repo: "org/my-app",
+          path: repoDir,
+          defaultBranch: "main",
+          sessionPrefix: "app",
+        },
+      },
+    };
+    writeFileSync(configPath, yamlStringify(yamlContent, { indent: 2 }));
+
+    // Directly import and call addProjectToConfig to test path dedup
+    // We need the real addProjectToConfig, but it's not exported.
+    // Instead, verify via the path-argument branch:
+    // When findConfigFile returns our config, the path-match check at line 1253-1260
+    // should find the existing entry and skip addProjectToConfig.
+    // But if that check were removed, addProjectToConfig's own path dedup would
+    // catch it. To test addProjectToConfig directly, we'd need it exported.
+    //
+    // Instead, verify the existing path-match works by checking config is unchanged.
+    mockConfigRef.current = {
+      ...makeConfig({ "my-app": makeProject({ path: repoDir }) }),
+      configPath,
+    };
+
+    // Simulate the path-argument branch by using a project ID that matches
+    // Use no-arg branch with config already loaded
+    await program.parseAsync([
+      "node",
+      "test",
+      "start",
+      "--no-dashboard",
+      "--no-orchestrator",
+    ]);
+
+    // Verify no duplicate entry was created
+    const content = readFileSync(configPath, "utf-8");
+    const parsed = parseYaml(content) as { projects: Record<string, unknown> };
+    expect(Object.keys(parsed.projects)).toEqual(["my-app"]);
   });
 });

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -395,6 +395,9 @@ describe("start command — project resolution", () => {
   });
 
   it("errors when multiple projects and no arg", async () => {
+    // Non-interactive callers get an error instead of a prompt
+    mockIsHumanCaller.mockReturnValue(false);
+
     mockConfigRef.current = makeConfig({
       frontend: makeProject({ name: "Frontend" }),
       backend: makeProject({ name: "Backend" }),

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1372,57 +1372,110 @@ describe("start command — already-running detection", () => {
 // ---------------------------------------------------------------------------
 
 describe("start command — path-based deduplication in addProjectToConfig", () => {
-  it("returns existing project ID when path is already configured", async () => {
-    // This test verifies that addProjectToConfig() detects an existing project
-    // by path (not just name) and returns the existing ID without creating a duplicate.
-    // We use createConfigOnly + path arg flow through ao-core's real loadConfig.
+  it("skips addProjectToConfig when path arg matches an existing project", async () => {
+    // Pass a local path that's already registered in config.
+    // The path-argument branch should find the existing entry and skip addProjectToConfig.
     const repoDir = join(tmpDir, "my-app");
     createFakeRepo(repoDir, "https://github.com/org/my-app.git");
 
-    // Create a config file that already has this path registered
     const configPath = join(tmpDir, "agent-orchestrator.yaml");
     const { stringify: yamlStringify } = await import("yaml");
-    const yamlContent = {
-      defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
-      projects: {
-        "my-app": {
-          name: "My App",
-          repo: "org/my-app",
-          path: repoDir,
-          defaultBranch: "main",
-          sessionPrefix: "app",
-        },
-      },
-    };
-    writeFileSync(configPath, yamlStringify(yamlContent, { indent: 2 }));
-
-    // Directly import and call addProjectToConfig to test path dedup
-    // We need the real addProjectToConfig, but it's not exported.
-    // Instead, verify via the path-argument branch:
-    // When findConfigFile returns our config, the path-match check at line 1253-1260
-    // should find the existing entry and skip addProjectToConfig.
-    // But if that check were removed, addProjectToConfig's own path dedup would
-    // catch it. To test addProjectToConfig directly, we'd need it exported.
-    //
-    // Instead, verify the existing path-match works by checking config is unchanged.
-    mockConfigRef.current = {
-      ...makeConfig({ "my-app": makeProject({ path: repoDir }) }),
+    writeFileSync(
       configPath,
-    };
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            "my-app": {
+              name: "My App",
+              repo: "org/my-app",
+              path: repoDir,
+              defaultBranch: "main",
+              sessionPrefix: "app",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
 
-    // Simulate the path-argument branch by using a project ID that matches
-    // Use no-arg branch with config already loaded
-    await program.parseAsync([
-      "node",
-      "test",
-      "start",
-      "--no-dashboard",
-      "--no-orchestrator",
-    ]);
+    // Set AO_CONFIG_PATH so findConfigFile() finds our config in the path-arg branch
+    const origEnv = process.env["AO_CONFIG_PATH"];
+    process.env["AO_CONFIG_PATH"] = configPath;
 
-    // Verify no duplicate entry was created
-    const content = readFileSync(configPath, "utf-8");
-    const parsed = parseYaml(content) as { projects: Record<string, unknown> };
-    expect(Object.keys(parsed.projects)).toEqual(["my-app"]);
+    try {
+      // Pass repoDir as a local path arg — enters the path-argument branch
+      await program.parseAsync([
+        "node",
+        "test",
+        "start",
+        repoDir,
+        "--no-dashboard",
+        "--no-orchestrator",
+      ]);
+
+      // Verify no duplicate entry was created in the YAML
+      const content = readFileSync(configPath, "utf-8");
+      const parsed = parseYaml(content) as { projects: Record<string, unknown> };
+      expect(Object.keys(parsed.projects)).toEqual(["my-app"]);
+    } finally {
+      if (origEnv === undefined) delete process.env["AO_CONFIG_PATH"];
+      else process.env["AO_CONFIG_PATH"] = origEnv;
+    }
+  });
+
+  it("deduplicates via addProjectToConfig when path exists under a different name", async () => {
+    // Register a project under name "old-name" pointing to repoDir.
+    // Then pass repoDir as a path arg with a config that doesn't match by name.
+    // addProjectToConfig's path dedup should return "old-name" without creating a duplicate.
+    const repoDir = join(tmpDir, "new-project");
+    createFakeRepo(repoDir, "https://github.com/org/new-project.git");
+
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+    writeFileSync(
+      configPath,
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            "old-name": {
+              name: "Old Name",
+              repo: "org/new-project",
+              path: repoDir,
+              defaultBranch: "main",
+              sessionPrefix: "old",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
+
+    // Set AO_CONFIG_PATH so findConfigFile() finds our config
+    const origEnv = process.env["AO_CONFIG_PATH"];
+    process.env["AO_CONFIG_PATH"] = configPath;
+
+    try {
+      // Pass repoDir as path arg. The path-argument branch's path-match check
+      // at lines 1304-1311 finds "old-name" by path and skips addProjectToConfig.
+      // If that outer check were removed, addProjectToConfig's own dedup (lines 656-665)
+      // would catch it. Either way, no duplicate entry should be created.
+      await program.parseAsync([
+        "node",
+        "test",
+        "start",
+        repoDir,
+        "--no-dashboard",
+        "--no-orchestrator",
+      ]);
+
+      const content = readFileSync(configPath, "utf-8");
+      const parsed = parseYaml(content) as { projects: Record<string, unknown> };
+      expect(Object.keys(parsed.projects)).toEqual(["old-name"]);
+    } finally {
+      if (origEnv === undefined) delete process.env["AO_CONFIG_PATH"];
+      else process.env["AO_CONFIG_PATH"] = origEnv;
+    }
   });
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -651,6 +651,16 @@ async function addProjectToConfig(
   await ensureGit("adding projects");
 
   const resolvedPath = resolve(projectPath.replace(/^~/, process.env["HOME"] || ""));
+
+  // Check if this path is already registered under any project name
+  const existingByPath = Object.entries(config.projects).find(
+    ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
+  );
+  if (existingByPath) {
+    console.log(chalk.dim(`  Path already configured as project "${existingByPath[0]}" — skipping add.`));
+    return existingByPath[0];
+  }
+
   let projectId = basename(resolvedPath);
 
   // Avoid overwriting an existing project with the same directory name
@@ -1214,6 +1224,57 @@ export function registerStart(program: Command): void {
           let projectId: string;
           let project: ProjectConfig;
 
+          // ── Already-running detection (before any config mutation) ──
+          const running = await isAlreadyRunning();
+          let startNewOrchestrator = false;
+          if (running) {
+            if (isHumanCaller()) {
+              console.log(chalk.cyan(`\nℹ AO is already running.`));
+              console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
+              console.log(`  PID: ${running.pid} | Up since: ${running.startedAt}`);
+              console.log(`  Projects: ${running.projects.join(", ")}\n`);
+
+              const choice = await promptSelect(
+                "AO is already running. What do you want to do?",
+                [
+                  { value: "open", label: "Open dashboard", hint: "Keep the current instance" },
+                  { value: "new", label: "Start new orchestrator", hint: "Add a new session for this project" },
+                  { value: "restart", label: "Restart everything", hint: "Stop the current instance first" },
+                  { value: "quit", label: "Quit" },
+                ],
+                "open",
+              );
+
+              if (choice === "open") {
+                const url = `http://localhost:${running.port}`;
+                openUrl(url);
+                process.exit(0);
+              } else if (choice === "new") {
+                // Defer config mutation until after config is loaded below
+                startNewOrchestrator = true;
+              } else if (choice === "restart") {
+                try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
+                if (!(await waitForExit(running.pid, 5000))) {
+                  console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
+                  try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
+                }
+                await unregister();
+                console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));
+                // Continue to startup below
+              } else {
+                process.exit(0);
+              }
+            } else {
+              // Agent/non-TTY caller — print info and exit
+              console.log(`AO is already running.`);
+              console.log(`Dashboard: http://localhost:${running.port}`);
+              console.log(`PID: ${running.pid}`);
+              console.log(`Projects: ${running.projects.join(", ")}`);
+              console.log(`To restart: ao stop && ao start`);
+              process.exit(0);
+            }
+          }
+
           if (projectArg && isRepoUrl(projectArg)) {
             // ── URL argument: clone + auto-config + start ──
             console.log(chalk.bold.cyan("\n  Agent Orchestrator — Quick Start\n"));
@@ -1281,81 +1342,35 @@ export function registerStart(program: Command): void {
             ({ projectId, project } = await resolveProject(config, projectArg));
           }
 
-          // ── Already-running detection (Step 9) ──
-          const running = await isAlreadyRunning();
-          if (running) {
-            if (isHumanCaller()) {
-              console.log(chalk.cyan(`\nℹ AO is already running.`));
-              console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
-              console.log(`  PID: ${running.pid} | Up since: ${running.startedAt}`);
-              console.log(`  Projects: ${running.projects.join(", ")}\n`);
+          // ── Handle "new orchestrator" choice (deferred from already-running check) ──
+          if (startNewOrchestrator) {
+            const rawYaml = readFileSync(config.configPath, "utf-8");
+            const rawConfig = yamlParse(rawYaml);
 
-              const choice = await promptSelect(
-                "AO is already running. What do you want to do?",
-                [
-                  { value: "open", label: "Open dashboard", hint: "Keep the current instance" },
-                  { value: "new", label: "Start new orchestrator", hint: "Add a new session for this project" },
-                  { value: "restart", label: "Restart everything", hint: "Stop the current instance first" },
-                  { value: "quit", label: "Quit" },
-                ],
-                "open",
-              );
+            // Collect existing prefixes to avoid collisions
+            const existingPrefixes = new Set(
+              Object.values(rawConfig.projects as Record<string, Record<string, unknown>>).map(
+                (p) => p.sessionPrefix as string,
+              ).filter(Boolean),
+            );
 
-              if (choice === "open") {
-                const url = `http://localhost:${running.port}`;
-                openUrl(url);
-                process.exit(0);
-              } else if (choice === "new") {
-                // Generate unique orchestrator: same project, new session
-                const rawYaml = readFileSync(config.configPath, "utf-8");
-                const rawConfig = yamlParse(rawYaml);
+            let newId: string;
+            let newPrefix: string;
+            do {
+              const suffix = Math.random().toString(36).slice(2, 6);
+              newId = `${projectId}-${suffix}`;
+              newPrefix = generateSessionPrefix(newId);
+            } while (rawConfig.projects[newId] || existingPrefixes.has(newPrefix));
 
-                // Collect existing prefixes to avoid collisions
-                const existingPrefixes = new Set(
-                  Object.values(rawConfig.projects as Record<string, Record<string, unknown>>).map(
-                    (p) => p.sessionPrefix as string,
-                  ).filter(Boolean),
-                );
-
-                let newId: string;
-                let newPrefix: string;
-                do {
-                  const suffix = Math.random().toString(36).slice(2, 6);
-                  newId = `${projectId}-${suffix}`;
-                  newPrefix = generateSessionPrefix(newId);
-                } while (rawConfig.projects[newId] || existingPrefixes.has(newPrefix));
-
-                rawConfig.projects[newId] = {
-                  ...rawConfig.projects[projectId],
-                  sessionPrefix: newPrefix,
-                };
-                writeFileSync(config.configPath, yamlStringify(rawConfig, { indent: 2 }));
-                console.log(chalk.green(`\n✓ New orchestrator "${newId}" added to config\n`));
-                config = loadConfig(config.configPath);
-                projectId = newId;
-                project = config.projects[newId];
-                // Continue to startup below
-              } else if (choice === "restart") {
-                try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
-                if (!(await waitForExit(running.pid, 5000))) {
-                  console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
-                  try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
-                }
-                await unregister();
-                console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));
-                // Continue to startup below
-              } else {
-                process.exit(0);
-              }
-            } else {
-              // Agent/non-TTY caller — print info and exit
-              console.log(`AO is already running.`);
-              console.log(`Dashboard: http://localhost:${running.port}`);
-              console.log(`PID: ${running.pid}`);
-              console.log(`Projects: ${running.projects.join(", ")}`);
-              console.log(`To restart: ao stop && ao start`);
-              process.exit(0);
-            }
+            rawConfig.projects[newId] = {
+              ...rawConfig.projects[projectId],
+              sessionPrefix: newPrefix,
+            };
+            writeFileSync(config.configPath, yamlStringify(rawConfig, { indent: 2 }));
+            console.log(chalk.green(`\n✓ New orchestrator "${newId}" added to config\n`));
+            config = loadConfig(config.configPath);
+            projectId = newId;
+            project = config.projects[newId];
           }
 
           // ── Agent selection prompt (Step 10)──

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -10,7 +10,7 @@
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { resolve, basename } from "node:path";
 import { cwd } from "node:process";
 import chalk from "chalk";
@@ -648,18 +648,25 @@ async function addProjectToConfig(
   config: OrchestratorConfig,
   projectPath: string,
 ): Promise<string> {
-  await ensureGit("adding projects");
-
   const resolvedPath = resolve(projectPath.replace(/^~/, process.env["HOME"] || ""));
 
-  // Check if this path is already registered under any project name
-  const existingByPath = Object.entries(config.projects).find(
-    ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
-  );
+  // Check if this path is already registered under any project name.
+  // Use realpathSync for canonical comparison (resolves symlinks, case variants).
+  // Done before ensureGit so already-registered paths return early without requiring git.
+  const canonicalPath = realpathSync(resolvedPath);
+  const existingByPath = Object.entries(config.projects).find(([, p]) => {
+    try {
+      return realpathSync(resolve(p.path.replace(/^~/, process.env["HOME"] || ""))) === canonicalPath;
+    } catch {
+      return false;
+    }
+  });
   if (existingByPath) {
     console.log(chalk.dim(`  Path already configured as project "${existingByPath[0]}" — skipping add.`));
     return existingByPath[0];
   }
+
+  await ensureGit("adding projects");
 
   let projectId = basename(resolvedPath);
 
@@ -1257,6 +1264,11 @@ export function registerStart(program: Command): void {
                 if (!(await waitForExit(running.pid, 5000))) {
                   console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
                   try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
+                  if (!(await waitForExit(running.pid, 3000))) {
+                    throw new Error(
+                      `Failed to stop AO process (PID ${running.pid}). Check permissions or stop it manually.`,
+                    );
+                  }
                 }
                 await unregister();
                 console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));


### PR DESCRIPTION
## Summary

- Move the `isAlreadyRunning()` check to execute **before** any config-mutating operations (`addProjectToConfig()`, `autoCreateConfig()`), so running `ao start` on an already-running project no longer writes a phantom duplicate entry to `agent-orchestrator.yaml`
- Add path-based deduplication in `addProjectToConfig()` — if the resolved path already exists under any project name, return the existing ID instead of appending a numeric suffix
- The "new orchestrator" interactive choice is deferred via a `startNewOrchestrator` flag until after config is loaded, preserving existing behavior

Closes #1150

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm --filter @aoagents/ao-cli test` — all 316 tests pass
- [ ] Manual: run `ao start` on a project, then run `ao start` again — verify no duplicate YAML entry is created
- [ ] Manual: select "new orchestrator" when prompted — verify it still correctly creates a new entry
- [ ] Manual: run `ao start /path/to/already-configured-project` — verify `addProjectToConfig()` returns the existing project ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)