### PR TITLE
fix: fail ao send when killed session delivery is not confirmed

### DIFF
--- a/packages/cli/__tests__/commands/send.test.ts
+++ b/packages/cli/__tests__/commands/send.test.ts
@@ -401,6 +401,39 @@ describe("send command", () => {
       expect(mockTmux).not.toHaveBeenCalledWith("has-session", "-t", expect.any(String));
     });
 
+    it("fails loudly when lifecycle delivery fails for an AO session", async () => {
+      mockConfigRef.current = makeConfig();
+      mockSessionManager.get.mockResolvedValue({
+        id: "app-1",
+        projectId: "my-app",
+        status: "killed",
+        activity: "exited",
+        branch: null,
+        issueId: null,
+        pr: null,
+        workspacePath: null,
+        runtimeHandle: { id: "tmux-target-1", runtimeName: "tmux", data: {} },
+        agentInfo: null,
+        createdAt: new Date(),
+        lastActivityAt: new Date(),
+        metadata: { agent: "opencode" },
+      });
+      mockSessionManager.send.mockRejectedValue(
+        new Error("Cannot send to session app-1: session is not running (restore timed out)"),
+      );
+
+      await expect(
+        program.parseAsync(["node", "test", "send", "app-1", "hello"]),
+      ).rejects.toThrow("process.exit(1)");
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Cannot send to session app-1: session is not running"),
+      );
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("Message sent and processing"),
+      );
+    });
+
     it("passes file contents through SessionManager.send for AO sessions", async () => {
       mockConfigRef.current = makeConfig();
       mockSessionManager.get.mockResolvedValue({

--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -184,8 +184,13 @@ export function registerSend(program: Command): void {
         }
 
         if (existingSession && sessionManager) {
-          await sessionManager.send(session, message);
-          console.log(chalk.green("Message sent and processing"));
+          try {
+            await sessionManager.send(session, message);
+            console.log(chalk.green("Message sent and processing"));
+          } catch (err) {
+            console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+            process.exit(1);
+          }
           return;
         }
 

--- a/packages/core/src/__tests__/session-manager/communication.test.ts
+++ b/packages/core/src/__tests__/session-manager/communication.test.ts
@@ -174,6 +174,42 @@ describe("send", () => {
     expect(mockRuntime.sendMessage).toHaveBeenCalled();
   });
 
+  it("resolves on restored session when confirmation never flips (soft success)", async () => {
+    // Regression test: on a restored session (post-#1074 fix), if
+    // sendMessage fires but the confirmation heuristics never flip,
+    // send() must still resolve — otherwise the lifecycle-manager's
+    // dispatch-hash never updates and the message re-sends next poll,
+    // reintroducing the duplicate-message bug that 77685a5 removed.
+    const wsPath = join(tmpDir, "ws-app-1");
+    mkdirSync(wsPath, { recursive: true });
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: wsPath,
+      branch: "feat/TEST-1",
+      status: "working",
+      project: "my-app",
+      issue: "TEST-1",
+      runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+    });
+
+    // rt-old is dead → restore kicks in → rt-restored is ready
+    vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => handle.id !== "rt-old");
+    vi.mocked(mockAgent.isProcessRunning).mockImplementation(
+      async (handle) => handle.id !== "rt-old",
+    );
+    vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+    // Steady output — confirmation heuristics will never flip
+    vi.mocked(mockRuntime.getOutput).mockResolvedValue("steady output");
+    vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.send("app-1", "retry after restore")).resolves.toBeUndefined();
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-restored"),
+      "retry after restore",
+    );
+  });
+
   it("throws for nonexistent session", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
     await expect(sm.send("nope", "hello")).rejects.toThrow("not found");

--- a/packages/core/src/__tests__/session-manager/communication.test.ts
+++ b/packages/core/src/__tests__/session-manager/communication.test.ts
@@ -86,6 +86,43 @@ describe("send", () => {
     );
   });
 
+  it("throws when a killed session cannot be restored to a ready state for delivery", async () => {
+    vi.useFakeTimers();
+    try {
+      const wsPath = join(tmpDir, "ws-app-1");
+      mkdirSync(wsPath, { recursive: true });
+
+      writeMetadata(sessionsDir, "app-1", {
+        worktree: wsPath,
+        branch: "feat/TEST-1",
+        status: "killed",
+        project: "my-app",
+        issue: "TEST-1",
+        runtimeHandle: JSON.stringify(makeHandle("rt-old")),
+      });
+
+      vi.mocked(mockRuntime.isAlive).mockImplementation(async (handle) => handle.id !== "rt-restored");
+      vi.mocked(mockAgent.isProcessRunning).mockImplementation(
+        async (handle) => handle.id !== "rt-restored",
+      );
+      vi.mocked(mockRuntime.create).mockResolvedValue(makeHandle("rt-restored"));
+      vi.mocked(mockRuntime.getOutput).mockResolvedValue("");
+      vi.mocked(mockAgent.detectActivity).mockReturnValue("idle");
+
+      const sm = createSessionManager({ config, registry: mockRegistry });
+      const sendPromise = sm.send("app-1", "hello");
+      const rejection = expect(sendPromise).rejects.toThrow(
+        "Cannot send to session app-1: session is not running",
+      );
+
+      await vi.runAllTimersAsync();
+      await rejection;
+      expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("waits for spawning sessions to become interactive before considering restore", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2285,9 +2285,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     };
 
-    const prepareSession = async (
-      forceRestore = false,
-    ): Promise<{ session: Session; restoredForDelivery: boolean }> => {
+    const prepareSession = async (forceRestore = false): Promise<Session> => {
       const current = await get(sessionId);
       if (!current) {
         throw new SessionNotFoundError(sessionId);
@@ -2303,15 +2301,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const normalized = current.runtimeHandle ? current : { ...current, runtimeHandle: handle };
 
       if (forceRestore || isRestorable(normalized)) {
-        return {
-          session: await restoreForDelivery(
-            forceRestore
-              ? "session needed to be restarted before delivery"
-              : "session is not running",
-            normalized,
-          ),
-          restoredForDelivery: true,
-        };
+        return restoreForDelivery(
+          forceRestore
+            ? "session needed to be restarted before delivery"
+            : "session is not running",
+          normalized,
+        );
       }
 
       let [runtimeAlive, processRunning] = await Promise.all([
@@ -2328,22 +2323,16 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
 
       if (!runtimeAlive || !processRunning) {
-        return {
-          session: await restoreForDelivery(
-            !runtimeAlive ? "runtime is not alive" : "agent process is not running",
-            normalized,
-          ),
-          restoredForDelivery: true,
-        };
+        return restoreForDelivery(
+          !runtimeAlive ? "runtime is not alive" : "agent process is not running",
+          normalized,
+        );
       }
 
-      return { session: normalized, restoredForDelivery: false };
+      return normalized;
     };
 
-    const sendWithConfirmation = async (
-      session: Session,
-      options: { requireConfirmation: boolean },
-    ): Promise<void> => {
+    const sendWithConfirmation = async (session: Session): Promise<void> => {
       const handle = session.runtimeHandle;
       if (!handle) {
         throw new Error(`Session ${sessionId} has no runtime handle`);
@@ -2377,10 +2366,6 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
 
-      if (options.requireConfirmation) {
-        throw new Error(`Could not confirm delivery to restored session ${sessionId}`);
-      }
-
       // Message was already sent via runtimePlugin.sendMessage above — if we
       // cannot *confirm* delivery (e.g. agent is slow to show output), treat it
       // as a soft success rather than throwing.  Throwing here caused the caller
@@ -2392,12 +2377,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     let prepared = await prepareSession();
 
     try {
-      await sendWithConfirmation(prepared.session, {
-        requireConfirmation: prepared.restoredForDelivery,
-      });
+      await sendWithConfirmation(prepared);
     } catch (err) {
       const shouldRetryWithRestore =
-        prepared.session.restoredAt === undefined && isRestorable(prepared.session);
+        prepared.restoredAt === undefined && isRestorable(prepared);
 
       if (!shouldRetryWithRestore) {
         if (err instanceof Error) {
@@ -2408,7 +2391,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       prepared = await prepareSession(true);
       try {
-        await sendWithConfirmation(prepared.session, { requireConfirmation: true });
+        await sendWithConfirmation(prepared);
       } catch (retryErr) {
         if (retryErr instanceof Error) {
           throw retryErr;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1970,10 +1970,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     };
 
-    const waitForRestoredSession = async (restoredSession: Session): Promise<void> => {
+    const waitForRestoredSession = async (restoredSession: Session): Promise<boolean> => {
       const handle = restoredSession.runtimeHandle;
       if (!handle) {
-        return;
+        return false;
       }
 
       const deadline = Date.now() + SEND_RESTORE_READY_TIMEOUT_MS;
@@ -1991,11 +1991,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           foregroundCommand === null || foregroundCommand === agentPlugin.processName;
 
         if (runtimeAlive && foregroundReady && (processRunning || output.trim().length > 0)) {
-          return;
+          return true;
         }
 
         if (Date.now() >= deadline) {
-          return;
+          return false;
         }
 
         await sleep(SEND_RESTORE_READY_POLL_MS);
@@ -2009,7 +2009,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       try {
         const restored = await restore(sessionId);
-        await waitForRestoredSession(restored);
+        const ready = await waitForRestoredSession(restored);
+        if (!ready) {
+          throw new Error("restored session did not become ready for delivery");
+        }
         return restored;
       } catch (err) {
         const detail = err instanceof Error ? err.message : String(err);
@@ -2019,7 +2022,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
     };
 
-    const prepareSession = async (forceRestore = false): Promise<Session> => {
+    const prepareSession = async (
+      forceRestore = false,
+    ): Promise<{ session: Session; restoredForDelivery: boolean }> => {
       const current = await get(sessionId);
       if (!current) {
         throw new SessionNotFoundError(sessionId);
@@ -2035,12 +2040,15 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       const normalized = current.runtimeHandle ? current : { ...current, runtimeHandle: handle };
 
       if (forceRestore || isRestorable(normalized)) {
-        return restoreForDelivery(
-          forceRestore
-            ? "session needed to be restarted before delivery"
-            : "session is not running",
-          normalized,
-        );
+        return {
+          session: await restoreForDelivery(
+            forceRestore
+              ? "session needed to be restarted before delivery"
+              : "session is not running",
+            normalized,
+          ),
+          restoredForDelivery: true,
+        };
       }
 
       let [runtimeAlive, processRunning] = await Promise.all([
@@ -2057,16 +2065,22 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }
 
       if (!runtimeAlive || !processRunning) {
-        return restoreForDelivery(
-          !runtimeAlive ? "runtime is not alive" : "agent process is not running",
-          normalized,
-        );
+        return {
+          session: await restoreForDelivery(
+            !runtimeAlive ? "runtime is not alive" : "agent process is not running",
+            normalized,
+          ),
+          restoredForDelivery: true,
+        };
       }
 
-      return normalized;
+      return { session: normalized, restoredForDelivery: false };
     };
 
-    const sendWithConfirmation = async (session: Session): Promise<void> => {
+    const sendWithConfirmation = async (
+      session: Session,
+      options: { requireConfirmation: boolean },
+    ): Promise<void> => {
       const handle = session.runtimeHandle;
       if (!handle) {
         throw new Error(`Session ${sessionId} has no runtime handle`);
@@ -2100,6 +2114,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
 
+      if (options.requireConfirmation) {
+        throw new Error(`Could not confirm delivery to restored session ${sessionId}`);
+      }
+
       // Message was already sent via runtimePlugin.sendMessage above — if we
       // cannot *confirm* delivery (e.g. agent is slow to show output), treat it
       // as a soft success rather than throwing.  Throwing here caused the caller
@@ -2111,10 +2129,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     let prepared = await prepareSession();
 
     try {
-      await sendWithConfirmation(prepared);
+      await sendWithConfirmation(prepared.session, {
+        requireConfirmation: prepared.restoredForDelivery,
+      });
     } catch (err) {
       const shouldRetryWithRestore =
-        prepared.restoredAt === undefined && !NON_RESTORABLE_STATUSES.has(prepared.status);
+        prepared.session.restoredAt === undefined &&
+        !NON_RESTORABLE_STATUSES.has(prepared.session.status);
 
       if (!shouldRetryWithRestore) {
         if (err instanceof Error) {
@@ -2125,7 +2146,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       prepared = await prepareSession(true);
       try {
-        await sendWithConfirmation(prepared);
+        await sendWithConfirmation(prepared.session, { requireConfirmation: true });
       } catch (retryErr) {
         if (retryErr instanceof Error) {
           throw retryErr;


### PR DESCRIPTION
## Summary

Fix `ao send` falsely reporting success for sessions that are already `status=killed`.

When delivery requires restoring a dead session, the send path now requires the restored runtime to become ready and requires delivery confirmation before treating the operation as successful. If restore/readiness/delivery confirmation fails, the CLI now prints the error and exits non-zero instead of printing `Message sent and processing`.

Closes #1074.

## Changes

- make `SessionManager.send()` fail when a restored session never becomes ready for delivery
- require delivery confirmation for sends that depend on restore instead of treating them as soft success
- make `ao send` surface lifecycle-send failures as a user-facing error with exit code `1`
- add core and CLI regression tests covering the killed-session case

## Testing

- `pnpm --filter @aoagents/ao-core exec vitest run src/__tests__/session-manager/communication.test.ts`
- `pnpm --filter @aoagents/ao-cli exec vitest run __tests__/commands/send.test.ts`

## Manual Verification

1. In a checkout on `main`, create or identify a killed session:
   - `ao spawn <issue>`
   - `ao session kill <session-id>`
   - confirm `ao session ls` shows `<session-id>` as `killed`
2. On `main`, run `ao send <session-id> "hello"` and observe the current buggy behavior:
   - it prints `Message sent and processing`
   - it exits `0`
   - no message is actually delivered
3. Switch to this branch and build the CLI:
   - `pnpm install`
   - `pnpm build`
4. Run `ao send <same-session-id> "hello"` again.
5. Confirm the fixed behavior:
   - it prints an error like `Cannot send to session <session-id>: session is not running ...`
   - it exits `1`
   - it does not report false success
