### PR TITLE
fix: prevent sidebar flash on session detail pages

### DIFF
--- a/packages/web/src/__tests__/components.test.tsx
+++ b/packages/web/src/__tests__/components.test.tsx
@@ -208,7 +208,7 @@ describe("SessionCard", () => {
     const session = makeSession({ id: "backend-5" });
     render(<SessionCard session={session} />);
     const link = screen.getByText("terminal");
-    expect(link).toHaveAttribute("href", "/sessions/backend-5");
+    expect(link).toHaveAttribute("href", "/sessions/backend-5#session-terminal-section");
   });
 
   it("shows restore button when agent has exited", () => {

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from "react";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, cleanup } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
 
@@ -86,6 +86,7 @@ describe("SessionPage project polling", () => {
   });
 
   afterEach(() => {
+    cleanup();
     vi.useRealTimers();
     vi.restoreAllMocks();
     notFoundSpy.mockReset();
@@ -312,5 +313,64 @@ describe("SessionPage project polling", () => {
 
     expect(latestAfterSidebarResolve.sidebarLoading).toBe(false);
     expect(latestAfterSidebarResolve.sidebarSessions).toEqual([workerSession]);
+  });
+
+  it("revalidates projects and sidebar sessions on remount even when cache exists", async () => {
+    const workerSession = makeWorkerSession();
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: [workerSession] }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    global.fetch = fetchMock as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    const firstRender = render(<SessionPage />);
+    await flushAsyncWork();
+    firstRender.unmount();
+
+    render(<SessionPage />);
+    await flushAsyncWork();
+
+    expect(
+      fetchMock.mock.calls.filter(([url]) => url === "/api/projects"),
+    ).toHaveLength(2);
+    expect(
+      fetchMock.mock.calls.filter(([url]) => url === "/api/sessions"),
+    ).toHaveLength(2);
   });
 });

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -9,7 +9,9 @@ const notFoundError = new Error("NEXT_NOT_FOUND");
 const notFoundSpy = vi.fn(() => {
   throw notFoundError;
 });
-const mockMuxState: { current?: { sessions: SessionPatch[] } } = {};
+const mockMuxState: {
+  current?: { sessions: SessionPatch[]; status?: "connecting" | "connected" | "reconnecting" | "disconnected" };
+} = {};
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "worker-1" }),
@@ -446,6 +448,7 @@ describe("SessionPage project polling", () => {
     let resolveSidebarSessions: ((value: Response) => void) | null = null;
 
     mockMuxState.current = {
+      status: "connected",
       sessions: [
         {
           id: "worker-1",

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -2,16 +2,22 @@ import React, { type ReactNode } from "react";
 import { act, render, screen, cleanup } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
+import type { SessionPatch } from "@/lib/mux-protocol";
 
 const sessionDetailSpy = vi.fn();
 const notFoundError = new Error("NEXT_NOT_FOUND");
 const notFoundSpy = vi.fn(() => {
   throw notFoundError;
 });
+const mockMuxState: { current?: { sessions: SessionPatch[] } } = {};
 
 vi.mock("next/navigation", () => ({
   useParams: () => ({ id: "worker-1" }),
   notFound: notFoundSpy,
+}));
+
+vi.mock("@/providers/MuxProvider", () => ({
+  useMuxOptional: () => mockMuxState.current,
 }));
 
 vi.mock("@/components/SessionDetail", () => ({
@@ -73,6 +79,8 @@ describe("SessionPage project polling", () => {
     vi.resetModules();
     sessionDetailSpy.mockClear();
     vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockMuxState.current = undefined;
 
     const eventSourceMock = {
       addEventListener: vi.fn(),
@@ -372,5 +380,144 @@ describe("SessionPage project polling", () => {
     expect(
       fetchMock.mock.calls.filter(([url]) => url === "/api/sessions"),
     ).toHaveLength(2);
+  });
+
+  it("surfaces sidebar fetch failures instead of leaving the loading skeleton active", async () => {
+    const workerSession = makeWorkerSession();
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({}),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    render(<SessionPage />);
+    await flushAsyncWork();
+
+    const latestProps = sessionDetailSpy.mock.lastCall?.[0] as {
+      sidebarError?: boolean;
+      sidebarLoading?: boolean;
+      sidebarSessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.sidebarLoading).toBe(false);
+    expect(latestProps.sidebarError).toBe(true);
+    expect(latestProps.sidebarSessions).toEqual([]);
+  });
+
+  it("applies mux snapshots that arrive before the initial sidebar fetch resolves", async () => {
+    const workerSession = makeWorkerSession();
+    const muxPatchedLastActivityAt = "2026-04-14T12:00:00.000Z";
+    let resolveSidebarSessions: ((value: Response) => void) | null = null;
+
+    mockMuxState.current = {
+      sessions: [
+        {
+          id: "worker-1",
+          status: "working",
+          activity: "ready",
+          attentionLevel: "pending",
+          lastActivityAt: muxPatchedLastActivityAt,
+        },
+      ],
+    };
+
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response);
+      }
+
+      if (url === "/api/sessions") {
+        return new Promise<Response>((resolve) => {
+          resolveSidebarSessions = resolve;
+        });
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    render(<SessionPage />);
+    await flushAsyncWork();
+
+    await act(async () => {
+      resolveSidebarSessions?.({
+        ok: true,
+        status: 200,
+        json: async () => ({ sessions: [workerSession] }),
+      } as Response);
+      await Promise.resolve();
+    });
+
+    const latestProps = sessionDetailSpy.mock.lastCall?.[0] as {
+      sidebarSessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.sidebarSessions).toEqual([
+      {
+        ...workerSession,
+        activity: "ready",
+        lastActivityAt: muxPatchedLastActivityAt,
+      },
+    ]);
   });
 });

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -70,6 +70,7 @@ class TestErrorBoundary extends React.Component<
 describe("SessionPage project polling", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.resetModules();
     sessionDetailSpy.mockClear();
     vi.spyOn(console, "error").mockImplementation(() => {});
 

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -92,14 +92,33 @@ describe("SessionPage project polling", () => {
 
   it("resolves orchestrator nav once for non-orchestrator pages and skips repeated project polling", async () => {
     const workerSession = makeWorkerSession();
+    const sidebarSessions = [workerSession];
 
     global.fetch = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
       if (url === "/api/sessions/worker-1") {
         return {
           ok: true,
           status: 200,
           json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ sessions: sidebarSessions }),
         } as Response;
       }
 
@@ -128,12 +147,9 @@ describe("SessionPage project polling", () => {
     render(<SessionPage />);
     await flushAsyncWork();
 
+    expect(fetch).toHaveBeenCalledWith("/api/projects");
     expect(fetch).toHaveBeenCalledWith("/api/sessions/worker-1");
-
-    await act(async () => {
-      await vi.advanceTimersByTimeAsync(2_000);
-    });
-    await flushAsyncWork();
+    expect(fetch).toHaveBeenCalledWith("/api/sessions");
 
     expect(fetch).toHaveBeenCalledWith("/api/sessions?project=my-app&orchestratorOnly=true");
 
@@ -153,6 +169,10 @@ describe("SessionPage project polling", () => {
         ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true",
       ),
     ).toHaveLength(1);
+
+    expect(
+      vi.mocked(fetch).mock.calls.filter(([url]) => url === "/api/sessions"),
+    ).toHaveLength(2);
   });
 
   it("routes 404 responses through notFound()", async () => {
@@ -219,5 +239,77 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(screen.getByTestId("route-error")).toHaveTextContent("HTTP 500");
+  });
+
+  it("marks sidebar data as loading until the sessions list resolves", async () => {
+    const workerSession = makeWorkerSession();
+    let resolveSidebarSessions: ((value: Response) => void) | null = null;
+
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response);
+      }
+
+      if (url === "/api/sessions") {
+        return new Promise<Response>((resolve) => {
+          resolveSidebarSessions = resolve;
+        });
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    render(<SessionPage />);
+    await flushAsyncWork();
+
+    const latestBeforeSidebarResolve = sessionDetailSpy.mock.lastCall?.[0] as {
+      sidebarLoading?: boolean;
+      sidebarSessions?: DashboardSession[] | null;
+    };
+
+    expect(latestBeforeSidebarResolve.sidebarLoading).toBe(true);
+    expect(latestBeforeSidebarResolve.sidebarSessions).toBeNull();
+
+    await act(async () => {
+      resolveSidebarSessions?.({
+        ok: true,
+        status: 200,
+        json: async () => ({ sessions: [workerSession] }),
+      } as Response);
+      await Promise.resolve();
+    });
+
+    const latestAfterSidebarResolve = sessionDetailSpy.mock.lastCall?.[0] as {
+      sidebarLoading?: boolean;
+      sidebarSessions?: DashboardSession[] | null;
+    };
+
+    expect(latestAfterSidebarResolve.sidebarLoading).toBe(false);
+    expect(latestAfterSidebarResolve.sidebarSessions).toEqual([workerSession]);
   });
 });

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -178,6 +178,7 @@ export default function SessionPage() {
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
   const pendingMuxSessionsRef = useRef<SessionPatch[] | null>(null);
+  const sidebarFetchIdRef = useRef(0);
 
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
@@ -309,12 +310,16 @@ export default function SessionPage() {
   }, []);
 
   const fetchSidebarSessions = useCallback(async () => {
+    // Track a per-invocation token so out-of-order responses from concurrent
+    // callers (5s poll, mux refetch, retry button) don't overwrite newer data.
+    const fetchId = ++sidebarFetchIdRef.current;
     try {
       const res = await fetch("/api/sessions");
       if (!res.ok) {
         throw new Error(`HTTP ${res.status}`);
       }
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
+      if (fetchId !== sidebarFetchIdRef.current) return;
       const restSessions = body?.sessions ?? [];
       const nextSessions =
         applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
@@ -325,6 +330,7 @@ export default function SessionPage() {
       ));
     } catch (err) {
       console.error("Failed to fetch sidebar sessions:", err);
+      if (fetchId !== sidebarFetchIdRef.current) return;
       setSidebarError(true);
       setSidebarSessions((current) => (current === null ? [] : current));
     }
@@ -332,6 +338,15 @@ export default function SessionPage() {
 
   useEffect(() => {
     if (!mux?.sessions) return;
+
+    // Only overlay mux snapshots onto REST refreshes while the WebSocket is
+    // live. After a disconnect `mux.sessions` retains the last snapshot, which
+    // would silently overwrite fresher REST data via `pendingMuxSessionsRef`.
+    if (mux.status !== "connected") {
+      pendingMuxSessionsRef.current = null;
+      return;
+    }
+
     pendingMuxSessionsRef.current = mux.sessions;
 
     // Read current sessions via the module-level cache so this effect reacts to
@@ -360,7 +375,7 @@ export default function SessionPage() {
         return;
       }
     }
-  }, [fetchSidebarSessions, mux?.sessions]);
+  }, [fetchSidebarSessions, mux?.sessions, mux?.status]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -334,8 +334,11 @@ export default function SessionPage() {
     if (!mux?.sessions) return;
     pendingMuxSessionsRef.current = mux.sessions;
 
-    const next = applyMuxSessionPatches(sidebarSessions, mux.sessions);
-    if (next !== sidebarSessions) {
+    // Read current sessions via the module-level cache so this effect reacts to
+    // new mux data only — keeping `sidebarSessions` out of the dep array avoids
+    // re-running on every state change that the effect itself produces.
+    const next = applyMuxSessionPatches(cachedSidebarSessions, mux.sessions);
+    if (next !== cachedSidebarSessions) {
       cachedSidebarSessions = next;
       setSidebarSessions(next);
     }
@@ -357,7 +360,7 @@ export default function SessionPage() {
         return;
       }
     }
-  }, [fetchSidebarSessions, mux?.sessions, sidebarSessions]);
+  }, [fetchSidebarSessions, mux?.sessions]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -57,6 +57,17 @@ interface ProjectSessionsBody {
 let cachedProjects: ProjectInfo[] | null = null;
 let cachedSidebarSessions: DashboardSession[] | null = null;
 
+function areProjectsEqual(previous: ProjectInfo[] | null, next: ProjectInfo[]): boolean {
+  if (!previous || previous.length !== next.length) {
+    return false;
+  }
+
+  return previous.every((project, index) => {
+    const candidate = next[index];
+    return JSON.stringify(project) === JSON.stringify(candidate);
+  });
+}
+
 function areSidebarSessionsEqual(
   previous: DashboardSession[] | null,
   next: DashboardSession[],
@@ -67,12 +78,7 @@ function areSidebarSessionsEqual(
 
   return previous.every((session, index) => {
     const candidate = next[index];
-    return (
-      session.id === candidate?.id &&
-      session.status === candidate.status &&
-      session.activity === candidate.activity &&
-      session.lastActivityAt === candidate.lastActivityAt
-    );
+    return JSON.stringify(session) === JSON.stringify(candidate);
   });
 }
 
@@ -148,7 +154,6 @@ export default function SessionPage() {
       setPrefixByProject(
         new Map(cachedProjects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
       );
-      return;
     }
 
     try {
@@ -156,11 +161,13 @@ export default function SessionPage() {
       if (!res.ok) return;
       const data = (await res.json()) as { projects?: ProjectInfo[] } | null;
       if (!data?.projects) return;
-      cachedProjects = data.projects;
-      setProjects(data.projects);
-      setPrefixByProject(
-        new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
-      );
+      if (!areProjectsEqual(cachedProjects, data.projects)) {
+        cachedProjects = data.projects;
+        setProjects(data.projects);
+        setPrefixByProject(
+          new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
+        );
+      }
     } catch {
       // non-critical — falls back to role metadata check
     }
@@ -314,9 +321,9 @@ export default function SessionPage() {
     void Promise.all([
       fetchProjects(),
       fetchSession(),
-      sidebarSessions === null ? fetchSidebarSessions() : Promise.resolve(),
+      fetchSidebarSessions(),
     ]);
-  }, [fetchProjects, fetchSession, fetchSidebarSessions, sidebarSessions]);
+  }, [fetchProjects, fetchSession, fetchSidebarSessions]);
 
   useEffect(() => {
     if (!sessionProjectId) return;

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { notFound, useParams } from "next/navigation";
-import { isOrchestratorSession } from "@aoagents/ao-core/types";
+import { ACTIVITY_STATE, SESSION_STATUS, isOrchestratorSession } from "@aoagents/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { type DashboardSession, type ActivityState, getAttentionLevel, type AttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
@@ -56,6 +56,17 @@ interface ProjectSessionsBody {
 
 let cachedProjects: ProjectInfo[] | null = null;
 let cachedSidebarSessions: DashboardSession[] | null = null;
+const validSessionStatuses = new Set<string>(Object.values(SESSION_STATUS));
+const validActivityStates = new Set<string>(Object.values(ACTIVITY_STATE));
+const warnedMuxPatchValues = new Set<string>();
+
+function isDashboardSessionStatus(value: string): value is DashboardSession["status"] {
+  return validSessionStatuses.has(value);
+}
+
+function isActivityState(value: string): value is ActivityState {
+  return validActivityStates.has(value);
+}
 
 function areProjectsEqual(previous: ProjectInfo[] | null, next: ProjectInfo[]): boolean {
   if (!previous || previous.length !== next.length) {
@@ -96,6 +107,30 @@ function applyMuxSessionPatches(current: DashboardSession[] | null, patches: Ses
       return session;
     }
 
+    if (!isDashboardSessionStatus(patch.status)) {
+      const warningKey = `status:${patch.status}`;
+      if (!warnedMuxPatchValues.has(warningKey)) {
+        warnedMuxPatchValues.add(warningKey);
+        console.warn("Ignoring mux session patch with unknown status", {
+          sessionId: patch.id,
+          status: patch.status,
+        });
+      }
+      return session;
+    }
+
+    if (patch.activity !== null && !isActivityState(patch.activity)) {
+      const warningKey = `activity:${patch.activity}`;
+      if (!warnedMuxPatchValues.has(warningKey)) {
+        warnedMuxPatchValues.add(warningKey);
+        console.warn("Ignoring mux session patch with unknown activity", {
+          sessionId: patch.id,
+          activity: patch.activity,
+        });
+      }
+      return session;
+    }
+
     if (
       session.status === patch.status &&
       session.activity === patch.activity &&
@@ -107,8 +142,8 @@ function applyMuxSessionPatches(current: DashboardSession[] | null, patches: Ses
     changed = true;
     const nextSession: DashboardSession = {
       ...session,
-      status: patch.status as DashboardSession["status"],
-      activity: patch.activity as ActivityState | null,
+      status: patch.status,
+      activity: patch.activity,
       lastActivityAt: patch.lastActivityAt,
     };
     return nextSession;
@@ -128,6 +163,7 @@ export default function SessionPage() {
   const [projects, setProjects] = useState<ProjectInfo[]>(() => cachedProjects ?? []);
   const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(() => cachedSidebarSessions);
   const [loading, setLoading] = useState(true);
+  const [sidebarError, setSidebarError] = useState(false);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
   const [prefixByProject, setPrefixByProject] = useState<Map<string, string>>(new Map());
@@ -141,6 +177,7 @@ export default function SessionPage() {
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
+  const pendingMuxSessionsRef = useRef<SessionPatch[] | null>(null);
 
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
@@ -158,7 +195,10 @@ export default function SessionPage() {
 
     try {
       const res = await fetch("/api/projects");
-      if (!res.ok) return;
+      if (!res.ok) {
+        console.error("Failed to fetch projects:", new Error(`HTTP ${res.status}`));
+        return;
+      }
       const data = (await res.json()) as { projects?: ProjectInfo[] } | null;
       if (!data?.projects) return;
       if (!areProjectsEqual(cachedProjects, data.projects)) {
@@ -168,8 +208,8 @@ export default function SessionPage() {
           new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
         );
       }
-    } catch {
-      // non-critical — falls back to role metadata check
+    } catch (err) {
+      console.error("Failed to fetch projects:", err);
     }
   }, []);
 
@@ -231,7 +271,10 @@ export default function SessionPage() {
         ? `/api/sessions?project=${encodeURIComponent(projectId)}`
         : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true`;
       const res = await fetch(query);
-      if (!res.ok) return;
+      if (!res.ok) {
+        console.error("Failed to fetch project sessions for", projectId, new Error(`HTTP ${res.status}`));
+        return;
+      }
       const body = (await res.json()) as ProjectSessionsBody;
       const sessions = body.sessions ?? [];
       const orchestratorId =
@@ -260,36 +303,42 @@ export default function SessionPage() {
         }
       }
       setZoneCounts(counts);
-    } catch {
-      // non-critical - status strip just won't show
+    } catch (err) {
+      console.error("Failed to fetch project sessions for", projectId, err);
     }
   }, []);
 
   const fetchSidebarSessions = useCallback(async () => {
     try {
       const res = await fetch("/api/sessions");
-      if (!res.ok) return;
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
-      const nextSessions = body?.sessions ?? [];
+      const restSessions = body?.sessions ?? [];
+      const nextSessions =
+        applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
       cachedSidebarSessions = nextSessions;
+      setSidebarError(false);
       setSidebarSessions((current) => (
         areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions
       ));
-    } catch {
-      // non-critical
+    } catch (err) {
+      console.error("Failed to fetch sidebar sessions:", err);
+      setSidebarError(true);
+      setSidebarSessions((current) => (current === null ? [] : current));
     }
   }, []);
 
   useEffect(() => {
     if (!mux?.sessions) return;
+    pendingMuxSessionsRef.current = mux.sessions;
 
-    setSidebarSessions((current) => {
-      const next = applyMuxSessionPatches(current, mux.sessions);
-      if (next !== current) {
-        cachedSidebarSessions = next;
-      }
-      return next;
-    });
+    const next = applyMuxSessionPatches(sidebarSessions, mux.sessions);
+    if (next !== sidebarSessions) {
+      cachedSidebarSessions = next;
+      setSidebarSessions(next);
+    }
 
     if (mux.sessions.length === 0 || !cachedSidebarSessions) {
       return;
@@ -308,7 +357,7 @@ export default function SessionPage() {
         return;
       }
     }
-  }, [fetchSidebarSessions, mux?.sessions]);
+  }, [fetchSidebarSessions, mux?.sessions, sidebarSessions]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {
@@ -370,6 +419,8 @@ export default function SessionPage() {
       projects={projects}
       sidebarSessions={sidebarSessions}
       sidebarLoading={sidebarSessions === null}
+      sidebarError={sidebarError}
+      onRetrySidebar={fetchSidebarSessions}
     />
   );
 }

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -52,6 +52,25 @@ interface ProjectSessionsBody {
   orchestrators?: Array<{ id: string; projectId: string; projectName: string }>;
 }
 
+function areSidebarSessionsEqual(
+  previous: DashboardSession[] | null,
+  next: DashboardSession[],
+): boolean {
+  if (!previous || previous.length !== next.length) {
+    return false;
+  }
+
+  return previous.every((session, index) => {
+    const candidate = next[index];
+    return (
+      session.id === candidate?.id &&
+      session.status === candidate.status &&
+      session.activity === candidate.activity &&
+      session.lastActivityAt === candidate.lastActivityAt
+    );
+  });
+}
+
 export default function SessionPage() {
   const params = useParams();
   const id = params.id as string;
@@ -60,7 +79,7 @@ export default function SessionPage() {
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[]>([]);
+  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(null);
   const [loading, setLoading] = useState(true);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
@@ -82,18 +101,19 @@ export default function SessionPage() {
   }, [prefixByProject]);
 
   // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
-  useEffect(() => {
-    fetch("/api/projects")
-      .then((res) => res.ok ? res.json() : null)
-      .then((data: { projects?: ProjectInfo[] } | null) => {
-        if (data?.projects) {
-          setProjects(data.projects);
-          setPrefixByProject(
-            new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
-          );
-        }
-      })
-      .catch(() => {/* non-critical — falls back to role metadata check */});
+  const fetchProjects = useCallback(async () => {
+    try {
+      const res = await fetch("/api/projects");
+      if (!res.ok) return;
+      const data = (await res.json()) as { projects?: ProjectInfo[] } | null;
+      if (!data?.projects) return;
+      setProjects(data.projects);
+      setPrefixByProject(
+        new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
+      );
+    } catch {
+      // non-critical — falls back to role metadata check
+    }
   }, []);
 
   // Subscribe to SSE for real-time activity updates (title emoji)
@@ -193,7 +213,10 @@ export default function SessionPage() {
       const res = await fetch("/api/sessions");
       if (!res.ok) return;
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
-      setSidebarSessions(body?.sessions ?? []);
+      const nextSessions = body?.sessions ?? [];
+      setSidebarSessions((current) => (
+        areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions
+      ));
     } catch {
       // non-critical
     }
@@ -205,14 +228,19 @@ export default function SessionPage() {
     }
   }, [sessionIsOrchestrator]);
 
-  // Initial fetch — session first, zone counts after (avoids blocking on slow /api/sessions)
+  // Initial fetch — load independent sidebar/session data in parallel.
   useEffect(() => {
-    fetchSession();
-    fetchSidebarSessions();
-    // Delay zone counts so the heavy /api/sessions call doesn't contend with session load
-    const t = setTimeout(fetchProjectSessions, 2000);
-    return () => clearTimeout(t);
-  }, [fetchSession, fetchProjectSessions, fetchSidebarSessions]);
+    void Promise.all([
+      fetchProjects(),
+      fetchSession(),
+      fetchSidebarSessions(),
+    ]);
+  }, [fetchProjects, fetchSession, fetchSidebarSessions]);
+
+  useEffect(() => {
+    if (!sessionProjectId) return;
+    void fetchProjectSessions();
+  }, [fetchProjectSessions, sessionIsOrchestrator, sessionProjectId]);
 
   // Poll every 5s
   useEffect(() => {
@@ -253,6 +281,7 @@ export default function SessionPage() {
       projectOrchestratorId={projectOrchestratorId}
       projects={projects}
       sidebarSessions={sidebarSessions}
+      sidebarLoading={sidebarSessions === null}
     />
   );
 }

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -9,6 +9,8 @@ import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
 import { useSSESessionActivity } from "@/hooks/useSSESessionActivity";
+import { useMuxOptional } from "@/providers/MuxProvider";
+import type { SessionPatch } from "@/lib/mux-protocol";
 
 function truncate(s: string, max: number): string {
   return s.length > max ? s.slice(0, max) + "..." : s;
@@ -52,6 +54,9 @@ interface ProjectSessionsBody {
   orchestrators?: Array<{ id: string; projectId: string; projectName: string }>;
 }
 
+let cachedProjects: ProjectInfo[] | null = null;
+let cachedSidebarSessions: DashboardSession[] | null = null;
+
 function areSidebarSessionsEqual(
   previous: DashboardSession[] | null,
   next: DashboardSession[],
@@ -71,15 +76,51 @@ function areSidebarSessionsEqual(
   });
 }
 
+function applyMuxSessionPatches(current: DashboardSession[] | null, patches: SessionPatch[]): DashboardSession[] | null {
+  if (!current || patches.length === 0) {
+    return current;
+  }
+
+  const patchById = new Map(patches.map((patch) => [patch.id, patch]));
+  let changed = false;
+
+  const next = current.map((session) => {
+    const patch = patchById.get(session.id);
+    if (!patch) {
+      return session;
+    }
+
+    if (
+      session.status === patch.status &&
+      session.activity === patch.activity &&
+      session.lastActivityAt === patch.lastActivityAt
+    ) {
+      return session;
+    }
+
+    changed = true;
+    const nextSession: DashboardSession = {
+      ...session,
+      status: patch.status as DashboardSession["status"],
+      activity: patch.activity as ActivityState | null,
+      lastActivityAt: patch.lastActivityAt,
+    };
+    return nextSession;
+  });
+
+  return changed ? next : current;
+}
+
 export default function SessionPage() {
   const params = useParams();
   const id = params.id as string;
+  const mux = useMuxOptional();
 
   const [session, setSession] = useState<DashboardSession | null>(null);
   const [zoneCounts, setZoneCounts] = useState<ZoneCounts | null>(null);
   const [projectOrchestratorId, setProjectOrchestratorId] = useState<string | null | undefined>(undefined);
-  const [projects, setProjects] = useState<ProjectInfo[]>([]);
-  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(null);
+  const [projects, setProjects] = useState<ProjectInfo[]>(() => cachedProjects ?? []);
+  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(() => cachedSidebarSessions);
   const [loading, setLoading] = useState(true);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
@@ -102,11 +143,20 @@ export default function SessionPage() {
 
   // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
   const fetchProjects = useCallback(async () => {
+    if (cachedProjects) {
+      setProjects(cachedProjects);
+      setPrefixByProject(
+        new Map(cachedProjects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
+      );
+      return;
+    }
+
     try {
       const res = await fetch("/api/projects");
       if (!res.ok) return;
       const data = (await res.json()) as { projects?: ProjectInfo[] } | null;
       if (!data?.projects) return;
+      cachedProjects = data.projects;
       setProjects(data.projects);
       setPrefixByProject(
         new Map(data.projects.map((p) => [p.id, p.sessionPrefix ?? p.id])),
@@ -214,6 +264,7 @@ export default function SessionPage() {
       if (!res.ok) return;
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
       const nextSessions = body?.sessions ?? [];
+      cachedSidebarSessions = nextSessions;
       setSidebarSessions((current) => (
         areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions
       ));
@@ -221,6 +272,36 @@ export default function SessionPage() {
       // non-critical
     }
   }, []);
+
+  useEffect(() => {
+    if (!mux?.sessions) return;
+
+    setSidebarSessions((current) => {
+      const next = applyMuxSessionPatches(current, mux.sessions);
+      if (next !== current) {
+        cachedSidebarSessions = next;
+      }
+      return next;
+    });
+
+    if (mux.sessions.length === 0 || !cachedSidebarSessions) {
+      return;
+    }
+
+    const cachedIds = new Set(cachedSidebarSessions.map((sidebarSession) => sidebarSession.id));
+    const muxIds = new Set(mux.sessions.map((muxSession) => muxSession.id));
+    if (cachedIds.size !== muxIds.size) {
+      void fetchSidebarSessions();
+      return;
+    }
+
+    for (const muxId of muxIds) {
+      if (!cachedIds.has(muxId)) {
+        void fetchSidebarSessions();
+        return;
+      }
+    }
+  }, [fetchSidebarSessions, mux?.sessions]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {
@@ -233,9 +314,9 @@ export default function SessionPage() {
     void Promise.all([
       fetchProjects(),
       fetchSession(),
-      fetchSidebarSessions(),
+      sidebarSessions === null ? fetchSidebarSessions() : Promise.resolve(),
     ]);
-  }, [fetchProjects, fetchSession, fetchSidebarSessions]);
+  }, [fetchProjects, fetchSession, fetchSidebarSessions, sidebarSessions]);
 
   useEffect(() => {
     if (!sessionProjectId) return;

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -150,6 +150,26 @@ function ProjectSidebarInner({
           </button>
         </div>
 
+        {/* Stale-data banner: keep cached sessions visible on fetch failure but
+            surface the error so users know the list may be out of date. */}
+        {error && sessions && sessions.length > 0 ? (
+          <div
+            role="status"
+            className="mx-3 mb-2 flex items-center justify-between gap-2 rounded-md border border-[var(--color-border-strong)] bg-[var(--color-bg-primary)] px-2 py-1.5 text-[11px] text-[var(--color-text-tertiary)]"
+          >
+            <span>Failed to refresh · showing cached sessions</span>
+            {onRetry ? (
+              <button
+                type="button"
+                onClick={onRetry}
+                className="font-medium text-[var(--color-link)] hover:underline"
+              >
+                Retry
+              </button>
+            ) : null}
+          </div>
+        ) : null}
+
         {/* Project tree */}
         <div className="project-sidebar__tree flex-1 overflow-y-auto overflow-x-hidden">
           {projects.map((project) => {

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -15,6 +15,8 @@ interface ProjectSidebarProps {
   activeProjectId: string | undefined;
   activeSessionId: string | undefined;
   loading?: boolean;
+  error?: boolean;
+  onRetry?: () => void;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
   mobileOpen?: boolean;
@@ -57,12 +59,15 @@ function ProjectSidebarInner({
   activeProjectId,
   activeSessionId,
   loading = false,
+  error = false,
+  onRetry,
   collapsed = false,
   onToggleCollapsed: _onToggleCollapsed,
   mobileOpen = false,
   onMobileClose,
 }: ProjectSidebarProps) {
   const router = useRouter();
+  const isLoading = loading || sessions === null;
 
   const [expandedProjects, setExpandedProjects] = useState<Set<string>>(
     () => new Set(activeProjectId && activeProjectId !== "all" ? [activeProjectId] : []),
@@ -200,7 +205,7 @@ function ProjectSidebarInner({
                 {/* Sessions */}
                 {isExpanded && (
                   <div className="project-sidebar__sessions">
-                    {loading ? (
+                    {isLoading ? (
                       <div className="space-y-2 px-3 py-2" aria-label="Loading sessions">
                         {Array.from({ length: 3 }, (_, index) => (
                           <div
@@ -249,6 +254,17 @@ function ProjectSidebarInner({
                           </button>
                         );
                       })
+                    ) : error ? (
+                      <div className="px-3 py-2">
+                        <div className="project-sidebar__empty">Failed to load sessions</div>
+                        <button
+                          type="button"
+                          className="mt-2 text-xs font-medium text-[var(--color-link)] hover:underline"
+                          onClick={onRetry}
+                        >
+                          Retry
+                        </button>
+                      </div>
                     ) : (
                       <div className="project-sidebar__empty">No active sessions</div>
                     )}

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -11,9 +11,10 @@ import { ThemeToggle } from "./ThemeToggle";
 
 interface ProjectSidebarProps {
   projects: ProjectInfo[];
-  sessions: DashboardSession[];
+  sessions: DashboardSession[] | null;
   activeProjectId: string | undefined;
   activeSessionId: string | undefined;
+  loading?: boolean;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
   mobileOpen?: boolean;
@@ -55,6 +56,7 @@ function ProjectSidebarInner({
   sessions,
   activeProjectId,
   activeSessionId,
+  loading = false,
   collapsed = false,
   onToggleCollapsed: _onToggleCollapsed,
   mobileOpen = false,
@@ -84,6 +86,7 @@ function ProjectSidebarInner({
 
   const sessionsByProject = useMemo(() => {
     const map = new Map<string, DashboardSession[]>();
+    if (!sessions) return map;
     for (const s of sessions) {
       if (isOrchestratorSession(s, prefixByProject.get(s.projectId), allPrefixes)) continue;
       const list = map.get(s.projectId) ?? [];
@@ -197,7 +200,20 @@ function ProjectSidebarInner({
                 {/* Sessions */}
                 {isExpanded && (
                   <div className="project-sidebar__sessions">
-                    {visibleSessions.length > 0 ? (
+                    {loading ? (
+                      <div className="space-y-2 px-3 py-2" aria-label="Loading sessions">
+                        {Array.from({ length: 3 }, (_, index) => (
+                          <div
+                            key={`${project.id}-loading-${index}`}
+                            className="flex items-center gap-3 rounded-lg px-2 py-2"
+                          >
+                            <div className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-[var(--color-border-strong)]" />
+                            <div className="h-3 flex-1 animate-pulse rounded bg-[var(--color-bg-primary)]" />
+                            <div className="h-3 w-12 animate-pulse rounded bg-[var(--color-bg-primary)]" />
+                          </div>
+                        ))}
+                      </div>
+                    ) : visibleSessions.length > 0 ? (
                       visibleSessions.map((session) => {
                         const level = getAttentionLevel(session);
                         const isSessionActive = activeSessionId === session.id;

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -48,6 +48,8 @@ interface SessionDetailProps {
   projects?: ProjectInfo[];
   sidebarSessions?: DashboardSession[] | null;
   sidebarLoading?: boolean;
+  sidebarError?: boolean;
+  onRetrySidebar?: () => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -453,6 +455,8 @@ export function SessionDetail({
   projects = [],
   sidebarSessions = [],
   sidebarLoading = false,
+  sidebarError = false,
+  onRetrySidebar,
 }: SessionDetailProps) {
   const searchParams = useSearchParams();
   const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
@@ -596,6 +600,8 @@ export function SessionDetail({
               projects={projects}
               sessions={sidebarSessions}
               loading={sidebarLoading}
+              error={sidebarError}
+              onRetry={onRetrySidebar}
               activeProjectId={session.projectId}
               activeSessionId={session.id}
               collapsed={sidebarCollapsed}

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -46,7 +46,8 @@ interface SessionDetailProps {
   orchestratorZones?: OrchestratorZones;
   projectOrchestratorId?: string | null;
   projects?: ProjectInfo[];
-  sidebarSessions?: DashboardSession[];
+  sidebarSessions?: DashboardSession[] | null;
+  sidebarLoading?: boolean;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -451,6 +452,7 @@ export function SessionDetail({
   projectOrchestratorId = null,
   projects = [],
   sidebarSessions = [],
+  sidebarLoading = false,
 }: SessionDetailProps) {
   const searchParams = useSearchParams();
   const isMobile = useMediaQuery(MOBILE_BREAKPOINT);
@@ -593,6 +595,7 @@ export function SessionDetail({
             <ProjectSidebar
               projects={projects}
               sessions={sidebarSessions}
+              loading={sidebarLoading}
               activeProjectId={session.projectId}
               activeSessionId={session.id}
               collapsed={sidebarCollapsed}

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -212,4 +212,19 @@ describe("ProjectSidebar", () => {
     expect(container.querySelector(".project-sidebar--collapsed")).not.toBeNull();
     expect(screen.queryByText("Projects")).not.toBeInTheDocument();
   });
+
+  it("shows loading skeletons instead of the empty state while sessions are loading", () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={null}
+        loading
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    expect(screen.getByLabelText("Loading sessions")).toBeInTheDocument();
+    expect(screen.queryByText("No active sessions")).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- keep session-detail sidebar data nullable until it loads and render sidebar skeleton rows instead of the terminal empty state
- parallelize the initial session/projects/sidebar fetches and stop replacing sidebar session state when the polled payload is unchanged
- add coverage for the new loading path and align the existing terminal-link test with current SessionCard behavior

Closes #1230

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm --filter @aoagents/ao-web test