### PR TITLE
revert: support multiple concurrent orchestrators (PR #870)

### DIFF
--- a/packages/cli/__tests__/lib/session-utils.test.ts
+++ b/packages/cli/__tests__/lib/session-utils.test.ts
@@ -165,49 +165,4 @@ describe("isOrchestratorSessionName", () => {
     const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
     expect(isOrchestratorSessionName(config, "app-12", "my-app")).toBe(false);
   });
-
-  it("matches worktree orchestrator IDs (orchestrator-N) for a known project", () => {
-    const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1", "my-app")).toBe(true);
-    expect(isOrchestratorSessionName(config, "app-orchestrator-42", "my-app")).toBe(true);
-  });
-
-  it("matches worktree orchestrator IDs without an explicit project", () => {
-    const config = makeConfig({ "my-app": { sessionPrefix: "app" } });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1")).toBe(true);
-  });
-
-  it("does not false-positive on a worker when prefix ends with -orchestrator", () => {
-    const config = makeConfig({ "my-app": { sessionPrefix: "my-orchestrator" } });
-    // my-orchestrator-1 is a worker session, not a worktree orchestrator
-    expect(isOrchestratorSessionName(config, "my-orchestrator-1", "my-app")).toBe(false);
-    // my-orchestrator-orchestrator is the canonical orchestrator
-    expect(isOrchestratorSessionName(config, "my-orchestrator-orchestrator", "my-app")).toBe(true);
-  });
-
-  it("does not cross-project false-positive when one prefix is another's {prefix}-orchestrator", () => {
-    // project A prefix "app", project B prefix "app-orchestrator"
-    // "app-orchestrator-1" is a worker of B, NOT an orchestrator of A
-    const config = makeConfig({
-      "project-a": { sessionPrefix: "app" },
-      "project-b": { sessionPrefix: "app-orchestrator" },
-    });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1")).toBe(false);
-    // "app-orchestrator-orchestrator-1" IS an orchestrator of B
-    expect(isOrchestratorSessionName(config, "app-orchestrator-orchestrator-1")).toBe(true);
-  });
-
-  it("does not cross-project false-positive when projectId is provided", () => {
-    // project A prefix "app", project B prefix "app-orchestrator"
-    // "app-orchestrator-1" is a worker of B — must not be classified as orchestrator of A
-    // even when called with projectId="project-a"
-    const config = makeConfig({
-      "project-a": { sessionPrefix: "app" },
-      "project-b": { sessionPrefix: "app-orchestrator" },
-    });
-    expect(isOrchestratorSessionName(config, "app-orchestrator-1", "project-a")).toBe(false);
-    // The canonical orchestrator of A is still recognized
-    expect(isOrchestratorSessionName(config, "app-orchestrator", "project-a")).toBe(true);
-    expect(isOrchestratorSessionName(config, "app-orchestrator-2", "project-a")).toBe(false);
-  });
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1029,12 +1029,9 @@ async function runStartup(
         { cause: err },
       );
     }
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
-    );
     const existingOrchestrators = allSessions.filter(
       (s) =>
-        isOrchestratorSession(s, project.sessionPrefix ?? projectId, allSessionPrefixes) &&
+        isOrchestratorSession(s) &&
         !isTerminalSession(s),
     );
 

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -74,11 +74,7 @@ async function gatherSessionInfo(
   scm: SCM,
   projectConfig: ReturnType<typeof loadConfig>,
 ): Promise<SessionInfo> {
-  const sessionPrefix = projectConfig.projects[session.projectId]?.sessionPrefix ?? session.projectId;
-  const allSessionPrefixes = Object.entries(projectConfig.projects).map(
-    ([id, p]) => p.sessionPrefix ?? id,
-  );
-  const suppressPROwnership = isOrchestratorSession(session, sessionPrefix, allSessionPrefixes);
+  const suppressPROwnership = isOrchestratorSession(session);
   let branch = session.branch;
   const status = session.status;
   const summary = session.metadata["summary"] ?? null;
@@ -148,7 +144,7 @@ async function gatherSessionInfo(
 
   return {
     name: session.id,
-    role: isOrchestratorSession(session, sessionPrefix, allSessionPrefixes) ? "orchestrator" : "worker",
+    role: isOrchestratorSession(session) ? "orchestrator" : "worker",
     branch,
     status,
     summary,

--- a/packages/cli/src/lib/session-utils.ts
+++ b/packages/cli/src/lib/session-utils.ts
@@ -40,27 +40,10 @@ export function isOrchestratorSessionName(
   sessionName: string,
   projectId?: string,
 ): boolean {
-  // If sessionName is a numbered worker for any configured project, it is not an orchestrator.
-  // This guard runs first to prevent cross-project false positives: e.g. prefix "app" would
-  // match "app-orchestrator-1" as an orchestrator pattern, but if another project has prefix
-  // "app-orchestrator" then "app-orchestrator-1" is a worker, not an orchestrator.
-  for (const [id, project] of Object.entries(config.projects) as Array<
-    [string, OrchestratorConfig["projects"][string]]
-  >) {
-    const prefix = project.sessionPrefix || id;
-    if (matchesPrefix(sessionName, prefix)) return false;
-  }
-
   if (projectId) {
     const project = config.projects[projectId];
-    if (project) {
-      const prefix = project.sessionPrefix || projectId;
-      if (
-        sessionName === `${prefix}-orchestrator` ||
-        new RegExp(`^${escapeRegex(prefix)}-orchestrator-\\d+$`).test(sessionName)
-      ) {
-        return true;
-      }
+    if (project && sessionName === `${project.sessionPrefix || projectId}-orchestrator`) {
+      return true;
     }
   }
 
@@ -68,10 +51,7 @@ export function isOrchestratorSessionName(
     [string, OrchestratorConfig["projects"][string]]
   >) {
     const prefix = project.sessionPrefix || id;
-    if (
-      sessionName === `${prefix}-orchestrator` ||
-      new RegExp(`^${escapeRegex(prefix)}-orchestrator-\\d+$`).test(sessionName)
-    ) {
+    if (sessionName === `${prefix}-orchestrator`) {
       return true;
     }
   }

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, readFileSync, existsSync } from "node:fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync, existsSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
 import { validateConfig } from "../../config.js";
@@ -7,6 +7,8 @@ import {
   writeMetadata,
   readMetadata,
   readMetadataRaw,
+  reserveSessionId,
+  deleteMetadata,
 } from "../../metadata.js";
 import type {
   OrchestratorConfig,
@@ -15,6 +17,7 @@ import type {
   Agent,
   Workspace,
   Tracker,
+  RuntimeHandle,
 } from "../../types.js";
 import {
   setupTestContext,
@@ -968,67 +971,18 @@ describe("spawn", () => {
   }, 20_000);
 
   describe("spawnOrchestrator", () => {
-    it("throws when no workspace plugin is configured", async () => {
-      const registryNoWorkspace: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return mockAgent;
-          return null; // no workspace plugin
-        }),
-      };
-      const sm = createSessionManager({ config, registry: registryNoWorkspace });
-
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "spawnOrchestrator requires a workspace plugin",
-      );
-
-      // Reserved session metadata should be cleaned up
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
-      expect(mockRuntime.create).not.toHaveBeenCalled();
-    });
 
     it("creates orchestrator session with correct ID", async () => {
       const sm = createSessionManager({ config, registry: mockRegistry });
 
       const session = await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      expect(session.id).toBe("app-orchestrator-1");
+      expect(session.id).toBe("app-orchestrator");
       expect(session.status).toBe("working");
       expect(session.projectId).toBe("my-app");
-      expect(session.branch).toBe("orchestrator/app-orchestrator-1");
+      expect(session.branch).toBe("main");
       expect(session.issueId).toBeNull();
-      expect(session.workspacePath).toBe("/tmp/ws");
-    });
-
-    it("creates a worktree with an orchestrator branch", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(mockWorkspace.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          sessionId: "app-orchestrator-1",
-          branch: "orchestrator/app-orchestrator-1",
-          projectId: "my-app",
-        }),
-      );
-    });
-
-    it("uses the worktree path returned by the workspace plugin", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(session.workspacePath).toBe(worktreePath);
-      expect(session.branch).toBe("orchestrator/app-orchestrator-1");
+      expect(session.workspacePath).toBe(join(tmpDir, "my-app"));
     });
 
     it("writes metadata with proper fields", async () => {
@@ -1036,104 +990,14 @@ describe("spawn", () => {
 
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      const meta = readMetadata(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadata(sessionsDir, "app-orchestrator");
       expect(meta).not.toBeNull();
       expect(meta!.status).toBe("working");
       expect(meta!.project).toBe("my-app");
-      expect(meta!.branch).toBe("orchestrator/app-orchestrator-1");
+      expect(meta!.worktree).toBe(join(tmpDir, "my-app"));
+      expect(meta!.branch).toBe("main");
       expect(meta!.tmuxName).toBeDefined();
       expect(meta!.runtimeHandle).toBeDefined();
-    });
-
-    it("writes metadata with worktree path and orchestrator role", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
-      expect(meta?.["role"]).toBe("orchestrator");
-      expect(meta?.["branch"]).toBe("orchestrator/app-orchestrator-1");
-      expect(meta?.["status"]).toBe("working");
-      expect(meta?.["project"]).toBe("my-app");
-    });
-
-    it("increments the orchestrator counter for each new session", async () => {
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      const s1 = await sm.spawnOrchestrator({ projectId: "my-app" });
-      const s2 = await sm.spawnOrchestrator({ projectId: "my-app" });
-
-      expect(s1.id).toBe("app-orchestrator-1");
-      expect(s2.id).toBe("app-orchestrator-2");
-      expect(mockWorkspace.create).toHaveBeenCalledTimes(2);
-    });
-
-    it("cleans up reserved metadata on workspace creation failure", async () => {
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error("workspace creation failed"),
-      );
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "workspace creation failed",
-      );
-
-      // Reserved session file should be cleaned up
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
-    });
-
-    it("destroys the worktree and metadata when runtime creation fails", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws-rt-fail");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
-      (mockRuntime.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-        new Error("runtime creation failed"),
-      );
-      const sm = createSessionManager({ config, registry: mockRegistry });
-
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "runtime creation failed",
-      );
-
-      expect(mockWorkspace.destroy).toHaveBeenCalledWith(worktreePath);
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
-    });
-
-    it("destroys the worktree when post-launch setup fails", async () => {
-      const worktreePath = join(tmpDir, "orchestrator-ws-postlaunch-fail");
-      (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        path: worktreePath,
-        branch: "orchestrator/app-orchestrator-1",
-        sessionId: "app-orchestrator-1",
-        projectId: "my-app",
-      });
-      const postLaunchError = new Error("post-launch setup failed");
-      const agentWithPostLaunch: typeof mockAgent = {
-        ...mockAgent,
-        postLaunchSetup: vi.fn().mockRejectedValueOnce(postLaunchError),
-      };
-      const registryWithPostLaunch: PluginRegistry = {
-        ...mockRegistry,
-        get: vi.fn().mockImplementation((slot: string) => {
-          if (slot === "runtime") return mockRuntime;
-          if (slot === "agent") return agentWithPostLaunch;
-          if (slot === "workspace") return mockWorkspace;
-          return null;
-        }),
-      };
-      const sm = createSessionManager({ config, registry: registryWithPostLaunch });
-
-      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
-        "post-launch setup failed",
-      );
-
-      expect(mockRuntime.destroy).toHaveBeenCalled();
-      expect(mockWorkspace.destroy).toHaveBeenCalledWith(worktreePath);
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")).toBeNull();
     });
 
     it("deletes previous OpenCode orchestrator sessions before starting", async () => {
@@ -1141,8 +1005,8 @@ describe("spawn", () => {
       const mockBin = installMockOpencode(
         tmpDir,
         JSON.stringify([
-          { id: "ses_old", title: "AO:app-orchestrator-1", updated: "2025-01-01T00:00:00.000Z" },
-          { id: "ses_new", title: "AO:app-orchestrator-1", updated: "2025-01-02T00:00:00.000Z" },
+          { id: "ses_old", title: "AO:app-orchestrator", updated: "2025-01-01T00:00:00.000Z" },
+          { id: "ses_new", title: "AO:app-orchestrator", updated: "2025-01-02T00:00:00.000Z" },
         ]),
         deleteLogPath,
       );
@@ -1184,14 +1048,14 @@ describe("spawn", () => {
 
       expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "app-orchestrator-1",
+          sessionId: "app-orchestrator",
           projectConfig: expect.objectContaining({
             agentConfig: expect.not.objectContaining({ opencodeSessionId: expect.any(String) }),
           }),
         }),
       );
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["agent"]).toBe("opencode");
       expect(meta?.["opencodeSessionId"]).toBeUndefined();
     });
@@ -1203,7 +1067,7 @@ describe("spawn", () => {
         JSON.stringify([
           {
             id: "ses_discovered_orchestrator",
-            title: "AO:app-orchestrator-1",
+            title: "AO:app-orchestrator",
             updated: 1_772_777_000_000,
           },
         ]),
@@ -1241,23 +1105,31 @@ describe("spawn", () => {
       const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["opencodeSessionId"]).toBe("ses_discovered_orchestrator");
     });
 
-    it("reuses mapped OpenCode session id when strategy is reuse and opencode lists it by title", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-restart.log");
-      const mockBin = installMockOpencode(
-        tmpDir,
-        JSON.stringify([
-          {
-            id: "ses_existing",
-            title: "AO:app-orchestrator-1",
-            updated: 1_772_777_000_000,
-          },
-        ]),
-        deleteLogPath,
+    it("reuses an existing orchestrator session when strategy is reuse", async () => {
+      const listLogPath = join(tmpDir, "opencode-list-orchestrator-reuse.log");
+      const mockBin = join(tmpDir, "mock-bin-reuse-no-list");
+      mkdirSync(mockBin, { recursive: true });
+      const scriptPath = join(mockBin, "opencode");
+      writeFileSync(
+        scriptPath,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'if [[ "$1" == "session" && "$2" == "list" ]]; then',
+          `  printf '%s\\n' "$*" >> '${listLogPath.replace(/'/g, "'\\''")}'`,
+          "  printf '[]\\n'",
+          "  exit 0",
+          "fi",
+          "exit 0",
+          "",
+        ].join("\n"),
+        "utf-8",
       );
+      chmodSync(scriptPath, 0o755);
       process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
 
       const opencodeAgent: Agent = {
@@ -1286,6 +1158,130 @@ describe("spawn", () => {
           },
         },
       };
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        opencodeSessionId: "ses_existing",
+        createdAt: new Date().toISOString(),
+      });
+
+      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
+      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(session.metadata["orchestratorSessionReused"]).toBe("true");
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+      expect(mockRuntime.destroy).not.toHaveBeenCalled();
+      expect(existsSync(listLogPath)).toBe(false);
+    });
+
+    it("destroys orphaned runtime when reuse strategy finds alive runtime but get returns null", async () => {
+      const deleteLogPath = join(tmpDir, "opencode-delete-orphaned-runtime.log");
+      const mockBin = installMockOpencode(tmpDir, "[]", deleteLogPath);
+      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+      const opencodeAgent: Agent = {
+        ...mockAgent,
+        name: "opencode",
+      };
+      const registryWithOpenCode: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return opencodeAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+
+      const configWithReuse: OrchestratorConfig = {
+        ...config,
+        defaults: { ...config.defaults, agent: "opencode" },
+        projects: {
+          ...config.projects,
+          "my-app": {
+            ...config.projects["my-app"],
+            agent: "opencode",
+            orchestratorSessionStrategy: "reuse",
+          },
+        },
+      };
+
+      const orphanedHandle = makeHandle("rt-orphaned");
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(orphanedHandle),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle: RuntimeHandle) => {
+        if (handle?.id === "rt-orphaned") {
+          deleteMetadata(sessionsDir, "app-orchestrator");
+          return true;
+        }
+        return false;
+      });
+
+      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
+      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(mockRuntime.destroy).toHaveBeenCalledWith(orphanedHandle);
+      expect(mockRuntime.create).toHaveBeenCalled();
+    });
+
+    it("reuses mapped OpenCode session id when strategy is reuse and runtime is restarted", async () => {
+      const opencodeAgent: Agent = {
+        ...mockAgent,
+        name: "opencode",
+      };
+      const registryWithOpenCode: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return opencodeAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+
+      const configWithReuse: OrchestratorConfig = {
+        ...config,
+        defaults: { ...config.defaults, agent: "opencode" },
+        projects: {
+          ...config.projects,
+          "my-app": {
+            ...config.projects["my-app"],
+            agent: "opencode",
+            orchestratorSessionStrategy: "reuse",
+          },
+        },
+      };
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        opencodeSessionId: "ses_existing",
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
 
       const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
       await sm.spawnOrchestrator({ projectId: "my-app" });
@@ -1297,16 +1293,17 @@ describe("spawn", () => {
           }),
         }),
       );
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["opencodeSessionId"]).toBe("ses_existing");
     });
 
-    it("discovers OpenCode mapping by title when no archived mapping exists for new session id", async () => {
-      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-title-fallback.log");
+    it("reuses archived OpenCode mapping for orchestrator when active metadata has no mapping", async () => {
+      const deleteLogPath = join(tmpDir, "opencode-delete-orchestrator-reuse-archived.log");
       const mockBin = installMockOpencode(
         tmpDir,
         JSON.stringify([
-          { id: "ses_existing", title: "AO:app-orchestrator-1", updated: 1_772_777_000_000 },
+          null,
+          { id: "ses_existing", title: "AO:app-orchestrator", updated: 1_772_777_000_000 },
         ]),
         deleteLogPath,
       );
@@ -1338,6 +1335,31 @@ describe("spawn", () => {
           },
         },
       };
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        opencodeSessionId: "ses_existing",
+        createdAt: new Date().toISOString(),
+      });
+      deleteMetadata(sessionsDir, "app-orchestrator", true);
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
 
       const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
       await sm.spawnOrchestrator({ projectId: "my-app" });
@@ -1356,7 +1378,8 @@ describe("spawn", () => {
       const mockBin = installMockOpencode(
         tmpDir,
         JSON.stringify([
-          { id: "ses_title_match", title: "AO:app-orchestrator-1", updated: 1_772_777_000_000 },
+          null,
+          { id: "ses_title_match", title: "AO:app-orchestrator", updated: 1_772_777_000_000 },
         ]),
         deleteLogPath,
       );
@@ -1389,6 +1412,19 @@ describe("spawn", () => {
         },
       };
 
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
       const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
@@ -1399,11 +1435,81 @@ describe("spawn", () => {
           }),
         }),
       );
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["opencodeSessionId"]).toBe("ses_title_match");
     });
 
-    it("calls agent.setupWorkspaceHooks on worktree path", async () => {
+    it("starts fresh without deleting prior OpenCode sessions when strategy is ignore", async () => {
+      const deleteLogPath = join(tmpDir, "opencode-delete-ignore.log");
+      const mockBin = installMockOpencode(
+        tmpDir,
+        JSON.stringify([
+          { id: "ses_old", title: "AO:app-orchestrator", updated: "2025-01-01T00:00:00.000Z" },
+        ]),
+        deleteLogPath,
+      );
+      process.env.PATH = `${mockBin}:${originalPath ?? ""}`;
+
+      const opencodeAgent: Agent = {
+        ...mockAgent,
+        name: "opencode",
+      };
+      const registryWithOpenCode: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return opencodeAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+
+      const configWithIgnoreNew: OrchestratorConfig = {
+        ...config,
+        defaults: { ...config.defaults, agent: "opencode" },
+        projects: {
+          ...config.projects,
+          "my-app": {
+            ...config.projects["my-app"],
+            agent: "opencode",
+            orchestratorSessionStrategy: "ignore",
+          },
+        },
+      };
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValueOnce(true);
+
+      const sm = createSessionManager({
+        config: configWithIgnoreNew,
+        registry: registryWithOpenCode,
+      });
+      await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(mockRuntime.destroy).toHaveBeenCalledWith(makeHandle("rt-existing"));
+      expect(mockRuntime.create).toHaveBeenCalled();
+      expect(existsSync(deleteLogPath)).toBe(false);
+    });
+
+    it("skips workspace creation", async () => {
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(mockWorkspace.create).not.toHaveBeenCalled();
+    });
+
+    it("calls agent.setupWorkspaceHooks on project path", async () => {
       const agentWithHooks: Agent = {
         ...mockAgent,
         setupWorkspaceHooks: vi.fn().mockResolvedValue(undefined),
@@ -1422,7 +1528,7 @@ describe("spawn", () => {
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
       expect(agentWithHooks.setupWorkspaceHooks).toHaveBeenCalledWith(
-        "/tmp/ws",
+        join(tmpDir, "my-app"),
         expect.objectContaining({ dataDir: sessionsDir }),
       );
     });
@@ -1434,7 +1540,7 @@ describe("spawn", () => {
 
       expect(mockRuntime.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          workspacePath: "/tmp/ws",
+          workspacePath: join(tmpDir, "my-app"),
           launchCommand: "mock-agent --start",
         }),
       );
@@ -1445,8 +1551,29 @@ describe("spawn", () => {
 
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
-      const meta = readMetadataRaw(sessionsDir, "app-orchestrator-1");
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
       expect(meta?.["orchestratorSessionReused"]).toBeUndefined();
+    });
+
+    it("respawns the orchestrator when stale metadata exists but the runtime is dead", async () => {
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        project: "my-app",
+        role: "orchestrator",
+        runtimeHandle: JSON.stringify(makeHandle("rt-stale")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+      const meta = readMetadataRaw(sessionsDir, "app-orchestrator");
+      expect(meta?.["runtimeHandle"]).toBe(JSON.stringify(makeHandle("rt-1")));
     });
 
     it("uses orchestratorModel when configured", async () => {
@@ -1547,7 +1674,7 @@ describe("spawn", () => {
 
       expect(mockCodexAgent.getLaunchCommand).toHaveBeenCalled();
       expect(mockAgent.getLaunchCommand).not.toHaveBeenCalled();
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")?.["agent"]).toBe("codex");
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")?.["agent"]).toBe("codex");
     });
 
     it("uses defaults orchestrator agent when project agent is not set", async () => {
@@ -1594,7 +1721,7 @@ describe("spawn", () => {
       await sm.spawnOrchestrator({ projectId: "my-app" });
 
       expect(mockCodexAgent.getLaunchCommand).toHaveBeenCalled();
-      expect(readMetadataRaw(sessionsDir, "app-orchestrator-1")?.["agent"]).toBe("codex");
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")?.["agent"]).toBe("codex");
     });
 
     it("keeps shared worker permissions when role-specific config only overrides model", async () => {
@@ -1696,8 +1823,8 @@ describe("spawn", () => {
       // Should pass systemPromptFile (not inline systemPrompt) to avoid tmux truncation
       expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
         expect.objectContaining({
-          sessionId: "app-orchestrator-1",
-          systemPromptFile: expect.stringContaining("orchestrator-prompt-app-orchestrator-1.md"),
+          sessionId: "app-orchestrator",
+          systemPromptFile: expect.stringContaining("orchestrator-prompt.md"),
         }),
       );
 
@@ -1736,5 +1863,101 @@ describe("spawn", () => {
       expect(session.runtimeHandle).toEqual(makeHandle("rt-1"));
     });
 
+    it("reuses existing orchestrator on reservation conflict when strategy is reuse", async () => {
+      const opencodeAgent: Agent = {
+        ...mockAgent,
+        name: "opencode",
+      };
+      const registryWithOpenCode: PluginRegistry = {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return opencodeAgent;
+          if (slot === "workspace") return mockWorkspace;
+          return null;
+        }),
+      };
+
+      const configWithReuse: OrchestratorConfig = {
+        ...config,
+        defaults: { ...config.defaults, agent: "opencode" },
+        projects: {
+          ...config.projects,
+          "my-app": {
+            ...config.projects["my-app"],
+            agent: "opencode",
+            orchestratorSessionStrategy: "reuse",
+          },
+        },
+      };
+
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        agent: "opencode",
+        runtimeHandle: JSON.stringify(makeHandle("rt-concurrent")),
+        opencodeSessionId: "ses_concurrent",
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(true);
+
+      const sm = createSessionManager({ config: configWithReuse, registry: registryWithOpenCode });
+      const session = await sm.spawnOrchestrator({ projectId: "my-app" });
+
+      expect(session.metadata["orchestratorSessionReused"]).toBe("true");
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+    });
+
+    it("recovers reservation conflict when existing session is not usable", async () => {
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "killed",
+        role: "orchestrator",
+        project: "my-app",
+        runtimeHandle: JSON.stringify(makeHandle("rt-dead")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).resolves.toBeDefined();
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates only one runtime on reservation conflict", async () => {
+      writeMetadata(sessionsDir, "app-orchestrator", {
+        worktree: join(tmpDir, "my-app"),
+        branch: "main",
+        status: "working",
+        role: "orchestrator",
+        project: "my-app",
+        runtimeHandle: JSON.stringify(makeHandle("rt-existing")),
+        createdAt: new Date().toISOString(),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockResolvedValue(false);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).resolves.toBeDefined();
+      expect(mockRuntime.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not delete an in-progress reservation file without runtime metadata", async () => {
+      expect(reserveSessionId(sessionsDir, "app-orchestrator")).toBe(true);
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      await expect(sm.spawnOrchestrator({ projectId: "my-app" })).rejects.toThrow(
+        "already exists but is not in a reusable state",
+      );
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+      expect(readMetadataRaw(sessionsDir, "app-orchestrator")).toEqual({});
+    });
   });
 });

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -4,35 +4,19 @@ import { isOrchestratorSession, isIssueNotFoundError } from "../types.js";
 describe("isOrchestratorSession", () => {
   it("detects orchestrators by explicit role metadata", () => {
     expect(
-      isOrchestratorSession({ id: "app-control", metadata: { role: "orchestrator" } }, "app"),
+      isOrchestratorSession({
+        id: "app-control",
+        metadata: { role: "orchestrator" },
+      }),
     ).toBe(true);
   });
 
   it("falls back to orchestrator naming for legacy sessions", () => {
-    expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} }, "app")).toBe(true);
+    expect(isOrchestratorSession({ id: "app-orchestrator", metadata: {} })).toBe(true);
   });
 
-  it("detects numbered worktree orchestrators by prefix pattern", () => {
-    expect(isOrchestratorSession({ id: "app-orchestrator-1", metadata: {} }, "app")).toBe(true);
-    expect(isOrchestratorSession({ id: "app-orchestrator-42", metadata: {} }, "app")).toBe(true);
-  });
-
-  it("does not false-positive on worker sessions", () => {
-    expect(isOrchestratorSession({ id: "app-7", metadata: { role: "worker" } }, "app")).toBe(false);
-  });
-
-  it("does not false-positive when prefix ends with -orchestrator", () => {
-    // my-orchestrator-1 is a worker when prefix is "my-orchestrator"
-    expect(
-      isOrchestratorSession({ id: "my-orchestrator-1", metadata: {} }, "my-orchestrator"),
-    ).toBe(false);
-    // my-orchestrator-orchestrator-1 is the real worktree orchestrator
-    expect(
-      isOrchestratorSession(
-        { id: "my-orchestrator-orchestrator-1", metadata: {} },
-        "my-orchestrator",
-      ),
-    ).toBe(true);
+  it("does not classify worker sessions as orchestrators", () => {
+    expect(isOrchestratorSession({ id: "app-7", metadata: { role: "worker" } })).toBe(false);
   });
 });
 

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -20,10 +20,9 @@ export interface ResolvedAgentSelection {
 
 export function resolveSessionRole(
   sessionId: string,
-  metadata: Record<string, string> | undefined,
-  sessionPrefix: string,
+  metadata?: Record<string, string>,
 ): SessionRole {
-  return isOrchestratorSession({ id: sessionId, metadata }, sessionPrefix) ? "orchestrator" : "worker";
+  return isOrchestratorSession({ id: sessionId, metadata }) ? "orchestrator" : "worker";
 }
 
 export function resolveAgentSelection(params: {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -355,7 +355,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     if (!project) return session.status;
 
     const agentName = resolveAgentSelection({
-      role: resolveSessionRole(session.id, session.metadata, project.sessionPrefix),
+      role: resolveSessionRole(session.id, session.metadata),
       project,
       defaults: config.defaults,
       persistedAgent: session.metadata["agent"],

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -31,7 +31,7 @@ export async function validateSession(
 
   const runtimeName = project.runtime ?? config.defaults.runtime;
   const agentName = resolveAgentSelection({
-    role: resolveSessionRole(sessionId, rawMetadata, project.sessionPrefix),
+    role: resolveSessionRole(sessionId, rawMetadata),
     project,
     defaults: config.defaults,
     persistedAgent: rawMetadata["agent"],

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -11,7 +11,7 @@
  * Reference: scripts/claude-ao-session, scripts/send-to-session
  */
 
-import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync, unlinkSync } from "node:fs";
+import { statSync, existsSync, readdirSync, writeFileSync, mkdirSync, utimesSync } from "node:fs";
 import { execFile } from "node:child_process";
 import { basename, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -41,6 +41,7 @@ import {
   type PluginRegistry,
   type RuntimeHandle,
   type Issue,
+  isOrchestratorSession,
   PR_STATE,
 } from "./types.js";
 import {
@@ -59,6 +60,7 @@ import {
   getWorktreesDir,
   getProjectBaseDir,
   generateTmuxName,
+  generateConfigHash,
   validateAndStoreOrigin,
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
@@ -329,17 +331,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   function isOrchestratorSessionRecord(
     sessionId: string,
     raw: Record<string, string> | null | undefined,
-    sessionPrefix?: string,
   ): boolean {
     if (!raw) return false;
-    if (raw["role"] === "orchestrator" || sessionId.endsWith("-orchestrator")) return true;
-    // Check the -orchestrator-N pattern only when the prefix is known so the
-    // regex is anchored to the project prefix, preventing false-positives when
-    // the user-configured sessionPrefix itself ends with "-orchestrator".
-    if (sessionPrefix) {
-      return new RegExp(`^${escapeRegex(sessionPrefix)}-orchestrator-\\d+$`).test(sessionId);
-    }
-    return false;
+    return raw["role"] === "orchestrator" || sessionId.endsWith("-orchestrator");
   }
 
   function isCleanupProtectedSession(
@@ -347,7 +341,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionId: string,
     metadata?: Record<string, string> | null,
   ): boolean {
-    return isOrchestratorSessionRecord(sessionId, metadata ?? {}, project.sessionPrefix);
+    const canonicalOrchestratorId = `${project.sessionPrefix}-orchestrator`;
+    return (
+      sessionId === canonicalOrchestratorId ||
+      isOrchestratorSession({ id: sessionId, metadata: metadata ?? undefined })
+    );
   }
 
   function applyMetadataUpdatesToRaw(
@@ -397,10 +395,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   function repairSingleSessionMetadataOnRead(
     sessionsDir: string,
     record: ActiveSessionRecord,
-    sessionPrefix?: string,
   ): ActiveSessionRecord {
     const repaired = { ...record, raw: { ...record.raw } };
-    if (!isOrchestratorSessionRecord(repaired.sessionName, repaired.raw, sessionPrefix)) {
+    if (!isOrchestratorSessionRecord(repaired.sessionName, repaired.raw)) {
       return repaired;
     }
 
@@ -440,14 +437,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   function repairSessionMetadataOnRead(
     sessionsDir: string,
     records: ActiveSessionRecord[],
-    sessionPrefix?: string,
   ): ActiveSessionRecord[] {
     const repaired = records.map((record) => ({ ...record, raw: { ...record.raw } }));
     const duplicatePRAttachments = new Map<string, ActiveSessionRecord[]>();
 
     for (const record of repaired) {
-      if (isOrchestratorSessionRecord(record.sessionName, record.raw, sessionPrefix)) {
-        record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record, sessionPrefix).raw;
+      if (isOrchestratorSessionRecord(record.sessionName, record.raw)) {
+        record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record).raw;
         continue;
       }
 
@@ -508,7 +504,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       return [{ sessionName, raw, modifiedAt } satisfies ActiveSessionRecord];
     });
 
-    return repairSessionMetadataOnRead(sessionsDir, records, project.sessionPrefix);
+    return repairSessionMetadataOnRead(sessionsDir, records);
   }
 
   function markArchivedOpenCodeCleanup(sessionsDir: string, sessionId: SessionId): void {
@@ -679,66 +675,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
   }
 
-  /**
-   * Reserve a unique orchestrator identity ({prefix}-orchestrator-N) for a worktree-based orchestrator.
-   * Unlike worker sessions, orchestrator IDs are assigned locally without remote branch checks.
-   */
-  function reserveNextOrchestratorIdentity(
-    project: ProjectConfig,
-    sessionsDir: string,
-  ): { num: number; sessionId: string; tmuxName: string | undefined } {
-    const orchestratorPrefix = `${project.sessionPrefix}-orchestrator`;
-    const usedNumbers = new Set<number>();
-
-    const orchestratorPattern = new RegExp(`^${escapeRegex(orchestratorPrefix)}-(\\d+)$`);
-    for (const sessionName of [
-      ...listMetadata(sessionsDir),
-      ...listArchivedSessionIds(sessionsDir),
-    ]) {
-      const match = sessionName.match(orchestratorPattern);
-      if (match) {
-        const parsed = Number.parseInt(match[1], 10);
-        if (!Number.isNaN(parsed)) usedNumbers.add(parsed);
-      }
-    }
-
-    // Build worker-ID patterns for all other projects. If another project has
-    // sessionPrefix === orchestratorPrefix (e.g. project B has prefix "app-orchestrator"),
-    // then its workers are named "app-orchestrator-1", "app-orchestrator-2", etc. — which
-    // would collide with our orchestrator IDs. Detect this impossible configuration early.
-    for (const [otherProjectId, otherProject] of Object.entries(config.projects)) {
-      const otherPrefix = otherProject.sessionPrefix ?? otherProjectId;
-      if (otherPrefix === project.sessionPrefix) continue;
-      if (otherPrefix === orchestratorPrefix) {
-        // Another project's workers are "{otherPrefix}-\d+" which equals "{orchestratorPrefix}-\d+".
-        // Every candidate ID we would generate collides — fail immediately with a clear message.
-        throw new Error(
-          `Cannot spawn orchestrator for project "${project.sessionPrefix}": the orchestrator ID prefix "${orchestratorPrefix}" ` +
-            `conflicts with the session prefix of project "${otherProjectId}" ("${otherPrefix}"). ` +
-            `Rename one of the project sessionPrefix values to avoid this overlap.`,
-        );
-      }
-    }
-
-    let num = 1;
-    for (let attempts = 0; attempts < 10_000; attempts++) {
-      if (!usedNumbers.has(num)) {
-        const sessionId = `${orchestratorPrefix}-${num}`;
-        const tmuxName = config.configPath
-          ? generateTmuxName(config.configPath, orchestratorPrefix, num)
-          : undefined;
-        if (reserveSessionId(sessionsDir, sessionId)) {
-          return { num, sessionId, tmuxName };
-        }
-      }
-      num += 1;
-    }
-
-    throw new Error(
-      `Failed to reserve orchestrator session ID after 10000 attempts (prefix: ${orchestratorPrefix})`,
-    );
-  }
-
   /** Resolve which plugins to use for a project. */
   function resolvePlugins(project: ProjectConfig, agentName?: string) {
     const runtime = registry.get<Runtime>("runtime", project.runtime ?? config.defaults.runtime);
@@ -762,7 +698,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     metadata: Record<string, string>,
   ) {
     return resolveAgentSelection({
-      role: resolveSessionRole(sessionId, metadata, project.sessionPrefix),
+      role: resolveSessionRole(sessionId, metadata),
       project,
       defaults: config.defaults,
       persistedAgent: metadata["agent"],
@@ -803,11 +739,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         modifiedAt = undefined;
       }
 
-      const repaired = repairSingleSessionMetadataOnRead(
-        sessionsDir,
-        { sessionName: sessionId, raw, modifiedAt },
-        project.sessionPrefix,
-      );
+      const repaired = repairSingleSessionMetadataOnRead(sessionsDir, {
+        sessionName: sessionId,
+        raw,
+        modifiedAt,
+      });
 
       return { raw: repaired.raw, sessionsDir, project, projectId };
     }
@@ -1271,88 +1207,29 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new Error(`Agent plugin '${selection.agentName}' not found`);
     }
 
+    const sessionId = `${project.sessionPrefix}-orchestrator`;
     const orchestratorSessionStrategy = normalizeOrchestratorSessionStrategy(
       project.orchestratorSessionStrategy,
     );
 
+    // Generate tmux name if using new architecture
+    let tmuxName: string | undefined;
+    if (config.configPath) {
+      const hash = generateConfigHash(config.configPath);
+      tmuxName = `${hash}-${sessionId}`;
+    }
+
     // Get the sessions directory for this project
     const sessionsDir = getProjectSessionsDir(project);
 
-    // Validate and store .origin file before reserving any identity so that
-    // a validation failure does not leave an orphaned metadata entry.
+    // Validate and store .origin file
     if (config.configPath) {
       validateAndStoreOrigin(config.configPath, project.path);
     }
 
-    // Reserve a new unique orchestrator identity (e.g. {prefix}-orchestrator-1, -2, …).
-    // Each spawnOrchestrator call gets its own numbered session and isolated worktree.
-    const identity = reserveNextOrchestratorIdentity(project, sessionsDir);
-    const sessionId = identity.sessionId;
-    const tmuxName = identity.tmuxName;
-
-    // Each orchestrator gets an isolated worktree on its own branch.
-    const branch = `orchestrator/${sessionId}`;
-
-    if (!plugins.workspace) {
-      try {
-        deleteMetadata(sessionsDir, sessionId, false);
-      } catch {
-        /* best effort */
-      }
-      throw new Error(
-        `spawnOrchestrator requires a workspace plugin but none is configured for project '${orchestratorConfig.projectId}'`,
-      );
-    }
-
-    let workspacePath: string;
-    try {
-      const wsInfo = await plugins.workspace.create({
-        projectId: orchestratorConfig.projectId,
-        project,
-        sessionId,
-        branch,
-      });
-      workspacePath = wsInfo.path;
-    } catch (err) {
-      try {
-        deleteMetadata(sessionsDir, sessionId, false);
-      } catch {
-        /* best effort */
-      }
-      throw err;
-    }
-
-    // Helper: undo worktree + metadata if anything between workspace creation
-    // and a fully-written metadata record fails.
-    const cleanupWorktreeAndMetadata = async (promptFile?: string): Promise<void> => {
-      try {
-        // plugins.workspace is guaranteed non-null here: we threw above if it was null
-        await plugins.workspace!.destroy(workspacePath);
-      } catch {
-        /* best effort */
-      }
-      try {
-        deleteMetadata(sessionsDir, sessionId, false);
-      } catch {
-        /* best effort */
-      }
-      if (promptFile) {
-        try {
-          unlinkSync(promptFile);
-        } catch {
-          /* best effort */
-        }
-      }
-    };
-
     // Setup agent hooks for automatic metadata updates
-    try {
-      if (plugins.agent.setupWorkspaceHooks) {
-        await plugins.agent.setupWorkspaceHooks(workspacePath, { dataDir: sessionsDir });
-      }
-    } catch (err) {
-      await cleanupWorktreeAndMetadata();
-      throw err;
+    if (plugins.agent.setupWorkspaceHooks) {
+      await plugins.agent.setupWorkspaceHooks(project.path, { dataDir: sessionsDir });
     }
 
     // Write system prompt to a file to avoid shell/tmux truncation.
@@ -1360,38 +1237,93 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     // via tmux send-keys or paste-buffer. File-based approach is reliable.
     let systemPromptFile: string | undefined;
     if (orchestratorConfig.systemPrompt) {
-      try {
-        const baseDir = getProjectBaseDir(config.configPath, project.path);
-        mkdirSync(baseDir, { recursive: true });
-        systemPromptFile = join(baseDir, `orchestrator-prompt-${sessionId}.md`);
-        writeFileSync(systemPromptFile, orchestratorConfig.systemPrompt, "utf-8");
-      } catch (err) {
-        await cleanupWorktreeAndMetadata(systemPromptFile);
-        throw err;
+      const baseDir = getProjectBaseDir(config.configPath, project.path);
+      mkdirSync(baseDir, { recursive: true });
+      systemPromptFile = join(baseDir, "orchestrator-prompt.md");
+      writeFileSync(systemPromptFile, orchestratorConfig.systemPrompt, "utf-8");
+    }
+
+    const existingRaw = readMetadataRaw(sessionsDir, sessionId);
+    const existingOrchestrator = existingRaw?.["runtimeHandle"]
+      ? metadataToSession(sessionId, existingRaw, orchestratorConfig.projectId)
+      : null;
+    if (existingOrchestrator?.runtimeHandle) {
+      const existingAlive = await plugins.runtime
+        .isAlive(existingOrchestrator.runtimeHandle)
+        .catch(() => false);
+      if (existingAlive && orchestratorSessionStrategy === "reuse") {
+        const persistedRaw = readMetadataRaw(sessionsDir, sessionId);
+        if (persistedRaw?.["runtimeHandle"]) {
+          const persisted = metadataToSession(
+            sessionId,
+            persistedRaw,
+            orchestratorConfig.projectId,
+          );
+          persisted.metadata["orchestratorSessionReused"] = "true";
+          return persisted;
+        }
+        await plugins.runtime.destroy(existingOrchestrator.runtimeHandle).catch(() => undefined);
+        deleteMetadata(sessionsDir, sessionId, false);
+      }
+      if (existingAlive && orchestratorSessionStrategy !== "reuse") {
+        await plugins.runtime.destroy(existingOrchestrator.runtimeHandle).catch(() => undefined);
+        // Destroy runtime and delete metadata without archive for ignore strategy
+        deleteMetadata(sessionsDir, sessionId, false);
+      }
+      // For dead runtime, delete metadata so reserveSessionId can succeed:
+      // - With reuse strategy + opencode: archive to preserve opencodeSessionId for reuse lookup
+      // - With non-reuse strategy: delete without archive to respawn fresh
+      if (!existingAlive) {
+        deleteMetadata(sessionsDir, sessionId, orchestratorSessionStrategy === "reuse");
       }
     }
 
-    let reusableOpenCodeSessionId: string | undefined;
-    try {
-      reusableOpenCodeSessionId =
-        plugins.agent.name === "opencode" && orchestratorSessionStrategy === "reuse"
-          ? await resolveOpenCodeSessionReuse({
-              sessionsDir,
-              criteria: { sessionId },
-              strategy: "reuse",
-            })
-          : undefined;
-      if (plugins.agent.name === "opencode" && orchestratorSessionStrategy === "delete") {
-        await resolveOpenCodeSessionReuse({
-          sessionsDir,
-          criteria: { sessionId },
-          strategy: "delete",
-          includeTitleDiscoveryForSessionId: true,
-        });
+    // Atomically reserve the session ID before creating any resources.
+    // This prevents race conditions where concurrent spawnOrchestrator calls
+    // both see no existing session and proceed to create duplicate runtimes.
+    let reserved = reserveSessionId(sessionsDir, sessionId);
+    if (!reserved) {
+      // Reservation failed - another process reserved it first.
+      // Check if the session now exists and is alive.
+      const concurrentRaw = readMetadataRaw(sessionsDir, sessionId);
+      const concurrentSession = concurrentRaw?.["runtimeHandle"]
+        ? metadataToSession(sessionId, concurrentRaw, orchestratorConfig.projectId)
+        : null;
+      if (concurrentSession?.runtimeHandle) {
+        const concurrentAlive = await plugins.runtime
+          .isAlive(concurrentSession.runtimeHandle)
+          .catch(() => false);
+        if (concurrentAlive && orchestratorSessionStrategy === "reuse") {
+          concurrentSession.metadata["orchestratorSessionReused"] = "true";
+          return concurrentSession;
+        }
+        if (!concurrentAlive) {
+          deleteMetadata(sessionsDir, sessionId, orchestratorSessionStrategy === "reuse");
+          reserved = reserveSessionId(sessionsDir, sessionId);
+        }
+      } else {
+        reserved = reserveSessionId(sessionsDir, sessionId);
       }
-    } catch (err) {
-      await cleanupWorktreeAndMetadata(systemPromptFile);
-      throw err;
+      if (!reserved) {
+        throw new Error(`Session ${sessionId} already exists but is not in a reusable state`);
+      }
+    }
+
+    const reusableOpenCodeSessionId =
+      plugins.agent.name === "opencode" && orchestratorSessionStrategy === "reuse"
+        ? await resolveOpenCodeSessionReuse({
+            sessionsDir,
+            criteria: { sessionId },
+            strategy: "reuse",
+          })
+        : undefined;
+    if (plugins.agent.name === "opencode" && orchestratorSessionStrategy === "delete") {
+      await resolveOpenCodeSessionReuse({
+        sessionsDir,
+        criteria: { sessionId },
+        strategy: "delete",
+        includeTitleDiscoveryForSessionId: true,
+      });
     }
 
     // Get agent launch config — uses systemPromptFile, no issue/tracker interaction.
@@ -1415,29 +1347,22 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     const launchCommand = plugins.agent.getLaunchCommand(agentLaunchConfig);
     const environment = plugins.agent.getEnvironment(agentLaunchConfig);
 
-    // Create runtime — clean up worktree and metadata on failure
-    let handle: RuntimeHandle;
-    try {
-      handle = await plugins.runtime.create({
-        sessionId: tmuxName ?? sessionId,
-        workspacePath,
-        launchCommand,
-        environment: {
-          ...environment,
-          AO_SESSION: sessionId,
-          AO_DATA_DIR: sessionsDir,
-          AO_SESSION_NAME: sessionId,
-          ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
-          AO_CALLER_TYPE: "orchestrator",
-          AO_PROJECT_ID: orchestratorConfig.projectId,
-          AO_CONFIG_PATH: config.configPath,
-          ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
-        },
-      });
-    } catch (err) {
-      await cleanupWorktreeAndMetadata(systemPromptFile);
-      throw err;
-    }
+    const handle = await plugins.runtime.create({
+      sessionId: tmuxName ?? sessionId,
+      workspacePath: project.path,
+      launchCommand,
+      environment: {
+        ...environment,
+        AO_SESSION: sessionId,
+        AO_DATA_DIR: sessionsDir,
+        AO_SESSION_NAME: sessionId,
+        ...(tmuxName && { AO_TMUX_NAME: tmuxName }),
+        AO_CALLER_TYPE: "orchestrator",
+        AO_PROJECT_ID: orchestratorConfig.projectId,
+        AO_CONFIG_PATH: config.configPath,
+        ...(config.port !== undefined && config.port !== null && { AO_PORT: String(config.port) }),
+      },
+    });
 
     // Write metadata and run post-launch setup
     const session: Session = {
@@ -1445,10 +1370,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       projectId: orchestratorConfig.projectId,
       status: "working",
       activity: "active",
-      branch,
+      branch: project.defaultBranch,
       issueId: null,
       pr: null,
-      workspacePath,
+      workspacePath: project.path,
       runtimeHandle: handle,
       agentInfo: null,
       createdAt: new Date(),
@@ -1460,8 +1385,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     try {
       writeMetadata(sessionsDir, sessionId, {
-        worktree: workspacePath,
-        branch,
+        worktree: project.path,
+        branch: project.defaultBranch,
         status: "working",
         role: "orchestrator",
         tmuxName,
@@ -1500,7 +1425,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       } catch {
         /* best effort */
       }
-      await cleanupWorktreeAndMetadata(systemPromptFile);
+      try {
+        deleteMetadata(sessionsDir, sessionId, false);
+      } catch {
+        /* best effort */
+      }
       throw err;
     }
 
@@ -1591,11 +1520,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         // If stat fails, timestamps will fall back to current time
       }
 
-      const repaired = repairSingleSessionMetadataOnRead(
-        sessionsDir,
-        { sessionName: sessionId, raw, modifiedAt },
-        project.sessionPrefix,
-      );
+      const repaired = repairSingleSessionMetadataOnRead(sessionsDir, {
+        sessionName: sessionId,
+        raw,
+        modifiedAt,
+      });
 
       const session = metadataToSession(sessionId, repaired.raw, projectId, createdAt, modifiedAt);
 
@@ -2132,7 +2061,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     if (!reference) throw new Error("PR reference is required");
 
     const { raw, sessionsDir, project, projectId } = requireSessionRecord(sessionId);
-    if (isOrchestratorSessionRecord(sessionId, raw, project.sessionPrefix)) {
+    if (isOrchestratorSessionRecord(sessionId, raw)) {
       throw new Error(`Session ${sessionId} is an orchestrator session and cannot claim PRs`);
     }
 
@@ -2159,7 +2088,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     );
 
     for (const { sessionName, raw: otherRaw } of activeRecords) {
-      if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw, project.sessionPrefix)) continue;
+      if (!otherRaw || isOrchestratorSessionRecord(sessionName, otherRaw)) continue;
 
       const samePr = otherRaw["pr"] === pr.url;
       const sameBranch =

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,37 +189,11 @@ export interface Session {
   metadata: Record<string, string>;
 }
 
-export function isOrchestratorSession(
-  session: { id: SessionId; metadata?: Record<string, string> },
-  sessionPrefix?: string,
-  allSessionPrefixes?: string[],
-): boolean {
-  if (session.metadata?.["role"] === "orchestrator" || session.id.endsWith("-orchestrator")) {
-    return true;
-  }
-  if (!sessionPrefix) {
-    return false;
-  }
-  const escaped = sessionPrefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (!new RegExp(`^${escaped}-orchestrator-\\d+$`).test(session.id)) {
-    return false;
-  }
-  // Guard against cross-project false positives: if the session ID is a plain
-  // numbered worker for any other known prefix (e.g. prefix "app-orchestrator"
-  // matches "app-orchestrator-1" as a worker), it is not an orchestrator.
-  if (allSessionPrefixes) {
-    for (const prefix of allSessionPrefixes) {
-      if (prefix === sessionPrefix) continue;
-      if (
-        new RegExp(
-          `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`,
-        ).test(session.id)
-      ) {
-        return false;
-      }
-    }
-  }
-  return true;
+export function isOrchestratorSession(session: {
+  id: SessionId;
+  metadata?: Record<string, string>;
+}): boolean {
+  return session.metadata?.["role"] === "orchestrator" || session.id.endsWith("-orchestrator");
 }
 
 /** Config for creating a new session */

--- a/packages/web/src/app/api/orchestrators/route.ts
+++ b/packages/web/src/app/api/orchestrators/route.ts
@@ -1,5 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { generateOrchestratorPrompt, generateSessionPrefix } from "@composio/ao-core";
+import { generateOrchestratorPrompt } from "@composio/ao-core";
 import { getServices } from "@/lib/services";
 import { validateIdentifier, validateConfiguredProject } from "@/lib/validation";
 import { mapSessionsToOrchestrators } from "@/lib/orchestrator-utils";
@@ -27,13 +27,8 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: configProjectErr }, { status: 404 });
     }
     const project = config.projects[projectId];
-    const sessionPrefix = project.sessionPrefix ?? projectId;
-
     const allSessions = await sessionManager.list(projectId);
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
-    );
-    const orchestrators = mapSessionsToOrchestrators(allSessions, sessionPrefix, project.name, allSessionPrefixes);
+    const orchestrators = mapSessionsToOrchestrators(allSessions, project.name);
 
     return NextResponse.json({ orchestrators, projectName: project.name });
   } catch (err) {

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -58,17 +58,7 @@ export async function GET(request: Request) {
       );
     }
 
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([projectId, p]) => p.sessionPrefix ?? projectId,
-    );
-    let workerSessions = visibleSessions.filter(
-      (session) =>
-        !isOrchestratorSession(
-          session,
-          config.projects[session.projectId]?.sessionPrefix ?? session.projectId,
-          allSessionPrefixes,
-        ),
-    );
+    let workerSessions = visibleSessions.filter((session) => !isOrchestratorSession(session));
 
     // Convert to dashboard format
     let dashboardSessions = workerSessions.map(sessionToDashboard);

--- a/packages/web/src/app/orchestrators/page.tsx
+++ b/packages/web/src/app/orchestrators/page.tsx
@@ -2,7 +2,6 @@ import type { Metadata } from "next";
 import { OrchestratorSelector, type Orchestrator } from "@/components/OrchestratorSelector";
 import { getServices } from "@/lib/services";
 import { getAllProjects } from "@/lib/project-name";
-import { generateSessionPrefix } from "@composio/ao-core";
 import { mapSessionsToOrchestrators } from "@/lib/orchestrator-utils";
 
 export const dynamic = "force-dynamic";
@@ -56,12 +55,8 @@ export default async function OrchestratorsRoute(props: {
       error = `Project "${projectId}" not found`;
     } else {
       projectName = project.name;
-      const sessionPrefix = project.sessionPrefix ?? projectId;
       const allSessions = await sessionManager.list(projectId);
-      const allSessionPrefixes = Object.entries(config.projects).map(
-        ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
-      );
-      orchestrators = mapSessionsToOrchestrators(allSessions, sessionPrefix, project.name, allSessionPrefixes);
+      orchestrators = mapSessionsToOrchestrators(allSessions, project.name);
     }
   } catch (err) {
     error = err instanceof Error ? err.message : "Failed to load orchestrators";

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -6,7 +6,6 @@ import { isOrchestratorSession } from "@composio/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, type ActivityState, getAttentionLevel, type AttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
-import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
 import { useSSESessionActivity } from "@/hooks/useSSESessionActivity";
 
@@ -17,14 +16,12 @@ function truncate(s: string, max: number): string {
 /** Build a descriptive tab title from session data. */
 function buildSessionTitle(
   session: DashboardSession,
-  prefixByProject: Map<string, string>,
   activityOverride?: ActivityState | null,
 ): string {
   const id = session.id;
   const activity = activityOverride !== undefined ? activityOverride : session.activity;
   const emoji = activity ? (activityIcon[activity] ?? "") : "";
-  const allPrefixes = [...prefixByProject.values()];
-  const isOrchestrator = isOrchestratorSession(session, prefixByProject.get(session.projectId), allPrefixes);
+  const isOrchestrator = isOrchestratorSession(session);
 
   let detail: string;
 
@@ -62,36 +59,12 @@ export default function SessionPage() {
   const [loading, setLoading] = useState(true);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
-  const [prefixByProject, setPrefixByProject] = useState<Map<string, string>>(new Map());
   const sessionProjectId = session?.projectId ?? null;
-  const allPrefixes = [...prefixByProject.values()];
-  const sessionIsOrchestrator = session
-    ? isOrchestratorSession(session, prefixByProject.get(session.projectId), allPrefixes)
-    : false;
+  const sessionIsOrchestrator = session ? isOrchestratorSession(session) : false;
   const sessionProjectIdRef = useRef<string | null>(null);
   const sessionIsOrchestratorRef = useRef(false);
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
-  const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
-
-  // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
-  useEffect(() => {
-    prefixByProjectRef.current = prefixByProject;
-  }, [prefixByProject]);
-
-  // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
-  useEffect(() => {
-    fetch("/api/projects")
-      .then((res) => res.ok ? res.json() : null)
-      .then((data: { projects?: ProjectInfo[] } | null) => {
-        if (data?.projects) {
-          setPrefixByProject(
-            new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
-          );
-        }
-      })
-      .catch(() => {/* non-critical — falls back to role metadata check */});
-  }, []);
 
   // Subscribe to SSE for real-time activity updates (title emoji)
   const sseActivity = useSSESessionActivity(id);
@@ -99,11 +72,11 @@ export default function SessionPage() {
   // Update document title based on session data + SSE activity override
   useEffect(() => {
     if (session) {
-      document.title = buildSessionTitle(session, prefixByProject, sseActivity?.activity);
+      document.title = buildSessionTitle(session, sseActivity?.activity);
     } else {
       document.title = `${id} | Session Detail`;
     }
-  }, [session, id, prefixByProject, sseActivity]);
+  }, [session, id, sseActivity]);
 
   useEffect(() => {
     sessionProjectIdRef.current = sessionProjectId;
@@ -173,9 +146,8 @@ export default function SessionPage() {
         working: 0,
         done: 0,
       };
-      const allPrefixes = [...prefixByProjectRef.current.values()];
       for (const s of sessions) {
-        if (!isOrchestratorSession(s, prefixByProjectRef.current.get(s.projectId), allPrefixes)) {
+        if (!isOrchestratorSession(s)) {
           counts[getAttentionLevel(s) as AttentionLevel]++;
         }
       }

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -21,14 +21,8 @@ interface ProjectSidebarProps {
 
 type ProjectHealth = "red" | "yellow" | "green" | "gray";
 
-function computeProjectHealth(
-  sessions: DashboardSession[],
-  prefixByProject: Map<string, string>,
-  allPrefixes: string[],
-): ProjectHealth {
-  const workers = sessions.filter(
-    (s) => !isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes),
-  );
+function computeProjectHealth(sessions: DashboardSession[]): ProjectHealth {
+  const workers = sessions.filter((s) => !isOrchestratorSession(s));
   if (workers.length === 0) return "gray";
   for (const s of workers) {
     if (getAttentionLevel(s) === "respond") return "red";
@@ -137,16 +131,6 @@ function ProjectSidebarInner({
     router.push(pathname + `?project=${encodeURIComponent(projectId)}`);
   };
 
-  const prefixByProject = useMemo(
-    () => new Map(projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
-    [projects],
-  );
-
-  const allPrefixes = useMemo(
-    () => projects.map((p) => p.sessionPrefix ?? p.id),
-    [projects],
-  );
-
   const sessionsByProject = useMemo(() => {
     const map = new Map<string, { all: DashboardSession[]; workers: DashboardSession[] }>();
     let totalWorkers = 0;
@@ -160,7 +144,7 @@ function ProjectSidebarInner({
         map.set(s.projectId, entry);
       }
       entry.all.push(s);
-      if (!isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes)) {
+      if (!isOrchestratorSession(s)) {
         entry.workers.push(s);
         totalWorkers++;
       }
@@ -170,7 +154,7 @@ function ProjectSidebarInner({
     }
 
     return { map, totalWorkers, needsInput, reviewLoad };
-  }, [sessions, prefixByProject, allPrefixes]);
+  }, [sessions]);
 
   const { totalWorkers: totalWorkerSessions, needsInput: needsInputCount, reviewLoad: reviewLoadCount } = sessionsByProject;
 
@@ -184,7 +168,7 @@ function ProjectSidebarInner({
           <div className="flex flex-1 flex-col items-center gap-2">
             {projects.map((project) => {
               const entry = sessionsByProject.map.get(project.id);
-              const health = entry ? computeProjectHealth(entry.all, prefixByProject, allPrefixes) : ("gray" as ProjectHealth);
+              const health = entry ? computeProjectHealth(entry.all) : ("gray" as ProjectHealth);
               const isActive = activeProjectId === project.id;
               const initial = project.name.charAt(0).toUpperCase();
               return (
@@ -303,7 +287,7 @@ function ProjectSidebarInner({
           const entry = sessionsByProject.map.get(project.id);
           const projectSessions = entry?.all ?? [];
           const workerSessions = entry?.workers ?? [];
-          const health = computeProjectHealth(projectSessions, prefixByProject, allPrefixes);
+          const health = computeProjectHealth(projectSessions);
           const isExpanded = expandedProjects.has(project.id);
           const isActive = activeProjectId === project.id;
 

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -1,11 +1,10 @@
 "use client";
 
 import { useEffect, useReducer, useRef } from "react";
-import {
-  getAttentionLevel,
-  type AttentionLevel,
-  type DashboardSession,
-  type SSESnapshotEvent,
+import type {
+  AttentionLevel,
+  DashboardSession,
+  SSESnapshotEvent,
 } from "@/lib/types";
 
 /** Debounce before fetching full session list after membership change. */
@@ -176,13 +175,9 @@ export function useSessionEvents(
               }
 
               lastRefreshAtRef.current = Date.now();
-              const sseAttentionLevels = Object.fromEntries(
-                updated.sessions.map((s) => [s.id, getAttentionLevel(s)]),
-              ) as SSEAttentionMap;
               dispatch({
                 type: "reset",
                 sessions: updated.sessions,
-                sseAttentionLevels,
               });
             },
           )

--- a/packages/web/src/lib/orchestrator-utils.ts
+++ b/packages/web/src/lib/orchestrator-utils.ts
@@ -8,9 +8,7 @@ import type { Orchestrator } from "@/components/OrchestratorSelector";
  */
 export function mapSessionsToOrchestrators(
   sessions: Session[],
-  _sessionPrefix: string,
   projectName: string,
-  _allSessionPrefixes?: string[],
 ): Orchestrator[] {
   return sessions
     .filter((s) => isOrchestratorSession(s) && !isTerminalSession(s))

--- a/packages/web/src/lib/orchestrator-utils.ts
+++ b/packages/web/src/lib/orchestrator-utils.ts
@@ -8,12 +8,12 @@ import type { Orchestrator } from "@/components/OrchestratorSelector";
  */
 export function mapSessionsToOrchestrators(
   sessions: Session[],
-  sessionPrefix: string,
+  _sessionPrefix: string,
   projectName: string,
-  allSessionPrefixes?: string[],
+  _allSessionPrefixes?: string[],
 ): Orchestrator[] {
   return sessions
-    .filter((s) => isOrchestratorSession(s, sessionPrefix, allSessionPrefixes) && !isTerminalSession(s))
+    .filter((s) => isOrchestratorSession(s) && !isTerminalSession(s))
     .map((s) => ({
       id: s.id,
       projectId: s.projectId,

--- a/packages/web/src/lib/project-name.ts
+++ b/packages/web/src/lib/project-name.ts
@@ -6,7 +6,6 @@ import { loadConfig } from "@composio/ao-core";
 export interface ProjectInfo {
   id: string;
   name: string;
-  sessionPrefix?: string;
 }
 
 export const getProjectName = cache((): string => {
@@ -40,7 +39,6 @@ export const getAllProjects = cache((): ProjectInfo[] => {
     return Object.entries(config.projects).map(([id, project]) => ({
       id,
       name: project.name ?? id,
-      sessionPrefix: project.sessionPrefix ?? id,
     }));
   } catch {
     return [];

--- a/packages/web/src/lib/project-utils.ts
+++ b/packages/web/src/lib/project-utils.ts
@@ -44,16 +44,6 @@ export function filterWorkerSessions<T extends SessionLike>(
   projectFilter: string | null | undefined,
   projects: Record<string, ProjectWithPrefix>,
 ): T[] {
-  const allSessionPrefixes = Object.entries(projects).map(
-    ([projectId, p]) => p.sessionPrefix ?? projectId,
-  );
-  const workers = sessions.filter(
-    (s) =>
-      !isOrchestratorSession(
-        s,
-        projects[s.projectId]?.sessionPrefix ?? s.projectId,
-        allSessionPrefixes,
-      ),
-  );
+  const workers = sessions.filter((s) => !isOrchestratorSession(s));
   return filterProjectSessions(workers, projectFilter, projects);
 }

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -75,17 +75,8 @@ export function listDashboardOrchestrators(
   sessions: Session[],
   projects: Record<string, ProjectConfig>,
 ): DashboardOrchestratorLink[] {
-  const allSessionPrefixes = Object.entries(projects).map(
-    ([projectId, p]) => p.sessionPrefix ?? projectId,
-  );
   return sessions
-    .filter((session) =>
-      isOrchestratorSession(
-        session,
-        projects[session.projectId]?.sessionPrefix ?? session.projectId,
-        allSessionPrefixes,
-      ),
-    )
+    .filter((session) => isOrchestratorSession(session))
     .map((session) => ({
       id: session.id,
       projectId: session.projectId,

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -227,16 +227,8 @@ export async function pollBacklog(): Promise<void> {
     // Detect reopened issues: open state + agent:done label → relabel as agent:backlog
     await relabelReopenedIssues(config, registry);
 
-    const allSessionPrefixes = Object.entries(config.projects).map(
-      ([id, p]) => p.sessionPrefix ?? id,
-    );
     const workerSessions = allSessions.filter(
-      (session) =>
-        !isOrchestratorSession(
-          session,
-          config.projects[session.projectId]?.sessionPrefix ?? session.projectId,
-          allSessionPrefixes,
-        ) && !TERMINAL_STATUSES.has(session.status),
+      (session) => !isOrchestratorSession(session) && !TERMINAL_STATUSES.has(session.status),
     );
     const activeIssueIds = new Set(
       workerSessions


### PR DESCRIPTION
## Summary

- Reverts PR #870 (`feat: support multiple concurrent orchestrators with isolated worktrees`)
- Removes multi-orchestrator session isolation, project-prefix routing, and per-project SSE filtering
- Restores single-orchestrator session management behavior

## Files changed

Reverts changes across 20 files in `core`, `cli`, and `web` packages — session manager, types, lifecycle manager, dashboard routing, and tests.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] Verify `ao start` works with single orchestrator
- [ ] Verify dashboard loads sessions correctly