### PR TITLE
fix(web): route SessionPage fetches through NEXT_PUBLIC_BASE_PATH

### DIFF
--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -8,6 +8,7 @@ import { type DashboardSession, type ActivityState, getAttentionLevel, type Atte
 import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
+import { apiPath } from "@/lib/api-path";
 import { useSSESessionActivity } from "@/hooks/useSSESessionActivity";
 
 function truncate(s: string, max: number): string {
@@ -75,6 +76,7 @@ export default function SessionPage() {
   const resolvedProjectSessionsKeyRef = useRef<string | null>(null);
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(false);
+  const fetchSessionFailingRef = useRef(false);
 
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
@@ -83,7 +85,7 @@ export default function SessionPage() {
 
   // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
   useEffect(() => {
-    fetch("/api/projects")
+    fetch(apiPath("/api/projects"))
       .then((res) => res.ok ? res.json() : null)
       .then((data: { projects?: ProjectInfo[] } | null) => {
         if (data?.projects) {
@@ -119,7 +121,7 @@ export default function SessionPage() {
   // Fetch session data (memoized to avoid recreating on every render)
   const fetchSession = useCallback(async () => {
     try {
-      const res = await fetch(`/api/sessions/${encodeURIComponent(id)}`);
+      const res = await fetch(apiPath(`/api/sessions/${encodeURIComponent(id)}`));
       if (res.status === 404) {
         if (!hasLoadedSessionRef.current) {
           setSessionMissing(true);
@@ -133,8 +135,14 @@ export default function SessionPage() {
       setRouteError(null);
       setSessionMissing(false);
       hasLoadedSessionRef.current = true;
+      fetchSessionFailingRef.current = false;
     } catch (err) {
-      console.error("Failed to fetch session:", err);
+      // Only log the first failure in a streak so the 5s polling loop doesn't
+      // flood the console on transient errors (e.g. proxy blip, offline tab).
+      if (!fetchSessionFailingRef.current) {
+        console.error("Failed to fetch session:", err);
+        fetchSessionFailingRef.current = true;
+      }
       if (!hasLoadedSessionRef.current) {
         setRouteError(err instanceof Error ? err : new Error("Failed to load session"));
       }
@@ -153,7 +161,7 @@ export default function SessionPage() {
       const query = isOrchestrator
         ? `/api/sessions?project=${encodeURIComponent(projectId)}`
         : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true`;
-      const res = await fetch(query);
+      const res = await fetch(apiPath(query));
       if (!res.ok) return;
       const body = (await res.json()) as ProjectSessionsBody;
       const sessions = body.sessions ?? [];
@@ -190,7 +198,7 @@ export default function SessionPage() {
 
   const fetchSidebarSessions = useCallback(async () => {
     try {
-      const res = await fetch("/api/sessions");
+      const res = await fetch(apiPath("/api/sessions"));
       if (!res.ok) return;
       const body = (await res.json()) as { sessions?: DashboardSession[] } | null;
       setSidebarSessions(body?.sessions ?? []);

--- a/packages/web/src/lib/__tests__/api-path.test.ts
+++ b/packages/web/src/lib/__tests__/api-path.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { apiPath } from "../api-path";
+
+const ORIGINAL_BASE = process.env.NEXT_PUBLIC_BASE_PATH;
+
+afterEach(() => {
+  if (ORIGINAL_BASE === undefined) {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+  } else {
+    process.env.NEXT_PUBLIC_BASE_PATH = ORIGINAL_BASE;
+  }
+});
+
+describe("apiPath", () => {
+  it("returns the path unchanged when NEXT_PUBLIC_BASE_PATH is unset", () => {
+    delete process.env.NEXT_PUBLIC_BASE_PATH;
+    expect(apiPath("/api/sessions")).toBe("/api/sessions");
+  });
+
+  it("returns the path unchanged when NEXT_PUBLIC_BASE_PATH is empty", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "";
+    expect(apiPath("/api/sessions")).toBe("/api/sessions");
+  });
+
+  it("prepends the base path to a leading-slash path", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/terminal";
+    expect(apiPath("/api/sessions/abc")).toBe("/terminal/api/sessions/abc");
+  });
+
+  it("prepends the base path to a relative path", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/terminal";
+    expect(apiPath("api/sessions")).toBe("/terminal/api/sessions");
+  });
+
+  it("strips trailing slashes from the base path before concatenating", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/terminal/";
+    expect(apiPath("/api/sessions")).toBe("/terminal/api/sessions");
+  });
+
+  it("handles nested base paths", () => {
+    process.env.NEXT_PUBLIC_BASE_PATH = "/tools/ao";
+    expect(apiPath("/api/events?project=x")).toBe("/tools/ao/api/events?project=x");
+  });
+});

--- a/packages/web/src/lib/api-path.ts
+++ b/packages/web/src/lib/api-path.ts
@@ -1,0 +1,17 @@
+/**
+ * Prefixes an API path with `NEXT_PUBLIC_BASE_PATH` so fetches resolve through
+ * reverse proxies that mount the app under a subpath (e.g. `/terminal/*`).
+ *
+ * Without the prefix, `fetch("/api/...")` from a page served at
+ * `https://host/terminal/sessions/abc` resolves to `https://host/api/...`
+ * — which hits the wrong upstream and surfaces as `TypeError: Failed to fetch`.
+ * See issue #935 for the incident.
+ *
+ * Defaults to an empty string, so root-served deployments keep the existing
+ * behavior.
+ */
+export function apiPath(path: string): string {
+  const base = (process.env.NEXT_PUBLIC_BASE_PATH ?? "").replace(/\/+$/, "");
+  if (!base) return path;
+  return path.startsWith("/") ? `${base}${path}` : `${base}/${path}`;
+}


### PR DESCRIPTION
## Summary
- Add `apiPath()` helper that prepends `NEXT_PUBLIC_BASE_PATH` to API URLs so fetches resolve correctly when the app is mounted at a reverse-proxy subpath (e.g. Caddy at `https://host/terminal/*`). Defaults to empty string, so root-served deployments keep working unchanged.
- Route every `/api/*` fetch in `packages/web/src/app/sessions/[id]/page.tsx` through `apiPath()`.
- Dedupe the `fetchSession` catch-log so a sustained failure streak logs once rather than once per 5s poll cycle.

## Why
Relative `/api/sessions/...` URLs resolve against the page origin, not the page path. When SessionPage was served from `https://host/terminal/sessions/abc`, fetches went to `https://host/api/sessions/abc` and hit the wrong upstream, producing `TypeError: Failed to fetch` every 5 seconds in the console.

Fixes #935

## Test plan
- [x] `pnpm --filter @aoagents/ao-web typecheck`
- [x] `pnpm --filter @aoagents/ao-web test` — 600/600 pass, including 6 new `api-path` tests
- [x] `pnpm lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)