### PR TITLE
fix(web): terminal button deep-links to terminal section

### DIFF
--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -469,7 +469,7 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
         )}
         {!isTerminal && (
           <a
-            href={`/sessions/${encodeURIComponent(session.id)}`}
+            href={`/sessions/${encodeURIComponent(session.id)}#session-terminal-section`}
             onClick={(e) => e.stopPropagation()}
             className="session-card__control session-card__terminal-link"
           >


### PR DESCRIPTION
## What

The `terminal` button on the kanban session card now scrolls directly to the terminal section on the session detail page, instead of just navigating to the top of the page (same as "View current context →").

## Change

`SessionCard.tsx` line 472 — added `#session-terminal-section` hash to the terminal link href.

The anchor `<div id="session-terminal-section">` already exists in `SessionDetail.tsx`.

## Before / After

- **Before:** Both `terminal` and `View current context →` → `/sessions/{id}` (page top)
- **After:** `terminal` → `/sessions/{id}#session-terminal-section` (scrolls to terminal), `View current context →` → `/sessions/{id}` (unchanged)

Fixes #1217