### PR TITLE
fix(web): hyperlink CI check chips to GitHub workflow runs in session detail

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -864,21 +864,36 @@ function SessionDetailPRCard({ pr, sessionId, metadata }: { pr: DashboardPR; ses
         {pr.ciChecks.length > 0 && (
           <>
             <div className="session-detail-pr-sep" />
-            {pr.ciChecks.map((check) => (
-              <span
-                key={check.name}
-                className={cn(
-                  "session-detail-ci-chip",
-                  check.status === "passed" && "session-detail-ci-chip--pass",
-                  check.status === "failed" && "session-detail-ci-chip--fail",
-                  check.status === "pending" && "session-detail-ci-chip--pending",
-                  check.status !== "passed" && check.status !== "failed" && check.status !== "pending" && "session-detail-ci-chip--queued",
-                )}
-              >
-                {check.status === "passed" ? "\u2713" : check.status === "failed" ? "\u2717" : check.status === "pending" ? "\u25CF" : "\u25CB"}{" "}
-                {check.name}
-              </span>
-            ))}
+            {pr.ciChecks.map((check) => {
+              const chip = (
+                <span
+                  className={cn(
+                    "session-detail-ci-chip",
+                    check.status === "passed" && "session-detail-ci-chip--pass",
+                    check.status === "failed" && "session-detail-ci-chip--fail",
+                    check.status === "pending" && "session-detail-ci-chip--pending",
+                    check.status !== "passed" && check.status !== "failed" && check.status !== "pending" && "session-detail-ci-chip--queued",
+                  )}
+                >
+                  {check.status === "passed" ? "\u2713" : check.status === "failed" ? "\u2717" : check.status === "pending" ? "\u25CF" : "\u25CB"}{" "}
+                  {check.name}
+                </span>
+              );
+              return check.url ? (
+                <a
+                  key={check.name}
+                  href={check.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="hover:no-underline"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {chip}
+                </a>
+              ) : (
+                <span key={check.name}>{chip}</span>
+              );
+            })}
           </>
         )}
       </div>


### PR DESCRIPTION
Fixes #1195

## Summary
CI check chips in SessionDetail (✓ run-lint, ✓ run-tests, etc.) were rendered
as plain <span> elements with no link. The check.url field — already populated
by the GitHub SCM plugin and passed through the serializer — was never used.

Now wraps each chip in an <a> tag when check.url is present, matching the
pattern already used in CIBadge.tsx's CICheckList component.

## Test
1. Open the AO web dashboard
2. Navigate to a session detail with an open PR that has CI checks
3. Click any CI chip (e.g., ✓ run-lint) — it should open the GitHub workflow run URL