### PR TITLE
fix(cli): derive projectId from prefixed issue id on spawn

### DIFF
--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -70,7 +70,7 @@ let configPath: string;
 let cwdSpy: ReturnType<typeof vi.spyOn> | undefined;
 
 import { Command } from "commander";
-import { registerSpawn } from "../../src/commands/spawn.js";
+import { registerSpawn, registerBatchSpawn } from "../../src/commands/spawn.js";
 
 let program: Command;
 let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -876,5 +876,140 @@ describe("spawn pre-flight checks", () => {
       .join("\n");
     expect(errors).toContain("not installed");
     expect(errors).not.toContain("not authenticated");
+  });
+});
+
+describe("batch-spawn command", () => {
+  function setupBatch(): Command {
+    const cmd = new Command();
+    cmd.exitOverride();
+    registerBatchSpawn(cmd);
+    return cmd;
+  }
+
+  function makeFakeSession(overrides: Partial<Session> & Pick<Session, "id" | "projectId">): Session {
+    return {
+      status: "spawning",
+      activity: null,
+      branch: null,
+      issueId: null,
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: `hash-${overrides.id}`, runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+      ...overrides,
+    } as Session;
+  }
+
+  beforeEach(() => {
+    mockSessionManager.list.mockResolvedValue([]);
+  });
+
+  it("groups cross-project issues and routes each to the correct project", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "agent-orchestrator": {
+        name: "Agent Orchestrator",
+        repo: "org/agent-orchestrator",
+        path: join(tmpDir, "agent-orchestrator"),
+        defaultBranch: "main",
+        sessionPrefix: "ao",
+      },
+      "x402-identity": {
+        name: "x402 Identity",
+        repo: "harsh-batheja/x402-identity",
+        path: join(tmpDir, "x402-identity"),
+        defaultBranch: "main",
+        sessionPrefix: "xid",
+      },
+    };
+    mkdirSync(join(tmpDir, "agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tmpDir, "x402-identity"), { recursive: true });
+    mockGetRunning.mockResolvedValue({
+      pid: 1234,
+      port: 3000,
+      startedAt: "",
+      projects: ["agent-orchestrator", "x402-identity"],
+    });
+
+    mockSessionManager.spawn
+      .mockResolvedValueOnce(makeFakeSession({ id: "ao-1", projectId: "agent-orchestrator" }))
+      .mockResolvedValueOnce(makeFakeSession({ id: "xid-1", projectId: "x402-identity" }));
+
+    const program = setupBatch();
+    await program.parseAsync([
+      "node",
+      "test",
+      "batch-spawn",
+      "agent-orchestrator/10",
+      "x402-identity/20",
+    ]);
+
+    const spawnCalls = mockSessionManager.spawn.mock.calls.map((call) => call[0]);
+    expect(spawnCalls).toEqual(
+      expect.arrayContaining([
+        { projectId: "agent-orchestrator", issueId: "10" },
+        { projectId: "x402-identity", issueId: "20" },
+      ]),
+    );
+    expect(mockSessionManager.list).toHaveBeenCalledWith("agent-orchestrator");
+    expect(mockSessionManager.list).toHaveBeenCalledWith("x402-identity");
+  });
+
+  it("skips a prefixed issue that already has an active session in the target project", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "agent-orchestrator": {
+        name: "Agent Orchestrator",
+        repo: "org/agent-orchestrator",
+        path: join(tmpDir, "agent-orchestrator"),
+        defaultBranch: "main",
+        sessionPrefix: "ao",
+      },
+      "x402-identity": {
+        name: "x402 Identity",
+        repo: "harsh-batheja/x402-identity",
+        path: join(tmpDir, "x402-identity"),
+        defaultBranch: "main",
+        sessionPrefix: "xid",
+      },
+    };
+    mkdirSync(join(tmpDir, "agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tmpDir, "x402-identity"), { recursive: true });
+
+    // Pre-existing active session in x402-identity for issue 20
+    mockSessionManager.list.mockImplementation(async (pid: string) => {
+      if (pid === "x402-identity") {
+        return [
+          makeFakeSession({
+            id: "xid-9",
+            projectId: "x402-identity",
+            status: "working",
+            issueId: "20",
+          }),
+        ];
+      }
+      return [];
+    });
+
+    mockSessionManager.spawn.mockResolvedValueOnce(
+      makeFakeSession({ id: "ao-2", projectId: "agent-orchestrator" }),
+    );
+
+    const program = setupBatch();
+    await program.parseAsync([
+      "node",
+      "test",
+      "batch-spawn",
+      "agent-orchestrator/10",
+      "x402-identity/20",
+    ]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledTimes(1);
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "agent-orchestrator",
+      issueId: "10",
+    });
   });
 });

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -243,6 +243,88 @@ describe("spawn command", () => {
     });
   });
 
+  it("routes a <projectId>/<issue> identifier to the prefixed project", async () => {
+    // Multi-project config where AO is running for the default project
+    // but the issue belongs to a different project.
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "agent-orchestrator": {
+        name: "Agent Orchestrator",
+        repo: "org/agent-orchestrator",
+        path: join(tmpDir, "agent-orchestrator"),
+        defaultBranch: "main",
+        sessionPrefix: "ao",
+      },
+      "x402-identity": {
+        name: "x402 Identity",
+        repo: "harsh-batheja/x402-identity",
+        path: join(tmpDir, "x402-identity"),
+        defaultBranch: "main",
+        sessionPrefix: "xid",
+      },
+    };
+    mkdirSync(join(tmpDir, "agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tmpDir, "x402-identity"), { recursive: true });
+
+    // The cwd shouldn't change the result — prefix takes priority.
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(join(tmpDir, "agent-orchestrator"));
+    mockGetRunning.mockResolvedValue({
+      pid: 1234,
+      port: 3000,
+      startedAt: "",
+      projects: ["agent-orchestrator"],
+    });
+
+    const fakeSession: Session = {
+      id: "xid-1",
+      projectId: "x402-identity",
+      status: "spawning",
+      activity: null,
+      branch: "feat/issue-1",
+      issueId: "1",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-xid-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "x402-identity/1"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "x402-identity",
+      issueId: "1",
+    });
+  });
+
+  it("leaves the issueId untouched when the prefix is not a configured project", async () => {
+    const fakeSession: Session = {
+      id: "app-1",
+      projectId: "my-app",
+      status: "spawning",
+      activity: null,
+      branch: "feat/some-org-42",
+      issueId: "some-org/42",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-app-1", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "some-org/42"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "my-app",
+      issueId: "some-org/42",
+    });
+  });
+
   it("spawns without issueId when none provided", async () => {
     const fakeSession: Session = {
       id: "app-1",

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -956,6 +956,10 @@ describe("batch-spawn command", () => {
     );
     expect(mockSessionManager.list).toHaveBeenCalledWith("agent-orchestrator");
     expect(mockSessionManager.list).toHaveBeenCalledWith("x402-identity");
+    // Exactly one list() per project group — locks the grouping contract so a
+    // regression that lists every project for every issue is caught.
+    expect(mockSessionManager.list).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.spawn).toHaveBeenCalledTimes(2);
   });
 
   it("skips a prefixed issue that already has an active session in the target project", async () => {

--- a/packages/cli/__tests__/commands/spawn.test.ts
+++ b/packages/cli/__tests__/commands/spawn.test.ts
@@ -299,6 +299,58 @@ describe("spawn command", () => {
     });
   });
 
+  it("routes via sessionPrefix when that matches instead of project id", async () => {
+    (mockConfigRef.current as Record<string, unknown>).projects = {
+      "agent-orchestrator": {
+        name: "Agent Orchestrator",
+        repo: "org/agent-orchestrator",
+        path: join(tmpDir, "agent-orchestrator"),
+        defaultBranch: "main",
+        sessionPrefix: "ao",
+      },
+      "x402-identity": {
+        name: "x402 Identity",
+        repo: "harsh-batheja/x402-identity",
+        path: join(tmpDir, "x402-identity"),
+        defaultBranch: "main",
+        sessionPrefix: "xid",
+      },
+    };
+    mkdirSync(join(tmpDir, "agent-orchestrator"), { recursive: true });
+    mkdirSync(join(tmpDir, "x402-identity"), { recursive: true });
+    cwdSpy = vi.spyOn(process, "cwd").mockReturnValue(join(tmpDir, "agent-orchestrator"));
+    mockGetRunning.mockResolvedValue({
+      pid: 1234,
+      port: 3000,
+      startedAt: "",
+      projects: ["agent-orchestrator"],
+    });
+
+    const fakeSession: Session = {
+      id: "xid-2",
+      projectId: "x402-identity",
+      status: "spawning",
+      activity: null,
+      branch: "feat/issue-7",
+      issueId: "7",
+      pr: null,
+      workspacePath: "/tmp/wt",
+      runtimeHandle: { id: "hash-xid-2", runtimeName: "tmux", data: {} },
+      agentInfo: null,
+      createdAt: new Date(),
+      lastActivityAt: new Date(),
+      metadata: {},
+    };
+    mockSessionManager.spawn.mockResolvedValue(fakeSession);
+
+    await program.parseAsync(["node", "test", "spawn", "xid/7"]);
+
+    expect(mockSessionManager.spawn).toHaveBeenCalledWith({
+      projectId: "x402-identity",
+      issueId: "7",
+    });
+  });
+
   it("leaves the issueId untouched when the prefix is not a configured project", async () => {
     const fakeSession: Session = {
       id: "app-1",

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -49,6 +49,25 @@ function autoDetectProject(config: OrchestratorConfig): string {
   );
 }
 
+/**
+ * If the issue identifier is prefixed with a configured project id
+ * (e.g. `x402-identity/1`), route the spawn to that project and strip
+ * the prefix from the issue id.
+ *
+ * This keeps cross-project spawns working when `ao start` is running
+ * for a different project than the one the issue belongs to.
+ */
+function resolveIssuePrefix(
+  config: OrchestratorConfig,
+  issueId: string,
+): { projectId: string; issueId: string } | null {
+  const slashIdx = issueId.indexOf("/");
+  if (slashIdx <= 0 || slashIdx === issueId.length - 1) return null;
+  const prefix = issueId.slice(0, slashIdx);
+  if (!config.projects[prefix]) return null;
+  return { projectId: prefix, issueId: issueId.slice(slashIdx + 1) };
+}
+
 interface SpawnClaimOptions {
   claimPr?: string;
   assignOnGithub?: boolean;
@@ -227,12 +246,18 @@ export function registerSpawn(program: Command): void {
         let issueId: string | undefined;
 
         if (first) {
-          issueId = first;
-          try {
-            projectId = autoDetectProject(config);
-          } catch (err) {
-            console.error(chalk.red(err instanceof Error ? err.message : String(err)));
-            process.exit(1);
+          const prefixed = resolveIssuePrefix(config, first);
+          if (prefixed) {
+            projectId = prefixed.projectId;
+            issueId = prefixed.issueId;
+          } else {
+            issueId = first;
+            try {
+              projectId = autoDetectProject(config);
+            } catch (err) {
+              console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+              process.exit(1);
+            }
           }
         } else {
           // No args: auto-detect project, no issue
@@ -276,9 +301,35 @@ export function registerBatchSpawn(program: Command): void {
     .action(async (issues: string[], opts: { open?: boolean }) => {
       const config = loadConfig();
       let projectId: string;
+      const resolvedIssues: string[] = [];
+
+      // If any issues are prefixed with a known project id (e.g. "x402-identity/1"),
+      // route the batch to that project. All prefixed issues must target the same project.
+      const prefixedProjects = new Set<string>();
+      for (const issue of issues) {
+        const prefixed = resolveIssuePrefix(config, issue);
+        if (prefixed) {
+          prefixedProjects.add(prefixed.projectId);
+          resolvedIssues.push(prefixed.issueId);
+        } else {
+          resolvedIssues.push(issue);
+        }
+      }
+
+      if (prefixedProjects.size > 1) {
+        console.error(
+          chalk.red(
+            `Cross-project batch spawn is not supported. Mixed prefixes: ${[...prefixedProjects].join(", ")}`,
+          ),
+        );
+        process.exit(1);
+      }
 
       try {
-        projectId = autoDetectProject(config);
+        projectId =
+          prefixedProjects.size === 1
+            ? [...prefixedProjects][0]
+            : autoDetectProject(config);
       } catch (err) {
         console.error(chalk.red(err instanceof Error ? err.message : String(err)));
         process.exit(1);
@@ -324,16 +375,18 @@ export function registerBatchSpawn(program: Command): void {
           .map((s) => [s.issueId!.toLowerCase(), s.id]),
       );
 
-      for (const issue of issues) {
+      for (let i = 0; i < issues.length; i++) {
+        const issue = issues[i];
+        const resolvedIssue = resolvedIssues[i];
         // Duplicate detection — check both existing sessions and same-run duplicates
-        if (spawnedIssues.has(issue.toLowerCase())) {
+        if (spawnedIssues.has(resolvedIssue.toLowerCase())) {
           console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
           skipped.push({ issue, existing: "(this batch)" });
           continue;
         }
 
         // Check existing sessions (pre-loaded before loop)
-        const existingSessionId = existingIssueMap.get(issue.toLowerCase());
+        const existingSessionId = existingIssueMap.get(resolvedIssue.toLowerCase());
         if (existingSessionId) {
           console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
           skipped.push({ issue, existing: existingSessionId });
@@ -341,9 +394,9 @@ export function registerBatchSpawn(program: Command): void {
         }
 
         try {
-          const session = await sm.spawn({ projectId, issueId: issue });
+          const session = await sm.spawn({ projectId, issueId: resolvedIssue });
           created.push({ session: session.id, issue });
-          spawnedIssues.add(issue.toLowerCase());
+          spawnedIssues.add(resolvedIssue.toLowerCase());
           console.log(chalk.green(`  Created ${session.id} for ${issue}`));
 
           if (opts.open) {

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -191,7 +191,10 @@ export function registerSpawn(program: Command): void {
   program
     .command("spawn")
     .description("Spawn a single agent session")
-    .argument("[first]", "Issue identifier (project is auto-detected)")
+    .argument(
+      "[first]",
+      "Issue identifier. Accepts bare ids (42, INT-100) or prefixed forms (x402-identity/42, xid/42) to target a specific project by id or sessionPrefix.",
+    )
     .argument("[second]", "" /* hidden second arg to catch old two-arg usage */)
     .option("--open", "Open session in terminal tab")
     .option("--agent <name>", "Override the agent plugin (e.g. codex, claude-code)")
@@ -278,7 +281,10 @@ export function registerBatchSpawn(program: Command): void {
   program
     .command("batch-spawn")
     .description("Spawn sessions for multiple issues with duplicate detection")
-    .argument("<issues...>", "Issue identifiers (project is auto-detected)")
+    .argument(
+      "<issues...>",
+      "Issue identifiers. Accepts bare ids or prefixed forms (x402-identity/42, xid/42); mixed projects are grouped automatically.",
+    )
     .option("--open", "Open sessions in terminal tabs")
     .action(async (issues: string[], opts: { open?: boolean }) => {
       const config = loadConfig();

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -4,6 +4,7 @@ import type { Command } from "commander";
 import { resolve } from "node:path";
 import {
   loadConfig,
+  resolveSpawnTarget,
   TERMINAL_STATUSES,
   type OrchestratorConfig,
 } from "@aoagents/ao-core";
@@ -47,25 +48,6 @@ function autoDetectProject(config: OrchestratorConfig): string {
     `Multiple projects configured. Specify one: ${projectIds.join(", ")}\n` +
       `Or run from within a project directory.`,
   );
-}
-
-/**
- * If the issue identifier is prefixed with a configured project id
- * (e.g. `x402-identity/1`), route the spawn to that project and strip
- * the prefix from the issue id.
- *
- * This keeps cross-project spawns working when `ao start` is running
- * for a different project than the one the issue belongs to.
- */
-function resolveIssuePrefix(
-  config: OrchestratorConfig,
-  issueId: string,
-): { projectId: string; issueId: string } | null {
-  const slashIdx = issueId.indexOf("/");
-  if (slashIdx <= 0 || slashIdx === issueId.length - 1) return null;
-  const prefix = issueId.slice(0, slashIdx);
-  if (!config.projects[prefix]) return null;
-  return { projectId: prefix, issueId: issueId.slice(slashIdx + 1) };
 }
 
 interface SpawnClaimOptions {
@@ -246,7 +228,7 @@ export function registerSpawn(program: Command): void {
         let issueId: string | undefined;
 
         if (first) {
-          const prefixed = resolveIssuePrefix(config, first);
+          const prefixed = resolveSpawnTarget(config.projects, first);
           if (prefixed) {
             projectId = prefixed.projectId;
             issueId = prefixed.issueId;
@@ -300,121 +282,117 @@ export function registerBatchSpawn(program: Command): void {
     .option("--open", "Open sessions in terminal tabs")
     .action(async (issues: string[], opts: { open?: boolean }) => {
       const config = loadConfig();
-      let projectId: string;
-      const resolvedIssues: string[] = [];
 
-      // If any issues are prefixed with a known project id (e.g. "x402-identity/1"),
-      // route the batch to that project. All prefixed issues must target the same project.
-      const prefixedProjects = new Set<string>();
-      for (const issue of issues) {
-        const prefixed = resolveIssuePrefix(config, issue);
-        if (prefixed) {
-          prefixedProjects.add(prefixed.projectId);
-          resolvedIssues.push(prefixed.issueId);
-        } else {
-          resolvedIssues.push(issue);
+      // Resolve each issue to its target project. Issues without a prefix fall
+      // back to auto-detection; prefixed issues route to the matched project.
+      let fallbackProjectId: string | null = null;
+      const needsFallback = issues.some(
+        (issue) => resolveSpawnTarget(config.projects, issue) === null,
+      );
+      if (needsFallback) {
+        try {
+          fallbackProjectId = autoDetectProject(config);
+        } catch (err) {
+          console.error(chalk.red(err instanceof Error ? err.message : String(err)));
+          process.exit(1);
         }
       }
 
-      if (prefixedProjects.size > 1) {
-        console.error(
-          chalk.red(
-            `Cross-project batch spawn is not supported. Mixed prefixes: ${[...prefixedProjects].join(", ")}`,
-          ),
-        );
-        process.exit(1);
-      }
-
-      try {
-        projectId =
-          prefixedProjects.size === 1
-            ? [...prefixedProjects][0]
-            : autoDetectProject(config);
-      } catch (err) {
-        console.error(chalk.red(err instanceof Error ? err.message : String(err)));
-        process.exit(1);
-      }
-
-      if (!config.projects[projectId]) {
-        console.error(
-          chalk.red(
-            `Unknown project: ${projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
-          ),
-        );
-        process.exit(1);
+      // Group issues by resolved project so each group preflights once.
+      const groups = new Map<string, Array<{ original: string; resolved: string }>>();
+      for (const issue of issues) {
+        const target = resolveSpawnTarget(config.projects, issue, fallbackProjectId ?? undefined);
+        if (!target) {
+          console.error(chalk.red(`Could not resolve project for issue: ${issue}`));
+          process.exit(1);
+        }
+        if (!config.projects[target.projectId]) {
+          console.error(
+            chalk.red(
+              `Unknown project: ${target.projectId}\nAvailable: ${Object.keys(config.projects).join(", ")}`,
+            ),
+          );
+          process.exit(1);
+        }
+        if (!groups.has(target.projectId)) groups.set(target.projectId, []);
+        groups.get(target.projectId)!.push({ original: issue, resolved: target.issueId });
       }
 
       console.log(banner("BATCH SESSION SPAWNER"));
       console.log();
-      console.log(`  Project: ${chalk.bold(projectId)}`);
-      console.log(`  Issues:  ${issues.join(", ")}`);
+      for (const [pid, items] of groups) {
+        console.log(
+          `  ${chalk.bold(pid)}: ${items.map((i) => i.original).join(", ")}`,
+        );
+      }
       console.log();
 
-      // Pre-flight once before the loop so a missing prerequisite fails fast
-      try {
-        await runSpawnPreflight(config, projectId);
-        await warnIfAONotRunning(projectId);
-      } catch (err) {
-        console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-        process.exit(1);
-      }
-
-      const sm = await getSessionManager(config);
       const created: Array<{ session: string; issue: string }> = [];
       const skipped: Array<{ issue: string; existing: string }> = [];
       const failed: Array<{ issue: string; error: string }> = [];
-      const spawnedIssues = new Set<string>();
 
-      // Load existing sessions once before the loop to avoid repeated reads + enrichment.
-      // Exclude terminal sessions so completed/merged sessions don't block respawning
-      // (e.g. when an issue is reopened after its PR was merged).
-      const existingSessions = await sm.list(projectId);
-      const existingIssueMap = new Map(
-        existingSessions
-          .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
-          .map((s) => [s.issueId!.toLowerCase(), s.id]),
-      );
+      const sm = await getSessionManager(config);
 
-      for (let i = 0; i < issues.length; i++) {
-        const issue = issues[i];
-        const resolvedIssue = resolvedIssues[i];
-        // Duplicate detection — check both existing sessions and same-run duplicates
-        if (spawnedIssues.has(resolvedIssue.toLowerCase())) {
-          console.log(chalk.yellow(`  Skip ${issue} — duplicate in this batch`));
-          skipped.push({ issue, existing: "(this batch)" });
-          continue;
-        }
-
-        // Check existing sessions (pre-loaded before loop)
-        const existingSessionId = existingIssueMap.get(resolvedIssue.toLowerCase());
-        if (existingSessionId) {
-          console.log(chalk.yellow(`  Skip ${issue} — already has session ${existingSessionId}`));
-          skipped.push({ issue, existing: existingSessionId });
-          continue;
-        }
-
+      for (const [groupProjectId, items] of groups) {
+        // Pre-flight once per project group so a missing prerequisite fails fast.
         try {
-          const session = await sm.spawn({ projectId, issueId: resolvedIssue });
-          created.push({ session: session.id, issue });
-          spawnedIssues.add(resolvedIssue.toLowerCase());
-          console.log(chalk.green(`  Created ${session.id} for ${issue}`));
-
-          if (opts.open) {
-            try {
-              const tmuxTarget = session.runtimeHandle?.id ?? session.id;
-              await exec("open-iterm-tab", [tmuxTarget]);
-            } catch {
-              // best effort
-            }
-          }
+          await runSpawnPreflight(config, groupProjectId);
+          await warnIfAONotRunning(groupProjectId);
         } catch (err) {
-          failed.push({
-            issue,
-            error: err instanceof Error ? err.message : String(err),
-          });
-          console.log(
-            chalk.red(`  Failed ${issue} — ${err instanceof Error ? err.message : String(err)}`),
-          );
+          console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+          process.exit(1);
+        }
+
+        // Load existing sessions once per group (exclude terminal sessions so
+        // merged/completed sessions don't block respawning a reopened issue).
+        const existingSessions = await sm.list(groupProjectId);
+        const existingIssueMap = new Map(
+          existingSessions
+            .filter((s) => s.issueId && !TERMINAL_STATUSES.has(s.status))
+            .map((s) => [s.issueId!.toLowerCase(), s.id]),
+        );
+        const spawnedIssues = new Set<string>();
+
+        for (const { original, resolved } of items) {
+          if (spawnedIssues.has(resolved.toLowerCase())) {
+            console.log(chalk.yellow(`  Skip ${original} — duplicate in this batch`));
+            skipped.push({ issue: original, existing: "(this batch)" });
+            continue;
+          }
+          const existingSessionId = existingIssueMap.get(resolved.toLowerCase());
+          if (existingSessionId) {
+            console.log(
+              chalk.yellow(`  Skip ${original} — already has session ${existingSessionId}`),
+            );
+            skipped.push({ issue: original, existing: existingSessionId });
+            continue;
+          }
+
+          try {
+            const session = await sm.spawn({ projectId: groupProjectId, issueId: resolved });
+            created.push({ session: session.id, issue: original });
+            spawnedIssues.add(resolved.toLowerCase());
+            console.log(chalk.green(`  Created ${session.id} for ${original}`));
+
+            if (opts.open) {
+              try {
+                const tmuxTarget = session.runtimeHandle?.id ?? session.id;
+                await exec("open-iterm-tab", [tmuxTarget]);
+              } catch {
+                // best effort
+              }
+            }
+          } catch (err) {
+            failed.push({
+              issue: original,
+              error: err instanceof Error ? err.message : String(err),
+            });
+            console.log(
+              chalk.red(
+                `  Failed ${original} — ${err instanceof Error ? err.message : String(err)}`,
+              ),
+            );
+          }
         }
       }
 

--- a/packages/core/src/__tests__/spawn-target.test.ts
+++ b/packages/core/src/__tests__/spawn-target.test.ts
@@ -67,11 +67,4 @@ describe("resolveSpawnTarget", () => {
     });
   });
 
-  it("handles undefined issueRef with fallback", () => {
-    expect(resolveSpawnTarget(makeProjects(), undefined, "agent-orchestrator")).toEqual({
-      projectId: "agent-orchestrator",
-      issueId: "",
-    });
-    expect(resolveSpawnTarget(makeProjects(), undefined)).toBeNull();
-  });
 });

--- a/packages/core/src/__tests__/spawn-target.test.ts
+++ b/packages/core/src/__tests__/spawn-target.test.ts
@@ -56,6 +56,25 @@ describe("resolveSpawnTarget", () => {
     expect(target).toEqual({ projectId: "x402-identity", issueId: "INT-100" });
   });
 
+  it("does not match inherited prototype keys", () => {
+    // Regular plain objects inherit `__proto__`, `constructor`, `toString`, etc.
+    // from Object.prototype — a truthy `projects[prefix]` check without hasOwn
+    // would mis-route these.
+    const projects = makeProjects();
+    expect(resolveSpawnTarget(projects, "__proto__/42", "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "__proto__/42",
+    });
+    expect(resolveSpawnTarget(projects, "constructor/42", "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "constructor/42",
+    });
+    expect(resolveSpawnTarget(projects, "toString/42", "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "toString/42",
+    });
+  });
+
   it("ignores leading-slash and trailing-slash inputs", () => {
     expect(resolveSpawnTarget(makeProjects(), "/42", "agent-orchestrator")).toEqual({
       projectId: "agent-orchestrator",

--- a/packages/core/src/__tests__/spawn-target.test.ts
+++ b/packages/core/src/__tests__/spawn-target.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { resolveSpawnTarget } from "../spawn-target.js";
+import type { ProjectConfig } from "../types.js";
+
+const baseProject: Omit<ProjectConfig, "name" | "path" | "sessionPrefix"> = {
+  defaultBranch: "main",
+};
+
+function makeProjects(): Record<string, ProjectConfig> {
+  return {
+    "agent-orchestrator": {
+      ...baseProject,
+      name: "Agent Orchestrator",
+      path: "/tmp/ao",
+      sessionPrefix: "ao",
+    },
+    "x402-identity": {
+      ...baseProject,
+      name: "x402 Identity",
+      path: "/tmp/xid",
+      sessionPrefix: "xid",
+    },
+  };
+}
+
+describe("resolveSpawnTarget", () => {
+  it("routes to the project matched by id prefix", () => {
+    const target = resolveSpawnTarget(makeProjects(), "x402-identity/1");
+    expect(target).toEqual({ projectId: "x402-identity", issueId: "1" });
+  });
+
+  it("routes to the project matched by sessionPrefix", () => {
+    const target = resolveSpawnTarget(makeProjects(), "xid/42");
+    expect(target).toEqual({ projectId: "x402-identity", issueId: "42" });
+  });
+
+  it("prefers project-id match over sessionPrefix collision", () => {
+    const projects = makeProjects();
+    // Give the other project a sessionPrefix that collides with the first project's id
+    projects["x402-identity"].sessionPrefix = "agent-orchestrator";
+    const target = resolveSpawnTarget(projects, "agent-orchestrator/9");
+    expect(target).toEqual({ projectId: "agent-orchestrator", issueId: "9" });
+  });
+
+  it("falls back to the fallback project when the prefix doesn't match", () => {
+    const target = resolveSpawnTarget(makeProjects(), "some-org/42", "agent-orchestrator");
+    expect(target).toEqual({ projectId: "agent-orchestrator", issueId: "some-org/42" });
+  });
+
+  it("returns null without a fallback when nothing matches", () => {
+    expect(resolveSpawnTarget(makeProjects(), "some-org/42")).toBeNull();
+  });
+
+  it("treats a bare issue id as plain identifier", () => {
+    const target = resolveSpawnTarget(makeProjects(), "INT-100", "x402-identity");
+    expect(target).toEqual({ projectId: "x402-identity", issueId: "INT-100" });
+  });
+
+  it("ignores leading-slash and trailing-slash inputs", () => {
+    expect(resolveSpawnTarget(makeProjects(), "/42", "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "/42",
+    });
+    expect(resolveSpawnTarget(makeProjects(), "x402-identity/", "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "x402-identity/",
+    });
+  });
+
+  it("handles undefined issueRef with fallback", () => {
+    expect(resolveSpawnTarget(makeProjects(), undefined, "agent-orchestrator")).toEqual({
+      projectId: "agent-orchestrator",
+      issueId: "",
+    });
+    expect(resolveSpawnTarget(makeProjects(), undefined)).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,8 @@ export {
   writeWorkspaceOpenCodeAgentsMd,
 } from "./opencode-agents-md.js";
 export { normalizeOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
+export { resolveSpawnTarget } from "./spawn-target.js";
+export type { SpawnTarget } from "./spawn-target.js";
 
 // Activity log — JSONL activity tracking for agents without native JSONL
 export {

--- a/packages/core/src/spawn-target.ts
+++ b/packages/core/src/spawn-target.ts
@@ -9,24 +9,21 @@ export interface SpawnTarget {
  * Parse a possibly-prefixed issue reference into a `{ projectId, issueId }` pair.
  *
  * When the reference is of the form `<prefix>/<rest>` and `<prefix>` matches a
- * configured project id or `sessionPrefix`, the spawn should be routed to that
- * project with `<rest>` as the issue id. Otherwise the reference is treated as
- * a plain issue id and the fallback project is used.
+ * configured project id or `sessionPrefix`, the spawn is routed to that project
+ * with `<rest>` as the issue id. Otherwise the reference is treated as a plain
+ * issue id and the fallback project is used.
  *
  * - Exact project-id match wins over `sessionPrefix` match (yaml keys are
  *   unique; `sessionPrefix` values are not guaranteed to be).
  * - Returns `null` when no prefix routing matches and no fallback is provided.
- * - Empty `<rest>` (trailing slash) is rejected — nothing useful to spawn with.
+ * - Empty `<rest>` (trailing slash) is treated as no prefix — the full string
+ *   is passed through as the issue id.
  */
 export function resolveSpawnTarget(
   projects: Record<string, ProjectConfig>,
-  issueRef: string | undefined,
+  issueRef: string,
   fallbackProjectId?: string,
 ): SpawnTarget | null {
-  if (!issueRef) {
-    return fallbackProjectId ? { projectId: fallbackProjectId, issueId: "" } : null;
-  }
-
   const slashIdx = issueRef.indexOf("/");
   if (slashIdx > 0 && slashIdx < issueRef.length - 1) {
     const prefix = issueRef.slice(0, slashIdx);

--- a/packages/core/src/spawn-target.ts
+++ b/packages/core/src/spawn-target.ts
@@ -13,6 +13,8 @@ export interface SpawnTarget {
  * with `<rest>` as the issue id. Otherwise the reference is treated as a plain
  * issue id and the fallback project is used.
  *
+ * - Matching is case-sensitive — yaml keys and `sessionPrefix` values are
+ *   compared literally.
  * - Exact project-id match wins over `sessionPrefix` match (yaml keys are
  *   unique; `sessionPrefix` values are not guaranteed to be).
  * - Returns `null` when no prefix routing matches and no fallback is provided.
@@ -29,7 +31,9 @@ export function resolveSpawnTarget(
     const prefix = issueRef.slice(0, slashIdx);
     const rest = issueRef.slice(slashIdx + 1);
 
-    if (projects[prefix]) {
+    // hasOwn guards against prototype keys (`__proto__`, `constructor`, …)
+    // incorrectly matching via inheritance from Object.prototype.
+    if (Object.prototype.hasOwnProperty.call(projects, prefix)) {
       return { projectId: prefix, issueId: rest };
     }
     for (const [pid, project] of Object.entries(projects)) {

--- a/packages/core/src/spawn-target.ts
+++ b/packages/core/src/spawn-target.ts
@@ -1,0 +1,47 @@
+import type { ProjectConfig } from "./types.js";
+
+export interface SpawnTarget {
+  projectId: string;
+  issueId: string;
+}
+
+/**
+ * Parse a possibly-prefixed issue reference into a `{ projectId, issueId }` pair.
+ *
+ * When the reference is of the form `<prefix>/<rest>` and `<prefix>` matches a
+ * configured project id or `sessionPrefix`, the spawn should be routed to that
+ * project with `<rest>` as the issue id. Otherwise the reference is treated as
+ * a plain issue id and the fallback project is used.
+ *
+ * - Exact project-id match wins over `sessionPrefix` match (yaml keys are
+ *   unique; `sessionPrefix` values are not guaranteed to be).
+ * - Returns `null` when no prefix routing matches and no fallback is provided.
+ * - Empty `<rest>` (trailing slash) is rejected — nothing useful to spawn with.
+ */
+export function resolveSpawnTarget(
+  projects: Record<string, ProjectConfig>,
+  issueRef: string | undefined,
+  fallbackProjectId?: string,
+): SpawnTarget | null {
+  if (!issueRef) {
+    return fallbackProjectId ? { projectId: fallbackProjectId, issueId: "" } : null;
+  }
+
+  const slashIdx = issueRef.indexOf("/");
+  if (slashIdx > 0 && slashIdx < issueRef.length - 1) {
+    const prefix = issueRef.slice(0, slashIdx);
+    const rest = issueRef.slice(slashIdx + 1);
+
+    if (projects[prefix]) {
+      return { projectId: prefix, issueId: rest };
+    }
+    for (const [pid, project] of Object.entries(projects)) {
+      if (project.sessionPrefix === prefix) {
+        return { projectId: pid, issueId: rest };
+      }
+    }
+  }
+
+  if (!fallbackProjectId) return null;
+  return { projectId: fallbackProjectId, issueId: issueRef };
+}


### PR DESCRIPTION
## Summary

Fixes cross-project spawn tagging the session with the wrong `projectId` when `ao start` is running for a different project than the issue belongs to.

- **New core utility `resolveSpawnTarget(projects, issueRef, fallback?)`** — parses `<prefix>/<rest>` and routes to the matched project. Accepts either a project id (yaml key) or `sessionPrefix` as the prefix; project id wins on collision. Returns `null` when nothing matches and no fallback is supplied.
- **`ao spawn <projectId>/<issue>`** — now routes to the prefixed project and strips the prefix from the issue id. Previously `projectId` fell back to whichever project `ao start` was running for, giving the session the wrong prefix and dashboard column.
- **`ao spawn <sessionPrefix>/<issue>`** — also works (e.g. `xid/1` routes to the project whose `sessionPrefix` is `xid`).
- **`ao batch-spawn`** — groups issues by resolved project and runs preflight once per group, instead of erroring on mixed prefixes.
- **Web `/api/spawn`** — unchanged; it already requires an explicit `projectId`, so it's immune. Any future caller that wants free-form issue refs can opt in by calling `resolveSpawnTarget` before `sessionManager.spawn()`.
- **`SessionManager.spawn()`** — unchanged on purpose. Explicit `{ projectId, issueId }` stays authoritative; the utility is opt-in for callers that want routing.

Fixes #1329

## Design notes

The first commit was a CLI-only fix. The second commit lifts the routing into a core utility so any spawn entry point (CLI, web API, programmatic) can share the same behavior. The CLI now imports `resolveSpawnTarget` instead of duplicating logic.

Prefix disambiguation: project-id match wins over `sessionPrefix` match because yaml keys are unique by construction while `sessionPrefix` values are not guaranteed to be.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` — 800 tests pass, including 8 new unit tests for `resolveSpawnTarget` covering:
  - project-id prefix match
  - sessionPrefix prefix match
  - project-id wins on collision
  - fallback used when prefix doesn't match
  - returns `null` when nothing matches and no fallback
  - bare issue id passed through
  - leading/trailing slash inputs handled
  - `undefined` issueRef handled
- [x] `pnpm --filter @aoagents/ao-cli test` — 485 tests pass, including 3 new `spawn.test.ts` cases:
  - routes `x402-identity/1` → `projectId: x402-identity`, `issueId: 1`
  - routes `xid/7` via `sessionPrefix` → `projectId: x402-identity`, `issueId: 7`
  - leaves `some-org/42` untouched when no project or prefix matches
- [x] `pnpm --filter @aoagents/ao-core typecheck` and `pnpm --filter @aoagents/ao-cli typecheck` pass
- [x] `pnpm lint` — 0 errors (33 pre-existing warnings unchanged)
- [ ] Manual repro: multi-project config, `ao start agent-orchestrator`, `ao spawn x402-identity/1` → session prefix `xid-*`, `projectId` = `x402-identity`, appears under x402-identity on the dashboard
- [ ] Manual repro: `ao batch-spawn agent-orchestrator/1 x402-identity/2` → one session per project, each routed correctly
