### PR TITLE
fix(web): add restore button to session detail page

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, type ReactNode } from "react";
+import { useState, useEffect, useRef, useMemo, useCallback, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import {
   type DashboardSession,
   type DashboardPR,
   TERMINAL_STATUSES,
+  NON_RESTORABLE_STATUSES,
   isPRMergeReady,
   isPRRateLimited,
   isPRUnenriched,
@@ -136,6 +137,7 @@ function SessionTopStrip({
   crumbLabel,
   rightSlot,
   onKill,
+  onRestore,
 }: {
   headline: string;
   crumbId: string;
@@ -148,6 +150,7 @@ function SessionTopStrip({
   crumbLabel: string;
   rightSlot?: ReactNode;
   onKill?: () => void;
+  onRestore?: () => void;
 }) {
   return (
     <div className="session-detail-top-strip">
@@ -238,7 +241,25 @@ function SessionTopStrip({
           </div>
         ) : (
           <div className="session-detail-identity__actions">
-            {onKill ? (
+            {onRestore ? (
+              <button
+                type="button"
+                className="done-restore-btn"
+                onClick={onRestore}
+              >
+                <svg
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  viewBox="0 0 24 24"
+                  className="h-3 w-3"
+                >
+                  <polyline points="1 4 1 10 7 10" />
+                  <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10" />
+                </svg>
+                Restore
+              </button>
+            ) : onKill ? (
               <button
                 type="button"
                 className="session-detail-action-btn session-detail-action-btn--danger"
@@ -438,6 +459,7 @@ export function SessionDetail({
   const [showTerminal, setShowTerminal] = useState(false);
   const pr = session.pr;
   const terminalEnded = TERMINAL_STATUSES.has(session.status);
+  const isRestorable = terminalEnded && !NON_RESTORABLE_STATUSES.has(session.status);
   const activity = (session.activity && activityMeta[session.activity]) ?? {
     label: session.activity ?? "unknown",
     color: "var(--color-text-muted)",
@@ -463,6 +485,26 @@ export function SessionDetail({
   const prsHref = session.projectId ? `/prs?project=${encodeURIComponent(session.projectId)}` : "/prs";
   const crumbHref = dashboardHref;
   const crumbLabel = "Dashboard";
+
+  const handleKill = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}/kill`, { method: "POST" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      window.location.reload();
+    } catch (err) {
+      console.error("Failed to kill session:", err);
+    }
+  }, [session.id]);
+
+  const handleRestore = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}/restore`, { method: "POST" });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      window.location.reload();
+    } catch (err) {
+      console.error("Failed to restore session:", err);
+    }
+  }, [session.id]);
   const headerProjectLabel =
     projects.find((project) => project.id === session.projectId)?.name ?? session.projectId;
   const showHeaderProjectLabel =
@@ -573,7 +615,8 @@ export function SessionDetail({
                       isOrchestrator={isOrchestrator}
                       crumbHref={crumbHref}
                       crumbLabel={crumbLabel}
-                      onKill={isOrchestrator ? undefined : () => {}}
+                      onKill={isOrchestrator || terminalEnded ? undefined : handleKill}
+                      onRestore={isOrchestrator || !isRestorable ? undefined : handleRestore}
                     />
                   )}
 


### PR DESCRIPTION
Fixes #1205

## Problem

The session detail page (`/sessions/[id]`) shows a **Kill** button for active sessions but no **Restore** button when the session is in a terminal state (killed, terminated, done, errored, cleanup). Users must navigate back to the dashboard to restore sessions.

Additionally, the existing Kill button is a no-op `() => {}` — clicking it does nothing.

## Changes

- **`SessionTopStrip`**: Added `onRestore` prop. When `onRestore` is provided, shows a Restore button (reuses `done-restore-btn` styling from SessionCard). Falls back to Kill button when `onKill` is provided.
- **`SessionDetail`** main component:
  - Added `isRestorable` flag: `terminalEnded && !NON_RESTORABLE_STATUSES.has(session.status)`
  - Added `handleKill` callback that calls `POST /api/sessions/:id/kill`
  - Added `handleRestore` callback that calls `POST /api/sessions/:id/restore`
  - Both callbacks reload the page on success
- Conditional rendering: Restore shown when restorable, Kill shown when active, neither for orchestrator sessions

## Screenshot

![session detail showing Kill but no Restore](https://raw.githubusercontent.com/ComposioHQ/agent-orchestrator/issue-assets-1205/.issue-assets/session-detail-no-restore-1205.png)

## Test Plan

1. Kill a session via CLI (`ao kill <session-id>`)
2. Navigate to `/sessions/<id>`
3. ✅ Verify **Restore** button appears (not Kill)
4. Click Restore → session restores and page reloads with active terminal
5. ✅ Verify merged sessions show **no** Restore or Kill button