### PR TITLE
Fix: Sessions page scrolling issue by allowing vertical overflow

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1023,7 +1023,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   flex: 1;
   min-height: 0;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
   background: var(--color-bg-base);
 }
 


### PR DESCRIPTION
The Sessions detail page was unable to scroll when content exceeded viewport height due to the parent container having overflow: hidden. This prevented users from reaching content below the fold.

Changed .dashboard-main--desktop overflow property from hidden to overflow-y: auto to allow vertical scrolling while maintaining proper layout constraints.

Verification:
- pnpm build: Passed
- All 2413 tests passed
- SessionDetail component tests: Passed
- No regressions detected

Closes #1235