### PR TITLE
Fix terminal theme sync in session detail

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -654,7 +654,6 @@ export function SessionDetail({
                         sessionId={session.id}
                         startFullscreen={startFullscreen}
                         variant={terminalVariant}
-                        appearance="dark"
                         height={terminalHeight}
                         isOpenCodeSession={isOpenCodeSession}
                         reloadCommand={isOpenCodeSession ? reloadCommand : undefined}
@@ -715,7 +714,6 @@ export function SessionDetail({
             sessionId={session.id}
             startFullscreen={startFullscreen}
             variant={terminalVariant}
-            appearance="dark"
             height="100%"
             chromeless
             isOpenCodeSession={isOpenCodeSession}

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -10,8 +10,18 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("../DirectTerminal", () => ({
-  DirectTerminal: ({ sessionId }: { sessionId: string }) => (
-    <div data-testid="direct-terminal">{sessionId}</div>
+  DirectTerminal: ({
+    sessionId,
+    appearance,
+  }: {
+    sessionId: string;
+    appearance?: string;
+  }) => (
+    <div
+      data-testid="direct-terminal"
+      data-session-id={sessionId}
+      data-appearance={appearance ?? ""}
+    />
   ),
 }));
 
@@ -210,5 +220,18 @@ describe("SessionDetail desktop layout", () => {
 
     expect(screen.queryByRole("link", { name: "Orchestrator" })).not.toBeInTheDocument();
     expect(screen.getByText("orchestrator")).toBeInTheDocument();
+  });
+
+  it("lets the terminal inherit the active app theme on desktop", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-themed",
+          projectId: "my-app",
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("direct-terminal")).toHaveAttribute("data-appearance", "");
   });
 });

--- a/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.mobile.test.tsx
@@ -8,8 +8,18 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("../DirectTerminal", () => ({
-  DirectTerminal: ({ sessionId }: { sessionId: string }) => (
-    <div data-testid="direct-terminal">{sessionId}</div>
+  DirectTerminal: ({
+    sessionId,
+    appearance,
+  }: {
+    sessionId: string;
+    appearance?: string;
+  }) => (
+    <div
+      data-testid="direct-terminal"
+      data-session-id={sessionId}
+      data-appearance={appearance ?? ""}
+    />
   ),
 }));
 
@@ -32,6 +42,11 @@ function mockMobileViewport() {
 describe("SessionDetail mobile navbar", () => {
   beforeEach(() => {
     mockMobileViewport();
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    window.cancelAnimationFrame = vi.fn();
   });
 
   it("shows dashboard, PRs, and orchestrator nav on orchestrator pages", () => {
@@ -187,5 +202,19 @@ describe("SessionDetail mobile navbar", () => {
 
     expect(screen.getByRole("link", { name: /PR #89/i })).toBeInTheDocument();
     expect(screen.getByText("worker-merged")).toBeInTheDocument();
+  });
+
+  it("lets the terminal inherit the active app theme on mobile", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-mobile-theme",
+          projectId: "my-app",
+        })}
+        projectOrchestratorId="my-app-orchestrator"
+      />,
+    );
+
+    expect(screen.getByTestId("direct-terminal")).toHaveAttribute("data-appearance", "");
   });
 });


### PR DESCRIPTION
Fixes #1283

## Summary
- stop forcing `SessionDetail` terminals into `appearance="dark"`
- add desktop and mobile regression tests that verify the terminal can inherit the active app theme

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/components/__tests__/SessionDetail.desktop.test.tsx src/components/__tests__/SessionDetail.mobile.test.tsx`
- `pnpm lint`
- `pnpm -r --filter '!@aoagents/ao-web' build && pnpm --filter @aoagents/ao-web build`
