### PR TITLE
fix(web): link passing CI check chips to their check run URL

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -208,7 +208,7 @@ describe("SessionCard", () => {
     const session = makeSession({ id: "backend-5" });
     render(<SessionCard session={session} />);
     const link = screen.getByText("terminal");
-    expect(link).toHaveAttribute("href", "/sessions/backend-5");
+    expect(link).toHaveAttribute("href", "/sessions/backend-5#session-terminal-section");
   });
 
   it("shows restore button when agent has exited", () => {
@@ -267,6 +267,68 @@ describe("SessionCard", () => {
     render(<SessionCard session={session} onMerge={onMerge} />);
     fireEvent.click(screen.getByRole("button", { name: /merge/i }));
     expect(onMerge).toHaveBeenCalledWith(42);
+  });
+
+  it("renders passing CI check chips as hyperlinks when url is present", () => {
+    const pr = makePR({
+      state: "open",
+      ciStatus: "passing",
+      ciChecks: [
+        { name: "lint-and-type-checks", status: "passed", url: "https://github.com/owner/repo/runs/111" },
+        { name: "tests", status: "passed", url: "https://github.com/owner/repo/runs/222" },
+        { name: "no-url-check", status: "passed" },
+      ],
+      reviewDecision: "approved",
+      mergeability: {
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      },
+    });
+    const session = makeSession({ status: "mergeable", activity: "idle", pr });
+    render(<SessionCard session={session} />);
+
+    const lintLink = screen.getByRole("link", { name: /lint-and-type-checks/ });
+    expect(lintLink).toHaveAttribute("href", "https://github.com/owner/repo/runs/111");
+    expect(lintLink).toHaveAttribute("target", "_blank");
+    expect(lintLink).toHaveAttribute("rel", "noopener noreferrer");
+
+    const testsLink = screen.getByRole("link", { name: /^tests$/ });
+    expect(testsLink).toHaveAttribute("href", "https://github.com/owner/repo/runs/222");
+
+    // Check without url should still render as plain text, not a link
+    expect(screen.queryByRole("link", { name: /no-url-check/ })).not.toBeInTheDocument();
+    expect(screen.getByText("no-url-check")).toBeInTheDocument();
+  });
+
+  it("stops propagation when clicking a passing CI chip link", () => {
+    const onClick = vi.fn();
+    const pr = makePR({
+      state: "open",
+      ciStatus: "passing",
+      ciChecks: [
+        { name: "build", status: "passed", url: "https://github.com/owner/repo/runs/333" },
+      ],
+      reviewDecision: "approved",
+      mergeability: {
+        mergeable: true,
+        ciPassing: true,
+        approved: true,
+        noConflicts: true,
+        blockers: [],
+      },
+    });
+    const session = makeSession({ status: "mergeable", activity: "idle", pr });
+    render(
+      <div onClick={onClick}>
+        <SessionCard session={session} />
+      </div>,
+    );
+    const link = screen.getByRole("link", { name: /build/ });
+    fireEvent.click(link);
+    expect(onClick).not.toHaveBeenCalled();
   });
 
   it("shows CI failing alert", () => {

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -571,14 +571,32 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
 
         {visiblePassingChecks.length > 0 && (
           <div className="card__ci">
-            {visiblePassingChecks.map((check) => (
-              <span key={check.name} className="ci-chip ci-chip--pass">
-                <svg width="8" height="8" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24" aria-hidden="true">
-                  <path d="M20 6 9 17l-5-5" />
-                </svg>
-                {check.name}
-              </span>
-            ))}
+            {visiblePassingChecks.map((check) => {
+              const chipContent = (
+                <>
+                  <svg width="8" height="8" fill="none" stroke="currentColor" strokeWidth="2.5" viewBox="0 0 24 24" aria-hidden="true">
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                  {check.name}
+                </>
+              );
+              return check.url ? (
+                <a
+                  key={check.name}
+                  href={check.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="ci-chip ci-chip--pass"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {chipContent}
+                </a>
+              ) : (
+                <span key={check.name} className="ci-chip ci-chip--pass">
+                  {chipContent}
+                </span>
+              );
+            })}
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Wrap passing CI check chips in `SessionCard.tsx` in `<a>` tags when `check.url` is present, so users can navigate directly to the check run from the kanban view. Follows the same pattern already used by `CICheckList` in `CIBadge.tsx`.
- `stopPropagation` on the chip click so it does not trigger the card's own navigation handler.
- Falls back to a plain `<span>` when `url` is absent.
- Drive-by: update a broken test from #1218 that still expected the pre-anchor terminal href (`/sessions/backend-5` vs `/sessions/backend-5#session-terminal-section`), which was blocking the web test suite.

## Test plan
- [x] `pnpm build`
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors)
- [x] `pnpm --filter @aoagents/ao-web test` — 597 tests passing, including 2 new tests for the passing-chip hyperlink and its `stopPropagation` behavior
- [x] `pnpm test` — all other package suites pass
- [ ] Manually verify in the dashboard: open a session with a PR that has passing checks, click a green chip, confirm it opens the check run in a new tab without navigating the card.

Fixes #1209