### PR TITLE
fix(web): surface dashboard SSR load failures

### DIFF
--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -30,6 +30,7 @@ export default async function Home(props: { searchParams: Promise<{ project?: st
       projects={pageData.projects}
       orchestrators={pageData.orchestrators}
       attentionZones={pageData.attentionZones}
+      dashboardLoadError={pageData.dashboardLoadError}
     />
   );
 }

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -82,7 +82,7 @@ function DoneCard({
     session.issueTitle ||
     session.summary ||
     session.id;
-  const isMerged = session.pr?.state === "merged";
+  const isMerged = session.pr?.state === "merged" || session.status === "merged";
   const isTerminated = session.status === "killed" || session.status === "terminated";
   const badgeLabel = isMerged ? "merged" : isTerminated ? "terminated" : "done";
   const badgeClass = `done-card__badge ${isTerminated ? "done-card__badge--terminated" : "done-card__badge--merged"}`;
@@ -109,16 +109,18 @@ function DoneCard({
           </a>
         ) : null}
         <span className="done-card__age">{formatRelativeTimeCompact(session.lastActivityAt)}</span>
-        <button
-          type="button"
-          className="done-card__restore"
-          onClick={(e) => {
-            e.stopPropagation();
-            onRestore(session.id);
-          }}
-        >
-          Restore
-        </button>
+        {!isMerged ? (
+          <button
+            type="button"
+            className="done-card__restore"
+            onClick={(e) => {
+              e.stopPropagation();
+              onRestore(session.id);
+            }}
+          >
+            Restore
+          </button>
+        ) : null}
       </div>
     </div>
   );
@@ -143,14 +145,14 @@ function DashboardInner({
     }
     return levels;
   }, [initialSessions, attentionZones]);
-  const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents({
+  const { sessions, connectionStatus, sseAttentionLevels, liveSessionsResolved } = useSessionEvents({
     initialSessions,
     project: projectId,
     muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
     attentionZones,
   });
-  const recoveredFromLoadError = Boolean(dashboardLoadError) && sessions.length > 0;
+  const recoveredFromLoadError = Boolean(dashboardLoadError) && liveSessionsResolved;
   const visibleDashboardLoadError = recoveredFromLoadError ? undefined : dashboardLoadError;
   const searchParams = useSearchParams();
   const activeSessionId = searchParams.get("session") ?? undefined;

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -30,6 +30,8 @@ interface DashboardProps {
   orchestrators?: DashboardOrchestratorLink[];
   /** Dashboard attention zone mode (defaults to "simple" — 4 zones). */
   attentionZones?: DashboardAttentionZoneMode;
+  /** SSR/services failure — show an error banner instead of a misleading empty dashboard */
+  dashboardLoadError?: string;
 }
 
 const SIMPLE_KANBAN_LEVELS = ["working", "pending", "action", "merge"] as const;
@@ -129,6 +131,7 @@ function DashboardInner({
   projects = [],
   orchestrators,
   attentionZones = "simple",
+  dashboardLoadError,
 }: DashboardProps) {
   const orchestratorLinks = orchestrators ?? EMPTY_ORCHESTRATORS;
   const mux = useMuxOptional();
@@ -140,11 +143,13 @@ function DashboardInner({
     }
     return levels;
   }, [initialSessions, attentionZones]);
+  const disableRealtime = Boolean(dashboardLoadError);
   const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents({
     initialSessions,
     project: projectId,
     muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
+    disabled: disableRealtime,
     attentionZones,
   });
   const searchParams = useSearchParams();
@@ -399,7 +404,22 @@ function DashboardInner({
   };
 
   const hasAnySessions = kanbanLevels.some((level) => grouped[level].length > 0);
-  const showEmptyState = !allProjectsView && !hasAnySessions;
+  const showEmptyState = !allProjectsView && !hasAnySessions && !dashboardLoadError;
+
+  const loadErrorBanner = dashboardLoadError ? (
+    <div
+      className="dashboard-alert mb-6 flex flex-col gap-1.5 border border-[color-mix(in_srgb,var(--color-status-error)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-status-error)_10%,transparent)] px-3.5 py-2.5 text-[11px] md:mb-4"
+      role="alert"
+      aria-live="assertive"
+    >
+      <span className="font-semibold text-[var(--color-status-error)]">Orchestrator failed to load</span>
+      <span className="break-words text-[var(--color-text-secondary)]">{dashboardLoadError}</span>
+      <span className="text-[var(--color-text-secondary)]">
+        Confirm <span className="font-mono text-[10px]">agent-orchestrator.yaml</span> exists and is valid, then run{" "}
+        <span className="font-mono text-[10px]">ao doctor</span> for diagnostics.
+      </span>
+    </div>
+  ) : null;
 
   const anyRateLimited = useMemo(
     () => sessions.some((session) => session.pr && isPRRateLimited(session.pr)),
@@ -522,6 +542,7 @@ function DashboardInner({
               </div>
 
               <div className="dashboard-main__body">
+                {loadErrorBanner}
                 {anyRateLimited && !rateLimitDismissed && (
                   <div className="dashboard-alert mb-4 flex items-center gap-2.5 border border-[color-mix(in_srgb,var(--color-status-attention)_25%,transparent)] bg-[var(--color-tint-yellow)] px-3.5 py-2.5 text-[11px] text-[var(--color-status-attention)]">
                     <svg

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -143,15 +143,15 @@ function DashboardInner({
     }
     return levels;
   }, [initialSessions, attentionZones]);
-  const disableRealtime = Boolean(dashboardLoadError);
   const { sessions, connectionStatus, sseAttentionLevels } = useSessionEvents({
     initialSessions,
     project: projectId,
     muxSessions: mux?.status === "connected" ? mux.sessions : undefined,
     initialAttentionLevels,
-    disabled: disableRealtime,
     attentionZones,
   });
+  const recoveredFromLoadError = Boolean(dashboardLoadError) && sessions.length > 0;
+  const visibleDashboardLoadError = recoveredFromLoadError ? undefined : dashboardLoadError;
   const searchParams = useSearchParams();
   const activeSessionId = searchParams.get("session") ?? undefined;
   const [rateLimitDismissed, setRateLimitDismissed] = useState(false);
@@ -404,16 +404,16 @@ function DashboardInner({
   };
 
   const hasAnySessions = kanbanLevels.some((level) => grouped[level].length > 0);
-  const showEmptyState = !allProjectsView && !hasAnySessions && !dashboardLoadError;
+  const showEmptyState = !allProjectsView && !hasAnySessions && !visibleDashboardLoadError;
 
-  const loadErrorBanner = dashboardLoadError ? (
+  const loadErrorBanner = visibleDashboardLoadError ? (
     <div
       className="dashboard-alert mb-6 flex flex-col gap-1.5 border border-[color-mix(in_srgb,var(--color-status-error)_28%,transparent)] bg-[color-mix(in_srgb,var(--color-status-error)_10%,transparent)] px-3.5 py-2.5 text-[11px] md:mb-4"
       role="alert"
       aria-live="assertive"
     >
       <span className="font-semibold text-[var(--color-status-error)]">Orchestrator failed to load</span>
-      <span className="break-words text-[var(--color-text-secondary)]">{dashboardLoadError}</span>
+      <span className="break-words text-[var(--color-text-secondary)]">{visibleDashboardLoadError}</span>
       <span className="text-[var(--color-text-secondary)]">
         Confirm <span className="font-mono text-[10px]">agent-orchestrator.yaml</span> exists and is valid, then run{" "}
         <span className="font-mono text-[10px]">ao doctor</span> for diagnostics.

--- a/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Dashboard } from "../Dashboard";
 
+const eventSourceConstructorMock = vi.hoisted(() => vi.fn());
+
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
   usePathname: () => "/",
@@ -14,8 +16,9 @@ beforeEach(() => {
     onerror: null,
     close: vi.fn(),
   };
-  const eventSourceConstructor = vi.fn(() => eventSourceMock as unknown as EventSource);
-  global.EventSource = Object.assign(eventSourceConstructor, {
+  eventSourceConstructorMock.mockReset();
+  eventSourceConstructorMock.mockImplementation(() => eventSourceMock as unknown as EventSource);
+  global.EventSource = Object.assign(eventSourceConstructorMock, {
     CONNECTING: 0,
     OPEN: 1,
     CLOSED: 2,
@@ -69,6 +72,7 @@ describe("Dashboard empty state", () => {
     expect(screen.queryByText(/Ready to orchestrate/i)).not.toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent("Orchestrator failed to load");
     expect(screen.getByRole("alert")).toHaveTextContent("No agent-orchestrator.yaml found");
+    expect(eventSourceConstructorMock).toHaveBeenCalledTimes(1);
   });
 
   it("shows empty state when only done sessions exist", () => {

--- a/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.emptyState.test.tsx
@@ -59,6 +59,18 @@ describe("Dashboard empty state", () => {
     expect(queryByText(/Ready to orchestrate/i)).not.toBeInTheDocument();
   });
 
+  it("shows load error banner instead of empty state when SSR services failed", () => {
+    render(
+      <Dashboard
+        initialSessions={[]}
+        dashboardLoadError="No agent-orchestrator.yaml found"
+      />,
+    );
+    expect(screen.queryByText(/Ready to orchestrate/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Orchestrator failed to load");
+    expect(screen.getByRole("alert")).toHaveTextContent("No agent-orchestrator.yaml found");
+  });
+
   it("shows empty state when only done sessions exist", () => {
     render(
       <Dashboard

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -178,7 +178,7 @@ describe("ProjectSidebar", () => {
         projects={projects}
         sessions={[
           makeSession({
-            id: "project-1-orchestrator",
+            id: "project-1-orchestrator-0",
             projectId: "project-1",
             summary: "Orchestrator",
           }),

--- a/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
+++ b/packages/web/src/hooks/__tests__/useSessionEvents.mux.test.ts
@@ -38,7 +38,7 @@ describe("useSessionEvents - mux", () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith(
         "/api/sessions?project=proj",
-        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+        expect.objectContaining({ signal: expect.any(AbortSignal), cache: "no-store" }),
       );
     });
   });

--- a/packages/web/src/hooks/useSessionEvents.ts
+++ b/packages/web/src/hooks/useSessionEvents.ts
@@ -27,12 +27,19 @@ interface State {
   connectionStatus: ConnectionStatus;
   /** Attention levels from the latest SSE snapshot (server-computed, includes PR state). */
   sseAttentionLevels: SSEAttentionMap;
+  /**
+   * True after a real success signal from the live path: HTTP 200 `/api/sessions` refresh,
+   * an SSE snapshot, or a mux snapshot — not inferred from session count (which can mislead
+   * when SSR failed or responses are stale).
+   */
+  liveSessionsResolved: boolean;
 }
 
 type Action =
   | { type: "reset"; sessions: DashboardSession[]; sseAttentionLevels?: SSEAttentionMap }
   | { type: "snapshot"; patches: SSESnapshotEvent["sessions"] }
-  | { type: "setConnection"; status: ConnectionStatus };
+  | { type: "setConnection"; status: ConnectionStatus }
+  | { type: "markLiveSessionsResolved" };
 
 function reducer(state: State, action: Action): State {
   switch (action.type) {
@@ -44,6 +51,9 @@ function reducer(state: State, action: Action): State {
           ? { sseAttentionLevels: action.sseAttentionLevels }
           : {}),
       };
+    case "markLiveSessionsResolved":
+      if (state.liveSessionsResolved) return state;
+      return { ...state, liveSessionsResolved: true };
     case "setConnection":
       return { ...state, connectionStatus: action.status };
     case "snapshot": {
@@ -127,6 +137,7 @@ export function useSessionEvents(options: UseSessionEventsOptions): State {
     sessions: initialSessions,
     connectionStatus: "connected" as ConnectionStatus,
     sseAttentionLevels: initialAttentionLevels ?? ({} as SSEAttentionMap),
+    liveSessionsResolved: false,
   });
   const sessionsRef = useRef(state.sessions);
   const initialAttentionLevelsRef = useRef(initialAttentionLevels);
@@ -179,7 +190,7 @@ export function useSessionEvents(options: UseSessionEventsOptions): State {
         ? `/api/sessions?project=${encodeURIComponent(project)}`
         : "/api/sessions";
 
-      void fetch(sessionsUrl, { signal: refreshController.signal })
+      void fetch(sessionsUrl, { signal: refreshController.signal, cache: "no-store" })
         .then((res) => (res.ok ? res.json() : null))
         .then(
           (updated: { sessions?: DashboardSession[] } | null) => {
@@ -192,6 +203,7 @@ export function useSessionEvents(options: UseSessionEventsOptions): State {
             }
 
             lastRefreshAtRef.current = Date.now();
+            dispatch({ type: "markLiveSessionsResolved" });
             const sseAttentionLevels = Object.fromEntries(
               updated.sessions.map((s) => [s.id, getAttentionLevel(s, attentionZones)]),
             ) as SSEAttentionMap;
@@ -249,6 +261,7 @@ export function useSessionEvents(options: UseSessionEventsOptions): State {
     // knows. So if we see ANY id we don't have, trigger a refresh to find out.
     const hasUnknownIds = muxSessions.some((s) => !currentIds.has(s.id));
 
+    dispatch({ type: "markLiveSessionsResolved" });
     dispatch({ type: "snapshot", patches: scopedMuxSessions as SSESnapshotEvent["sessions"] });
 
     const currentMembershipKey = createMembershipKey(sessionsRef.current);
@@ -315,6 +328,7 @@ export function useSessionEvents(options: UseSessionEventsOptions): State {
         const data = JSON.parse(event.data as string) as { type: string };
         if (data.type === "snapshot") {
           const snapshot = data as SSESnapshotEvent;
+          dispatch({ type: "markLiveSessionsResolved" });
           dispatch({ type: "snapshot", patches: snapshot.sessions });
 
           const currentMembershipKey = createMembershipKey(sessionsRef.current);

--- a/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
@@ -146,6 +146,23 @@ describe("getDashboardPageData fast path", () => {
     expect(pageData.dashboardLoadError).toBe("No agent-orchestrator.yaml found");
   });
 
+  it("applies attentionZones from config when getServices succeeds but sessionManager.list fails", async () => {
+    hoisted.getServicesMock.mockResolvedValue({
+      config: {
+        projects: { docs: { id: "docs" } },
+        dashboard: { attentionZones: "detailed" },
+      },
+      registry: { scm: "registry" },
+      sessionManager: { list: vi.fn().mockRejectedValue(new Error("list boom")) },
+    });
+
+    const pageData = await getDashboardPageData("docs");
+
+    expect(pageData.attentionZones).toBe("detailed");
+    expect(pageData.dashboardLoadError).toBe("list boom");
+    expect(pageData.sessions).toEqual([]);
+  });
+
   it("keeps the session list when PR enrichment fails", async () => {
     const core = { id: "session-pr", status: "working", pr: { number: 7 } };
     const dashboardSession = { id: "session-pr", pr: { state: "open", enriched: false } };

--- a/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
@@ -145,4 +145,27 @@ describe("getDashboardPageData fast path", () => {
     expect(pageData.orchestrators).toEqual([]);
     expect(pageData.dashboardLoadError).toBe("No agent-orchestrator.yaml found");
   });
+
+  it("keeps the session list when PR enrichment fails", async () => {
+    const core = { id: "session-pr", status: "working", pr: { number: 7 } };
+    const dashboardSession = { id: "session-pr", pr: { state: "open", enriched: false } };
+
+    hoisted.getServicesMock.mockResolvedValue({
+      config: { projects: { docs: { id: "docs" } } },
+      registry: { scm: "registry" },
+      sessionManager: { list: vi.fn().mockResolvedValue([core]) },
+    });
+    hoisted.filterProjectSessionsMock.mockReturnValue([core]);
+    hoisted.filterWorkerSessionsMock.mockReturnValue([core]);
+    hoisted.sessionToDashboardMock.mockReturnValue(dashboardSession);
+    hoisted.resolveProjectMock.mockReturnValue({ id: "docs" });
+    hoisted.getSCMMock.mockReturnValue({ provider: "github" });
+    hoisted.enrichSessionPRMock.mockRejectedValue(new Error("cache read failed"));
+
+    const pageData = await getDashboardPageData("docs");
+
+    expect(pageData.dashboardLoadError).toBeUndefined();
+    expect(pageData.sessions).toEqual([dashboardSession]);
+    expect(pageData.orchestrators).toEqual([{ id: "orch-1", projectId: "docs", projectName: "Docs" }]);
+  });
 });

--- a/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.fast-path.test.ts
@@ -135,4 +135,14 @@ describe("getDashboardPageData fast path", () => {
       vi.useRealTimers();
     }
   });
+
+  it("surfaces getServices failure as dashboardLoadError instead of a silent empty list", async () => {
+    hoisted.getServicesMock.mockRejectedValue(new Error("No agent-orchestrator.yaml found"));
+
+    const pageData = await getDashboardPageData("all");
+
+    expect(pageData.sessions).toEqual([]);
+    expect(pageData.orchestrators).toEqual([]);
+    expect(pageData.dashboardLoadError).toBe("No agent-orchestrator.yaml found");
+  });
 });

--- a/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/services", () => ({
   getSCM: vi.fn(),
 }));
 
-import { resolveDashboardProjectFilter } from "@/lib/dashboard-page-data";
+import { formatDashboardLoadError, resolveDashboardProjectFilter } from "@/lib/dashboard-page-data";
 
 describe("resolveDashboardProjectFilter", () => {
   beforeEach(() => {
@@ -44,5 +44,25 @@ describe("resolveDashboardProjectFilter", () => {
 
   it("falls back to primary project when no project is given", () => {
     expect(resolveDashboardProjectFilter(undefined)).toBe("mono");
+  });
+});
+
+describe("formatDashboardLoadError", () => {
+  it("uses Error.message when present", () => {
+    expect(formatDashboardLoadError(new Error("No agent-orchestrator.yaml found"))).toBe(
+      "No agent-orchestrator.yaml found",
+    );
+  });
+
+  it("trims whitespace from Error messages", () => {
+    expect(formatDashboardLoadError(new Error("  boom  "))).toBe("boom");
+  });
+
+  it("accepts string throws", () => {
+    expect(formatDashboardLoadError("config invalid")).toBe("config invalid");
+  });
+
+  it("falls back for unknown throws", () => {
+    expect(formatDashboardLoadError(null)).toMatch(/could not load dashboard data/i);
   });
 });

--- a/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
+++ b/packages/web/src/lib/__tests__/dashboard-page-data.test.ts
@@ -58,6 +58,12 @@ describe("formatDashboardLoadError", () => {
     expect(formatDashboardLoadError(new Error("  boom  "))).toBe("boom");
   });
 
+  it("keeps only the first non-empty line from multiline errors", () => {
+    expect(formatDashboardLoadError(new Error("\n  config parse failed  \n  at line 4\n"))).toBe(
+      "config parse failed",
+    );
+  });
+
   it("accepts string throws", () => {
     expect(formatDashboardLoadError("config invalid")).toBe("config invalid");
   });

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -96,8 +96,13 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     const services = await getServices();
     config = services.config;
     registry = services.registry;
-    allSessions = await services.sessionManager.list();
     pageData.attentionZones = config.dashboard?.attentionZones ?? DEFAULT_ATTENTION_ZONE_MODE;
+    try {
+      allSessions = await services.sessionManager.list();
+    } catch (listErr) {
+      pageData.dashboardLoadError = formatDashboardLoadError(listErr);
+      return pageData;
+    }
   } catch (err) {
     pageData.dashboardLoadError = formatDashboardLoadError(err);
     return pageData;

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -20,6 +20,19 @@ import { settlesWithin } from "@/lib/async-utils";
 
 const FAST_METADATA_ENRICH_TIMEOUT_MS = 3_000;
 
+/**
+ * Normalize thrown values from dashboard SSR into a single-line message for the UI.
+ * Avoids dumping stack traces into the banner.
+ */
+export function formatDashboardLoadError(err: unknown): string {
+  if (err instanceof Error && err.message.trim()) {
+    return err.message.trim();
+  }
+  if (typeof err === "string" && err.trim()) {
+    return err.trim();
+  }
+  return "The orchestrator could not load dashboard data. Check your configuration file.";
+}
 
 interface DashboardPageData {
   sessions: DashboardSession[];
@@ -28,6 +41,8 @@ interface DashboardPageData {
   projects: ProjectInfo[];
   selectedProjectId?: string;
   attentionZones: DashboardAttentionZoneMode;
+  /** Present when services initialization or session listing failed during SSR (distinct from an empty session list). */
+  dashboardLoadError?: string;
 }
 
 /** Default zone mode when no config is loaded or `dashboard` block is absent. */
@@ -93,9 +108,10 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
         await enrichSessionPR(pageData.sessions[i], scm, core.pr, { cacheOnly: true });
       }
     }
-  } catch {
+  } catch (err) {
     pageData.sessions = [];
     pageData.orchestrators = [];
+    pageData.dashboardLoadError = formatDashboardLoadError(err);
   }
 
   return pageData;

--- a/packages/web/src/lib/dashboard-page-data.ts
+++ b/packages/web/src/lib/dashboard-page-data.ts
@@ -25,11 +25,19 @@ const FAST_METADATA_ENRICH_TIMEOUT_MS = 3_000;
  * Avoids dumping stack traces into the banner.
  */
 export function formatDashboardLoadError(err: unknown): string {
-  if (err instanceof Error && err.message.trim()) {
-    return err.message.trim();
-  }
-  if (typeof err === "string" && err.trim()) {
-    return err.trim();
+  const rawMessage =
+    err instanceof Error
+      ? err.message
+      : typeof err === "string"
+        ? err
+        : "";
+
+  if (rawMessage.trim()) {
+    const firstLine = rawMessage
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find((line) => line.length > 0);
+    if (firstLine) return firstLine;
   }
   return "The orchestrator could not load dashboard data. Check your configuration file.";
 }
@@ -80,38 +88,51 @@ export const getDashboardPageData = cache(async function getDashboardPageData(pr
     attentionZones: DEFAULT_ATTENTION_ZONE_MODE,
   };
 
+  let config: Awaited<ReturnType<typeof getServices>>["config"];
+  let registry: Awaited<ReturnType<typeof getServices>>["registry"];
+  let allSessions: Awaited<ReturnType<Awaited<ReturnType<typeof getServices>>["sessionManager"]["list"]>>;
+
   try {
-    const { config, registry, sessionManager } = await getServices();
+    const services = await getServices();
+    config = services.config;
+    registry = services.registry;
+    allSessions = await services.sessionManager.list();
     pageData.attentionZones = config.dashboard?.attentionZones ?? DEFAULT_ATTENTION_ZONE_MODE;
-    const allSessions = await sessionManager.list();
+  } catch (err) {
+    pageData.dashboardLoadError = formatDashboardLoadError(err);
+    return pageData;
+  }
 
-    const visibleSessions = filterProjectSessions(allSessions, projectFilter, config.projects);
-    pageData.orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
+  const visibleSessions = filterProjectSessions(allSessions, projectFilter, config.projects);
+  pageData.orchestrators = listDashboardOrchestrators(visibleSessions, config.projects);
 
-    const coreSessions = filterWorkerSessions(allSessions, projectFilter, config.projects);
-    pageData.sessions = coreSessions.map(sessionToDashboard);
+  const coreSessions = filterWorkerSessions(allSessions, projectFilter, config.projects);
+  pageData.sessions = coreSessions.map(sessionToDashboard);
 
-    // Fast enrichment: issue labels (sync) + agent summaries (local disk I/O).
-    // Keep a hard cap here so a slow local agent plugin can't stall SSR indefinitely.
+  // Fast enrichment: issue labels (sync) + agent summaries (local disk I/O).
+  // Keep a hard cap here so a slow local agent plugin can't stall SSR indefinitely.
+  try {
     await settlesWithin(
       enrichSessionsMetadataFast(coreSessions, pageData.sessions, config, registry),
       FAST_METADATA_ENRICH_TIMEOUT_MS,
     );
+  } catch (err) {
+    console.warn("[dashboard-page-data] metadata fast enrichment failed:", err);
+  }
 
-    // PR cache hits only (in-memory lookup, no SCM API calls).
-    for (let i = 0; i < coreSessions.length; i++) {
-      const core = coreSessions[i];
-      if (!core.pr) continue;
+  // PR cache hits only (in-memory lookup, no SCM API calls).
+  for (let i = 0; i < coreSessions.length; i++) {
+    const core = coreSessions[i];
+    if (!core.pr) continue;
+    try {
       const projectConfig = resolveProject(core, config.projects);
       const scm = getSCM(registry, projectConfig);
       if (scm) {
         await enrichSessionPR(pageData.sessions[i], scm, core.pr, { cacheOnly: true });
       }
+    } catch (err) {
+      console.warn(`[dashboard-page-data] PR enrichment failed for session ${core.id}:`, err);
     }
-  } catch (err) {
-    pageData.sessions = [];
-    pageData.orchestrators = [];
-    pageData.dashboardLoadError = formatDashboardLoadError(err);
   }
 
   return pageData;


### PR DESCRIPTION
## Summary

When `getDashboardPageData` failed (typically `getServices()` or `sessionManager.list()`), the home page still rendered the normal empty dashboard: zero sessions and the default "Ready to orchestrate" empty state. That made config and startup issues look like there was simply no work in flight.

This change captures the thrown error during SSR, passes it to the dashboard as `dashboardLoadError`, and shows an alert banner with the message plus a short pointer to `agent-orchestrator.yaml` and `ao doctor`. The misleading empty state is suppressed while the banner is shown. Realtime updates (`useSessionEvents`) are disabled in that situation so the client does not keep reconnecting against a broken backend.

## How to test

1. Temporarily break config loading (e.g. rename `agent-orchestrator.yaml` or introduce invalid YAML) and open `/`.
2. You should see the red alert with the error text, not the default empty-state CTA.
3. Restore the config and refresh; the dashboard should behave as before.

```bash
pnpm --filter @aoagents/ao-web typecheck
pnpm --filter @aoagents/ao-web test -- --run src/lib/__tests__/dashboard-page-data.test.ts src/lib/__tests__/dashboard-page-data.fast-path.test.ts src/components/__tests__/Dashboard.emptyState.test.tsx
```
