### PR TITLE
feat(web): collapse attention zones to 4 with 5-zone feature flag

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -239,6 +239,12 @@ const PowerConfigSchema = z
   })
   .default({});
 
+const DashboardConfigSchema = z
+  .object({
+    attentionZones: z.enum(["simple", "detailed"]).default("simple"),
+  })
+  .strict();
+
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),
   terminalPort: z.number().optional(),
@@ -247,6 +253,7 @@ const OrchestratorConfigSchema = z.object({
   power: PowerConfigSchema,
   defaults: DefaultPluginsSchema.default({}),
   plugins: z.array(InstalledPluginConfigSchema).default([]),
+  dashboard: DashboardConfigSchema.optional(),
   projects: z.record(
     z.string().regex(/^[a-zA-Z0-9_-]+$/, "Project ID must match [a-zA-Z0-9_-]+ (no dots, slashes, or special characters)"),
     ProjectConfigSchema,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -239,11 +239,9 @@ const PowerConfigSchema = z
   })
   .default({});
 
-const DashboardConfigSchema = z
-  .object({
-    attentionZones: z.enum(["simple", "detailed"]).default("simple"),
-  })
-  .strict();
+const DashboardConfigSchema = z.object({
+  attentionZones: z.enum(["simple", "detailed"]).default("simple"),
+});
 
 const OrchestratorConfigSchema = z.object({
   port: z.number().default(3000),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1046,6 +1046,9 @@ export interface OrchestratorConfig {
   /** Project configurations */
   projects: Record<string, ProjectConfig>;
 
+  /** Dashboard UI configuration */
+  dashboard?: DashboardConfig;
+
   /** Notification channel configs */
   notifiers: Record<string, NotifierConfig>;
 
@@ -1091,6 +1094,22 @@ export interface ExternalPluginEntryRef {
    * When undefined, any manifest.name is accepted and config is updated with it.
    */
   expectedPluginName?: string;
+}
+
+/**
+ * Dashboard attention zone display mode.
+ *
+ * - "simple" (default): collapses the 5 detailed zones into 4 by merging
+ *   REVIEW + RESPOND into a single ACTION column. The card-level badges
+ *   still expose the underlying state (ci_failed, needs_input, changes_requested).
+ * - "detailed": preserves the original 5-zone Kanban layout for power users
+ *   who want REVIEW and RESPOND as distinct columns.
+ */
+export type DashboardAttentionZoneMode = "simple" | "detailed";
+
+export interface DashboardConfig {
+  /** Attention zone layout (defaults to "simple") */
+  attentionZones?: DashboardAttentionZoneMode;
 }
 
 export interface DefaultPlugins {

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -22,7 +22,7 @@ describe("SessionBroadcaster", () => {
     id,
     status: "working",
     activity: "active",
-    attentionLevel: "none",
+    attentionLevel: "working" as const,
     lastActivityAt: new Date().toISOString(),
   });
 

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -35,11 +35,21 @@ type ServerMessage =
   | { ch: "system"; type: "pong" }
   | { ch: "system"; type: "error"; message: string };
 
+// Mirrors AttentionLevel in src/lib/types.ts — keep in sync.
+type AttentionLevel =
+  | "merge"
+  | "action"
+  | "respond"
+  | "review"
+  | "pending"
+  | "working"
+  | "done";
+
 interface SessionPatch {
   id: string;
   status: string;
   activity: string | null;
-  attentionLevel: string;
+  attentionLevel: AttentionLevel;
   lastActivityAt: string;
 }
 

--- a/packages/web/src/__tests__/get-attention-level.test.ts
+++ b/packages/web/src/__tests__/get-attention-level.test.ts
@@ -271,4 +271,136 @@ describe("getAttentionLevel", () => {
       expect(getAttentionLevel(session)).toBe("done");
     });
   });
+
+  // ── SIMPLE MODE (4-zone Kanban — respond + review → action) ───────
+  describe("simple mode", () => {
+    it("collapses waiting_input (respond) into action", () => {
+      const session = makeSession({ activity: "waiting_input" });
+      expect(getAttentionLevel(session, "simple")).toBe("action");
+    });
+
+    it("collapses needs_input status into action", () => {
+      const session = makeSession({ status: "needs_input", activity: "idle" });
+      expect(getAttentionLevel(session, "simple")).toBe("action");
+    });
+
+    it("collapses stuck/errored statuses into action", () => {
+      expect(
+        getAttentionLevel(makeSession({ status: "stuck", activity: "idle" }), "simple"),
+      ).toBe("action");
+      expect(
+        getAttentionLevel(makeSession({ status: "errored", activity: "idle" }), "simple"),
+      ).toBe("action");
+    });
+
+    it("collapses CI failure (review) into action", () => {
+      const pr = makePR({
+        ciStatus: "failing",
+        reviewDecision: "approved",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: true,
+          noConflicts: true,
+          blockers: ["CI failing"],
+        },
+      });
+      const session = makeSession({ status: "ci_failed", activity: "idle", pr });
+      expect(getAttentionLevel(session, "simple")).toBe("action");
+    });
+
+    it("collapses changes_requested (review) into action", () => {
+      const pr = makePR({
+        reviewDecision: "changes_requested",
+        mergeability: {
+          mergeable: false,
+          ciPassing: true,
+          approved: false,
+          noConflicts: true,
+          blockers: ["Changes requested"],
+        },
+      });
+      const session = makeSession({ status: "changes_requested", activity: "idle", pr });
+      expect(getAttentionLevel(session, "simple")).toBe("action");
+    });
+
+    it("preserves merge zone in simple mode", () => {
+      const pr = makePR({
+        mergeability: {
+          mergeable: true,
+          ciPassing: true,
+          approved: true,
+          noConflicts: true,
+          blockers: [],
+        },
+      });
+      const session = makeSession({ status: "mergeable", activity: "idle", pr });
+      expect(getAttentionLevel(session, "simple")).toBe("merge");
+    });
+
+    it("preserves pending zone in simple mode", () => {
+      const pr = makePR({
+        reviewDecision: "pending",
+        mergeability: {
+          mergeable: false,
+          ciPassing: true,
+          approved: false,
+          noConflicts: true,
+          blockers: ["Needs review"],
+        },
+      });
+      const session = makeSession({ status: "review_pending", activity: "idle", pr });
+      expect(getAttentionLevel(session, "simple")).toBe("pending");
+    });
+
+    it("preserves working zone in simple mode", () => {
+      const session = makeSession({ status: "working", activity: "active", pr: null });
+      expect(getAttentionLevel(session, "simple")).toBe("working");
+    });
+
+    it("preserves done zone in simple mode", () => {
+      const session = makeSession({ status: "killed", activity: "exited", pr: null });
+      expect(getAttentionLevel(session, "simple")).toBe("done");
+    });
+
+    it("merge takes priority over action in simple mode", () => {
+      const pr = makePR({
+        mergeability: {
+          mergeable: true,
+          ciPassing: true,
+          approved: true,
+          noConflicts: true,
+          blockers: [],
+        },
+      });
+      const session = makeSession({ status: "mergeable", activity: "blocked", pr });
+      expect(getAttentionLevel(session, "simple")).toBe("merge");
+    });
+  });
+
+  // ── DETAILED MODE (explicit — should match function default) ──────
+  describe("detailed mode", () => {
+    it("keeps respond and review as distinct levels", () => {
+      const waiting = makeSession({ activity: "waiting_input" });
+      expect(getAttentionLevel(waiting, "detailed")).toBe("respond");
+
+      const pr = makePR({
+        ciStatus: "failing",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: true,
+          noConflicts: true,
+          blockers: ["CI failing"],
+        },
+      });
+      const ciFailed = makeSession({ status: "ci_failed", activity: "idle", pr });
+      expect(getAttentionLevel(ciFailed, "detailed")).toBe("review");
+    });
+
+    it("matches the function default (detailed is the default mode)", () => {
+      const session = makeSession({ activity: "waiting_input" });
+      expect(getAttentionLevel(session)).toBe(getAttentionLevel(session, "detailed"));
+    });
+  });
 });

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -81,6 +81,7 @@ export async function GET(request: Request): Promise<Response> {
           const dashboardSessions = workerSessions.map(sessionToDashboard);
           const projectObserver = ensureObserver(config);
 
+          const attentionZones = config.dashboard?.attentionZones ?? "simple";
           const initialEvent = {
             type: "snapshot",
             correlationId,
@@ -89,7 +90,7 @@ export async function GET(request: Request): Promise<Response> {
               id: s.id,
               status: s.status,
               activity: s.activity,
-              attentionLevel: getAttentionLevel(s),
+              attentionLevel: getAttentionLevel(s, attentionZones),
               lastActivityAt: s.lastActivityAt,
             })),
           };
@@ -155,6 +156,7 @@ export async function GET(request: Request): Promise<Response> {
             }
 
             try {
+              const attentionZones = config.dashboard?.attentionZones ?? "simple";
               const event = {
                 type: "snapshot",
                 correlationId,
@@ -163,7 +165,7 @@ export async function GET(request: Request): Promise<Response> {
                   id: s.id,
                   status: s.status,
                   activity: s.activity,
-                  attentionLevel: getAttentionLevel(s),
+                  attentionLevel: getAttentionLevel(s, attentionZones),
                   lastActivityAt: s.lastActivityAt,
                 })),
               };

--- a/packages/web/src/app/api/sessions/patches/route.ts
+++ b/packages/web/src/app/api/sessions/patches/route.ts
@@ -22,12 +22,14 @@ export async function GET(request: Request) {
     // Convert to dashboard format
     const dashboardSessions = visibleSessions.map(sessionToDashboard);
 
+    const attentionZones = config.dashboard?.attentionZones ?? "simple";
+
     // Extract lightweight patches
     const patches = dashboardSessions.map((session) => ({
       id: session.id,
       status: session.status,
       activity: session.activity,
-      attentionLevel: getAttentionLevel(session),
+      attentionLevel: getAttentionLevel(session, attentionZones),
       lastActivityAt: session.lastActivityAt,
     }));
 

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1406,6 +1406,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .sidebar-session-dot[data-level="respond"] {
   background: var(--color-status-respond);
 }
+.sidebar-session-dot[data-level="action"] {
+  background: var(--color-status-respond);
+}
 .sidebar-session-dot[data-level="merge"] {
   background: var(--color-status-ready);
 }
@@ -1452,6 +1455,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   background: var(--color-accent-orange);
 }
 .kanban-column__dot[data-level="respond"] {
+  background: var(--color-status-respond);
+}
+.kanban-column__dot[data-level="action"] {
   background: var(--color-status-respond);
 }
 .kanban-column__dot[data-level="merge"] {
@@ -4110,6 +4116,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   .mobile-action-pill__dot[data-level="respond"] {
     background: var(--color-status-respond);
   }
+  .mobile-action-pill__dot[data-level="action"] {
+    background: var(--color-status-respond);
+  }
   .mobile-action-pill__dot[data-level="merge"] {
     background: var(--color-status-ready);
   }
@@ -4118,6 +4127,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   }
 
   .mobile-action-pill__count[data-level="respond"] {
+    color: var(--color-status-respond);
+  }
+  .mobile-action-pill__count[data-level="action"] {
     color: var(--color-status-respond);
   }
   .mobile-action-pill__count[data-level="merge"] {
@@ -4584,6 +4596,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   .accordion-header__dot[data-level="respond"] {
     background: var(--color-status-respond);
   }
+  .accordion-header__dot[data-level="action"] {
+    background: var(--color-status-respond);
+  }
   .accordion-header__dot[data-level="merge"] {
     background: var(--color-status-ready);
   }
@@ -4598,6 +4613,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     background: var(--color-accent-orange);
   }
   .mobile-session-row__dot[data-level="respond"] {
+    background: var(--color-status-respond);
+  }
+  .mobile-session-row__dot[data-level="action"] {
     background: var(--color-status-respond);
   }
   .mobile-session-row__dot[data-level="merge"] {
@@ -4793,6 +4811,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   }
 
   .mobile-feed-card__strip[data-level="respond"] {
+    background: var(--color-status-respond);
+  }
+  .mobile-feed-card__strip[data-level="action"] {
     background: var(--color-status-respond);
   }
   .mobile-feed-card__strip[data-level="merge"] {
@@ -5423,6 +5444,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .bottom-sheet__preview-strip[data-level="respond"] {
+  background: var(--color-status-respond);
+}
+
+.bottom-sheet__preview-strip[data-level="action"] {
   background: var(--color-status-respond);
 }
 

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1458,7 +1458,12 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   background: var(--color-status-respond);
 }
 .kanban-column__dot[data-level="action"] {
-  background: var(--color-status-respond);
+  /* Yellow-severity to match DynamicFavicon.computeHealthFromLevels: the
+     collapsed bucket includes routine review work (ci_failed,
+     changes_requested) that used to be orange. Painting it at
+     --color-status-respond (red) would disagree with the favicon and make
+     every typical review PR scream critical. */
+  background: var(--color-accent-orange);
 }
 .kanban-column__dot[data-level="merge"] {
   background: var(--color-status-ready);

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -29,6 +29,7 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
       projectName={pageData.projectName}
       projects={pageData.projects}
       orchestrators={pageData.orchestrators}
+      attentionZones={pageData.attentionZones}
     />
   );
 }

--- a/packages/web/src/app/prs/page.tsx
+++ b/packages/web/src/app/prs/page.tsx
@@ -31,6 +31,7 @@ export default async function PullRequestsRoute(props: {
       projectName={pageData.projectName}
       projects={pageData.projects}
       orchestrators={pageData.orchestrators}
+      attentionZones={pageData.attentionZones}
     />
   );
 }

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -39,6 +39,7 @@ function buildSessionTitle(
 
 interface ZoneCounts {
   merge: number;
+  action: number;
   respond: number;
   review: number;
   pending: number;
@@ -170,6 +171,7 @@ export default function SessionPage() {
 
       const counts: ZoneCounts = {
         merge: 0,
+        action: 0,
         respond: 0,
         review: 0,
         pending: 0,

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { notFound, useParams } from "next/navigation";
 import { isOrchestratorSession } from "@aoagents/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
-import { type DashboardSession, type ActivityState, getAttentionLevel, type AttentionLevel } from "@/lib/types";
+import { type DashboardSession, type ActivityState, getAttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
@@ -37,9 +37,14 @@ function buildSessionTitle(
   return emoji ? `${emoji} ${id} | ${detail}` : `${id} | ${detail}`;
 }
 
+// NOTE: No `action` field here by design. This status strip is a detail-page
+// summary, and `SessionDetail.OrchestratorZones` (the consumer of these
+// counts) only renders the detailed 5-zone breakdown. `getAttentionLevel()`
+// below is called without a mode so it defaults to "detailed" and never
+// returns "action" — the strip stays in detailed mode independent of the
+// dashboard's `attentionZones` config.
 interface ZoneCounts {
   merge: number;
-  action: number;
   respond: number;
   review: number;
   pending: number;
@@ -171,7 +176,6 @@ export default function SessionPage() {
 
       const counts: ZoneCounts = {
         merge: 0,
-        action: 0,
         respond: 0,
         review: 0,
         pending: 0,
@@ -181,7 +185,11 @@ export default function SessionPage() {
       const allPrefixes = [...prefixByProjectRef.current.values()];
       for (const s of sessions) {
         if (!isOrchestratorSession(s, prefixByProjectRef.current.get(s.projectId), allPrefixes)) {
-          counts[getAttentionLevel(s) as AttentionLevel]++;
+          // Detailed mode by default — "action" never appears. The guard
+          // is a compile-time narrowing hint for the index below.
+          const level = getAttentionLevel(s);
+          if (level === "action") continue;
+          counts[level]++;
         }
       }
       setZoneCounts(counts);

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -39,6 +39,10 @@ const zoneConfig: Record<
     label: "Ready",
     emptyMessage: "Nothing cleared to land yet.",
   },
+  action: {
+    label: "Action",
+    emptyMessage: "No agents need your input.",
+  },
   respond: {
     label: "Respond",
     emptyMessage: "No agents need your input.",
@@ -280,6 +284,20 @@ function SessionStateChip({
 
   if (level === "merge" && session.pr && isPRMergeReady(session.pr)) {
     label = "ready";
+  } else if (level === "action") {
+    // Simple-mode collapsed chip: prefer the more specific underlying state
+    // when we can derive it from session/activity/PR data.
+    if (
+      session.activity === "waiting_input" ||
+      session.activity === "blocked" ||
+      session.activity === "exited"
+    ) {
+      label = session.activity === "waiting_input" ? "waiting" : "needs input";
+    } else if (session.pr?.reviewDecision === "changes_requested") {
+      label = "changes";
+    } else {
+      label = "action";
+    }
   } else if (level === "respond") {
     label = session.activity === "waiting_input" ? "waiting" : "needs input";
   } else if (level === "review") {

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -302,8 +302,13 @@ function SessionStateChip({
       label = "changes";
     } else if (session.activity === "waiting_input") {
       label = "waiting";
-    } else if (session.activity === "blocked" || session.activity === "exited") {
-      label = "needs input";
+    } else if (session.activity === "exited") {
+      // Exited agent with non-terminal status = the process crashed. The
+      // user needs to investigate or restart it, not send a message — so
+      // don't mislabel this as "needs input".
+      label = "crashed";
+    } else if (session.activity === "blocked") {
+      label = "blocked";
     } else if (session.pr?.ciStatus === "failing") {
       label = "ci failed";
     } else if (session.pr?.reviewDecision === "changes_requested") {

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -278,21 +278,28 @@ function MobileSessionRow({
  *
  * Exported for unit tests. Returns the most specific human-readable reason
  * to intervene on a session that has collapsed into the simple-mode `action`
- * bucket. Status-based signals are checked first — they're authoritative
- * and shouldn't be masked by stale activity values.
+ * bucket. Precedence mirrors `getDetailedAttentionLevel` in `lib/types.ts`:
+ * respond-class signals (status errored/needs_input/stuck, then activity
+ * waiting_input/exited/blocked) outrank review-class signals (ci_failed /
+ * changes_requested / PR conflicts). Otherwise a crashed agent whose PR
+ * also has `changes_requested` would be mislabeled "changes" and hide the
+ * crash, steering the operator toward PR review instead of restart.
  */
 export function getActionChipLabel(session: DashboardSession): string {
+  // Respond-class: status (authoritative, can't be masked by stale activity)
   if (session.status === "needs_input") return "needs input";
   if (session.status === "stuck") return "stuck";
   if (session.status === "errored") return "errored";
-  if (session.status === "ci_failed") return "ci failed";
-  if (session.status === "changes_requested") return "changes";
+  // Respond-class: activity — check before review-class status so a crashed
+  // agent with a non-terminal status (e.g. changes_requested) still reads
+  // as "crashed" and not "changes".
   if (session.activity === "waiting_input") return "waiting";
-  // Exited agent with non-terminal status = the process crashed. The user
-  // needs to investigate or restart it, not send a message — so don't
-  // mislabel this as "needs input".
   if (session.activity === "exited") return "crashed";
   if (session.activity === "blocked") return "blocked";
+  // Review-class: status
+  if (session.status === "ci_failed") return "ci failed";
+  if (session.status === "changes_requested") return "changes";
+  // Review-class: PR signals
   if (session.pr?.ciStatus === "failing") return "ci failed";
   if (session.pr?.reviewDecision === "changes_requested") return "changes";
   if (session.pr && !session.pr.mergeability.noConflicts) return "conflicts";

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -273,6 +273,32 @@ function MobileSessionRow({
   );
 }
 
+/**
+ * Pure label picker for the mobile action chip.
+ *
+ * Exported for unit tests. Returns the most specific human-readable reason
+ * to intervene on a session that has collapsed into the simple-mode `action`
+ * bucket. Status-based signals are checked first — they're authoritative
+ * and shouldn't be masked by stale activity values.
+ */
+export function getActionChipLabel(session: DashboardSession): string {
+  if (session.status === "needs_input") return "needs input";
+  if (session.status === "stuck") return "stuck";
+  if (session.status === "errored") return "errored";
+  if (session.status === "ci_failed") return "ci failed";
+  if (session.status === "changes_requested") return "changes";
+  if (session.activity === "waiting_input") return "waiting";
+  // Exited agent with non-terminal status = the process crashed. The user
+  // needs to investigate or restart it, not send a message — so don't
+  // mislabel this as "needs input".
+  if (session.activity === "exited") return "crashed";
+  if (session.activity === "blocked") return "blocked";
+  if (session.pr?.ciStatus === "failing") return "ci failed";
+  if (session.pr?.reviewDecision === "changes_requested") return "changes";
+  if (session.pr && !session.pr.mergeability.noConflicts) return "conflicts";
+  return "action";
+}
+
 function SessionStateChip({
   session,
   level,
@@ -285,39 +311,7 @@ function SessionStateChip({
   if (level === "merge" && session.pr && isPRMergeReady(session.pr)) {
     label = "ready";
   } else if (level === "action") {
-    // Simple-mode collapsed chip: surface the most specific underlying
-    // cause we can derive so mobile users keep the reason-to-intervene
-    // even though the column header is the generic "Action" bucket.
-    // Check status-based signals first — they're authoritative and
-    // don't get masked by stale activity values.
-    if (session.status === "needs_input") {
-      label = "needs input";
-    } else if (session.status === "stuck") {
-      label = "stuck";
-    } else if (session.status === "errored") {
-      label = "errored";
-    } else if (session.status === "ci_failed") {
-      label = "ci failed";
-    } else if (session.status === "changes_requested") {
-      label = "changes";
-    } else if (session.activity === "waiting_input") {
-      label = "waiting";
-    } else if (session.activity === "exited") {
-      // Exited agent with non-terminal status = the process crashed. The
-      // user needs to investigate or restart it, not send a message — so
-      // don't mislabel this as "needs input".
-      label = "crashed";
-    } else if (session.activity === "blocked") {
-      label = "blocked";
-    } else if (session.pr?.ciStatus === "failing") {
-      label = "ci failed";
-    } else if (session.pr?.reviewDecision === "changes_requested") {
-      label = "changes";
-    } else if (session.pr && !session.pr.mergeability.noConflicts) {
-      label = "conflicts";
-    } else {
-      label = "action";
-    }
+    label = getActionChipLabel(session);
   } else if (level === "respond") {
     label = session.activity === "waiting_input" ? "waiting" : "needs input";
   } else if (level === "review") {

--- a/packages/web/src/components/AttentionZone.tsx
+++ b/packages/web/src/components/AttentionZone.tsx
@@ -285,16 +285,31 @@ function SessionStateChip({
   if (level === "merge" && session.pr && isPRMergeReady(session.pr)) {
     label = "ready";
   } else if (level === "action") {
-    // Simple-mode collapsed chip: prefer the more specific underlying state
-    // when we can derive it from session/activity/PR data.
-    if (
-      session.activity === "waiting_input" ||
-      session.activity === "blocked" ||
-      session.activity === "exited"
-    ) {
-      label = session.activity === "waiting_input" ? "waiting" : "needs input";
+    // Simple-mode collapsed chip: surface the most specific underlying
+    // cause we can derive so mobile users keep the reason-to-intervene
+    // even though the column header is the generic "Action" bucket.
+    // Check status-based signals first — they're authoritative and
+    // don't get masked by stale activity values.
+    if (session.status === "needs_input") {
+      label = "needs input";
+    } else if (session.status === "stuck") {
+      label = "stuck";
+    } else if (session.status === "errored") {
+      label = "errored";
+    } else if (session.status === "ci_failed") {
+      label = "ci failed";
+    } else if (session.status === "changes_requested") {
+      label = "changes";
+    } else if (session.activity === "waiting_input") {
+      label = "waiting";
+    } else if (session.activity === "blocked" || session.activity === "exited") {
+      label = "needs input";
+    } else if (session.pr?.ciStatus === "failing") {
+      label = "ci failed";
     } else if (session.pr?.reviewDecision === "changes_requested") {
       label = "changes";
+    } else if (session.pr && !session.pr.mergeability.noConflicts) {
+      label = "conflicts";
     } else {
       label = "action";
     }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -1179,7 +1179,11 @@ function ProjectOverviewGrid({
                 <ProjectMetric label="Review" value={counts.review} tone="orange" />
               </>
             ) : (
-              <ProjectMetric label="Action" value={counts.action} tone="error" />
+              // "action" collapses respond + review — use orange (the less
+              // severe of the two merged tones) to match the favicon's
+              // yellow-severity treatment. Red would cry wolf on routine
+              // review work like ci_failed / changes_requested.
+              <ProjectMetric label="Action" value={counts.action} tone="orange" />
             )}
             <ProjectMetric label="Pending" value={counts.pending} tone="attention" />
             <ProjectMetric label="Working" value={counts.working} tone="working" />

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import {
   type DashboardPR,
   type AttentionLevel,
   type DashboardOrchestratorLink,
+  type DashboardAttentionZoneMode,
   getAttentionLevel,
   isPRRateLimited,
   isPRMergeReady,
@@ -32,12 +33,23 @@ interface DashboardProps {
   projectName?: string;
   projects?: ProjectInfo[];
   orchestrators?: DashboardOrchestratorLink[];
+  /** Dashboard attention zone mode (defaults to "simple" — 4 zones). */
+  attentionZones?: DashboardAttentionZoneMode;
 }
 
-const KANBAN_LEVELS = ["working", "pending", "review", "respond", "merge"] as const;
+const SIMPLE_KANBAN_LEVELS = ["working", "pending", "action", "merge"] as const;
+const DETAILED_KANBAN_LEVELS = ["working", "pending", "review", "respond", "merge"] as const;
 /** Urgency-first order for the mobile accordion (reversed from desktop) */
-const MOBILE_KANBAN_ORDER = ["respond", "merge", "review", "pending", "working"] as const;
-const MOBILE_FILTERS = [
+const SIMPLE_MOBILE_KANBAN_ORDER = ["action", "merge", "pending", "working"] as const;
+const DETAILED_MOBILE_KANBAN_ORDER = ["respond", "merge", "review", "pending", "working"] as const;
+const SIMPLE_MOBILE_FILTERS = [
+  { value: "all", label: "All" },
+  { value: "action", label: "Action" },
+  { value: "merge", label: "Ready" },
+  { value: "pending", label: "Pending" },
+  { value: "working", label: "Working" },
+] as const;
+const DETAILED_MOBILE_FILTERS = [
   { value: "all", label: "All" },
   { value: "respond", label: "Respond" },
   { value: "merge", label: "Ready" },
@@ -46,7 +58,9 @@ const MOBILE_FILTERS = [
   { value: "working", label: "Working" },
 ] as const;
 
-type MobileFilterValue = (typeof MOBILE_FILTERS)[number]["value"];
+type MobileFilterValue =
+  | (typeof SIMPLE_MOBILE_FILTERS)[number]["value"]
+  | (typeof DETAILED_MOBILE_FILTERS)[number]["value"];
 const EMPTY_ORCHESTRATORS: DashboardOrchestratorLink[] = [];
 
 function formatRelativeTimeCompact(isoDate: string | null): string {
@@ -238,22 +252,28 @@ function DashboardInner({
   projectName,
   projects = [],
   orchestrators,
+  attentionZones = "simple",
 }: DashboardProps) {
   const orchestratorLinks = orchestrators ?? EMPTY_ORCHESTRATORS;
   const mux = useMuxOptional();
+  const kanbanLevels = attentionZones === "detailed" ? DETAILED_KANBAN_LEVELS : SIMPLE_KANBAN_LEVELS;
+  const mobileKanbanOrder =
+    attentionZones === "detailed" ? DETAILED_MOBILE_KANBAN_ORDER : SIMPLE_MOBILE_KANBAN_ORDER;
+  const mobileFilters = attentionZones === "detailed" ? DETAILED_MOBILE_FILTERS : SIMPLE_MOBILE_FILTERS;
   const initialAttentionLevels = useMemo(() => {
     const levels: Record<string, AttentionLevel> = {};
     for (const s of initialSessions) {
-      levels[s.id] = getAttentionLevel(s);
+      levels[s.id] = getAttentionLevel(s, attentionZones);
     }
     return levels;
-  }, [initialSessions]);
+  }, [initialSessions, attentionZones]);
   const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents(
     initialSessions,
     projectId,
     mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
     false,
+    attentionZones,
   );
   const searchParams = useSearchParams();
   const activeSessionId = searchParams.get("session") ?? undefined;
@@ -360,9 +380,9 @@ function DashboardInner({
 
   useEffect(() => {
     if (!sheetState || sheetState.mode !== "confirm-kill" || !hydratedSheetSession) return;
-    if (getAttentionLevel(hydratedSheetSession) !== "done") return;
+    if (getAttentionLevel(hydratedSheetSession, attentionZones) !== "done") return;
     setSheetState(null);
-  }, [hydratedSheetSession, sheetState]);
+  }, [hydratedSheetSession, sheetState, attentionZones]);
 
   useEffect(() => {
     if (!sheetState) {
@@ -395,6 +415,7 @@ function DashboardInner({
   const grouped = useMemo(() => {
     const zones: Record<AttentionLevel, DashboardSession[]> = {
       merge: [],
+      action: [],
       respond: [],
       review: [],
       pending: [],
@@ -402,10 +423,10 @@ function DashboardInner({
       done: [],
     };
     for (const session of displaySessions) {
-      zones[getAttentionLevel(session)].push(session);
+      zones[getAttentionLevel(session, attentionZones)].push(session);
     }
     return zones;
-  }, [displaySessions]);
+  }, [displaySessions, attentionZones]);
 
   // Auto-expand the most urgent non-empty section when switching to mobile.
   // Intentionally seeded once per mobile mode change, not on every session update.
@@ -433,6 +454,7 @@ function DashboardInner({
       const projectSessions = sessionsByProject.get(project.id) ?? [];
       const counts: Record<AttentionLevel, number> = {
         merge: 0,
+        action: 0,
         respond: 0,
         review: 0,
         pending: 0,
@@ -441,7 +463,7 @@ function DashboardInner({
       };
 
       for (const session of projectSessions) {
-        counts[getAttentionLevel(session)]++;
+        counts[getAttentionLevel(session, attentionZones)]++;
       }
 
       return {
@@ -453,7 +475,7 @@ function DashboardInner({
         counts,
       };
     });
-  }, [activeOrchestrators, allProjectsView, projects, sessionsByProject]);
+  }, [activeOrchestrators, allProjectsView, attentionZones, projects, sessionsByProject]);
 
   const handlePillTap = useCallback((level: AttentionLevel) => {
     if (level === "done") return;
@@ -465,9 +487,10 @@ function DashboardInner({
   }, []);
 
   const mobileFeedSessions = useMemo(() => {
-    const levels = mobileFilter === "all"
-      ? MOBILE_KANBAN_ORDER
-      : MOBILE_KANBAN_ORDER.filter((level) => level === mobileFilter);
+    const levels: ReadonlyArray<AttentionLevel> =
+      mobileFilter === "all"
+        ? mobileKanbanOrder
+        : mobileKanbanOrder.filter((level) => level === mobileFilter);
     const feed: Array<{ session: DashboardSession; level: AttentionLevel }> = [];
     for (const level of levels) {
       for (const session of grouped[level]) {
@@ -475,7 +498,7 @@ function DashboardInner({
       }
     }
     return feed;
-  }, [grouped, mobileFilter]);
+  }, [grouped, mobileFilter, mobileKanbanOrder]);
 
   const showDesktopPrsLink = hasMounted && !isMobile;
 
@@ -642,7 +665,7 @@ function DashboardInner({
     }
   };
 
-  const hasAnySessions = KANBAN_LEVELS.some((level) => grouped[level].length > 0);
+  const hasAnySessions = kanbanLevels.some((level) => grouped[level].length > 0);
   const showEmptyState = !allProjectsView && !hasAnySessions;
 
   const anyRateLimited = useMemo(
@@ -788,13 +811,14 @@ function DashboardInner({
                     onSpawnOrchestrator={handleSpawnOrchestrator}
                     spawningProjectIds={spawningProjectIds}
                     spawnErrors={spawnErrors}
+                    attentionZones={attentionZones}
                   />
                 )}
 
                 {!allProjectsView && hasAnySessions && (
                   <div className="kanban-board-wrap">
                     <div className="kanban-board">
-                      {KANBAN_LEVELS.map((level) => (
+                      {kanbanLevels.map((level) => (
                         <AttentionZone
                           key={level}
                           level={level}
@@ -930,13 +954,17 @@ function DashboardInner({
             {isMobile ? (
               <section className="mobile-priority-row" aria-label="Needs attention">
                 <div className="mobile-priority-row__label">Needs attention</div>
-                <MobileActionStrip grouped={grouped} onPillTap={handlePillTap} />
+                <MobileActionStrip
+                  grouped={grouped}
+                  onPillTap={handlePillTap}
+                  attentionZones={attentionZones}
+                />
               </section>
             ) : null}
 
             {isMobile ? (
               <section className="mobile-filter-row" aria-label="Dashboard filters">
-                {MOBILE_FILTERS.map((filter) => (
+                {mobileFilters.map((filter) => (
                   <button
                     key={filter.value}
                     type="button"
@@ -990,6 +1018,7 @@ function DashboardInner({
                 onSpawnOrchestrator={handleSpawnOrchestrator}
                 spawningProjectIds={spawningProjectIds}
                 spawnErrors={spawnErrors}
+                attentionZones={attentionZones}
               />
             )}
 
@@ -1012,7 +1041,7 @@ function DashboardInner({
                   </div>
                 ) : (
                   <div className="kanban-board">
-                    {KANBAN_LEVELS.map((level) => (
+                    {kanbanLevels.map((level) => (
                       <AttentionZone
                         key={level}
                         level={level}
@@ -1103,6 +1132,7 @@ function ProjectOverviewGrid({
   onSpawnOrchestrator,
   spawningProjectIds,
   spawnErrors,
+  attentionZones,
 }: {
   overviews: Array<{
     project: ProjectInfo;
@@ -1114,6 +1144,7 @@ function ProjectOverviewGrid({
   onSpawnOrchestrator: (project: ProjectInfo) => Promise<void>;
   spawningProjectIds: string[];
   spawnErrors: Record<string, string>;
+  attentionZones: DashboardAttentionZoneMode;
 }) {
   return (
     <div className="mb-8 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
@@ -1142,8 +1173,14 @@ function ProjectOverviewGrid({
 
           <div className="mb-4 flex flex-wrap gap-2">
             <ProjectMetric label="Merge" value={counts.merge} tone="ready" />
-            <ProjectMetric label="Respond" value={counts.respond} tone="error" />
-            <ProjectMetric label="Review" value={counts.review} tone="orange" />
+            {attentionZones === "detailed" ? (
+              <>
+                <ProjectMetric label="Respond" value={counts.respond} tone="error" />
+                <ProjectMetric label="Review" value={counts.review} tone="orange" />
+              </>
+            ) : (
+              <ProjectMetric label="Action" value={counts.action} tone="error" />
+            )}
             <ProjectMetric label="Pending" value={counts.pending} tone="attention" />
             <ProjectMetric label="Working" value={counts.working} tone="working" />
           </div>
@@ -1200,7 +1237,11 @@ function ProjectMetric({ label, value, tone }: { label: string; value: number; t
   );
 }
 
-const MOBILE_ACTION_STRIP_LEVELS = [
+const SIMPLE_MOBILE_ACTION_STRIP_LEVELS = [
+  { level: "action" as const, label: "action" },
+  { level: "merge" as const, label: "merge" },
+] satisfies Array<{ level: AttentionLevel; label: string }>;
+const DETAILED_MOBILE_ACTION_STRIP_LEVELS = [
   { level: "respond" as const, label: "respond" },
   { level: "merge" as const, label: "merge" },
   { level: "review" as const, label: "review" },
@@ -1209,11 +1250,17 @@ const MOBILE_ACTION_STRIP_LEVELS = [
 function MobileActionStrip({
   grouped,
   onPillTap,
+  attentionZones,
 }: {
   grouped: Record<AttentionLevel, DashboardSession[]>;
   onPillTap: (level: AttentionLevel) => void;
+  attentionZones: DashboardAttentionZoneMode;
 }) {
-  const activePills = MOBILE_ACTION_STRIP_LEVELS.filter(({ level }) => grouped[level].length > 0);
+  const stripLevels =
+    attentionZones === "detailed"
+      ? DETAILED_MOBILE_ACTION_STRIP_LEVELS
+      : SIMPLE_MOBILE_ACTION_STRIP_LEVELS;
+  const activePills = stripLevels.filter(({ level }) => grouped[level].length > 0);
 
   if (activePills.length === 0) {
     return (

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -267,14 +267,13 @@ function DashboardInner({
     }
     return levels;
   }, [initialSessions, attentionZones]);
-  const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents(
+  const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents({
     initialSessions,
-    projectId,
-    mux?.status === "connected" ? mux.sessions : undefined,
+    project: projectId,
+    muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
-    false,
     attentionZones,
-  );
+  });
   const searchParams = useSearchParams();
   const activeSessionId = searchParams.get("session") ?? undefined;
   const [rateLimitDismissed, setRateLimitDismissed] = useState(false);

--- a/packages/web/src/components/DynamicFavicon.tsx
+++ b/packages/web/src/components/DynamicFavicon.tsx
@@ -16,7 +16,8 @@ function computeHealthFromLevels(levels: SSEAttentionMap): "green" | "yellow" | 
   let hasYellow = false;
 
   for (const level of entries) {
-    if (level === "respond") return "red";
+    // "respond" (detailed) and "action" (simple) both signal urgent intervention.
+    if (level === "respond" || level === "action") return "red";
     if (level === "review" || level === "merge") hasYellow = true;
   }
 
@@ -38,11 +39,16 @@ function generateFaviconSvg(initial: string, color: string): string {
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 
-/** Count sessions that need human attention (respond, review, merge). */
+/** Count sessions that need human attention (respond, review, action, merge). */
 export function countNeedingAttention(levels: SSEAttentionMap): number {
   let count = 0;
   for (const level of Object.values(levels)) {
-    if (level === "respond" || level === "review" || level === "merge") {
+    if (
+      level === "respond" ||
+      level === "review" ||
+      level === "action" ||
+      level === "merge"
+    ) {
       count++;
     }
   }

--- a/packages/web/src/components/DynamicFavicon.tsx
+++ b/packages/web/src/components/DynamicFavicon.tsx
@@ -16,9 +16,15 @@ function computeHealthFromLevels(levels: SSEAttentionMap): "green" | "yellow" | 
   let hasYellow = false;
 
   for (const level of entries) {
-    // "respond" (detailed) and "action" (simple) both signal urgent intervention.
-    if (level === "respond" || level === "action") return "red";
-    if (level === "review" || level === "merge") hasYellow = true;
+    // Only "respond" (detailed mode) escalates the favicon to red. "action"
+    // (simple mode) collapses respond + review into one bucket, so it
+    // necessarily includes routine review work (ci_failed, changes_requested)
+    // that used to be yellow. Treating it as red would make every typical
+    // review PR scream critical. Keep it at yellow severity.
+    if (level === "respond") return "red";
+    if (level === "review" || level === "action" || level === "merge") {
+      hasYellow = true;
+    }
   }
 
   return hasYellow ? "yellow" : "green";

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -20,7 +20,14 @@ interface ProjectSidebarProps {
   onMobileClose?: () => void;
 }
 
-type SessionDotLevel = "respond" | "review" | "pending" | "working" | "merge" | "done";
+type SessionDotLevel =
+  | "respond"
+  | "review"
+  | "action"
+  | "pending"
+  | "working"
+  | "merge"
+  | "done";
 
 function SessionDot({ level }: { level: SessionDotLevel }) {
   return (
@@ -39,6 +46,7 @@ const LEVEL_LABELS: Record<AttentionLevel, string> = {
   pending: "pending",
   review: "review",
   respond: "respond",
+  action: "action",
   merge: "merge",
   done: "done",
 };

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -41,6 +41,11 @@ function SessionDot({ level }: { level: SessionDotLevel }) {
   );
 }
 
+// ProjectSidebar consumes `getAttentionLevel()` without passing a mode,
+// so the function defaults to "detailed" and `action` never appears here
+// in practice. The entry is kept for exhaustiveness — TypeScript requires
+// every `AttentionLevel` variant to be present in this `Record` — and
+// as forward-compat in case the sidebar ever opts into simple mode.
 const LEVEL_LABELS: Record<AttentionLevel, string> = {
   working: "working",
   pending: "pending",

--- a/packages/web/src/components/PullRequestsPage.tsx
+++ b/packages/web/src/components/PullRequestsPage.tsx
@@ -7,6 +7,7 @@ import {
   type DashboardSession,
   type DashboardPR,
   type DashboardOrchestratorLink,
+  type DashboardAttentionZoneMode,
   getAttentionLevel,
 } from "@/lib/types";
 import { useSessionEvents } from "@/hooks/useSessionEvents";
@@ -25,6 +26,8 @@ interface PullRequestsPageProps {
   projectName?: string;
   projects?: ProjectInfo[];
   orchestrators?: DashboardOrchestratorLink[];
+  /** Dashboard attention zone mode (defaults to "simple" — 4 zones). */
+  attentionZones?: DashboardAttentionZoneMode;
 }
 
 const EMPTY_ORCHESTRATORS: DashboardOrchestratorLink[] = [];
@@ -44,21 +47,28 @@ export function PullRequestsPage({
   projectName,
   projects = [],
   orchestrators,
+  attentionZones = "simple",
 }: PullRequestsPageProps) {
   const orchestratorLinks = orchestrators ?? EMPTY_ORCHESTRATORS;
   const mux = useMuxOptional();
+  // Seed initial attention levels using the same mode the server SSE will
+  // use when it sends snapshots (read from `config.dashboard.attentionZones`
+  // upstream). This prevents the sseAttentionLevels map from oscillating
+  // between detailed (seed/refresh) and simple (server snapshot) values.
   const initialAttentionLevels = useMemo(() => {
     const levels: Record<string, ReturnType<typeof getAttentionLevel>> = {};
     for (const s of initialSessions) {
-      levels[s.id] = getAttentionLevel(s);
+      levels[s.id] = getAttentionLevel(s, attentionZones);
     }
     return levels;
-  }, [initialSessions]);
+  }, [initialSessions, attentionZones]);
   const { sessions, sseAttentionLevels } = useSessionEvents(
     initialSessions,
     projectId,
     mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
+    false,
+    attentionZones,
   );
   const searchParams = useSearchParams();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);

--- a/packages/web/src/components/PullRequestsPage.tsx
+++ b/packages/web/src/components/PullRequestsPage.tsx
@@ -62,14 +62,13 @@ export function PullRequestsPage({
     }
     return levels;
   }, [initialSessions, attentionZones]);
-  const { sessions, sseAttentionLevels } = useSessionEvents(
+  const { sessions, sseAttentionLevels } = useSessionEvents({
     initialSessions,
-    projectId,
-    mux?.status === "connected" ? mux.sessions : undefined,
+    project: projectId,
+    muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
-    false,
     attentionZones,
-  );
+  });
   const searchParams = useSearchParams();
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);

--- a/packages/web/src/components/__tests__/AttentionZone.actionChip.test.ts
+++ b/packages/web/src/components/__tests__/AttentionZone.actionChip.test.ts
@@ -146,6 +146,29 @@ describe("getActionChipLabel", () => {
       expect(getActionChipLabel(session)).toBe("crashed");
     });
 
+    it("activity: exited wins over status: changes_requested", () => {
+      // A crashed agent whose PR also has changes_requested must still read
+      // as "crashed" — labeling this "changes" hides the crash and steers the
+      // operator toward PR review instead of restart. Mirrors the precedence
+      // in getDetailedAttentionLevel (lib/types.ts): activity=exited classifies
+      // as respond BEFORE status=changes_requested classifies as review.
+      const session = makeSession({
+        status: "changes_requested",
+        activity: "exited",
+        pr: null,
+      });
+      expect(getActionChipLabel(session)).toBe("crashed");
+    });
+
+    it("activity: waiting_input wins over status: ci_failed", () => {
+      const session = makeSession({
+        status: "ci_failed",
+        activity: "waiting_input",
+        pr: null,
+      });
+      expect(getActionChipLabel(session)).toBe("waiting");
+    });
+
     it("PR ci_failing wins over PR changes_requested", () => {
       // CI failure is a harder blocker than review feedback.
       const pr = makePR({

--- a/packages/web/src/components/__tests__/AttentionZone.actionChip.test.ts
+++ b/packages/web/src/components/__tests__/AttentionZone.actionChip.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import { getActionChipLabel } from "../AttentionZone";
+import { makeSession, makePR } from "@/__tests__/helpers";
+
+describe("getActionChipLabel", () => {
+  // ── Status-based signals take precedence (most authoritative) ────────
+
+  describe("status-based", () => {
+    it("returns 'needs input' for status: needs_input", () => {
+      const session = makeSession({ status: "needs_input", activity: "idle" });
+      expect(getActionChipLabel(session)).toBe("needs input");
+    });
+
+    it("returns 'stuck' for status: stuck", () => {
+      const session = makeSession({ status: "stuck", activity: "idle" });
+      expect(getActionChipLabel(session)).toBe("stuck");
+    });
+
+    it("returns 'errored' for status: errored", () => {
+      const session = makeSession({ status: "errored", activity: "idle" });
+      expect(getActionChipLabel(session)).toBe("errored");
+    });
+
+    it("returns 'ci failed' for status: ci_failed", () => {
+      const session = makeSession({ status: "ci_failed", activity: "idle" });
+      expect(getActionChipLabel(session)).toBe("ci failed");
+    });
+
+    it("returns 'changes' for status: changes_requested", () => {
+      const session = makeSession({ status: "changes_requested", activity: "idle" });
+      expect(getActionChipLabel(session)).toBe("changes");
+    });
+
+    it("status signals win over conflicting activity values", () => {
+      // status: stuck + activity: active — status is authoritative
+      const session = makeSession({ status: "stuck", activity: "active" });
+      expect(getActionChipLabel(session)).toBe("stuck");
+    });
+  });
+
+  // ── Activity-based signals (used when status is non-authoritative) ───
+
+  describe("activity-based", () => {
+    it("returns 'waiting' for activity: waiting_input", () => {
+      const session = makeSession({ status: "working", activity: "waiting_input" });
+      expect(getActionChipLabel(session)).toBe("waiting");
+    });
+
+    it("returns 'crashed' for activity: exited (non-terminal status)", () => {
+      // An exited agent with a non-terminal status = the process crashed.
+      // Critical: must not be labeled "needs input" — user needs to
+      // investigate/restart, not send a message.
+      const session = makeSession({ status: "working", activity: "exited", pr: null });
+      expect(getActionChipLabel(session)).toBe("crashed");
+    });
+
+    it("returns 'blocked' for activity: blocked", () => {
+      const session = makeSession({ status: "working", activity: "blocked" });
+      expect(getActionChipLabel(session)).toBe("blocked");
+    });
+  });
+
+  // ── PR-based signals (fallback when session-level is quiet) ──────────
+
+  describe("PR-based", () => {
+    it("returns 'ci failed' when PR ciStatus is failing", () => {
+      const pr = makePR({
+        ciStatus: "failing",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: true,
+          noConflicts: true,
+          blockers: ["CI failing"],
+        },
+      });
+      const session = makeSession({ status: "working", activity: "idle", pr });
+      expect(getActionChipLabel(session)).toBe("ci failed");
+    });
+
+    it("returns 'changes' when PR reviewDecision is changes_requested", () => {
+      const pr = makePR({
+        ciStatus: "passing",
+        reviewDecision: "changes_requested",
+        mergeability: {
+          mergeable: false,
+          ciPassing: true,
+          approved: false,
+          noConflicts: true,
+          blockers: ["Changes requested"],
+        },
+      });
+      const session = makeSession({ status: "working", activity: "idle", pr });
+      expect(getActionChipLabel(session)).toBe("changes");
+    });
+
+    it("returns 'conflicts' when PR has merge conflicts", () => {
+      const pr = makePR({
+        ciStatus: "passing",
+        reviewDecision: "approved",
+        mergeability: {
+          mergeable: false,
+          ciPassing: true,
+          approved: true,
+          noConflicts: false,
+          blockers: ["Merge conflict"],
+        },
+      });
+      const session = makeSession({ status: "working", activity: "idle", pr });
+      expect(getActionChipLabel(session)).toBe("conflicts");
+    });
+  });
+
+  // ── Precedence (deeper conditions don't leak through) ────────────────
+
+  describe("precedence", () => {
+    it("status wins over PR ci_failing", () => {
+      const pr = makePR({
+        ciStatus: "failing",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: true,
+          noConflicts: true,
+          blockers: ["CI failing"],
+        },
+      });
+      const session = makeSession({ status: "stuck", activity: "idle", pr });
+      expect(getActionChipLabel(session)).toBe("stuck");
+    });
+
+    it("activity: exited wins over PR ci_failing", () => {
+      // Agent crashed during a PR with failing CI — the crash is the
+      // more urgent, more specific signal.
+      const pr = makePR({
+        ciStatus: "failing",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: true,
+          noConflicts: true,
+          blockers: ["CI failing"],
+        },
+      });
+      const session = makeSession({ status: "working", activity: "exited", pr });
+      expect(getActionChipLabel(session)).toBe("crashed");
+    });
+
+    it("PR ci_failing wins over PR changes_requested", () => {
+      // CI failure is a harder blocker than review feedback.
+      const pr = makePR({
+        ciStatus: "failing",
+        reviewDecision: "changes_requested",
+        mergeability: {
+          mergeable: false,
+          ciPassing: false,
+          approved: false,
+          noConflicts: true,
+          blockers: ["CI failing", "Changes requested"],
+        },
+      });
+      const session = makeSession({ status: "working", activity: "idle", pr });
+      expect(getActionChipLabel(session)).toBe("ci failed");
+    });
+  });
+
+  // ── Generic fallback ─────────────────────────────────────────────────
+
+  describe("fallback", () => {
+    it("returns 'action' when no specific signal is available", () => {
+      // Session is in the "action" bucket but we can't derive a more
+      // specific reason — generic label is the safe default.
+      const session = makeSession({ status: "working", activity: "idle", pr: null });
+      expect(getActionChipLabel(session)).toBe("action");
+    });
+  });
+});

--- a/packages/web/src/components/__tests__/DynamicFavicon.test.tsx
+++ b/packages/web/src/components/__tests__/DynamicFavicon.test.tsx
@@ -17,15 +17,16 @@ describe("countNeedingAttention", () => {
     expect(countNeedingAttention(levels)).toBe(0);
   });
 
-  it("counts respond, review, and merge sessions", () => {
+  it("counts respond, review, action, and merge sessions", () => {
     const levels: SSEAttentionMap = {
       "s-1": "respond",
       "s-2": "review",
       "s-3": "merge",
-      "s-4": "working",
-      "s-5": "done",
+      "s-4": "action",
+      "s-5": "working",
+      "s-6": "done",
     };
-    expect(countNeedingAttention(levels)).toBe(3);
+    expect(countNeedingAttention(levels)).toBe(4);
   });
 
   it("counts a single attention-needing session", () => {
@@ -61,6 +62,25 @@ describe("DynamicFavicon", () => {
 
   it("creates a red favicon when sessions need response", () => {
     const levels: SSEAttentionMap = { "s-1": "respond" };
+    render(<DynamicFavicon sseAttentionLevels={levels} projectName="Test" />);
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    expect(link!.href).toContain("%23ef4444"); // red
+  });
+
+  it("keeps favicon yellow (not red) for collapsed 'action' in simple mode", () => {
+    // "action" collapses respond + review, so it contains routine review work
+    // (ci_failed, changes_requested). Escalating to red would cry wolf on
+    // every typical PR.
+    const levels: SSEAttentionMap = { "s-1": "action", "s-2": "working" };
+    render(<DynamicFavicon sseAttentionLevels={levels} projectName="Test" />);
+
+    const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    expect(link!.href).toContain("%23eab308"); // yellow
+  });
+
+  it("still escalates to red when detailed 'respond' is present alongside 'action'", () => {
+    const levels: SSEAttentionMap = { "s-1": "action", "s-2": "respond" };
     render(<DynamicFavicon sseAttentionLevels={levels} projectName="Test" />);
 
     const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');

--- a/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
@@ -24,8 +24,8 @@ describe("useSessionEvents - mux", () => {
   it("triggers refresh when mux patch contains unknown id", async () => {
     const initialSessions = [s1];
     const muxSessions = [
-      { id: "s1", status: "working", activity: "active", attentionLevel: "none", lastActivityAt: now },
-      { id: "s2", status: "working", activity: "active", attentionLevel: "none", lastActivityAt: now },
+      { id: "s1", status: "working", activity: "active", attentionLevel: "working" as const, lastActivityAt: now },
+      { id: "s2", status: "working", activity: "active", attentionLevel: "working" as const, lastActivityAt: now },
     ];
     renderHook(() =>
       useSessionEvents({

--- a/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
@@ -27,7 +27,14 @@ describe("useSessionEvents - mux", () => {
       { id: "s1", status: "working", activity: "active", attentionLevel: "none", lastActivityAt: now },
       { id: "s2", status: "working", activity: "active", attentionLevel: "none", lastActivityAt: now },
     ];
-    renderHook(() => useSessionEvents(initialSessions, "proj", muxSessions));
+    renderHook(() =>
+      useSessionEvents({
+        initialSessions,
+        project: "proj",
+        muxSessions,
+        attentionZones: "simple",
+      }),
+    );
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         "/api/sessions?project=proj",

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -97,7 +97,7 @@ function createMembershipKey(
 export interface UseSessionEventsOptions {
   initialSessions: DashboardSession[];
   project?: string;
-  muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: string; lastActivityAt: string }>;
+  muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: AttentionLevel; lastActivityAt: string }>;
   initialAttentionLevels?: SSEAttentionMap;
   disabled?: boolean;
   /**

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -4,6 +4,7 @@ import { useEffect, useReducer, useRef, useCallback } from "react";
 import {
   getAttentionLevel,
   type AttentionLevel,
+  type DashboardAttentionZoneMode,
   type DashboardSession,
   type SSESnapshotEvent,
 } from "@/lib/types";
@@ -99,6 +100,7 @@ export function useSessionEvents(
   muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: string; lastActivityAt: string }>,
   initialAttentionLevels?: SSEAttentionMap,
   disabled = false,
+  attentionZones: DashboardAttentionZoneMode = "simple",
 ): State {
   const [state, dispatch] = useReducer(reducer, {
     sessions: initialSessions,
@@ -161,7 +163,7 @@ export function useSessionEvents(
 
             lastRefreshAtRef.current = Date.now();
             const sseAttentionLevels = Object.fromEntries(
-              updated.sessions.map((s) => [s.id, getAttentionLevel(s)]),
+              updated.sessions.map((s) => [s.id, getAttentionLevel(s, attentionZones)]),
             ) as SSEAttentionMap;
             dispatch({
               type: "reset",
@@ -202,7 +204,7 @@ export function useSessionEvents(
           pendingMembershipKeyRef.current = null;
         });
     }, MEMBERSHIP_REFRESH_DELAY_MS);
-  }, [project]);
+  }, [project, attentionZones]);
 
   // Mux-based session updates (replaces SSE when available)
   useEffect(() => {

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -100,7 +100,12 @@ export function useSessionEvents(
   muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: string; lastActivityAt: string }>,
   initialAttentionLevels?: SSEAttentionMap,
   disabled = false,
-  attentionZones: DashboardAttentionZoneMode = "simple",
+  // Default matches `getAttentionLevel`'s default so callers that omit a
+  // mode (e.g., PullRequestsPage, which seeds `initialAttentionLevels` with
+  // the function default) stay consistent with their seed after the first
+  // live SSE/refresh snapshot. Dashboard explicitly passes the config's
+  // `attentionZones` to opt into simple-mode collapse.
+  attentionZones: DashboardAttentionZoneMode = "detailed",
 ): State {
   const [state, dispatch] = useReducer(reducer, {
     sessions: initialSessions,

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -94,19 +94,35 @@ function createMembershipKey(
     .join("\u0000");
 }
 
-export function useSessionEvents(
-  initialSessions: DashboardSession[],
-  project?: string,
-  muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: string; lastActivityAt: string }>,
-  initialAttentionLevels?: SSEAttentionMap,
-  disabled = false,
-  // Default matches `getAttentionLevel`'s default so callers that omit a
-  // mode (e.g., PullRequestsPage, which seeds `initialAttentionLevels` with
-  // the function default) stay consistent with their seed after the first
-  // live SSE/refresh snapshot. Dashboard explicitly passes the config's
-  // `attentionZones` to opt into simple-mode collapse.
-  attentionZones: DashboardAttentionZoneMode = "detailed",
-): State {
+export interface UseSessionEventsOptions {
+  initialSessions: DashboardSession[];
+  project?: string;
+  muxSessions?: Array<{ id: string; status: string; activity: string | null; attentionLevel: string; lastActivityAt: string }>;
+  initialAttentionLevels?: SSEAttentionMap;
+  disabled?: boolean;
+  /**
+   * REQUIRED. Callers must explicitly pass the mode that the server SSE
+   * route is using (read from `config.dashboard?.attentionZones` upstream).
+   *
+   * A default here would be a footgun: any default value disagrees with
+   * the server whenever the config is set to the opposite mode, causing
+   * `sseAttentionLevels` to oscillate between modes as server snapshots
+   * and client refreshes interleave. Forcing every caller to pass this
+   * explicitly prevents the next page from silently re-introducing the
+   * bug we already fixed once for `PullRequestsPage`.
+   */
+  attentionZones: DashboardAttentionZoneMode;
+}
+
+export function useSessionEvents(options: UseSessionEventsOptions): State {
+  const {
+    initialSessions,
+    project,
+    muxSessions,
+    initialAttentionLevels,
+    disabled = false,
+    attentionZones,
+  } = options;
   const [state, dispatch] = useReducer(reducer, {
     sessions: initialSessions,
     connectionStatus: "connected" as ConnectionStatus,

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -1,7 +1,12 @@
 import "server-only";
 
 import { cache } from "react";
-import { TERMINAL_STATUSES, type DashboardSession, type DashboardOrchestratorLink } from "@/lib/types";
+import {
+  TERMINAL_STATUSES,
+  type DashboardSession,
+  type DashboardOrchestratorLink,
+  type DashboardAttentionZoneMode,
+} from "@/lib/types";
 import { getServices, getSCM } from "@/lib/services";
 import {
   sessionToDashboard,
@@ -23,7 +28,11 @@ interface DashboardPageData {
   projectName: string;
   projects: ProjectInfo[];
   selectedProjectId?: string;
+  attentionZones: DashboardAttentionZoneMode;
 }
+
+/** Default zone mode when no config is loaded or `dashboard` block is absent. */
+export const DEFAULT_ATTENTION_ZONE_MODE: DashboardAttentionZoneMode = "simple";
 
 export const getDashboardProjectName = cache(function getDashboardProjectName(
   projectFilter: string | undefined,
@@ -54,10 +63,12 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     projectName: getDashboardProjectName(projectFilter),
     projects: getAllProjects(),
     selectedProjectId: projectFilter === "all" ? undefined : projectFilter,
+    attentionZones: DEFAULT_ATTENTION_ZONE_MODE,
   };
 
   try {
     const { config, registry, sessionManager } = await getServices();
+    pageData.attentionZones = config.dashboard?.attentionZones ?? DEFAULT_ATTENTION_ZONE_MODE;
     const allSessions = await sessionManager.list();
 
     const visibleSessions = filterProjectSessions(allSessions, projectFilter, config.projects);

--- a/packages/web/src/lib/mux-protocol.ts
+++ b/packages/web/src/lib/mux-protocol.ts
@@ -1,3 +1,5 @@
+import type { AttentionLevel } from "./types";
+
 // ── Client → Server ──
 
 export type ClientMessage =
@@ -23,6 +25,9 @@ export interface SessionPatch {
   id: string;
   status: string;
   activity: string | null;
-  attentionLevel: string;
+  /** Tight union — server-computed via getAttentionLevel. Unvalidated strings
+   *  (e.g. "none") would lookup-miss downstream in DynamicFavicon and silently
+   *  drop urgent sessions from the favicon count. */
+  attentionLevel: AttentionLevel;
   lastActivityAt: string;
 }

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -15,6 +15,7 @@ export type {
   ReviewDecision,
   MergeReadiness,
   PRState,
+  DashboardAttentionZoneMode,
 } from "@aoagents/ao-core/types";
 
 import {
@@ -30,22 +31,35 @@ import {
   type SessionStatus,
   type ActivityState,
   type ReviewDecision,
+  type DashboardAttentionZoneMode,
 } from "@aoagents/ao-core/types";
 
 // Re-export for use in client components
 export { CI_STATUS, TERMINAL_STATUSES, TERMINAL_ACTIVITIES, NON_RESTORABLE_STATUSES };
 
 /**
- * Attention zone priority level, ordered by human action urgency:
+ * Attention zone priority level, ordered by human action urgency.
  *
+ * Detailed levels (5-zone Kanban):
  * 1. merge   — PR approved + CI green. One click to clear. Highest ROI.
  * 2. respond — Agent waiting for human input. Quick unblock, agent resumes.
  * 3. review  — CI failed, changes requested, conflicts. Needs investigation.
  * 4. pending — Waiting on external (reviewer, CI). Nothing to do right now.
  * 5. working — Agents doing their thing. Don't interrupt.
  * 6. done    — Merged or terminated. Archive.
+ *
+ * Simple levels (4-zone Kanban, default): respond + review collapse into a
+ * single `action` zone. The card-level badges still expose the underlying
+ * granular state (ci_failed, needs_input, changes_requested).
  */
-export type AttentionLevel = "merge" | "respond" | "review" | "pending" | "working" | "done";
+export type AttentionLevel =
+  | "merge"
+  | "action"
+  | "respond"
+  | "review"
+  | "pending"
+  | "working"
+  | "done";
 
 /**
  * Flattened session for dashboard rendering.
@@ -191,8 +205,31 @@ export function isPRMergeReady(pr: DashboardPR): boolean {
   );
 }
 
-/** Determines which attention zone a session belongs to */
-export function getAttentionLevel(session: DashboardSession): AttentionLevel {
+/**
+ * Determines which attention zone a session belongs to.
+ *
+ * @param session - the session to classify
+ * @param mode - "detailed" (default) returns the granular 5-zone result.
+ *               "simple" collapses respond + review into a single "action"
+ *               zone for the 4-column Kanban layout.
+ *
+ * Note: the function defaults to "detailed" so card-level callers
+ * (SessionCard, BottomSheet, ProjectSidebar, etc.) keep their granular
+ * behavior. Only the Dashboard kanban grouping passes "simple" when the
+ * config opts into the 4-zone layout.
+ */
+export function getAttentionLevel(
+  session: DashboardSession,
+  mode: DashboardAttentionZoneMode = "detailed",
+): AttentionLevel {
+  const level = getDetailedAttentionLevel(session);
+  if (mode === "simple" && (level === "respond" || level === "review")) {
+    return "action";
+  }
+  return level;
+}
+
+function getDetailedAttentionLevel(session: DashboardSession): AttentionLevel {
   // ── Done: terminal states ─────────────────────────────────────────
   if (
     session.status === "merged" ||

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -419,7 +419,7 @@ describe("MuxProvider message handling", () => {
     act(() => ws.simulateMessage({
       ch: "sessions",
       type: "snapshot",
-      sessions: [{ id: "s1", status: "working", activity: null, attentionLevel: "none", lastActivityAt: "" }],
+      sessions: [{ id: "s1", status: "working", activity: null, attentionLevel: "working", lastActivityAt: "" }],
     }));
 
     expect(result.current.sessions.length).toBe(1);


### PR DESCRIPTION
## Summary

- Default dashboard kanban now shows 4 zones: `WORKING`, `PENDING`, `ACTION`, `READY`. The former `REVIEW` and `RESPOND` columns collapse into a single `ACTION` zone that answers "does the human need to do something?".
- New config flag `dashboard.attentionZones` (`simple` | `detailed`, defaults to `simple`) opts into the original 5-zone layout for power users.
- Card-level badges continue to expose granular state (`ci_failed`, `needs_input`, `changes_requested`) — nothing is lost, it just moves off the column headers.

## ⚠️ Breaking visual change for existing deployments

**Existing deployments without a `dashboard` block in their `agent-orchestrator.yaml` will silently switch from 5 zones to 4 on next upgrade.** The Zod schema defaults `attentionZones` to `"simple"`, so any config that doesn't explicitly set it gets the new layout. No session data is affected — this is purely a visual change in the kanban board.

**Release notes suggestion:**
> The dashboard now defaults to a simpler 4-zone kanban (`WORKING` / `PENDING` / `ACTION` / `READY`). Granular state still shows on the session cards. To keep the original 5-zone layout, add to your `agent-orchestrator.yaml`:
> ```yaml
> dashboard:
>   attentionZones: detailed
> ```

## Config

```yaml
dashboard:
  attentionZones: simple      # default — 4 zones
  # attentionZones: detailed  # opt-in — original 5 zones
```

(camelCase to match other `OrchestratorConfig` fields like `readyThresholdMs`, `terminalPort`, `sessionPrefix`.)

## Implementation notes

- `packages/core/src/types.ts` — new `DashboardConfig` / `DashboardAttentionZoneMode` types on `OrchestratorConfig`.
- `packages/core/src/config.ts` — Zod schema for `dashboard.attentionZones` (default `"simple"`). Not strict — typos fall back to defaults like every other schema in this file.
- `packages/web/src/lib/types.ts` — added `"action"` to `AttentionLevel` and a `mode` param to `getAttentionLevel(session, mode = "detailed")`. Defaults to detailed so existing card-level callers (SessionCard, BottomSheet, ProjectSidebar, PullRequestsPage, sessions/[id]) keep their granular behavior. Only dashboard kanban and SSE server routes thread the mode through.
- `packages/web/src/components/Dashboard.tsx` — picks `SIMPLE_KANBAN_LEVELS` vs `DETAILED_KANBAN_LEVELS` based on the prop, same for mobile order, filters, and action strip pills. `ProjectOverviewGrid` shows 4 metrics in simple mode and 5 in detailed.
- `packages/web/src/app/api/events/route.ts` + `packages/web/src/app/api/sessions/patches/route.ts` — read `config.dashboard?.attentionZones` and pass the mode to `getAttentionLevel()` so SSE-computed levels stay consistent with the client.
- `packages/web/src/hooks/useSessionEvents.ts` — refactored to take an options object with `attentionZones` as a **required** field. TypeScript refuses to compile any caller that doesn't explicitly pass the mode, preventing the next page from silently re-introducing the PullRequestsPage oscillation bug.
- `DynamicFavicon` — treats `action` as yellow (not red). Since simple mode collapses respond + review into one bucket, escalating `action` would scream critical for routine review work. Only detailed-mode `respond` still triggers red.
- `AttentionZone` mobile chip — `getActionChipLabel()` helper picks the most specific underlying cause (needs input / stuck / errored / ci failed / changes / waiting / crashed / blocked / conflicts) so mobile users keep the reason to intervene.
- CSS: new `data-level="action"` rules mirror `"respond"` styling.

## Review feedback addressed

- **Cursor Bugbot [Medium]** — dropped `.strict()` from `DashboardConfigSchema` to match the rest of `config.ts` (d6bcbfad).
- **Codex [P2]** — `action` stays yellow in the favicon (d6bcbfad).
- **Codex [P3]** — mobile action chip surfaces granular cause (d6bcbfad).
- **Cursor Bugbot [Medium]** — threaded `attentionZones` through `PullRequestsPage` so seed + server SSE + client refresh all use the same mode (09ce0940).
- **Cursor Bugbot [Medium]** — mobile chip correctly distinguishes `exited` (crashed) from `blocked`; `ProjectMetric` for Action uses `tone="orange"` to match favicon severity (a73c9740).
- **Cursor Bugbot [Medium]** — `useSessionEvents` refactored to options object with **required** `attentionZones` field so future callers can't forget (8d27db79).
- **Human review [Medium]** — removed dead `action` field from `ZoneCounts` in sessions/[id]/page.tsx; extracted `getActionChipLabel()` helper with 16 unit tests covering every branch (e9786a91).
- **Human review [Low]** — added comment on `LEVEL_LABELS.action` in ProjectSidebar explaining exhaustiveness + forward-compat intent (e9786a91).

## Test plan

- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm test` (core: 594 passed; cli: 316 passed; integration: 190 passed)
- [x] `pnpm --filter @aoagents/ao-web test` (624 passed: 10 simple-mode + 2 favicon severity + 16 action chip)
- [ ] Manual dashboard smoke: both modes render, card badges still correct, favicon + attention count stay accurate.

Closes #1201