### PR TITLE
feat(cli): add hello command

### DIFF
--- a/packages/cli/__tests__/commands/hello.test.ts
+++ b/packages/cli/__tests__/commands/hello.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { Command } from "commander";
+import { registerHello } from "../../src/commands/hello.js";
+
+describe("hello command", () => {
+  let program: Command;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    registerHello(program);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("prints hello world", async () => {
+    await program.parseAsync(["node", "test", "hello"]);
+
+    expect(console.log).toHaveBeenCalledWith("hello world");
+  });
+});

--- a/packages/cli/__tests__/program.test.ts
+++ b/packages/cli/__tests__/program.test.ts
@@ -6,4 +6,8 @@ describe("createProgram", () => {
   it("uses the CLI package version", () => {
     expect(createProgram().version()).toBe(packageJson.version);
   });
+
+  it("registers the hello command", () => {
+    expect(createProgram().commands.some((command) => command.name() === "hello")).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/hello.ts
+++ b/packages/cli/src/commands/hello.ts
@@ -1,0 +1,10 @@
+import type { Command } from "commander";
+
+export function registerHello(program: Command): void {
+  program
+    .command("hello")
+    .description("Print hello world")
+    .action(() => {
+      console.log("hello world");
+    });
+}

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,7 @@ import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
+import { registerHello } from "./commands/hello.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -42,6 +43,7 @@ export function createProgram(): Command {
   registerUpdate(program);
   registerSetup(program);
   registerPlugin(program);
+  registerHello(program);
 
   program
     .command("config-help")


### PR DESCRIPTION
## Summary
- add a new `ao hello` CLI command that prints `hello world`
- register the command in the CLI program
- add focused tests for command output and command registration

## Testing
- `pnpm --filter @aoagents/ao-cli exec vitest run __tests__/commands/hello.test.ts __tests__/program.test.ts`
- `pnpm exec eslint packages/cli/src/program.ts packages/cli/src/commands/hello.ts packages/cli/__tests__/commands/hello.test.ts packages/cli/__tests__/program.test.ts`

## Issue
- No matching tracker issue was provided for this requested change.