### PR TITLE
fix: use a fixed desktop split layout on session detail

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1573,6 +1573,13 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     var(--color-bg-base);
 }
 
+.session-detail-page--desktop {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .session-page-header {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -1646,6 +1653,23 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .session-detail-layout {
   max-width: 1200px;
   padding: 16px 24px 48px;
+}
+
+.session-detail-layout--desktop {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  max-width: none;
+  padding-bottom: 24px;
+}
+
+.session-detail-content {
+  display: flex;
+  min-height: 0;
+  width: min(1200px, 100%);
+  flex: 1;
+  flex-direction: column;
 }
 
 .session-detail-top-strip {
@@ -1899,6 +1923,28 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 .session-detail-terminal-wrap {
   margin-bottom: 18px;
+}
+
+.session-detail-terminal-wrap--desktop {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  margin-bottom: 0;
+}
+
+.session-detail-terminal-panel {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  overflow: hidden;
+}
+
+.session-detail-terminal-panel > .direct-terminal,
+.session-detail-terminal-panel > .terminal-exited-placeholder,
+.session-detail-terminal-panel > .session-detail-terminal-placeholder {
+  min-height: 0;
+  flex: 1;
 }
 
 .session-detail-section-label {

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -469,9 +469,9 @@ export function SessionDetail({
   const accentColor = "var(--color-accent)";
   const terminalVariant = isOrchestrator ? "orchestrator" : "agent";
 
-  const terminalHeight = isOrchestrator
-    ? "clamp(400px, 52vh, 620px)"
-    : "clamp(380px, 48vh, 560px)";
+  const terminalHeight = isMobile
+    ? (isOrchestrator ? "clamp(400px, 52vh, 620px)" : "clamp(380px, 48vh, 560px)")
+    : "100%";
   const isOpenCodeSession = session.metadata["agent"] === "opencode";
   const opencodeSessionId =
     typeof session.metadata["opencodeSessionId"] === "string" &&
@@ -601,9 +601,9 @@ export function SessionDetail({
           ) : null}
 
           <div className="dashboard-main dashboard-main--desktop">
-            <main className="session-detail-page min-h-0 flex-1 overflow-y-auto bg-[var(--color-bg-base)]">
-              <div className="session-detail-layout">
-                <main className="min-w-0">
+            <main className="session-detail-page session-detail-page--desktop min-h-0 flex-1 overflow-hidden bg-[var(--color-bg-base)]">
+              <div className="session-detail-layout session-detail-layout--desktop">
+                <main className="session-detail-content min-w-0">
                   {(!isOrchestrator || (isOrchestrator && orchestratorZones)) && (
                     <SessionTopStrip
                       headline={headline}
@@ -630,7 +630,7 @@ export function SessionDetail({
                     </section>
                   ) : null}
 
-                  <section className="session-detail-terminal-wrap">
+                  <section className="session-detail-terminal-wrap session-detail-terminal-wrap--desktop">
                     <div id="session-terminal-section" aria-hidden="true" />
                     <div className="session-detail-section-label">
                       <div
@@ -641,25 +641,27 @@ export function SessionDetail({
                         Live Terminal
                       </span>
                     </div>
-                    {!showTerminal ? (
-                      <div className="session-detail-terminal-placeholder" style={{ height: terminalHeight }} />
-                    ) : terminalEnded ? (
-                      <div className="terminal-exited-placeholder" style={{ height: terminalHeight }}>
-                        <span className="terminal-exited-placeholder__text">
-                          Terminal session has ended
-                        </span>
-                      </div>
-                    ) : (
-                      <DirectTerminal
-                        sessionId={session.id}
-                        startFullscreen={startFullscreen}
-                        variant={terminalVariant}
-                        appearance="dark"
-                        height={terminalHeight}
-                        isOpenCodeSession={isOpenCodeSession}
-                        reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
-                      />
-                    )}
+                    <div className="session-detail-terminal-panel">
+                      {!showTerminal ? (
+                        <div className="session-detail-terminal-placeholder" style={{ height: terminalHeight }} />
+                      ) : terminalEnded ? (
+                        <div className="terminal-exited-placeholder" style={{ height: terminalHeight }}>
+                          <span className="terminal-exited-placeholder__text">
+                            Terminal session has ended
+                          </span>
+                        </div>
+                      ) : (
+                        <DirectTerminal
+                          sessionId={session.id}
+                          startFullscreen={startFullscreen}
+                          variant={terminalVariant}
+                          appearance="dark"
+                          height={terminalHeight}
+                          isOpenCodeSession={isOpenCodeSession}
+                          reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
+                        />
+                      )}
+                    </div>
                   </section>
                 </main>
               </div>

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -128,6 +128,23 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText("Live Terminal")).toBeInTheDocument();
   });
 
+  it("keeps the desktop session detail in a fixed split layout", () => {
+    const { container } = render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-split",
+          projectId: "my-app",
+          pr: null,
+        })}
+      />,
+    );
+
+    expect(container.querySelector(".session-detail-page--desktop")).toBeTruthy();
+    expect(container.querySelector(".session-detail-layout--desktop")).toBeTruthy();
+    expect(container.querySelector(".session-detail-terminal-wrap--desktop")).toBeTruthy();
+    expect(container.querySelector(".session-detail-terminal-panel")).toBeTruthy();
+  });
+
   it("sends unresolved comments back to the agent and shows sent state", async () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
## Summary
- switch the desktop session detail view to a fixed-height flex layout instead of page scrolling
- let the terminal panel consume the remaining viewport height and keep scrolling inside the terminal
- add a desktop layout test covering the fixed split-pane structure

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm --filter @aoagents/ao-web test -- --run SessionDetail.desktop.test.tsx
- pnpm test *(fails in existing unrelated integration test: `packages/integration-tests/src/agent-claude-code.integration.test.ts` expects `permission-mode` in real Claude data)*

Closes #1246