### PR TITLE
fix(web): remove orchestrator button from orchestrator webpage

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -517,7 +517,7 @@ export function SessionDetail({
           ) : null}
           <div className="dashboard-app-header__spacer" />
           <div className="dashboard-app-header__actions">
-            {orchestratorHref ? (
+            {!isOrchestrator && orchestratorHref ? (
               <a
                 href={orchestratorHref}
                 className="dashboard-app-btn dashboard-app-btn--amber"

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -186,4 +186,29 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText(/Terminal session has ended/i)).toBeInTheDocument();
     expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
   });
+
+  it("hides the desktop orchestrator button on orchestrator session pages", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "my-app-orchestrator",
+          summary: "Project orchestrator",
+        })}
+        isOrchestrator
+        orchestratorZones={{
+          merge: 1,
+          respond: 0,
+          review: 0,
+          pending: 0,
+          working: 2,
+          done: 3,
+        }}
+        projectOrchestratorId="my-app-orchestrator"
+        projects={[{ id: "my-app", name: "My App", path: "/tmp/my-app" }]}
+      />,
+    );
+
+    expect(screen.queryByRole("link", { name: "Orchestrator" })).not.toBeInTheDocument();
+    expect(screen.getByText("orchestrator")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- hide the desktop header Orchestrator button when the current session detail page is already an orchestrator page
- keep the button behavior unchanged for worker session pages
- add a regression test covering the orchestrator detail case

## Verification
- pnpm --filter @aoagents/ao-web test -- src/components/__tests__/SessionDetail.desktop.test.tsx
- pnpm build
- pnpm --filter @aoagents/ao-web typecheck