### PR TITLE
Fix dashboard issueUrl showing raw identifier instead of full URL

### DIFF
--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -858,7 +858,10 @@ describe("enrichSessionsMetadata", () => {
   it("starts issue-title fetches before agent summaries finish", async () => {
     let resolveSummary: ((value: { summary: string; summaryIsFallback: false; agentSessionId: string }) => void) | null = null;
 
-    const tracker = mockTracker("Fix auth bug");
+    const tracker = {
+      ...mockTracker("Fix auth bug"),
+      issueUrl: vi.fn().mockReturnValue(`${urlBase}-parallel`),
+    };
     const agent = {
       ...mockAgent(),
       getSessionInfo: vi.fn().mockImplementation(
@@ -1036,6 +1039,7 @@ describe("enrichSessionsMetadataFast", () => {
     const tracker: Tracker = {
       name: "mock-tracker",
       getIssue: vi.fn().mockResolvedValue({ id: "99", title: "Should not be called", url: urlBase }),
+      issueUrl: vi.fn().mockReturnValue(urlBase),
       issueLabel: vi.fn().mockReturnValue("#99"),
     } as unknown as Tracker;
     const agent: Agent = {

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -59,7 +59,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     activity: session.activity,
     branch: session.branch,
     issueId: session.issueId, // Deprecated: kept for backwards compatibility
-    issueUrl: session.issueId, // issueId is actually the full URL
+    issueUrl: null, // Will be enriched by enrichSessionIssue() via tracker.issueUrl()
     issueLabel: null, // Will be enriched by enrichSessionIssue()
     issueTitle: null, // Will be enriched by enrichSessionIssueTitle()
     userPrompt: session.metadata["userPrompt"] ?? null,
@@ -287,12 +287,23 @@ export async function enrichSessionPR(
   return true;
 }
 
-/** Enrich a DashboardSession's issue label using the tracker plugin. */
+/** Enrich a DashboardSession's issue URL and label using the tracker plugin. */
 export function enrichSessionIssue(
   dashboard: DashboardSession,
   tracker: Tracker,
   project: ProjectConfig,
 ): void {
+  if (!dashboard.issueId) return;
+
+  // Compute the full issue URL from the identifier using the tracker plugin
+  if (tracker.issueUrl) {
+    try {
+      dashboard.issueUrl = tracker.issueUrl(dashboard.issueId, project);
+    } catch {
+      // If issueUrl() fails, leave issueUrl null
+    }
+  }
+
   if (!dashboard.issueUrl) return;
 
   // Use tracker plugin to extract human-readable label from URL
@@ -396,9 +407,9 @@ function prepareSessionMetadataEnrichment(
 } {
   const projects = coreSessions.map((core) => resolveProject(core, config.projects));
 
-  // Issue labels (synchronous string parsing, no API calls)
+  // Issue URLs and labels (synchronous string parsing, no API calls)
   projects.forEach((project, i) => {
-    if (!dashboardSessions[i].issueUrl || !project?.tracker?.plugin) return;
+    if (!dashboardSessions[i].issueId || !project?.tracker?.plugin) return;
     const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
     if (!tracker) return;
     enrichSessionIssue(dashboardSessions[i], tracker, project);


### PR DESCRIPTION
## Summary
- Fixed `sessionToDashboard` which was setting `issueUrl` directly from `session.issueId` (a raw identifier like `"1"` or `"INT-42"`), causing broken links in the dashboard
- `issueUrl` is now initialized as `null` and computed during enrichment by calling `tracker.issueUrl(issueId, project)`, consistent with how `issueLabel` and `issueTitle` are already enriched
- Updated the `enrichSessionIssue` function to first compute the URL from the identifier, then derive the label from the URL

## Test plan
- [x] All 57 serialize tests pass
- [x] Verified `enrichSessionIssue` correctly calls `tracker.issueUrl()` to compute the full URL
- [x] Verified `enrichSessionIssueTitle` still works (depends on `issueUrl` being set by prior enrichment)
- [x] Verified graceful fallback when `tracker.issueUrl` is not implemented

Fixes #1213

🤖 Generated with [Claude Code](https://claude.com/claude-code)