### PR TITLE
fix(cli): scope already-running check by config path (fixes #1279)

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -106,6 +106,14 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
       if (path) return actual.loadConfig(path);
       return mockConfigRef.current;
     },
+    // Return the mocked config's path so the cross-project check in
+    // start.ts compares against a deterministic value instead of whatever
+    // the test process's real cwd resolves to.
+    findConfigFile: (startDir?: string) => {
+      const current = mockConfigRef.current as { configPath?: string } | null;
+      if (current?.configPath) return current.configPath;
+      return actual.findConfigFile(startDir);
+    },
   };
 });
 
@@ -288,6 +296,10 @@ beforeEach(async () => {
   mockWaitForExit.mockResolvedValue(true);
   mockIsHumanCaller.mockReset();
   mockIsHumanCaller.mockReturnValue(true);
+  // Reset the shared config ref so prior tests don't leak their
+  // configPath into findConfigFile() lookups (cross-project check in
+  // start.ts reads this path to compare against running.configPath).
+  mockConfigRef.current = null;
 });
 
 afterEach(() => {
@@ -1545,18 +1557,35 @@ describe("start command — autoCreateConfig", () => {
 // ---------------------------------------------------------------------------
 
 describe("start command — already-running detection", () => {
-  it("exits immediately for non-TTY caller when AO is already running", async () => {
+  // Helper: mock a running instance tied to the current test config
+  // (same-project scenario — configPath matches mockConfigRef.current.configPath).
+  function mockSameProjectRunning(): void {
+    const cfg = mockConfigRef.current as { configPath: string };
     mockIsAlreadyRunning.mockResolvedValue({
       pid: 9999,
-      configPath: "/fake/config.yaml",
+      configPath: cfg.configPath,
       port: 3000,
       startedAt: "2026-01-01T00:00:00Z",
       projects: ["my-app"],
     });
+  }
 
-    mockIsHumanCaller.mockReturnValue(false);
+  // Helper: mock a running instance for a different project than cwd
+  // (cross-project scenario — configPath differs from mockConfigRef.current.configPath).
+  function mockCrossProjectRunning(): void {
+    mockIsAlreadyRunning.mockResolvedValue({
+      pid: 9999,
+      configPath: "/some/other/project/agent-orchestrator.yaml",
+      port: 3000,
+      startedAt: "2026-01-01T00:00:00Z",
+      projects: ["other-project"],
+    });
+  }
 
+  it("exits immediately for non-TTY caller when AO is already running (same project)", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSameProjectRunning();
+    mockIsHumanCaller.mockReturnValue(false);
 
     // process.exit(0) throws in tests, caught by the action's catch block which calls exit(1)
     await expect(
@@ -1570,21 +1599,14 @@ describe("start command — already-running detection", () => {
       .join("\n");
     expect(output).toContain("AO is already running");
     expect(output).toContain("PID: 9999");
+    expect(output).not.toContain("different project");
   });
 
-  it("exits when human caller selects 'quit'", async () => {
-    mockIsAlreadyRunning.mockResolvedValue({
-      pid: 9999,
-      configPath: "/fake/config.yaml",
-      port: 3000,
-      startedAt: "2026-01-01T00:00:00Z",
-      projects: ["my-app"],
-    });
-
+  it("exits when human caller selects 'quit' (same project)", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSameProjectRunning();
     mockPromptSelect.mockResolvedValue("quit");
 
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-
     await expect(
       program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
     ).rejects.toThrow("process.exit(1)");
@@ -1596,19 +1618,11 @@ describe("start command — already-running detection", () => {
     expect(output).toContain("AO is already running");
   });
 
-  it("exits when human caller selects 'open'", async () => {
-    mockIsAlreadyRunning.mockResolvedValue({
-      pid: 9999,
-      configPath: "/fake/config.yaml",
-      port: 3000,
-      startedAt: "2026-01-01T00:00:00Z",
-      projects: ["my-app"],
-    });
-
+  it("exits when human caller selects 'open' (same project)", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSameProjectRunning();
     mockPromptSelect.mockResolvedValue("open");
 
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-
     await expect(
       program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
     ).rejects.toThrow("process.exit(1)");
@@ -1620,22 +1634,14 @@ describe("start command — already-running detection", () => {
     expect(output).toContain("AO is already running");
   });
 
-  it("kills existing process and continues when human caller selects 'restart'", async () => {
-    mockIsAlreadyRunning.mockResolvedValue({
-      pid: 9999,
-      configPath: "/fake/config.yaml",
-      port: 3000,
-      startedAt: "2026-01-01T00:00:00Z",
-      projects: ["my-app"],
-    });
-
+  it("kills existing process and continues when human caller selects 'restart' (same project)", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSameProjectRunning();
     mockWaitForExit.mockResolvedValue(true);
 
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
 
     mockPromptSelect.mockResolvedValue("restart");
-
-    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
 
     // After restart the startup flow continues — it may succeed or fail
     // depending on infrastructure mocks, so we just verify the restart actions
@@ -1657,15 +1663,7 @@ describe("start command — already-running detection", () => {
     killSpy.mockRestore();
   });
 
-  it("creates new orchestrator entry when human caller selects 'new'", async () => {
-    mockIsAlreadyRunning.mockResolvedValue({
-      pid: 9999,
-      configPath: "/fake/config.yaml",
-      port: 3000,
-      startedAt: "2026-01-01T00:00:00Z",
-      projects: ["my-app"],
-    });
-
+  it("creates new orchestrator entry when human caller selects 'new' (same project)", async () => {
     mockPromptSelect.mockResolvedValue("new");
 
     const configPath = join(tmpDir, "agent-orchestrator.yaml");
@@ -1691,6 +1689,7 @@ describe("start command — already-running detection", () => {
 
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     (mockConfigRef.current as Record<string, unknown>).configPath = configPath;
+    mockSameProjectRunning();
 
     // After "new" the startup flow continues — it may fail on infrastructure
     try {
@@ -1710,15 +1709,7 @@ describe("start command — already-running detection", () => {
     expect(newKey).toMatch(/^my-app-/);
   });
 
-  it("does not mutate YAML when non-TTY caller detects already running (path arg)", async () => {
-    mockIsAlreadyRunning.mockResolvedValue({
-      pid: 9999,
-      configPath: "/fake/config.yaml",
-      port: 3000,
-      startedAt: "2026-01-01T00:00:00Z",
-      projects: ["my-app"],
-    });
-
+  it("does not mutate YAML when non-TTY caller detects already running (path arg, same project)", async () => {
     mockIsHumanCaller.mockReturnValue(false);
 
     const repoDir = join(tmpDir, "some-project");
@@ -1744,6 +1735,7 @@ describe("start command — already-running detection", () => {
     writeFileSync(configPath, originalYaml);
 
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockSameProjectRunning();
     mockCwd(tmpDir);
 
     // process.exit(0) throws, caught by catch block which calls exit(1)
@@ -1761,6 +1753,98 @@ describe("start command — already-running detection", () => {
     // YAML should be unchanged — no duplicate entry added
     const afterYaml = readFileSync(configPath, "utf-8");
     expect(afterYaml).toBe(originalYaml);
+  });
+
+  // Cross-project detection — issue #1279
+  //
+  // When AO is running for project A and the user runs `ao start` in a
+  // folder belonging to a different project B, the CLI must NOT show
+  // A's dashboard URL as the default action.
+
+  it("shows cross-project warning for non-TTY caller when running instance is a different project", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockCrossProjectRunning();
+    mockIsHumanCaller.mockReturnValue(false);
+
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    // Makes it explicit that the running instance is a different project.
+    expect(output).toContain("different project");
+    expect(output).toContain("other-project");
+    expect(output).toContain("PID: 9999");
+    // Does NOT suggest the running dashboard URL as the primary action.
+    expect(output).toContain("ao stop --all && ao start");
+    // No new entry added to config.
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+
+  it("offers 'stop-start' default in cross-project prompt and kills other instance on confirm", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockCrossProjectRunning();
+    mockWaitForExit.mockResolvedValue(true);
+
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+
+    mockPromptSelect.mockResolvedValue("stop-start");
+
+    try {
+      await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+    } catch {
+      // Startup after stop-start may throw — that's OK for this test
+    }
+
+    expect(killSpy).toHaveBeenCalledWith(9999, "SIGTERM");
+    expect(mockUnregister).toHaveBeenCalled();
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("different project");
+    expect(output).toContain("Stopped other instance");
+
+    killSpy.mockRestore();
+  });
+
+  it("exits when cross-project human caller selects 'open-other'", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockCrossProjectRunning();
+    mockPromptSelect.mockResolvedValue("open-other");
+
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("different project");
+    // Did not proceed to start anything new.
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+
+  it("exits when cross-project human caller selects 'quit'", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+    mockCrossProjectRunning();
+    mockPromptSelect.mockResolvedValue("quit");
+
+    await expect(
+      program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]),
+    ).rejects.toThrow("process.exit(1)");
+
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("different project");
+    expect(mockUnregister).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1388,7 +1388,90 @@ export function registerStart(program: Command): void {
           const running = await isAlreadyRunning();
           let startNewOrchestrator = false;
           if (running) {
-            if (isHumanCaller()) {
+            // Determine whether the running instance belongs to the same
+            // project as the user's current directory. If the user has cd'd
+            // into a different repo with its own agent-orchestrator.yaml,
+            // the "Open dashboard" default would point at the wrong project
+            // (issue #1279). Comparing config paths disambiguates the two
+            // cases: same config → same project set; different config →
+            // cross-project.
+            let currentConfigPath: string | null = null;
+            try {
+              currentConfigPath = findConfigFile();
+            } catch {
+              currentConfigPath = null;
+            }
+            const isSameProject =
+              currentConfigPath !== null &&
+              resolve(currentConfigPath) === resolve(running.configPath);
+
+            if (!isSameProject) {
+              // Cross-project — running instance belongs to a different config.
+              if (isHumanCaller()) {
+                console.log(
+                  chalk.yellow(`\n⚠ AO is already running for a different project.`),
+                );
+                console.log(
+                  `  Running project(s): ${chalk.cyan(running.projects.join(", "))}`,
+                );
+                console.log(`  Running config:     ${chalk.dim(running.configPath)}`);
+                console.log(`  Current directory:  ${chalk.dim(cwd())}`);
+                console.log(
+                  `  Other dashboard:    ${chalk.cyan(`http://localhost:${running.port}`)} (PID ${running.pid})\n`,
+                );
+
+                const choice = await promptSelect(
+                  "What do you want to do?",
+                  [
+                    {
+                      value: "stop-start",
+                      label: "Stop the other instance and start here",
+                      hint: `Stops PID ${running.pid}`,
+                    },
+                    {
+                      value: "open-other",
+                      label: "Open the other project's dashboard",
+                      hint: `http://localhost:${running.port}`,
+                    },
+                    { value: "quit", label: "Quit" },
+                  ],
+                  "stop-start",
+                );
+
+                if (choice === "open-other") {
+                  openUrl(`http://localhost:${running.port}`);
+                  process.exit(0);
+                } else if (choice === "stop-start") {
+                  try { process.kill(running.pid, "SIGTERM"); } catch { /* already dead */ }
+                  if (!(await waitForExit(running.pid, 5000))) {
+                    console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
+                    try { process.kill(running.pid, "SIGKILL"); } catch { /* already dead */ }
+                    if (!(await waitForExit(running.pid, 3000))) {
+                      throw new Error(
+                        `Failed to stop AO process (PID ${running.pid}). Check permissions or stop it manually.`,
+                      );
+                    }
+                  }
+                  await unregister();
+                  console.log(
+                    chalk.yellow("\n  Stopped other instance. Starting this project...\n"),
+                  );
+                  // Continue to startup below
+                } else {
+                  process.exit(0);
+                }
+              } else {
+                // Agent/non-TTY caller — print cross-project info and exit.
+                console.log(`AO is already running for a different project.`);
+                console.log(`Running project(s): ${running.projects.join(", ")}`);
+                console.log(`Running config: ${running.configPath}`);
+                console.log(`Current directory: ${cwd()}`);
+                console.log(`Dashboard: http://localhost:${running.port}`);
+                console.log(`PID: ${running.pid}`);
+                console.log(`To start here: ao stop --all && ao start`);
+                process.exit(0);
+              }
+            } else if (isHumanCaller()) {
               console.log(chalk.cyan(`\nℹ AO is already running.`));
               console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
               console.log(`  PID: ${running.pid} | Up since: ${running.startedAt}`);


### PR DESCRIPTION
## Summary

- Fixes #1279 — `ao start` in folder B used to detect AO running for project A and default to opening A's dashboard.
- Compare the running instance's `configPath` against the config resolved from cwd. Same path → same-project prompt (unchanged). Different path → new cross-project flow.
- Cross-project prompt defaults to **Stop the other instance and start here** (no more accidentally opening the wrong dashboard). Other options: **Open the other project's dashboard** (explicitly labelled) and **Quit**.
- Non-TTY callers in the cross-project case now get a dedicated info block pointing them at `ao stop --all && ao start` instead of silently exiting with the other project's info.

## Why this fix (Option A from the issue)

Option B (multi-instance support via project-keyed state) is a larger refactor related to #1128. Scoping the existing check by `configPath` is a small, targeted change that removes the misleading default without touching the single-file running-state model.

## Test plan

- [x] All 55 tests in `start.test.ts` pass
- [x] All 487 CLI tests pass
- [x] Typecheck passes
- [x] Lint clean for modified files
- [ ] Manual check: `ao start` in project A, `cd` to project B, `ao start` → prompt shows cross-project warning, default is stop-start, "Open the other project's dashboard" is explicitly labelled
- [ ] Manual check: same project (cwd under A's repo), existing 4-option prompt still appears (open / new / restart / quit)
- [ ] Manual check: non-TTY (e.g. `ao start < /dev/null`) cross-project shows new info + `ao stop --all` hint and exits cleanly

## Test coverage added

- `exits immediately for non-TTY caller when AO is already running (same project)` — preserves existing same-project behaviour
- `shows cross-project warning for non-TTY caller when running instance is a different project` — new scenario
- `offers 'stop-start' default in cross-project prompt and kills other instance on confirm` — verifies kill path
- `exits when cross-project human caller selects 'open-other'` — verifies the user can still opt into opening the other dashboard
- `exits when cross-project human caller selects 'quit'` — quit path
- Renamed the existing same-project tests with `(same project)` suffix and wired a helper that keeps `running.configPath` aligned with `mockConfigRef.current.configPath`, so they actually exercise the same-project branch