### PR TITLE
fix: default dashboard services to loopback with explicit remote opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ cd ~/your-project && ao start
 
 That's it. The dashboard opens at `http://localhost:3000` and the orchestrator agent starts managing your project.
 
+By default, AO binds the dashboard and direct terminal to `127.0.0.1`. Remote exposure is now explicit:
+
+```bash
+# Expose both dashboard + direct terminal remotely
+HOST=0.0.0.0 ao start
+
+# Expose dashboard remotely but keep direct terminal local-only
+AO_DASHBOARD_HOST=0.0.0.0 AO_DIRECT_TERMINAL_HOST=127.0.0.1 ao start
+```
+
+`AO_DIRECT_TERMINAL_HOST` defaults to the dashboard host when you opt into remote binding, and otherwise falls back to `127.0.0.1`.
+
 ### Add more projects
 
 ```bash
@@ -140,7 +152,7 @@ See [`agent-orchestrator.yaml.example`](agent-orchestrator.yaml.example) for the
 
 ## Remote Access
 
-AO keeps your Mac awake while running, so you can access the dashboard remotely (e.g., via Tailscale from your phone) without the machine going to sleep.
+AO keeps your Mac awake while running, so remote access can stay available without the machine going to sleep once you've explicitly exposed the dashboard off loopback (for example via `HOST=0.0.0.0` or `AO_DASHBOARD_HOST=0.0.0.0`).
 
 **How it works:** On macOS, AO automatically holds an idle-sleep prevention assertion using `caffeinate`. When AO exits, the assertion is released.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,6 +14,8 @@ ao status --watch                      # Live-updating terminal status view
 ao dashboard                           # Open web dashboard in browser
 ```
 
+By default, `ao start` binds the dashboard and direct terminal to `127.0.0.1`. For remote access, set `HOST` or `AO_DASHBOARD_HOST`; `AO_DIRECT_TERMINAL_HOST` lets you keep the direct terminal local-only or expose it separately.
+
 ## Commands the orchestrator agent uses
 
 These are primarily invoked by the orchestrator agent running inside a tmux session. You can use them manually if needed, but the orchestrator handles this automatically.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -431,6 +431,13 @@ regexes = ['''your-pattern-here''']
 ## Environment Variables
 
 ```bash
+# Dashboard bind host (default: 127.0.0.1)
+HOST=127.0.0.1
+AO_DASHBOARD_HOST=127.0.0.1
+
+# Direct terminal bind host (defaults to AO_DIRECT_TERMINAL_HOST ?? AO_DASHBOARD_HOST ?? HOST ?? 127.0.0.1)
+AO_DIRECT_TERMINAL_HOST=127.0.0.1
+
 # Mux WebSocket server port (web dashboard terminal + session updates)
 DIRECT_TERMINAL_PORT=14801
 
@@ -440,6 +447,8 @@ LINEAR_API_KEY=lin_api_...
 SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
 ANTHROPIC_API_KEY=sk-ant-api03-...
 ```
+
+`packages/web` startup scripts honor these host variables on macOS, Linux, and Windows.
 
 Store in `.env.local` (gitignored). Never commit real values.
 

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -120,6 +120,7 @@ vi.mock("../../src/lib/lifecycle-service.js", () => ({
 vi.mock("../../src/lib/web-dir.js", () => ({
   findWebDir: vi.fn().mockReturnValue("/fake/web"),
   buildDashboardEnv: vi.fn().mockResolvedValue({}),
+  getExposureWarningLines: vi.fn().mockReturnValue([]),
   waitForPortAndOpen: (...args: unknown[]) => mockWaitForPortAndOpen(...args),
   isPortAvailable: vi.fn().mockResolvedValue(true),
   findFreePort: vi.fn().mockResolvedValue(3000),

--- a/packages/cli/__tests__/lib/web-dir.test.ts
+++ b/packages/cli/__tests__/lib/web-dir.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  buildDashboardEnv,
+  getExposureWarningLines,
+  isLoopbackHost,
+} from "../../src/lib/web-dir.js";
+
+const SAVED_HOST = process.env["HOST"];
+const SAVED_AO_DASHBOARD_HOST = process.env["AO_DASHBOARD_HOST"];
+const SAVED_AO_DIRECT_TERMINAL_HOST = process.env["AO_DIRECT_TERMINAL_HOST"];
+
+afterEach(() => {
+  if (SAVED_HOST === undefined) {
+    Reflect.deleteProperty(process.env, "HOST");
+  } else {
+    process.env["HOST"] = SAVED_HOST;
+  }
+
+  if (SAVED_AO_DASHBOARD_HOST === undefined) {
+    Reflect.deleteProperty(process.env, "AO_DASHBOARD_HOST");
+  } else {
+    process.env["AO_DASHBOARD_HOST"] = SAVED_AO_DASHBOARD_HOST;
+  }
+
+  if (SAVED_AO_DIRECT_TERMINAL_HOST === undefined) {
+    Reflect.deleteProperty(process.env, "AO_DIRECT_TERMINAL_HOST");
+  } else {
+    process.env["AO_DIRECT_TERMINAL_HOST"] = SAVED_AO_DIRECT_TERMINAL_HOST;
+  }
+});
+
+describe("buildDashboardEnv", () => {
+  it("defaults dashboard and terminal hosts to loopback", async () => {
+    Reflect.deleteProperty(process.env, "HOST");
+    Reflect.deleteProperty(process.env, "AO_DASHBOARD_HOST");
+    Reflect.deleteProperty(process.env, "AO_DIRECT_TERMINAL_HOST");
+
+    const env = await buildDashboardEnv(3000, null, 14800, 14801);
+
+    expect(env["HOST"]).toBe("127.0.0.1");
+    expect(env["AO_DASHBOARD_HOST"]).toBe("127.0.0.1");
+    expect(env["AO_DIRECT_TERMINAL_HOST"]).toBe("127.0.0.1");
+    expect(env["NEXT_PUBLIC_DIRECT_TERMINAL_HOST"]).toBe("127.0.0.1");
+  });
+
+  it("preserves explicit remote exposure overrides", async () => {
+    process.env["AO_DASHBOARD_HOST"] = "0.0.0.0";
+    process.env["AO_DIRECT_TERMINAL_HOST"] = "0.0.0.0";
+
+    const env = await buildDashboardEnv(3000, null, 14800, 14801);
+
+    expect(env["HOST"]).toBe("0.0.0.0");
+    expect(env["AO_DASHBOARD_HOST"]).toBe("0.0.0.0");
+    expect(env["AO_DIRECT_TERMINAL_HOST"]).toBe("0.0.0.0");
+  });
+
+  it("lets direct terminal inherit legacy HOST exposure when no override is set", async () => {
+    process.env["HOST"] = "0.0.0.0";
+    Reflect.deleteProperty(process.env, "AO_DASHBOARD_HOST");
+    Reflect.deleteProperty(process.env, "AO_DIRECT_TERMINAL_HOST");
+
+    const env = await buildDashboardEnv(3000, null, 14800, 14801);
+
+    expect(env["HOST"]).toBe("0.0.0.0");
+    expect(env["AO_DASHBOARD_HOST"]).toBe("0.0.0.0");
+    expect(env["AO_DIRECT_TERMINAL_HOST"]).toBe("0.0.0.0");
+    expect(env["NEXT_PUBLIC_DIRECT_TERMINAL_HOST"]).toBe("0.0.0.0");
+  });
+});
+
+describe("exposure helpers", () => {
+  it("recognizes loopback hosts", () => {
+    expect(isLoopbackHost("127.0.0.1")).toBe(true);
+    expect(isLoopbackHost("localhost")).toBe(true);
+    expect(isLoopbackHost("::1")).toBe(true);
+    expect(isLoopbackHost("0.0.0.0")).toBe(false);
+  });
+
+  it("returns warnings only for non-loopback exposure", () => {
+    expect(getExposureWarningLines("127.0.0.1", "127.0.0.1")).toEqual([]);
+    expect(getExposureWarningLines("0.0.0.0", "127.0.0.1")).toEqual([
+      "Security warning: dashboard HTTP API is bound to 0.0.0.0 without built-in auth.",
+    ]);
+  });
+});

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -3,7 +3,11 @@ import { resolve } from "node:path";
 import chalk from "chalk";
 import type { Command } from "commander";
 import { loadConfig } from "@aoagents/ao-core";
-import { findWebDir, buildDashboardEnv, waitForPortAndOpen } from "../lib/web-dir.js";
+import {
+  findWebDir,
+  buildDashboardEnv,
+  waitForPortAndOpen,
+} from "../lib/web-dir.js";
 import {
   findRunningDashboardPid,
   isInstalledUnderNodeModules,
@@ -12,6 +16,32 @@ import {
 } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
 import { DEFAULT_PORT } from "../lib/constants.js";
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+}
+
+function logExposureWarnings(env: Record<string, string>): void {
+  const dashboardHost = env["HOST"] ?? "127.0.0.1";
+  const directTerminalHost = env["AO_DIRECT_TERMINAL_HOST"] ?? "127.0.0.1";
+
+  if (!isLoopbackHost(dashboardHost)) {
+    console.log(
+      chalk.yellow(
+        `Security warning: dashboard HTTP API is bound to ${dashboardHost} without built-in auth.`,
+      ),
+    );
+  }
+
+  if (!isLoopbackHost(directTerminalHost)) {
+    console.log(
+      chalk.yellow(
+        `Security warning: direct terminal WebSocket is bound to ${directTerminalHost} without built-in auth.`,
+      ),
+    );
+  }
+}
 
 export function registerDashboard(program: Command): void {
   program
@@ -60,12 +90,14 @@ export function registerDashboard(program: Command): void {
 
       console.log(chalk.bold(`Starting dashboard on http://localhost:${port}\n`));
 
-      const env = await buildDashboardEnv(
-        port,
-        config.configPath,
-        config.terminalPort,
-        config.directTerminalPort,
-      );
+      const env =
+        (await buildDashboardEnv(
+          port,
+          config.configPath,
+          config.terminalPort,
+          config.directTerminalPort,
+        )) ?? {};
+      logExposureWarnings(env);
 
       const startScript = resolve(webDir, "dist-server", "start-all.js");
       const child = spawn("node", [startScript], {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -71,6 +71,32 @@ import { findProjectForDirectory } from "../lib/project-resolution.js";
 import { DEFAULT_PORT } from "../lib/constants.js";
 const IS_TTY = Boolean(process.stdin.isTTY && process.stdout.isTTY);
 
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+}
+
+function logExposureWarnings(env: Record<string, string>): void {
+  const dashboardHost = env["HOST"] ?? "127.0.0.1";
+  const directTerminalHost = env["AO_DIRECT_TERMINAL_HOST"] ?? "127.0.0.1";
+
+  if (!isLoopbackHost(dashboardHost)) {
+    console.log(
+      chalk.yellow(
+        `  Security warning: dashboard HTTP API is bound to ${dashboardHost} without built-in auth.`,
+      ),
+    );
+  }
+
+  if (!isLoopbackHost(directTerminalHost)) {
+    console.log(
+      chalk.yellow(
+        `  Security warning: direct terminal WebSocket is bound to ${directTerminalHost} without built-in auth.`,
+      ),
+    );
+  }
+}
+
 // =============================================================================
 // HELPERS
 // =============================================================================
@@ -821,7 +847,8 @@ async function startDashboard(
   directTerminalPort?: number,
   devMode?: boolean,
 ): Promise<ChildProcess> {
-  const env = await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort);
+  const env = (await buildDashboardEnv(port, configPath, terminalPort, directTerminalPort)) ?? {};
+  logExposureWarnings(env);
 
   // Detect monorepo vs npm install: the `server/` source directory only exists
   // in the monorepo. Published npm packages only have `dist-server/`.

--- a/packages/cli/src/lib/web-dir.ts
+++ b/packages/cli/src/lib/web-dir.ts
@@ -17,6 +17,8 @@ const require = createRequire(import.meta.url);
 
 /** Default terminal server base port (14800 range: zero IANA registrations, no dev tool conflicts) */
 const DEFAULT_TERMINAL_PORT = 14800;
+const DEFAULT_DASHBOARD_HOST = "127.0.0.1";
+const DEFAULT_DIRECT_TERMINAL_HOST = "127.0.0.1";
 
 /**
  * Check if a TCP port is available by attempting to connect to it.
@@ -120,6 +122,58 @@ async function findAvailablePortPair(base: number): Promise<[number, number]> {
   return [base, base + 1];
 }
 
+export function normalizeBindHost(
+  input: string | undefined,
+  fallback = DEFAULT_DASHBOARD_HOST,
+): string {
+  const trimmed = input?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+}
+
+export function resolveDashboardHosts(env: NodeJS.ProcessEnv): {
+  dashboardHost: string;
+  directTerminalHost: string;
+} {
+  const dashboardHost = normalizeBindHost(
+    env["AO_DASHBOARD_HOST"] ?? env["HOST"],
+    DEFAULT_DASHBOARD_HOST,
+  );
+
+  return {
+    dashboardHost,
+    directTerminalHost: normalizeBindHost(
+      env["AO_DIRECT_TERMINAL_HOST"] ?? dashboardHost,
+      DEFAULT_DIRECT_TERMINAL_HOST,
+    ),
+  };
+}
+
+export function getExposureWarningLines(
+  dashboardHost: string,
+  directTerminalHost: string,
+): string[] {
+  const warnings: string[] = [];
+
+  if (!isLoopbackHost(dashboardHost)) {
+    warnings.push(
+      `Security warning: dashboard HTTP API is bound to ${dashboardHost} without built-in auth.`,
+    );
+  }
+
+  if (!isLoopbackHost(directTerminalHost)) {
+    warnings.push(
+      `Security warning: direct terminal WebSocket is bound to ${directTerminalHost} without built-in auth.`,
+    );
+  }
+
+  return warnings;
+}
+
 /**
  * Build environment variables for spawning the dashboard process.
  * Shared between `ao start` and `ao dashboard` to avoid duplication.
@@ -135,6 +189,7 @@ export async function buildDashboardEnv(
   directTerminalPort?: number,
 ): Promise<Record<string, string>> {
   const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  const { dashboardHost, directTerminalHost } = resolveDashboardHosts(env);
 
   // Pass config path so dashboard uses the same config as the CLI
   if (configPath) {
@@ -142,6 +197,10 @@ export async function buildDashboardEnv(
   }
 
   env["PORT"] = String(port);
+  env["HOST"] = dashboardHost;
+  env["AO_DASHBOARD_HOST"] = dashboardHost;
+  env["AO_DIRECT_TERMINAL_HOST"] = directTerminalHost;
+  env["NEXT_PUBLIC_DIRECT_TERMINAL_HOST"] = directTerminalHost;
 
   // If explicit ports provided (config or env var), use them directly.
   // Otherwise, auto-detect an available pair starting from the default.

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -9,14 +9,15 @@
     ".next/*.json",
     ".next/BUILD_ID",
     "dist-server",
-    "next.config.js"
+    "next.config.js",
+    "scripts"
   ],
   "scripts": {
     "dev": "concurrently \"npm:dev:next\" \"npm:dev:direct-terminal\"",
-    "dev:next": "next dev -p ${PORT:-3000}",
+    "dev:next": "node scripts/run-next.cjs dev",
     "dev:direct-terminal": "tsx watch server/direct-terminal-ws.ts",
     "build": "next build && tsc -p tsconfig.server.json",
-    "start": "next start",
+    "start": "node scripts/run-next.cjs start",
     "start:all": "node dist-server/start-all.js",
     "dev:optimized": "next build && tsc -p tsconfig.server.json && node dist-server/start-all.js",
     "typecheck": "tsc --noEmit",

--- a/packages/web/scripts/run-next.cjs
+++ b/packages/web/scripts/run-next.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-require-imports */
+/* global require, process, __dirname, __filename */
+
+const { spawn } = require("node:child_process");
+const { createRequire } = require("node:module");
+const { dirname, resolve } = require("node:path");
+const { existsSync } = require("node:fs");
+
+const mode = process.argv[2];
+
+if (mode !== "dev" && mode !== "start") {
+  process.stderr.write("Usage: node scripts/run-next.cjs <dev|start>\n");
+  process.exit(1);
+}
+
+function normalizeEnvValue(value, fallback) {
+  if (typeof value !== "string") return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+}
+
+function resolveHosts(env) {
+  const dashboardHost = normalizeEnvValue(
+    env.AO_DASHBOARD_HOST ?? env.HOST,
+    "127.0.0.1",
+  );
+  const directTerminalHost = normalizeEnvValue(
+    env.AO_DIRECT_TERMINAL_HOST ?? dashboardHost,
+    "127.0.0.1",
+  );
+
+  return { dashboardHost, directTerminalHost };
+}
+
+function resolveNextCommand() {
+  const localBin = resolve(
+    __dirname,
+    "..",
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "next.cmd" : "next",
+  );
+
+  if (existsSync(localBin)) {
+    return { command: localBin, prefixArgs: [] };
+  }
+
+  const requireFromHere = createRequire(__filename);
+
+  try {
+    const nextPkg = requireFromHere.resolve("next/package.json");
+    return {
+      command: process.execPath,
+      prefixArgs: [resolve(dirname(nextPkg), "dist", "bin", "next")],
+    };
+  } catch {
+    return {
+      command: process.platform === "win32" ? "next.cmd" : "next",
+      prefixArgs: [],
+    };
+  }
+}
+
+const port = normalizeEnvValue(process.env.PORT, "3000");
+const { dashboardHost, directTerminalHost } = resolveHosts(process.env);
+const { command, prefixArgs } = resolveNextCommand();
+const childEnv = {
+  ...process.env,
+  PORT: port,
+  HOST: dashboardHost,
+  AO_DASHBOARD_HOST: dashboardHost,
+  AO_DIRECT_TERMINAL_HOST: directTerminalHost,
+  NEXT_PUBLIC_DIRECT_TERMINAL_HOST: directTerminalHost,
+};
+
+const child = spawn(
+  command,
+  [...prefixArgs, mode, "-H", dashboardHost, "-p", port],
+  { stdio: "inherit", env: childEnv },
+);
+
+child.on("error", (error) => {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -15,6 +15,15 @@ import { findTmux } from "../tmux-utils.js";
 import { createDirectTerminalServer, type DirectTerminalServer } from "../direct-terminal-ws.js";
 
 const TMUX = findTmux();
+const TMUX_AVAILABLE = (() => {
+  try {
+    execFileSync(TMUX, ["-V"], { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+const describeIfTmux = TMUX_AVAILABLE ? describe : describe.skip;
 const TEST_SESSION = `ao-test-integration-${process.pid}`;
 const TEST_HASH_SESSION = `abcdef123456-ao-test-hash-${process.pid}`;
 
@@ -83,6 +92,7 @@ function waitForMessage(
 // =============================================================================
 
 beforeAll(() => {
+  if (!TMUX_AVAILABLE) return;
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_SESSION, "-x", "80", "-y", "24"], {
     timeout: 5000,
   });
@@ -97,6 +107,7 @@ beforeAll(() => {
 });
 
 afterAll(() => {
+  if (!TMUX_AVAILABLE) return;
   terminal.shutdown();
   try { execFileSync(TMUX, ["kill-session", "-t", TEST_SESSION], { timeout: 5000 }); } catch { /* */ }
   try { execFileSync(TMUX, ["kill-session", "-t", TEST_HASH_SESSION], { timeout: 5000 }); } catch { /* */ }
@@ -106,7 +117,7 @@ afterAll(() => {
 // Health endpoint
 // =============================================================================
 
-describe("health endpoint", () => {
+describeIfTmux("health endpoint", () => {
   it("GET /health returns 200 with JSON body", async () => {
     const res = await httpGet("/health");
     expect(res.status).toBe(200);
@@ -131,7 +142,7 @@ describe("health endpoint", () => {
 // HTTP routing
 // =============================================================================
 
-describe("HTTP routing", () => {
+describeIfTmux("HTTP routing", () => {
   it("returns 404 for unknown path", async () => {
     expect((await httpGet("/unknown")).status).toBe(404);
   });
@@ -149,7 +160,7 @@ describe("HTTP routing", () => {
 // WebSocket upgrade routing
 // =============================================================================
 
-describe("WebSocket upgrade routing", () => {
+describeIfTmux("WebSocket upgrade routing", () => {
   it("accepts connections on /mux", async () => {
     const ws = await connectMux();
     expect(ws.readyState).toBe(WebSocket.OPEN);
@@ -172,7 +183,7 @@ describe("WebSocket upgrade routing", () => {
 // Mux protocol — session open/validation
 // =============================================================================
 
-describe("mux terminal open", () => {
+describeIfTmux("mux terminal open", () => {
   it("sends 'opened' response for a valid tmux session", async () => {
     const ws = await connectMux();
 
@@ -234,7 +245,7 @@ describe("mux terminal open", () => {
 // Mux protocol — terminal I/O
 // =============================================================================
 
-describe("mux terminal I/O", () => {
+describeIfTmux("mux terminal I/O", () => {
   it("receives terminal data after open", async () => {
     const ws = await connectMux();
 
@@ -320,7 +331,7 @@ describe("mux terminal I/O", () => {
 // Mux protocol — system channel
 // =============================================================================
 
-describe("mux system channel", () => {
+describeIfTmux("mux system channel", () => {
   it("responds to ping with pong", async () => {
     const ws = await connectMux();
 
@@ -337,7 +348,7 @@ describe("mux system channel", () => {
 // Server creation
 // =============================================================================
 
-describe("server creation", () => {
+describeIfTmux("server creation", () => {
   it("createDirectTerminalServer returns expected properties", () => {
     expect(terminal).toHaveProperty("server");
     expect(terminal).toHaveProperty("shutdown");

--- a/packages/web/server/direct-terminal-ws.ts
+++ b/packages/web/server/direct-terminal-ws.ts
@@ -13,6 +13,24 @@ export interface DirectTerminalServer {
   shutdown: () => void;
 }
 
+const DEFAULT_DIRECT_TERMINAL_HOST = "127.0.0.1";
+
+export function normalizeDirectTerminalHost(input: string | undefined): string {
+  const trimmed = input?.trim();
+  return trimmed ? trimmed : DEFAULT_DIRECT_TERMINAL_HOST;
+}
+
+export function resolveDirectTerminalHost(env: NodeJS.ProcessEnv): string {
+  return normalizeDirectTerminalHost(
+    env["AO_DIRECT_TERMINAL_HOST"] ?? env["AO_DASHBOARD_HOST"] ?? env["HOST"],
+  );
+}
+
+export function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+}
+
 /**
  * Create the direct terminal WebSocket server.
  * Separated from listen() so tests can control lifecycle.
@@ -100,9 +118,16 @@ if (isMainModule) {
 
   const { server, shutdown } = createDirectTerminalServer(TMUX);
   const PORT = parseInt(process.env.DIRECT_TERMINAL_PORT ?? "14801", 10);
+  const HOST = resolveDirectTerminalHost(process.env);
 
-  server.listen(PORT, () => {
-    console.log(`[DirectTerminal] WebSocket server listening on port ${PORT}`);
+  if (!isLoopbackHost(HOST)) {
+    console.warn(
+      `[DirectTerminal] Security warning: terminal WebSocket is bound to ${HOST} without built-in auth.`,
+    );
+  }
+
+  server.listen(PORT, HOST, () => {
+    console.log(`[DirectTerminal] WebSocket server listening on ${HOST}:${PORT}`);
   });
 
   function handleShutdown(signal: string) {

--- a/packages/web/server/start-all.ts
+++ b/packages/web/server/start-all.ts
@@ -17,9 +17,21 @@ const __dirname = dirname(__filename);
 const pkgRoot = resolve(__dirname, "..");
 
 const children: ChildProcess[] = [];
+const DEFAULT_DASHBOARD_HOST = "127.0.0.1";
+const DEFAULT_DIRECT_TERMINAL_HOST = "127.0.0.1";
 
 function log(label: string, msg: string): void {
   process.stdout.write(`[${label}] ${msg}\n`);
+}
+
+function normalizeBindHost(input: string | undefined, fallback: string): string {
+  const trimmed = input?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
 }
 
 function spawnProcess(
@@ -95,7 +107,30 @@ function resolveNextBin(): string {
 
 // Start Next.js production server
 const port = process.env["PORT"] || "3000";
-spawnProcess("next", resolveNextBin(), ["start", "-p", port]);
+const dashboardHost = normalizeBindHost(
+  process.env["AO_DASHBOARD_HOST"] ?? process.env["HOST"],
+  DEFAULT_DASHBOARD_HOST,
+);
+const directTerminalHost = normalizeBindHost(
+  process.env["AO_DIRECT_TERMINAL_HOST"] ?? dashboardHost,
+  DEFAULT_DIRECT_TERMINAL_HOST,
+);
+
+if (!isLoopbackHost(dashboardHost)) {
+  log(
+    "start-all",
+    `Security warning: dashboard HTTP API is bound to ${dashboardHost} without built-in auth.`,
+  );
+}
+
+if (!isLoopbackHost(directTerminalHost)) {
+  log(
+    "start-all",
+    `Security warning: direct terminal WebSocket is bound to ${directTerminalHost} without built-in auth.`,
+  );
+}
+
+spawnProcess("next", resolveNextBin(), ["start", "-p", port, "-H", dashboardHost]);
 
 // Start direct terminal WebSocket server (auto-restart on crash)
 spawnProcess("direct-terminal", "node", [resolve(__dirname, "direct-terminal-ws.js")], { restart: true });

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -391,24 +391,58 @@ describe("API Routes", () => {
       });
     }
 
-    it("returns runtime direct terminal port from server env", async () => {
-      await withEnv({ DIRECT_TERMINAL_PORT: "14803", TERMINAL_PORT: "14802" }, async () => {
+    it("returns runtime direct terminal port and host from server env", async () => {
+      await withEnv(
+        {
+          DIRECT_TERMINAL_PORT: "14803",
+          TERMINAL_PORT: "14802",
+          AO_DIRECT_TERMINAL_HOST: "0.0.0.0",
+        },
+        async () => {
         const res = await runtimeTerminalGET();
         expect(res.status).toBe(200);
         const data = await res.json();
         expect(data.directTerminalPort).toBe("14803");
         expect(data.terminalPort).toBe("14802");
-      });
+        expect(data.directTerminalHost).toBe("0.0.0.0");
+      },
+      );
     });
 
-    it("falls back to default ports when env vars are absent", async () => {
-      await withEnv({ DIRECT_TERMINAL_PORT: undefined, TERMINAL_PORT: undefined }, async () => {
+    it("falls back to default ports and loopback host when env vars are absent", async () => {
+      await withEnv(
+        {
+          DIRECT_TERMINAL_PORT: undefined,
+          TERMINAL_PORT: undefined,
+          HOST: undefined,
+          AO_DASHBOARD_HOST: undefined,
+          AO_DIRECT_TERMINAL_HOST: undefined,
+        },
+        async () => {
         const res = await runtimeTerminalGET();
         expect(res.status).toBe(200);
         const data = await res.json();
         expect(data.directTerminalPort).toBe("14801");
         expect(data.terminalPort).toBe("14800");
-      });
+        expect(data.directTerminalHost).toBe("127.0.0.1");
+      },
+      );
+    });
+
+    it("inherits legacy HOST exposure when direct terminal host is unset", async () => {
+      await withEnv(
+        {
+          HOST: "0.0.0.0",
+          AO_DASHBOARD_HOST: undefined,
+          AO_DIRECT_TERMINAL_HOST: undefined,
+        },
+        async () => {
+          const res = await runtimeTerminalGET();
+          expect(res.status).toBe(200);
+          const data = await res.json();
+          expect(data.directTerminalHost).toBe("0.0.0.0");
+        },
+      );
     });
 
     it("falls back to default ports for non-numeric env values", async () => {

--- a/packages/web/src/app/api/runtime/terminal/route.ts
+++ b/packages/web/src/app/api/runtime/terminal/route.ts
@@ -17,15 +17,26 @@ function normalizeProxyPath(input: string | undefined): string | null {
   return trimmed;
 }
 
+function normalizeHost(input: string | undefined, fallback: string): string {
+  const trimmed = input?.trim();
+  return trimmed ? trimmed : fallback;
+}
+
 export async function GET() {
   const terminalPort = normalizePort(process.env.TERMINAL_PORT, 14800);
   const directTerminalPort = normalizePort(process.env.DIRECT_TERMINAL_PORT, 14801);
+  const directTerminalHost = normalizeHost(
+    process.env.AO_DIRECT_TERMINAL_HOST ??
+      process.env.AO_DASHBOARD_HOST ??
+      process.env.HOST,
+    "127.0.0.1",
+  );
   const proxyWsPath = normalizeProxyPath(
     process.env.TERMINAL_WS_PATH ?? process.env.NEXT_PUBLIC_TERMINAL_WS_PATH,
   );
 
   return NextResponse.json(
-    { terminalPort, directTerminalPort, proxyWsPath },
+    { terminalPort, directTerminalPort, directTerminalHost, proxyWsPath },
     { headers: { "Cache-Control": "no-store" } },
   );
 }

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -510,6 +510,8 @@ export function DirectTerminal({
   const statusDotClass =
     displayStatus === "connected"
       ? "bg-[var(--color-status-ready)]"
+      : displayStatus === "unavailable"
+        ? "bg-[var(--color-status-respond)]"
       : displayStatus === "error" || displayStatus === "disconnected"
         ? "bg-[var(--color-status-error)]"
         : "bg-[var(--color-status-attention)] animate-[pulse_1.5s_ease-in-out_infinite]";
@@ -517,6 +519,8 @@ export function DirectTerminal({
   const statusText =
     displayStatus === "connected"
       ? "Connected"
+      : displayStatus === "unavailable"
+        ? "Terminal unavailable"
       : displayStatus === "error"
         ? (error ?? "Error")
         : displayStatus === "disconnected"
@@ -526,6 +530,8 @@ export function DirectTerminal({
   const statusTextColor =
     displayStatus === "connected"
       ? "text-[var(--color-status-ready)]"
+      : displayStatus === "unavailable"
+        ? "text-[var(--color-status-respond)]"
       : displayStatus === "error" || displayStatus === "disconnected"
         ? "text-[var(--color-status-error)]"
         : "text-[var(--color-text-tertiary)]";

--- a/packages/web/src/providers/MuxProvider.tsx
+++ b/packages/web/src/providers/MuxProvider.tsx
@@ -9,7 +9,7 @@ interface MuxContextValue {
   openTerminal: (id: string) => void;
   closeTerminal: (id: string) => void;
   resizeTerminal: (id: string, cols: number, rows: number) => void;
-  status: "connecting" | "connected" | "reconnecting" | "disconnected";
+  status: "connecting" | "connected" | "reconnecting" | "disconnected" | "unavailable";
   sessions: SessionPatch[];
 }
 
@@ -30,6 +30,7 @@ export function useMuxOptional(): MuxContextValue | undefined {
 
 interface RuntimeTerminalConfig {
   directTerminalPort?: unknown;
+  directTerminalHost?: unknown;
   proxyWsPath?: unknown;
 }
 
@@ -47,7 +48,22 @@ function normalizePathValue(value: unknown): string | undefined {
   return trimmed;
 }
 
-function buildMuxWsUrl(runtimeConfig: { directTerminalPort?: string; proxyWsPath?: string }): string {
+function normalizeHostValue(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function isLoopbackHost(host: string): boolean {
+  const normalized = host.trim().replace(/^\[(.*)\]$/, "$1").toLowerCase();
+  return normalized === "127.0.0.1" || normalized === "localhost" || normalized === "::1";
+}
+
+function buildMuxWsUrl(runtimeConfig: {
+  directTerminalPort?: string;
+  directTerminalHost?: string;
+  proxyWsPath?: string;
+}): string | null {
   const loc = window.location;
   const protocol = loc.protocol === "https:" ? "wss:" : "ws:";
 
@@ -64,6 +80,11 @@ function buildMuxWsUrl(runtimeConfig: { directTerminalPort?: string; proxyWsPath
   }
 
   // Direct port connection — prefer runtime-configured port, fall back to env/default
+  const directHost =
+    runtimeConfig.directTerminalHost ?? process.env.NEXT_PUBLIC_DIRECT_TERMINAL_HOST ?? "127.0.0.1";
+  if (isLoopbackHost(directHost) && !isLoopbackHost(loc.hostname)) {
+    return null;
+  }
   const port = runtimeConfig.directTerminalPort ?? process.env.NEXT_PUBLIC_DIRECT_TERMINAL_PORT ?? "14801";
   return `${protocol}//${loc.hostname}:${port}/mux`;
 }
@@ -72,13 +93,19 @@ export function MuxProvider({ children }: { children: ReactNode }) {
   const wsRef = useRef<WebSocket | null>(null);
   const subscribersRef = useRef(new Map<string, Set<(data: string) => void>>());
   const openedTerminalsRef = useRef(new Set<string>());
-  const [status, setStatus] = useState<"connecting" | "connected" | "reconnecting" | "disconnected">(
+  const [status, setStatus] = useState<
+    "connecting" | "connected" | "reconnecting" | "disconnected" | "unavailable"
+  >(
     "connecting",
   );
   const [sessions, setSessions] = useState<SessionPatch[]>([]);
   const reconnectAttempt = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const runtimeConfigRef = useRef<{ directTerminalPort?: string; proxyWsPath?: string }>({});
+  const runtimeConfigRef = useRef<{
+    directTerminalPort?: string;
+    directTerminalHost?: string;
+    proxyWsPath?: string;
+  }>({});
   const isDestroyedRef = useRef(false);
 
   const connect = useCallback(() => {
@@ -90,6 +117,11 @@ export function MuxProvider({ children }: { children: ReactNode }) {
 
     try {
       const url = buildMuxWsUrl(runtimeConfigRef.current);
+      if (!url) {
+        console.warn("[MuxProvider] Direct terminal is unavailable from this browser context");
+        setStatus("unavailable");
+        return;
+      }
       console.log("[MuxProvider] Connecting to", url);
       const ws = new WebSocket(url);
       // Assign immediately so cleanup can close it even during CONNECTING state
@@ -202,6 +234,7 @@ export function MuxProvider({ children }: { children: ReactNode }) {
           const data = (await res.json()) as RuntimeTerminalConfig;
           runtimeConfigRef.current = {
             directTerminalPort: normalizePortValue(data.directTerminalPort),
+            directTerminalHost: normalizeHostValue(data.directTerminalHost),
             proxyWsPath: normalizePathValue(data.proxyWsPath),
           };
         }

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -557,4 +557,34 @@ describe("buildMuxWsUrl", () => {
     await flushInit();
     expect(MockWebSocket.instances[0].url).toMatch(/\/ao-terminal-mux$/);
   });
+
+  it("marks terminal unavailable when direct terminal is loopback-only from a remote custom-port UI", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ directTerminalPort: 14802, directTerminalHost: "127.0.0.1" }),
+      })),
+    );
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: {
+        protocol: "http:",
+        host: "ao.example.test:3000",
+        hostname: "ao.example.test",
+        port: "3000",
+      },
+    });
+
+    const { result } = renderHook(() => useMux(), { wrapper });
+    await flushInit();
+
+    expect(result.current.status).toBe("unavailable");
+    expect(MockWebSocket.instances).toHaveLength(0);
+
+    Object.defineProperty(window, "location", {
+      writable: true,
+      value: { protocol: "http:", host: "localhost", hostname: "localhost", port: "" },
+    });
+  });
 });


### PR DESCRIPTION
## Why

This PR fixes the two verified security findings from the audit without introducing an app-level auth system:

1. the AO dashboard/control-plane HTTP surface was reachable remotely whenever the app was bound off-loopback; and
2. the direct terminal WebSocket (`/mux`) was likewise remotely reachable without built-in auth.

The constraint here was important: keep the OSS workflow simple, avoid bolting on login/auth, and make the smallest realistic change that materially improves the default security posture.

The result is a safer default with explicit remote opt-in.

## What changed

### 1) Dashboard and direct terminal now default to loopback

AO now binds both the Next.js dashboard and the direct terminal WebSocket to `127.0.0.1` by default.

That means a plain `ao start` behaves as a local-only control plane unless the operator explicitly opts into remote exposure.

### 2) Remote exposure is explicit, warned, and still supported

If someone intentionally wants remote access, they can still do it with env vars:

```bash
HOST=0.0.0.0 ao start
```

or more selectively:

```bash
AO_DASHBOARD_HOST=0.0.0.0 AO_DIRECT_TERMINAL_HOST=127.0.0.1 ao start
```

Startup now emits warnings whenever either the dashboard HTTP API or direct terminal WebSocket is intentionally bound off-loopback without built-in auth.

### 3) Existing `HOST=...` remote setups keep working

A key compatibility detail: if an existing deployment already uses the older `HOST=0.0.0.0` pattern, the direct terminal now inherits that host unless `AO_DIRECT_TERMINAL_HOST` is explicitly set.

That preserves existing remote workflows instead of silently making the dashboard reachable while leaving terminal access broken.

### 4) Runtime terminal config now includes host metadata

`GET /api/runtime/terminal` now returns the direct terminal host alongside the runtime-selected ports and proxy path.

That allows the browser to distinguish between:
- a directly reachable terminal endpoint,
- a reverse-proxied terminal path, and
- a terminal that is intentionally loopback-only.

### 5) The frontend degrades cleanly when direct terminal is intentionally local-only

When the browser is remote and the direct terminal is loopback-bound, the mux provider now marks the terminal as `unavailable` instead of endlessly retrying a broken connection path.

The DirectTerminal UI now surfaces this state as **"Terminal unavailable"**, which is much clearer than repeated reconnect churn.

### 6) `packages/web` startup scripts are now cross-platform

The web package previously relied on POSIX shell expansion for host defaults. This PR replaces that with a small Node launcher script so `dev`/`start` respect the same host rules on macOS, Linux, and Windows.

### 7) Tests and docs were updated with the new behavior

The PR adds regression coverage for:
- loopback-default host resolution,
- legacy `HOST` fallback compatibility,
- runtime terminal host reporting,
- remote/loopback terminal unavailability behavior, and
- tmux-missing integration environments skipping cleanly.

It also updates the docs so users understand the new defaults and the explicit env-based opt-in path for remote exposure.

## Behavioral summary

### Before
- `ao start` could expose the dashboard control plane remotely depending on bind host.
- direct terminal exposure followed the same general pattern and could be reachable remotely without app-layer auth.
- remote browsers could end up attempting terminal connections that were invalid for the actual network topology.

### After
- `ao start` is local-only by default.
- remote exposure requires an explicit operator choice.
- old `HOST=...` remote setups continue to work.
- remote browsers get a clean unavailable state when direct terminal is intentionally local-only.

## No-auth constraint preserved

This PR does **not** add login, sessions, auth middleware, or proxy-coupled assumptions.

Instead, it tightens the default network boundary and makes unsafe exposure an explicit, operator-controlled decision.

That felt like the right tradeoff for an OSS tool whose normal usage is local-first.

## Docs updated

- `README.md`
- `docs/CLI.md`
- `docs/DEVELOPMENT.md`

These now document:
- loopback-by-default behavior,
- explicit remote exposure examples,
- `HOST`, `AO_DASHBOARD_HOST`, and `AO_DIRECT_TERMINAL_HOST`, and
- the host fallback behavior used by the web launcher/runtime.

## Validation

Passed:

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (warnings only; existing warnings remain)
- `pnpm test`
- `pnpm --filter @aoagents/ao-web test`

Note: the direct terminal integration suite now skips cleanly when `tmux` is unavailable, rather than failing the run.

## Reviewer guide

The most important files to review are:

- `packages/cli/src/lib/web-dir.ts`
- `packages/web/server/start-all.ts`
- `packages/web/server/direct-terminal-ws.ts`
- `packages/web/src/app/api/runtime/terminal/route.ts`
- `packages/web/src/providers/MuxProvider.tsx`
- `packages/web/scripts/run-next.cjs`

## Practical operator notes

If you want the old remotely reachable behavior, it is still available — it is just no longer accidental.

Examples:

```bash
# expose both dashboard and direct terminal
HOST=0.0.0.0 ao start

# expose only the dashboard; keep direct terminal local
AO_DASHBOARD_HOST=0.0.0.0 AO_DIRECT_TERMINAL_HOST=127.0.0.1 ao start
```

That puts the operator in control of the risk boundary, which is exactly where it should be.
