### PR TITLE
fix (codex): write worker system instructions to system prompt file 

### DIFF
--- a/packages/core/src/__tests__/prompt-builder.test.ts
+++ b/packages/core/src/__tests__/prompt-builder.test.ts
@@ -3,7 +3,12 @@ import { mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
-import { buildPrompt, BASE_AGENT_PROMPT } from "../prompt-builder.js";
+import {
+  buildPrompt,
+  buildWorkerSystemInstructions,
+  buildWorkerTaskPrompt,
+  BASE_AGENT_PROMPT,
+} from "../prompt-builder.js";
 import type { ProjectConfig } from "../types.js";
 
 let tmpDir: string;
@@ -215,5 +220,152 @@ describe("BASE_AGENT_PROMPT", () => {
     expect(BASE_AGENT_PROMPT).toContain("Git Workflow");
     expect(BASE_AGENT_PROMPT).toContain("PR Best Practices");
     expect(BASE_AGENT_PROMPT).toContain("ao session claim-pr");
+  });
+});
+
+describe("buildWorkerSystemInstructions", () => {
+  it("includes base prompt", () => {
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain(BASE_AGENT_PROMPT);
+  });
+
+  it("includes project context", () => {
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain("## Project Context");
+    expect(result).toContain("Project: Test App");
+    expect(result).toContain("org/test-app");
+    expect(result).toContain("main");
+  });
+
+  it("includes tracker info", () => {
+    project.tracker = { plugin: "linear" };
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain("Tracker: linear");
+  });
+
+  it("includes project rules from agentRules", () => {
+    project.agentRules = "Always run tests before pushing.";
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain("## Project Rules");
+    expect(result).toContain("Always run tests before pushing.");
+  });
+
+  it("includes project rules from agentRulesFile", () => {
+    const rulesPath = join(tmpDir, "agent-rules.md");
+    writeFileSync(rulesPath, "Use conventional commits.");
+    project.agentRulesFile = "agent-rules.md";
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain("Use conventional commits.");
+  });
+
+  it("does NOT include issue/task content even when issueId is supplied", () => {
+    const result = buildWorkerSystemInstructions({
+      project,
+      projectId: "test-app",
+      issueId: "INT-999",
+      issueContext: "Some issue details",
+    });
+    expect(result).not.toContain("INT-999");
+    expect(result).not.toContain("Some issue details");
+    expect(result).not.toContain("## Task");
+    expect(result).not.toContain("## Issue Details");
+  });
+
+  it("does NOT include userPrompt even when supplied", () => {
+    const result = buildWorkerSystemInstructions({
+      project,
+      projectId: "test-app",
+      userPrompt: "Focus on the auth layer.",
+    });
+    expect(result).not.toContain("Focus on the auth layer.");
+    expect(result).not.toContain("## Additional Instructions");
+  });
+
+  it("includes automated reaction hints", () => {
+    project.reactions = {
+      "ci-failed": { auto: true, action: "send-to-agent" },
+      "approved-and-green": { auto: false, action: "notify" },
+    };
+    const result = buildWorkerSystemInstructions({ project, projectId: "test-app" });
+    expect(result).toContain("ci-failed");
+    expect(result).not.toContain("approved-and-green");
+  });
+});
+
+describe("buildWorkerTaskPrompt", () => {
+  it("returns empty string when no issue, context, or userPrompt", () => {
+    const result = buildWorkerTaskPrompt({ project, projectId: "test-app" });
+    expect(result).toBe("");
+  });
+
+  it("includes issue task section when issueId supplied", () => {
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      issueId: "INT-42",
+    });
+    expect(result).toContain("## Task");
+    expect(result).toContain("Work on issue: INT-42");
+    expect(result).toContain("feat/INT-42");
+  });
+
+  it("includes issue context when supplied", () => {
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      issueId: "INT-42",
+      issueContext: "Title: Fix login\nPriority: High",
+    });
+    expect(result).toContain("## Issue Details");
+    expect(result).toContain("Fix login");
+    expect(result).toContain("Priority: High");
+  });
+
+  it("includes userPrompt as additional instructions", () => {
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      userPrompt: "Focus on the auth layer.",
+    });
+    expect(result).toContain("## Additional Instructions");
+    expect(result).toContain("Focus on the auth layer.");
+  });
+
+  it("does NOT include base prompt or project context", () => {
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      issueId: "INT-42",
+      userPrompt: "Some task.",
+    });
+    expect(result).not.toContain(BASE_AGENT_PROMPT);
+    expect(result).not.toContain("## Project Context");
+    expect(result).not.toContain("Project: Test App");
+  });
+
+  it("does NOT include project rules", () => {
+    project.agentRules = "Inline rule.";
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      issueId: "INT-42",
+    });
+    expect(result).not.toContain("Inline rule.");
+    expect(result).not.toContain("## Project Rules");
+  });
+
+  it("ordering: task before issue details before additional instructions", () => {
+    const result = buildWorkerTaskPrompt({
+      project,
+      projectId: "test-app",
+      issueId: "INT-42",
+      issueContext: "Issue body here",
+      userPrompt: "Do this extra thing.",
+    });
+    const taskIdx = result.indexOf("## Task");
+    const detailsIdx = result.indexOf("## Issue Details");
+    const additionalIdx = result.indexOf("## Additional Instructions");
+    expect(taskIdx).toBeLessThan(detailsIdx);
+    expect(detailsIdx).toBeLessThan(additionalIdx);
   });
 });

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -979,8 +979,17 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
 
-  it("sends AO guidance post-launch even when no explicit prompt is provided", async () => {
+  it("does not send post-launch message when no task content — AO guidance goes to systemPromptFile instead", async () => {
     vi.useFakeTimers();
+    const wsPath = join(tmpDir, "ws-post-launch-no-task");
+    mkdirSync(wsPath, { recursive: true });
+    (mockWorkspace.create as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      path: wsPath,
+      branch: "session/app-1",
+      sessionId: "app-1",
+      projectId: "my-app",
+    });
+
     const postLaunchAgent = {
       ...mockAgent,
       promptDelivery: "post-launch" as const,
@@ -1000,9 +1009,13 @@ describe("spawn", () => {
     await vi.advanceTimersByTimeAsync(5_000);
     await spawnPromise;
 
-    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ id: expect.any(String) }),
-      expect.stringContaining("ao session claim-pr"),
+    // No sendMessage: task prompt is empty, AO guidance lives in the systemPromptFile
+    expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    // getLaunchCommand should have received systemPromptFile pointing into the worktree
+    expect(postLaunchAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        systemPromptFile: expect.stringContaining("worker-instructions"),
+      }),
     );
     vi.useRealTimers();
   });
@@ -1072,6 +1085,108 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalled();
     vi.useRealTimers();
   }, 20_000);
+
+  describe("worker system instructions file", () => {
+    function makeWsRegistry(wsPath: string): PluginRegistry {
+      const ws = {
+        ...mockWorkspace,
+        create: vi.fn().mockResolvedValue({
+          path: wsPath,
+          branch: "session/app-1",
+          sessionId: "app-1",
+          projectId: "my-app",
+        }),
+        destroy: vi.fn().mockResolvedValue(undefined),
+      };
+      return {
+        ...mockRegistry,
+        get: vi.fn().mockImplementation((slot: string) => {
+          if (slot === "runtime") return mockRuntime;
+          if (slot === "agent") return mockAgent;
+          if (slot === "workspace") return ws;
+          return null;
+        }),
+      };
+    }
+
+    it("writes worker instructions to .ao/ inside the worktree", async () => {
+      const wsPath = join(tmpDir, "ws-instr-write");
+      mkdirSync(wsPath, { recursive: true });
+      const sm = createSessionManager({ config, registry: makeWsRegistry(wsPath) });
+
+      await sm.spawn({ projectId: "my-app" });
+
+      const instrFile = join(wsPath, ".ao", "worker-instructions-app-1.md");
+      expect(existsSync(instrFile)).toBe(true);
+      const content = readFileSync(instrFile, "utf-8");
+      expect(content).toContain("ao session claim-pr");
+      expect(content).toContain("## Project Context");
+    });
+
+    it("passes systemPromptFile pointing into the worktree to getLaunchCommand", async () => {
+      const wsPath = join(tmpDir, "ws-sysprompt-pass");
+      mkdirSync(wsPath, { recursive: true });
+      const sm = createSessionManager({ config, registry: makeWsRegistry(wsPath) });
+
+      await sm.spawn({ projectId: "my-app" });
+
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          systemPromptFile: join(wsPath, ".ao", "worker-instructions-app-1.md"),
+        }),
+      );
+    });
+
+    it("task prompt contains only issue/task content — no BASE_AGENT_PROMPT", async () => {
+      const wsPath = join(tmpDir, "ws-task-no-base");
+      mkdirSync(wsPath, { recursive: true });
+      const sm = createSessionManager({ config, registry: makeWsRegistry(wsPath) });
+
+      await sm.spawn({ projectId: "my-app", issueId: "INT-77", prompt: "Do the thing" });
+
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: expect.stringContaining("INT-77"),
+        }),
+      );
+      // Base AO guidance must NOT appear in the task prompt
+      const callArg = (mockAgent.getLaunchCommand as ReturnType<typeof vi.fn>).mock
+        .calls[0][0] as { prompt?: string };
+      expect(callArg.prompt).not.toContain("ao session claim-pr");
+      expect(callArg.prompt).not.toContain("## Project Context");
+    });
+
+    it("sets prompt to undefined when no issue or userPrompt so nothing is inlined", async () => {
+      const wsPath = join(tmpDir, "ws-no-prompt");
+      mkdirSync(wsPath, { recursive: true });
+      const sm = createSessionManager({ config, registry: makeWsRegistry(wsPath) });
+
+      await sm.spawn({ projectId: "my-app" });
+
+      expect(mockAgent.getLaunchCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt: undefined,
+          systemPromptFile: expect.stringContaining("worker-instructions"),
+        }),
+      );
+    });
+
+    it("system instructions file contains base guidance and project context but not issue details", async () => {
+      const wsPath = join(tmpDir, "ws-instr-content");
+      mkdirSync(wsPath, { recursive: true });
+      const sm = createSessionManager({ config, registry: makeWsRegistry(wsPath) });
+
+      await sm.spawn({ projectId: "my-app", issueId: "INT-99" });
+
+      const instrFile = join(wsPath, ".ao", "worker-instructions-app-1.md");
+      const content = readFileSync(instrFile, "utf-8");
+      expect(content).toContain("Session Lifecycle");
+      expect(content).toContain("## Project Context");
+      expect(content).not.toContain("INT-99");
+      expect(content).not.toContain("## Task");
+      expect(content).not.toContain("## Issue Details");
+    });
+  });
 
   describe("spawnOrchestrator", () => {
     it("throws when no workspace plugin is configured", async () => {

--- a/packages/core/src/prompt-builder.ts
+++ b/packages/core/src/prompt-builder.ts
@@ -166,3 +166,81 @@ export function buildPrompt(config: PromptBuildConfig): string {
 
   return sections.join("\n\n");
 }
+
+/**
+ * Build the system-level instructions for a worker session.
+ *
+ * Contains: BASE_AGENT_PROMPT + project context + project rules.
+ * Does NOT include issue/task-specific content or the user prompt.
+ * This portion is written to a file and passed as systemPromptFile so it
+ * is never inlined into the first task message.
+ */
+export function buildWorkerSystemInstructions(config: PromptBuildConfig): string {
+  const { project, projectId } = config;
+  const userRules = readUserRules(project);
+  const sections: string[] = [];
+
+  // Layer 1: Base prompt
+  sections.push(BASE_AGENT_PROMPT);
+
+  // Layer 2: Project context (no issue/task sections)
+  const ctxLines: string[] = [];
+  ctxLines.push("## Project Context");
+  ctxLines.push(`- Project: ${project.name ?? projectId}`);
+  ctxLines.push(`- Repository: ${project.repo}`);
+  ctxLines.push(`- Default branch: ${project.defaultBranch}`);
+  if (project.tracker) {
+    ctxLines.push(`- Tracker: ${project.tracker.plugin}`);
+  }
+  if (project.reactions) {
+    const reactionHints: string[] = [];
+    for (const [event, reaction] of Object.entries(project.reactions)) {
+      if (reaction.auto && reaction.action === "send-to-agent") {
+        reactionHints.push(`- ${event}: auto-handled (you'll receive instructions)`);
+      }
+    }
+    if (reactionHints.length > 0) {
+      ctxLines.push(`\n## Automated Reactions`);
+      ctxLines.push("The orchestrator will automatically handle these events:");
+      ctxLines.push(...reactionHints);
+    }
+  }
+  sections.push(ctxLines.join("\n"));
+
+  // Layer 3: User rules
+  if (userRules) {
+    sections.push(`## Project Rules\n${userRules}`);
+  }
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Build the task-specific prompt for a worker session.
+ *
+ * Contains: issue/task section + issue details + additional user instructions.
+ * Does NOT include the base prompt or project context — those live in
+ * the system instructions file returned by buildWorkerSystemInstructions().
+ *
+ * Returns an empty string when there is no task-specific content.
+ */
+export function buildWorkerTaskPrompt(config: PromptBuildConfig): string {
+  const { issueId, issueContext, userPrompt } = config;
+  const sections: string[] = [];
+
+  if (issueId) {
+    sections.push(
+      `## Task\nWork on issue: ${issueId}\nCreate a branch named so that it auto-links to the issue tracker (e.g. feat/${issueId}).`,
+    );
+  }
+
+  if (issueContext) {
+    sections.push(`## Issue Details\n${issueContext}`);
+  }
+
+  if (userPrompt) {
+    sections.push(`## Additional Instructions\n${userPrompt}`);
+  }
+
+  return sections.join("\n\n");
+}

--- a/packages/core/src/prompt-builder.ts
+++ b/packages/core/src/prompt-builder.ts
@@ -64,8 +64,14 @@ export interface PromptBuildConfig {
 // LAYER 2: CONFIG-DERIVED CONTEXT
 // =============================================================================
 
-function buildConfigLayer(config: PromptBuildConfig): string {
-  const { project, projectId, issueId, issueContext } = config;
+/**
+ * Build the static project-context section (name, repo, branch, tracker,
+ * reactions).  Does NOT include issue/task-specific content.
+ * Shared by buildConfigLayer() and buildWorkerSystemInstructions() so that
+ * adding a new project-context field only requires a single edit.
+ */
+function buildStaticProjectContext(config: PromptBuildConfig): string {
+  const { project, projectId } = config;
   const lines: string[] = [];
 
   lines.push("## Project Context");
@@ -75,19 +81,6 @@ function buildConfigLayer(config: PromptBuildConfig): string {
 
   if (project.tracker) {
     lines.push(`- Tracker: ${project.tracker.plugin}`);
-  }
-
-  if (issueId) {
-    lines.push(`\n## Task`);
-    lines.push(`Work on issue: ${issueId}`);
-    lines.push(
-      `Create a branch named so that it auto-links to the issue tracker (e.g. feat/${issueId}).`,
-    );
-  }
-
-  if (issueContext) {
-    lines.push(`\n## Issue Details`);
-    lines.push(issueContext);
   }
 
   // Include reaction rules so the agent knows what to expect
@@ -103,6 +96,26 @@ function buildConfigLayer(config: PromptBuildConfig): string {
       lines.push("The orchestrator will automatically handle these events:");
       lines.push(...reactionHints);
     }
+  }
+
+  return lines.join("\n");
+}
+
+function buildConfigLayer(config: PromptBuildConfig): string {
+  const { issueId, issueContext } = config;
+  const lines: string[] = [buildStaticProjectContext(config)];
+
+  if (issueId) {
+    lines.push(`\n## Task`);
+    lines.push(`Work on issue: ${issueId}`);
+    lines.push(
+      `Create a branch named so that it auto-links to the issue tracker (e.g. feat/${issueId}).`,
+    );
+  }
+
+  if (issueContext) {
+    lines.push(`\n## Issue Details`);
+    lines.push(issueContext);
   }
 
   return lines.join("\n");
@@ -176,36 +189,14 @@ export function buildPrompt(config: PromptBuildConfig): string {
  * is never inlined into the first task message.
  */
 export function buildWorkerSystemInstructions(config: PromptBuildConfig): string {
-  const { project, projectId } = config;
-  const userRules = readUserRules(project);
+  const userRules = readUserRules(config.project);
   const sections: string[] = [];
 
   // Layer 1: Base prompt
   sections.push(BASE_AGENT_PROMPT);
 
-  // Layer 2: Project context (no issue/task sections)
-  const ctxLines: string[] = [];
-  ctxLines.push("## Project Context");
-  ctxLines.push(`- Project: ${project.name ?? projectId}`);
-  ctxLines.push(`- Repository: ${project.repo}`);
-  ctxLines.push(`- Default branch: ${project.defaultBranch}`);
-  if (project.tracker) {
-    ctxLines.push(`- Tracker: ${project.tracker.plugin}`);
-  }
-  if (project.reactions) {
-    const reactionHints: string[] = [];
-    for (const [event, reaction] of Object.entries(project.reactions)) {
-      if (reaction.auto && reaction.action === "send-to-agent") {
-        reactionHints.push(`- ${event}: auto-handled (you'll receive instructions)`);
-      }
-    }
-    if (reactionHints.length > 0) {
-      ctxLines.push(`\n## Automated Reactions`);
-      ctxLines.push("The orchestrator will automatically handle these events:");
-      ctxLines.push(...reactionHints);
-    }
-  }
-  sections.push(ctxLines.join("\n"));
+  // Layer 2: Static project context (shared with buildConfigLayer)
+  sections.push(buildStaticProjectContext(config));
 
   // Layer 3: User rules
   if (userRules) {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -53,7 +53,7 @@ import {
   listMetadata,
   reserveSessionId,
 } from "./metadata.js";
-import { buildPrompt } from "./prompt-builder.js";
+import { buildWorkerSystemInstructions, buildWorkerTaskPrompt } from "./prompt-builder.js";
 import {
   getSessionsDir,
   getWorktreesDir,
@@ -1062,13 +1062,42 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     }
 
-    const composedPrompt = buildPrompt({
+    const promptBuildConfig = {
       project,
       projectId: spawnConfig.projectId,
       issueId: spawnConfig.issueId,
       issueContext,
       userPrompt: spawnConfig.prompt,
-    });
+    };
+
+    // Write worker system instructions (base guidance + project context + rules) to a file
+    // inside the worktree so it is never inlined into the first task message.
+    // The .ao/ path is gitignored by convention (same dir used by PATH-wrapper hooks).
+    let workerSystemInstructionsFile: string | undefined;
+    try {
+      const systemInstructions = buildWorkerSystemInstructions(promptBuildConfig);
+      const aoDir = join(workspacePath, ".ao");
+      mkdirSync(aoDir, { recursive: true });
+      workerSystemInstructionsFile = join(aoDir, `worker-instructions-${sessionId}.md`);
+      writeFileSync(workerSystemInstructionsFile, systemInstructions, "utf-8");
+    } catch (err) {
+      // Clean up workspace, reserved ID, and the partially-written file on failure
+      if (workerSystemInstructionsFile) {
+        try { unlinkSync(workerSystemInstructionsFile); } catch { /* best effort */ }
+      }
+      if (
+        plugins.workspace &&
+        shouldDestroyWorkspacePath(project, spawnConfig.projectId, workspacePath)
+      ) {
+        try { await plugins.workspace.destroy(workspacePath); } catch { /* best effort */ }
+      }
+      try { deleteMetadata(sessionsDir, sessionId, false); } catch { /* best effort */ }
+      throw err;
+    }
+
+    // Task prompt contains only the issue/task-specific content; the system
+    // instructions (base guidance, project context, rules) live in the file above.
+    const taskPrompt = buildWorkerTaskPrompt(promptBuildConfig) || undefined;
 
     // Get agent launch config and create runtime — clean up workspace on failure
     const opencodeIssueSessionStrategy = project.opencodeIssueSessionStrategy ?? "reuse";
@@ -1090,10 +1119,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         },
       },
       issueId: spawnConfig.issueId,
-      prompt: composedPrompt,
+      prompt: taskPrompt,
       permissions: selection.permissions,
       model: selection.model,
       subagent: spawnConfig.subagent ?? selection.subagent,
+      systemPromptFile: workerSystemInstructionsFile,
     };
 
     let handle: RuntimeHandle;
@@ -1119,7 +1149,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         },
       });
     } catch (err) {
-      // Clean up workspace and reserved ID if agent config or runtime creation failed
+      // Clean up workspace, reserved ID, and instructions file on failure.
+      // The file lives inside the workspace so workspace.destroy() handles it,
+      // but we also attempt an explicit unlink for the no-workspace-plugin case.
+      if (workerSystemInstructionsFile) {
+        try { unlinkSync(workerSystemInstructionsFile); } catch { /* best effort */ }
+      }
       if (
         plugins.workspace &&
         shouldDestroyWorkspacePath(project, spawnConfig.projectId, workspacePath)
@@ -1200,6 +1235,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         await plugins.runtime.destroy(handle);
       } catch {
         /* best effort */
+      }
+      if (workerSystemInstructionsFile) {
+        try { unlinkSync(workerSystemInstructionsFile); } catch { /* best effort */ }
       }
       if (
         plugins.workspace &&


### PR DESCRIPTION
## Summary

- **Split worker prompt construction**: `buildWorkerSystemInstructions()` (base guidance + project context + project rules) and `buildWorkerTaskPrompt()` (issue/task + user instructions) replace the monolithic `buildPrompt()` call in `spawn()`.
- **File-based system instructions**: on every worker spawn, the system instructions are written to `{worktree}/.ao/worker-instructions-{sessionId}.md` (gitignored by convention) and passed to `AgentLaunchConfig.systemPromptFile` — mirroring the existing orchestrator pattern.
- **Clean first message**: the task prompt (sent as the first user turn / CLI argument) now contains only issue/task-specific content. `BASE_AGENT_PROMPT`, project context, and project rules no longer appear in it.
- **Codex wiring**: Codex already handles `systemPromptFile` as `-c model_instructions_file=<path>`; Claude Code as `--append-system-prompt "$(cat <path>)"`. No plugin changes needed.
- **Cleanup**: `workerSystemInstructionsFile` is cleaned up best-effort in both error paths (runtime-create failure and post-launch-setup failure).

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` — passes clean
- [x] `vitest run src/__tests__/prompt-builder.test.ts src/__tests__/session-manager/spawn.test.ts` — 109/109 pass
- [x] `pnpm --filter @aoagents/ao-core test` — 601/601 pass (unrelated plugin-integration failure is pre-existing, needs `ao-core` build artifact)
- [x] New `buildWorkerSystemInstructions` tests: contains BASE+context+rules, does NOT contain issue/task/userPrompt
- [x] New `buildWorkerTaskPrompt` tests: contains only issue/task content, does NOT contain BASE/context/rules
- [x] New spawn tests (`worker system instructions file` suite): file written to `.ao/`, `systemPromptFile` in `getLaunchCommand`, task prompt free of `ao session claim-pr`/`## Project Context`, prompt undefined when no task content

🤖 Generated with [Claude Code](https://claude.com/claude-code)