### PR TITLE
fix(workspace-worktree): resolve symlink source to absolute path

### DIFF
--- a/.changeset/fix-worktree-symlink-absolute-source.md
+++ b/.changeset/fix-worktree-symlink-absolute-source.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-plugin-workspace-worktree": patch
+---
+
+Fix self-referential symlinks when `project.path` is relative. The postCreate hook built `sourcePath` with `join(repoPath, symlinkPath)`, so a relative `project.path` like `"."` produced a relative `sourcePath` such as `"node_modules"`. Symlinks resolve relative to the symlink's own directory, so `<worktree>/node_modules -> node_modules` loops back to itself and the next `pnpm install` fails with `ELOOP: too many symbolic links encountered`. Use `resolve()` so the source is always absolute.

--- a/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
+++ b/packages/plugins/workspace-worktree/src/__tests__/index.test.ts
@@ -31,6 +31,7 @@ vi.mock("node:os", () => ({
 
 import * as childProcess from "node:child_process";
 import { existsSync, lstatSync, symlinkSync, rmSync, mkdirSync, readdirSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import { create, manifest } from "../index.js";
 
 // ---------------------------------------------------------------------------
@@ -917,5 +918,26 @@ describe("workspace.postCreate()", () => {
       "/mock-home/my-repo/data",
       "/mock-home/.worktrees/myproject/session-1/data",
     );
+  });
+
+  it("produces an absolute symlink source when project.path is relative", async () => {
+    // Regression: a relative project.path like "." produced a relative
+    // sourcePath such as "node_modules". Symlinks resolve relative to the
+    // symlink's own location, so `<worktree>/node_modules -> node_modules`
+    // loops back to itself and breaks the next `pnpm install` with ELOOP.
+    const ws = create();
+    const project = makeProject({ path: ".", symlinks: ["node_modules"] });
+
+    mockExistsSync.mockReturnValueOnce(true);
+    mockLstatSync.mockImplementationOnce(() => {
+      throw new Error("ENOENT");
+    });
+
+    await ws.postCreate!(workspaceInfo, project);
+
+    expect(mockSymlinkSync).toHaveBeenCalledTimes(1);
+    const [sourcePath] = mockSymlinkSync.mock.calls[0] as [string, string];
+    expect(isAbsolute(sourcePath)).toBe(true);
+    expect(sourcePath.endsWith("/node_modules")).toBe(true);
   });
 });

--- a/packages/plugins/workspace-worktree/src/index.ts
+++ b/packages/plugins/workspace-worktree/src/index.ts
@@ -323,7 +323,12 @@ export function create(config?: Record<string, unknown>): Workspace {
             );
           }
 
-          const sourcePath = join(repoPath, symlinkPath);
+          // Use resolve() (not join()) so that a relative project.path like
+          // "." produces an absolute sourcePath. Symlinks resolve relative to
+          // the symlink's own directory, so a relative source like
+          // "node_modules" becomes `<worktree>/node_modules -> node_modules` —
+          // a self-referential loop that breaks pnpm install with ELOOP.
+          const sourcePath = resolve(repoPath, symlinkPath);
           const targetPath = resolve(info.path, symlinkPath);
 
           // Verify resolved target is still within the workspace


### PR DESCRIPTION
## Summary

`postCreate` in `packages/plugins/workspace-worktree/src/index.ts` builds `sourcePath` with `join(repoPath, symlinkPath)`. When `project.path` is a relative path like `"."`, `repoPath` stays `"."` and `join(".", "node_modules")` returns `"node_modules"` — a relative string. `symlinkSync("node_modules", "/path/to/worktree/node_modules")` then creates a self-referential link:

```
<worktree>/node_modules -> node_modules
```

Symlinks are resolved relative to the **symlink's own directory**, so the link loops back to itself. The next `pnpm install` fails with:

```
ELOOP: too many symbolic links encountered, open '<worktree>/node_modules/.pnpm-workspace-state-v1.json'
```

`ao spawn` only surfaces the top-level `✖ Failed to create or initialize session` / `✗ Command failed: sh -c …` message, so the real ELOOP is swallowed — took a while to find it.

## Fix

Use `resolve(repoPath, symlinkPath)` instead of `join(…)`. `resolve()` anchors a relative `repoPath` against `process.cwd()` and leaves absolute / `~`-prefixed paths unchanged, so existing configs are unaffected.

```diff
- const sourcePath = join(repoPath, symlinkPath);
+ const sourcePath = resolve(repoPath, symlinkPath);
  const targetPath = resolve(info.path, symlinkPath);
```

The adjacent `targetPath` line already uses `resolve()` for the same reason — this just makes the two consistent.

## Repro

```yaml
# agent-orchestrator.yaml
projects:
  myproject:
    path: .
    symlinks: [node_modules]
```

Run `ao spawn` — every spawn fails until `symlinks:` is removed or the `path:` is made absolute.

## Tests

Added `produces an absolute symlink source when project.path is relative` in `workspace.postCreate()`. Fails on `main`, passes with the fix.

- 47/47 tests pass (`pnpm --filter @aoagents/ao-plugin-workspace-worktree test`)
- `pnpm typecheck` clean
- `pnpm lint` on changed files: 0 errors, 0 warnings
- `prettier --check` clean

Patch-level changeset included.

## Verified in production

Applied the equivalent patch to an installed 0.2.5 instance that had been blocked by this bug for ~2 days. `ao spawn` immediately started producing real sessions that progress through the full lifecycle and open PRs. Reverted once upstream publishes with the fix.