### PR TITLE
fix(web): guard xterm FitAddon against disposed terminal (#936)

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -29,6 +29,21 @@ interface DirectTerminalProps {
 
 type TerminalVariant = "agent" | "orchestrator";
 
+// FitAddon.fit() reads `terminal._core._renderService.dimensions`, which is
+// undefined when the terminal has been disposed (stale ref) or when the
+// container has zero size (layout not yet settled). Both cases throw
+// `Cannot read properties of undefined (reading 'dimensions')` and crash the
+// page. Wrap fit() so a deferred timer/RAF that races cleanup can't blow up.
+export function safeFit(fit: FitAddonType | null, terminal: TerminalType | null): boolean {
+  if (!fit || !terminal) return false;
+  try {
+    fit.fit();
+    return true;
+  } catch (err) {
+    console.warn("[DirectTerminal] fit.fit() skipped:", err);
+    return false;
+  }
+}
 
 export function buildTerminalThemes(variant: TerminalVariant): { dark: ITheme; light: ITheme } {
   const agentAccent = {
@@ -269,8 +284,9 @@ export function DirectTerminal({
         terminal.open(terminalRef.current);
         terminalInstance.current = terminal;
 
-        // Fit terminal to container
-        fit.fit();
+        // Fit terminal to container — may throw if the container has zero
+        // size at mount (e.g. hidden tab), so always go through safeFit.
+        safeFit(fit, terminal);
 
         // ── Preserve selection while terminal receives output ────────
         // xterm.js clears the selection on every terminal.write(). We
@@ -351,10 +367,8 @@ export function DirectTerminal({
 
         // Handle window resize
         const handleResize = () => {
-          if (fit) {
-            fit.fit();
-            resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-          }
+          if (!safeFit(fit, terminal)) return;
+          resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
         };
 
         window.addEventListener("resize", handleResize);
@@ -367,7 +381,12 @@ export function DirectTerminal({
         // Send initial size
         resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
 
-        // Store cleanup function to be called from useEffect cleanup
+        // Store cleanup function to be called from useEffect cleanup.
+        // We null out the refs BEFORE disposing so any concurrent effect
+        // (reconnect, fullscreen resize, deferred RAF/timer) that races
+        // cleanup sees `null` instead of a disposed terminal — calling
+        // fit.fit() on a disposed terminal throws
+        // `Cannot read properties of undefined (reading 'dimensions')`.
         cleanup = () => {
           selectionDisposable.dispose();
           if (safetyTimer) clearTimeout(safetyTimer);
@@ -376,6 +395,12 @@ export function DirectTerminal({
           inputDisposable = null;
           unsubscribe?.();
           closeTerminal(sessionId);
+          if (terminalInstance.current === terminal) {
+            terminalInstance.current = null;
+          }
+          if (fitAddon.current === fit) {
+            fitAddon.current = null;
+          }
           terminal.dispose();
         };
       })
@@ -407,8 +432,7 @@ export function DirectTerminal({
     if (muxStatus !== "connected") return;
     const fit = fitAddon.current;
     const terminal = terminalInstance.current;
-    if (!fit || !terminal) return;
-    fit.fit();
+    if (!safeFit(fit, terminal) || !terminal) return;
     resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
   }, [muxStatus, sessionId, resizeTerminalMux]);
 
@@ -423,11 +447,16 @@ export function DirectTerminal({
 
   // Re-fit terminal when fullscreen changes
   useEffect(() => {
-    const fit = fitAddon.current;
-    const terminal = terminalInstance.current;
     const container = terminalRef.current;
 
-    if (!fit || !terminal || muxStatusRef.current !== "connected" || !container) {
+    if (muxStatusRef.current !== "connected" || !container) {
+      return;
+    }
+    // Don't capture terminal/fit in a closure — they may be disposed and
+    // re-created (e.g. on theme change) while this effect's deferred
+    // timers/RAF callbacks are still pending. Always re-read the refs
+    // at call time so we see the current instance or bail safely.
+    if (!terminalInstance.current || !fitAddon.current) {
       return;
     }
 
@@ -452,13 +481,19 @@ export function DirectTerminal({
         return;
       }
 
+      // Re-read refs in case the terminal was disposed + re-created since
+      // the effect started (theme switch, reconnect, etc.).
+      const currentTerminal = terminalInstance.current;
+      const currentFit = fitAddon.current;
+      if (!currentTerminal || !currentFit) return;
+
       // Container is at target size, now resize terminal
-      terminal.refresh(0, terminal.rows - 1);
-      fit.fit();
-      terminal.refresh(0, terminal.rows - 1);
+      currentTerminal.refresh(0, currentTerminal.rows - 1);
+      if (!safeFit(currentFit, currentTerminal)) return;
+      currentTerminal.refresh(0, currentTerminal.rows - 1);
 
       // Send new size to server via mux
-      resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+      resizeTerminalMux(sessionId, currentTerminal.cols, currentTerminal.rows);
     };
 
     // Start resize polling

--- a/packages/web/src/components/__tests__/DirectTerminal.test.ts
+++ b/packages/web/src/components/__tests__/DirectTerminal.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from "vitest";
-import { buildTerminalThemes } from "@/components/DirectTerminal";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { Terminal as TerminalType } from "xterm";
+import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
+import { buildTerminalThemes, safeFit } from "@/components/DirectTerminal";
 
 const HEX_RE = /^#[0-9a-fA-F]{6}$/;
 const ANSI_KEYS = [
@@ -84,5 +86,45 @@ describe("buildTerminalThemes", () => {
   it("selection colors differ between dark and light themes", () => {
     const { dark, light } = buildTerminalThemes("agent");
     expect(dark.selectionBackground).not.toBe(light.selectionBackground);
+  });
+});
+
+describe("safeFit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const fakeTerminal = {} as TerminalType;
+
+  it("returns false when fit addon is null (disposed/stale ref)", () => {
+    expect(safeFit(null, fakeTerminal)).toBe(false);
+  });
+
+  it("returns false when terminal is null (disposed/stale ref)", () => {
+    const fit = { fit: vi.fn() } as unknown as FitAddonType;
+    expect(safeFit(fit, null)).toBe(false);
+    expect(fit.fit).not.toHaveBeenCalled();
+  });
+
+  it("returns true when fit() succeeds", () => {
+    const fit = { fit: vi.fn() } as unknown as FitAddonType;
+    expect(safeFit(fit, fakeTerminal)).toBe(true);
+    expect(fit.fit).toHaveBeenCalledOnce();
+  });
+
+  it("swallows the 'dimensions' TypeError thrown by FitAddon on a disposed terminal", () => {
+    // This is the exact error from issue #936: xterm's FitAddon reads
+    // `terminal._core._renderService.dimensions` and blows up when the
+    // render service has been torn down by dispose().
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fit = {
+      fit: vi.fn(() => {
+        throw new TypeError("Cannot read properties of undefined (reading 'dimensions')");
+      }),
+    } as unknown as FitAddonType;
+
+    expect(() => safeFit(fit, fakeTerminal)).not.toThrow();
+    expect(safeFit(fit, fakeTerminal)).toBe(false);
+    expect(warn).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
Fixes #936. The session detail page crashed with `TypeError: Cannot read properties of undefined (reading 'dimensions')` whenever the xterm.js terminal was disposed (theme switch, reconnect, unmount) while a deferred resize timer/RAF or the reconnect effect still held a stale ref. xterm's `FitAddon.fit()` reads `terminal._core._renderService.dimensions` internally — undefined after `dispose()` or on a zero-size container at first mount — and throws up through React.

## Changes
- New shared `safeFit()` helper wraps every `fit.fit()` call, catches the TypeError, logs a warning, and returns `false` so callers bail instead of crashing.
- Cleanup nulls out `terminalInstance.current` / `fitAddon.current` **before** `dispose()` so concurrent effects see `null` instead of a disposed instance.
- Fullscreen-resize effect no longer captures `terminal` / `fit` in closure — deferred RAF/setTimeout callbacks re-read the refs at call time so a mid-flight re-create (e.g. theme change) can't feed a disposed terminal to `refresh()` / `fit()`.

## Root cause
`DirectTerminal`'s main effect re-runs on `resolvedTheme` / `appearance` / `sessionId` changes. The old cleanup called `terminal.dispose()` but left the refs dangling; the "reconnect" and "fullscreen resize" effects then raced with the next async terminal creation and called `fit.fit()` on the disposed instance — triggering the `dimensions` TypeError reported in the issue. The `Failed to fetch` error mentioned in the issue was a symptom, not the cause: even with data loaded, the race still fired on any theme/layout change.

## Test plan
- [x] `pnpm --filter @aoagents/ao-web typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-web test` — 598 passed (4 new `safeFit` tests)
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` (web) — production build succeeds
- [x] New unit tests cover: null `fit`, null `terminal`, success path, and the exact `"Cannot read properties of undefined (reading 'dimensions')"` TypeError path from the issue

Closes #936