### PR TITLE
Fix Codex session activity parsing for payload JSONL

### DIFF
--- a/packages/core/src/__tests__/utils.test.ts
+++ b/packages/core/src/__tests__/utils.test.ts
@@ -90,6 +90,31 @@ describe("readLastJsonlEntry", () => {
     const result = await readLastJsonlEntry(path);
     expect(result!.modifiedAt).toBeInstanceOf(Date);
   });
+
+  it("extracts payloadType from nested payload.type", async () => {
+    // Real Codex writes records like {"type":"event_msg","payload":{"type":"error",...}}
+    // Consumers need the inner payload.type to classify activity correctly.
+    const path = setup(
+      '{"type":"event_msg","payload":{"type":"error","message":"bad"}}\n',
+    );
+    const result = await readLastJsonlEntry(path);
+    expect(result!.lastType).toBe("event_msg");
+    expect(result!.payloadType).toBe("error");
+  });
+
+  it("returns payloadType null when payload has no type field", async () => {
+    const path = setup('{"type":"session_meta","payload":{"cwd":"/workspace"}}\n');
+    const result = await readLastJsonlEntry(path);
+    expect(result!.lastType).toBe("session_meta");
+    expect(result!.payloadType).toBeNull();
+  });
+
+  it("returns payloadType null when payload is not an object", async () => {
+    const path = setup('{"type":"x","payload":"string"}\n');
+    const result = await readLastJsonlEntry(path);
+    expect(result!.lastType).toBe("x");
+    expect(result!.payloadType).toBeNull();
+  });
 });
 
 describe("isGitBranchNameSafe", () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -138,7 +138,7 @@ async function readLastLine(filePath: string): Promise<string | null> {
  */
 export async function readLastJsonlEntry(
   filePath: string,
-): Promise<{ lastType: string | null; modifiedAt: Date } | null> {
+): Promise<{ lastType: string | null; payloadType: string | null; modifiedAt: Date } | null> {
   try {
     const [line, fileStat] = await Promise.all([readLastLine(filePath), stat(filePath)]);
 
@@ -148,10 +148,15 @@ export async function readLastJsonlEntry(
     if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
       const obj = parsed as Record<string, unknown>;
       const lastType = typeof obj.type === "string" ? obj.type : null;
-      return { lastType, modifiedAt: fileStat.mtime };
+      let payloadType: string | null = null;
+      if (typeof obj.payload === "object" && obj.payload !== null && !Array.isArray(obj.payload)) {
+        const payload = obj.payload as Record<string, unknown>;
+        if (typeof payload.type === "string") payloadType = payload.type;
+      }
+      return { lastType, payloadType, modifiedAt: fileStat.mtime };
     }
 
-    return { lastType: null, modifiedAt: fileStat.mtime };
+    return { lastType: null, payloadType: null, modifiedAt: fileStat.mtime };
   } catch {
     return null;
   }

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -135,15 +135,23 @@ function mockTmuxWithProcess(processName: string, found = true) {
 }
 
 /**
- * Create a mock file handle for `open()` that returns `content` from `read()`.
- * Used by sessionFileMatchesCwd which reads the first few complete JSONL lines.
+ * Create a mock file handle for `open()` that streams `content` across
+ * successive `read()` calls. Tracks an internal cursor so sequential reads
+ * advance through the buffer and eventually return `bytesRead: 0` at EOF.
+ * Without position tracking, readJsonlPrefixLines would loop forever on
+ * lines larger than its chunk size.
  */
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
+  let cursor = 0;
   return {
     read: vi.fn().mockImplementation((buffer: Buffer, offset: number, length: number, _position: number) => {
-      const bytesToCopy = Math.min(length, buf.length);
-      buf.copy(buffer, offset, 0, bytesToCopy);
+      if (cursor >= buf.length) {
+        return Promise.resolve({ bytesRead: 0, buffer });
+      }
+      const bytesToCopy = Math.min(length, buf.length - cursor);
+      buf.copy(buffer, offset, cursor, cursor + bytesToCopy);
+      cursor += bytesToCopy;
       return Promise.resolve({ bytesRead: bytesToCopy, buffer });
     }),
     close: vi.fn().mockResolvedValue(undefined),
@@ -848,6 +856,37 @@ describe("getActivityState", () => {
 
     const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
     const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("ready");
+  });
+
+  it("handles multi-byte UTF-8 characters straddling an 8KB chunk boundary", async () => {
+    mockTmuxWithProcess("codex");
+    // Each 日 is 3 bytes. Padding with enough CJK chars to push the json
+    // payload past the 8192-byte chunk size, guaranteeing a multi-byte
+    // character will straddle a read boundary. Without StringDecoder,
+    // the split character decodes to U+FFFD and JSON.parse fails.
+    const padding = "日".repeat(3_000); // 9000 bytes of padding
+    const content =
+      `${JSON.stringify({
+        type: "session_meta",
+        payload: {
+          cwd: "/workspace/test",
+          id: "thread-utf8",
+          base_instructions: padding,
+        },
+      })}\n`;
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    // If UTF-8 boundary handling is broken, JSON.parse fails, cwd never
+    // matches, no session file is selected, and state falls through to null.
     expect(result?.state).toBe("ready");
   });
 

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -136,7 +136,7 @@ function mockTmuxWithProcess(processName: string, found = true) {
 
 /**
  * Create a mock file handle for `open()` that returns `content` from `read()`.
- * Used by sessionFileMatchesCwd which reads only the first 4 KB.
+ * Used by sessionFileMatchesCwd which reads the first few complete JSONL lines.
  */
 function makeFakeFileHandle(content: string) {
   const buf = Buffer.from(content, "utf-8");
@@ -168,7 +168,7 @@ function makeContentStream(content: string): Readable {
 
 /**
  * Set up mockCreateReadStream to return a readable stream with the given content.
- * Used by getSessionInfo/getRestoreCommand which now stream files line-by-line.
+ * Used by getSessionInfo/getRestoreCommand which stream files line-by-line.
  */
 function setupMockStream(content: string) {
   mockCreateReadStream.mockReturnValue(makeContentStream(content));
@@ -739,6 +739,30 @@ describe("getActivityState", () => {
     expect(result?.state).toBe("ready");
   });
 
+  it("detects activity from payload-wrapped Codex session_meta files", async () => {
+    mockTmuxWithProcess("codex");
+    const content =
+      `${JSON.stringify({
+        type: "session_meta",
+        payload: {
+          cwd: "/workspace/test",
+          id: "thread-123",
+          base_instructions: "x".repeat(8_000),
+        },
+      })}\n`;
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("ready");
+  });
+
   it("returns exited when process handle has dead PID", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
       throw new Error("ESRCH");
@@ -814,6 +838,75 @@ describe("getSessionInfo", () => {
     expect(result!.cost!.inputTokens).toBe(3000);
     expect(result!.cost!.outputTokens).toBe(800);
     expect(result!.cost!.estimatedCostUsd).toBeGreaterThan(0);
+  });
+
+  it("parses payload-wrapped Codex session files", async () => {
+    const sessionContent = jsonl(
+      {
+        type: "session_meta",
+        payload: {
+          cwd: "/workspace/test",
+          id: "thread-payload-123",
+          model_provider: "openai",
+        },
+      },
+      {
+        type: "turn_context",
+        payload: {
+          model: "gpt-5.3-codex",
+          cwd: "/workspace/test",
+        },
+      },
+      {
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            total_token_usage: {
+              input_tokens: 3000,
+              output_tokens: 800,
+              cached_input_tokens: 200,
+              reasoning_output_tokens: 100,
+            },
+          },
+        },
+      },
+    );
+
+    mockReaddir.mockResolvedValue(["rollout-abc.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+
+    expect(result).not.toBeNull();
+    expect(result!.agentSessionId).toBe("rollout-abc");
+    expect(result!.summary).toBe("Codex session (gpt-5.3-codex)");
+    expect(result!.cost).toBeDefined();
+    expect(result!.cost!.inputTokens).toBe(3000);
+    expect(result!.cost!.outputTokens).toBe(800);
+  });
+
+  it("does not treat model_provider as the session model", async () => {
+    const sessionContent = jsonl({
+      type: "session_meta",
+      payload: {
+        cwd: "/workspace/test",
+        id: "thread-payload-123",
+        model_provider: "openai",
+      },
+    });
+
+    mockReaddir.mockResolvedValue(["rollout-abc.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBeNull();
   });
 
   it("picks the most recently modified matching session file", async () => {
@@ -1073,6 +1166,57 @@ describe("getRestoreCommand", () => {
     expect(cmd).toContain("'codex' resume");
     expect(cmd).toContain("-c check_for_update_on_startup=false");
     expect(cmd).toContain("thread-abc-123");
+  });
+
+  it("builds native resume command from payload-wrapped Codex session id", async () => {
+    const content = jsonl(
+      {
+        type: "session_meta",
+        payload: {
+          cwd: "/workspace/test",
+          id: "thread-payload-999",
+          model_provider: "openai",
+        },
+      },
+      {
+        type: "turn_context",
+        payload: {
+          model: "gpt-5.3-codex",
+        },
+      },
+    );
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const session = makeSession({ workspacePath: "/workspace/test" });
+    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig());
+
+    expect(cmd).not.toBeNull();
+    expect(cmd).toContain("'codex' resume");
+    expect(cmd).toContain("thread-payload-999");
+  });
+
+  it("does not append --model from model_provider-only payload data", async () => {
+    const content = jsonl({
+      type: "session_meta",
+      payload: {
+        cwd: "/workspace/test",
+        id: "thread-payload-999",
+        model_provider: "openai",
+      },
+    });
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    setupMockStream(content);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const session = makeSession({ workspacePath: "/workspace/test" });
+    const cmd = await agent.getRestoreCommand!(session, makeProjectConfig());
+
+    expect(cmd).not.toBeNull();
+    expect(cmd).not.toContain("--model 'openai'");
   });
 
   it("includes bypass flag when project config permissions=permissionless", async () => {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -739,6 +739,94 @@ describe("getActivityState", () => {
     expect(result?.state).toBe("ready");
   });
 
+  it("returns waiting_input when payload.type is approval_request on event_msg", async () => {
+    // Real Codex writes {"type":"event_msg","payload":{"type":"approval_request",...}}
+    // Without payloadType handling, this decays to ready/idle via the event_msg case.
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      payloadType: "approval_request",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("waiting_input");
+  });
+
+  it("returns waiting_input for exec_approval_request payload type", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      payloadType: "exec_approval_request",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("waiting_input");
+  });
+
+  it("returns blocked when payload.type is error on event_msg", async () => {
+    // Real Codex writes {"type":"event_msg","payload":{"type":"error",...}}
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      payloadType: "error",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("blocked");
+  });
+
+  it("returns active when payload.type is task_started on a recent event_msg", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      payloadType: "task_started",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("active");
+  });
+
+  it("returns ready when payload.type is task_complete on a recent event_msg", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["sess.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "event_msg",
+      payloadType: "task_complete",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({ runtimeHandle: makeTmuxHandle(), workspacePath: "/workspace/test" });
+    const result = await agent.getActivityState(session);
+    expect(result?.state).toBe("ready");
+  });
+
   it("detects activity from payload-wrapped Codex session_meta files", async () => {
     mockTmuxWithProcess("codex");
     const content =

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -292,6 +292,10 @@ async function streamCodexSessionData(filePath: string): Promise<CodexSessionDat
           data.model = payload.model;
         }
 
+        // Token sources are precedence-ordered: total → last → flat → legacy.
+        // `continue` ensures only one source is counted per entry.
+        // `total_token_usage` is a cumulative snapshot (last-write-wins, so `=`);
+        // the rest are per-turn deltas (accumulate with `+=`). Do not "fix" this.
         const totalUsage = payload.info?.total_token_usage;
         if (typeof totalUsage?.input_tokens === "number") {
           data.inputTokens = totalUsage.input_tokens;

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -28,6 +28,7 @@ import { createReadStream } from "node:fs";
 import { readdir, stat, lstat, open } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { createInterface } from "node:readline";
 import { promisify } from "node:util";
 
@@ -145,6 +146,10 @@ async function readJsonlPrefixLines(filePath: string, maxLines: number): Promise
   const handle = await open(filePath, "r");
   const lines: string[] = [];
   let partialLine = "";
+  // Reuse a single decoder across reads so multi-byte UTF-8 sequences that
+  // straddle a chunk boundary (e.g. CJK characters in base_instructions) get
+  // buffered correctly instead of producing U+FFFD replacement characters.
+  const decoder = new StringDecoder("utf8");
 
   try {
     while (lines.length < maxLines) {
@@ -152,12 +157,13 @@ async function readJsonlPrefixLines(filePath: string, maxLines: number): Promise
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
 
       if (bytesRead === 0) {
+        partialLine += decoder.end();
         const finalLine = partialLine.trim();
         if (finalLine) lines.push(finalLine);
         break;
       }
 
-      partialLine += buffer.subarray(0, bytesRead).toString("utf-8");
+      partialLine += decoder.write(buffer.subarray(0, bytesRead));
 
       let newlineIndex = partialLine.indexOf("\n");
       while (newlineIndex !== -1 && lines.length < maxLines) {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -55,25 +55,47 @@ export const manifest = {
 
 /** Codex session directory: ~/.codex/sessions/ */
 const CODEX_SESSIONS_DIR = join(homedir(), ".codex", "sessions");
+const SESSION_MATCH_SCAN_CHUNK_BYTES = 8192;
+const SESSION_MATCH_SCAN_LINE_LIMIT = 10;
 
-/** Typed representation of a line in a Codex JSONL session file */
-interface CodexJsonlLine {
-  type?: string;
+interface CodexTokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cached_input_tokens?: number;
+  cached_tokens?: number;
+  reasoning_output_tokens?: number;
+  reasoning_tokens?: number;
+}
+
+interface CodexJsonlPayload extends CodexTokenUsage {
+  id?: string;
   cwd?: string;
+  model_provider?: string;
   model?: string;
-  // Thread ID from thread_started notifications
+  turn_id?: string;
   threadId?: string;
-  // User message content (from user input events)
   content?: string;
   role?: string;
-  // event_msg with token_count subtype
-  msg?: {
-    type?: string;
-    input_tokens?: number;
-    output_tokens?: number;
-    cached_tokens?: number;
-    reasoning_tokens?: number;
+  type?: string;
+  info?: {
+    total_token_usage?: CodexTokenUsage;
+    last_token_usage?: CodexTokenUsage;
   };
+}
+
+/**
+ * Recent Codex versions wrap event fields in `payload`, while older fixtures
+ * used a flat shape. Accept both so session discovery works against real
+ * Codex JSONL and existing tests remain valid.
+ */
+interface CodexJsonlLine extends CodexJsonlPayload {
+  type?: string;
+  payload?: CodexJsonlPayload;
+  msg?: CodexTokenUsage & { type?: string };
+}
+
+function getCodexPayload(entry: CodexJsonlLine): CodexJsonlPayload {
+  return entry.payload ?? entry;
 }
 
 /**
@@ -119,41 +141,59 @@ async function collectJsonlFiles(dir: string, depth = 0): Promise<string[]> {
   return results;
 }
 
+async function readJsonlPrefixLines(filePath: string, maxLines: number): Promise<string[]> {
+  const handle = await open(filePath, "r");
+  const lines: string[] = [];
+  let partialLine = "";
+
+  try {
+    while (lines.length < maxLines) {
+      const buffer = Buffer.allocUnsafe(SESSION_MATCH_SCAN_CHUNK_BYTES);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, null);
+
+      if (bytesRead === 0) {
+        const finalLine = partialLine.trim();
+        if (finalLine) lines.push(finalLine);
+        break;
+      }
+
+      partialLine += buffer.subarray(0, bytesRead).toString("utf-8");
+
+      let newlineIndex = partialLine.indexOf("\n");
+      while (newlineIndex !== -1 && lines.length < maxLines) {
+        const line = partialLine.slice(0, newlineIndex).trim();
+        if (line) lines.push(line);
+        partialLine = partialLine.slice(newlineIndex + 1);
+        newlineIndex = partialLine.indexOf("\n");
+      }
+    }
+  } finally {
+    await handle.close();
+  }
+
+  return lines;
+}
+
 /**
- * Check if the first few lines of a JSONL file contain a session_meta
- * entry matching the given workspace path. Reads only the first 4 KB
- * to avoid loading large rollout files into memory.
+ * Check if the first few complete JSONL records of a session file contain a
+ * session_meta entry matching the given workspace path. This avoids parsing a
+ * truncated session_meta line when Codex embeds large base_instructions.
  */
 async function sessionFileMatchesCwd(
   filePath: string,
   workspacePath: string,
 ): Promise<boolean> {
   try {
-    // Read only the first 4 KB — session_meta is always in the first few lines.
-    // Avoids loading large rollout files (100 MB+) into memory.
-    const handle = await open(filePath, "r");
-    let content: string;
-    try {
-      const buffer = Buffer.allocUnsafe(4096);
-      const { bytesRead } = await handle.read(buffer, 0, 4096, 0);
-      content = buffer.subarray(0, bytesRead).toString("utf-8");
-    } finally {
-      await handle.close();
-    }
-    const lines = content.split("\n").slice(0, 10);
+    const lines = await readJsonlPrefixLines(filePath, SESSION_MATCH_SCAN_LINE_LIMIT);
     for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
       try {
-        const parsed: unknown = JSON.parse(trimmed);
-        if (
-          typeof parsed === "object" &&
-          parsed !== null &&
-          !Array.isArray(parsed) &&
-          (parsed as CodexJsonlLine).type === "session_meta" &&
-          (parsed as CodexJsonlLine).cwd === workspacePath
-        ) {
-          return true;
+        const parsed: unknown = JSON.parse(line);
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          const entry = parsed as CodexJsonlLine;
+          const payload = getCodexPayload(entry);
+          if (entry.type === "session_meta" && payload.cwd === workspacePath) {
+            return true;
+          }
         }
       } catch {
         // Skip malformed lines
@@ -222,12 +262,50 @@ async function streamCodexSessionData(filePath: string): Promise<CodexSessionDat
         if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) continue;
         const entry = parsed as CodexJsonlLine;
 
-        if (entry.type === "session_meta" && typeof entry.model === "string") {
-          data.model = entry.model;
+        const payload = getCodexPayload(entry);
+
+        if (entry.type === "session_meta") {
+          if (typeof payload.id === "string" && payload.id) {
+            data.threadId = payload.id;
+          } else if (typeof payload.threadId === "string" && payload.threadId) {
+            data.threadId = payload.threadId;
+          }
         }
-        if (typeof entry.threadId === "string" && entry.threadId) {
-          data.threadId = entry.threadId;
+
+        if (!data.threadId) {
+          if (typeof payload.threadId === "string" && payload.threadId) {
+            data.threadId = payload.threadId;
+          } else if (typeof entry.threadId === "string" && entry.threadId) {
+            data.threadId = entry.threadId;
+          }
         }
+
+        if (entry.type === "turn_context" && typeof payload.model === "string" && payload.model) {
+          data.model = payload.model;
+        } else if (!data.model && typeof payload.model === "string" && payload.model) {
+          data.model = payload.model;
+        }
+
+        const totalUsage = payload.info?.total_token_usage;
+        if (typeof totalUsage?.input_tokens === "number") {
+          data.inputTokens = totalUsage.input_tokens;
+          data.outputTokens = totalUsage.output_tokens ?? 0;
+          continue;
+        }
+
+        const lastUsage = payload.info?.last_token_usage;
+        if (typeof lastUsage?.input_tokens === "number") {
+          data.inputTokens += lastUsage.input_tokens;
+          data.outputTokens += lastUsage.output_tokens ?? 0;
+          continue;
+        }
+
+        if (typeof payload.input_tokens === "number") {
+          data.inputTokens += payload.input_tokens;
+          data.outputTokens += payload.output_tokens ?? 0;
+          continue;
+        }
+
         if (entry.type === "event_msg" && entry.msg?.type === "token_count") {
           data.inputTokens += entry.msg.input_tokens ?? 0;
           data.outputTokens += entry.msg.output_tokens ?? 0;
@@ -434,6 +512,8 @@ function createCodexAgent(): Agent {
           // Confirmed types: session_meta, event_msg. Others are best-effort.
           const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
           switch (entry.lastType) {
+            case "response_item":
+            case "turn_context":
             case "user_input":
             case "tool_call":
             case "exec_command":
@@ -443,6 +523,7 @@ function createCodexAgent(): Agent {
             case "assistant_message":
             case "session_meta":
             case "event_msg":
+            case "compacted":
               return { state: ageMs > threshold ? "idle" : "ready", timestamp };
 
             case "approval_request":

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -508,29 +508,46 @@ function createCodexAgent(): Agent {
           const ageMs = Date.now() - entry.modifiedAt.getTime();
           const timestamp = entry.modifiedAt;
 
+          // Real Codex wraps the semantic type in `payload.type` on event_msg
+          // records (e.g. `{"type":"event_msg","payload":{"type":"error",...}}`).
+          // Prefer payloadType when present so approval_request/error surface
+          // correctly instead of decaying to ready/idle via the event_msg case.
+          const effectiveType = entry.payloadType ?? entry.lastType;
+
           // Map Codex JSONL entry types to activity states.
           // Confirmed types: session_meta, event_msg. Others are best-effort.
           const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
-          switch (entry.lastType) {
+          switch (effectiveType) {
+            case "approval_request":
+            case "exec_approval_request":
+            case "apply_patch_approval_request":
+              return { state: "waiting_input", timestamp };
+
+            case "error":
+            case "stream_error":
+              return { state: "blocked", timestamp };
+
+            case "task_started":
+            case "agent_reasoning":
             case "response_item":
             case "turn_context":
             case "user_input":
             case "tool_call":
             case "exec_command":
+            case "exec_command_begin":
+            case "exec_command_end":
               if (ageMs <= activeWindowMs) return { state: "active", timestamp };
               return { state: ageMs > threshold ? "idle" : "ready", timestamp };
 
+            case "task_complete":
+            case "turn_aborted":
+            case "agent_message":
             case "assistant_message":
             case "session_meta":
             case "event_msg":
             case "compacted":
+            case "token_count":
               return { state: ageMs > threshold ? "idle" : "ready", timestamp };
-
-            case "approval_request":
-              return { state: "waiting_input", timestamp };
-
-            case "error":
-              return { state: "blocked", timestamp };
 
             default:
               if (ageMs <= activeWindowMs) return { state: "active", timestamp };


### PR DESCRIPTION
## Summary
- support payload-wrapped Codex JSONL entries while preserving compatibility with the older flat fixture format
- read the first few complete JSONL records when matching `session_meta.cwd`, so large payload lines with `base_instructions` still resolve the right session file
- stop treating `model_provider` as a Codex model id and add regressions around activity detection, session info parsing, and native resume command generation

## Verification
- `pnpm --filter @aoagents/ao-plugin-agent-codex test -- src/index.test.ts`
- `pnpm --filter @aoagents/ao-plugin-agent-codex typecheck`
- `pnpm build`
- spawned fresh Codex sessions with `node packages/cli/dist/index.js spawn --agent codex --prompt "Say hello and stop."`
- verified the dashboard and `/api/sessions` show a concrete activity state (`exited`) instead of the `unknown` fallback

Fixes #1099
