### PR TITLE
fix(core): write long worker prompts to file to prevent truncation

### DIFF
--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1076,7 +1076,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       userPrompt: spawnConfig.prompt,
     });
 
-    // Get agent launch config and create runtime — clean up workspace on failure
+    // Write composed prompt to file for long prompts to avoid shell/tmux truncation.
+    // Mirrors spawnOrchestrator()'s systemPromptFile pattern.
+    let promptFile: string | undefined;
+    if (composedPrompt.length > 500) {
+      try {
+        const baseDir = getProjectBaseDir(config.configPath, project.path, project.storageKey);
+        mkdirSync(baseDir, { recursive: true });
+        promptFile = join(baseDir, `worker-prompt-${sessionId}.md`);
+        writeFileSync(promptFile, composedPrompt, "utf-8");
+      } catch {
+        // Non-fatal: fall back to inline prompt
+        promptFile = undefined;
+      }
+    }
+// Get agent launch config and create runtime — clean up workspace on failure
     const opencodeIssueSessionStrategy = project.opencodeIssueSessionStrategy ?? "reuse";
     const reusedOpenCodeSessionId =
       plugins.agent.name === "opencode" && spawnConfig.issueId
@@ -1096,7 +1110,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         },
       },
       issueId: spawnConfig.issueId,
-      prompt: composedPrompt,
+      ...(promptFile
+        ? { systemPromptFile: promptFile, prompt: spawnConfig.prompt }
+        : { prompt: composedPrompt }),
       permissions: selection.permissions,
       model: selection.model,
       subagent: spawnConfig.subagent ?? selection.subagent,


### PR DESCRIPTION
## Summary

Fixes #1304

When `ao spawn --prompt "xyz"` is used, `buildPrompt()` composes a layered prompt (BASE_AGENT_PROMPT + project context + rules + user prompt) that easily exceeds 500 chars. The full string was being inlined into a compound shell command and sent via tmux paste-buffer, where it could silently fail if session ID discovery failed.

**Fix:** Mirrors `spawnOrchestrator()`'s `systemPromptFile` pattern — long prompts (>500 chars) are written to a file, and the agent launch config uses `systemPromptFile` instead of the inline prompt. The opencode plugin already handles `systemPromptFile` correctly via `$(cat ...)` substitution.

## Changes

- **`packages/core/src/session-manager.ts`**: In the worker `spawn()` path, after composing the prompt via `buildPrompt()`, if the result exceeds 500 characters, write it to a file (`worker-prompt-<sessionId>.md`) and set `systemPromptFile` on the launch config. Falls back to inline prompt on write failure (non-fatal).

## Test Plan

1. `ao spawn --prompt "Fix the authentication bug"` — verify agent receives prompt
2. `ao spawn --prompt "short"` (under 500 chars) — verify inline prompt still works
3. Spawn from orchestrator — verify worker picks up the prompt
4. `pnpm --filter @aoagents/ao-core test` — verify existing tests pass