### PR TITLE
feat: code-review plugin slot — AI-powered peer review for worker PRs (#1275)

### DIFF
--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,0 +1,296 @@
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  createReviewManager,
+  loadConfig,
+  type CodeReview,
+  type OrchestratorConfig,
+  type PluginRegistry,
+  type ReviewManager,
+} from "@aoagents/ao-core";
+import { getPluginRegistry, getSessionManager } from "../lib/create-session-manager.js";
+
+function buildReviewManager(
+  config: OrchestratorConfig,
+  registry: PluginRegistry,
+): ReviewManager {
+  return createReviewManager({
+    configPath: config.configPath,
+    getProject: (projectId) => config.projects[projectId],
+    resolveReviewPlugin: (projectId) => {
+      const project = config.projects[projectId];
+      const pluginName = project?.codeReview?.plugin;
+      if (!pluginName) return null;
+      return registry.get<CodeReview>("code-review", pluginName);
+    },
+    getSessionPrefix: (projectId) => {
+      const project = config.projects[projectId];
+      return project?.sessionPrefix ?? projectId;
+    },
+  });
+}
+
+function formatSeverity(severity: string): string {
+  if (severity === "error") return chalk.red(severity.toUpperCase().padEnd(7));
+  if (severity === "warning") return chalk.yellow(severity.toUpperCase().padEnd(7));
+  return chalk.blue(severity.toUpperCase().padEnd(7));
+}
+
+function formatStatus(status: string): string {
+  if (status === "open") return chalk.cyan(status.padEnd(14));
+  if (status === "dismissed") return chalk.gray(status.padEnd(14));
+  if (status === "sent_to_agent") return chalk.yellow(status.padEnd(14));
+  return chalk.white(status.padEnd(14));
+}
+
+export function registerReview(program: Command): void {
+  const review = program
+    .command("review")
+    .description("AI-powered peer review of worker PRs (code-review plugin)");
+
+  review
+    .command("run")
+    .description("Trigger a code review for a worker session")
+    .argument("<session>", "Worker session ID")
+    .option("--base <branch>", "Base branch to diff against")
+    .action(async (sessionId: string, opts: { base?: string }) => {
+      const config = loadConfig();
+      const registry = await getPluginRegistry(config);
+      const sm = await getSessionManager(config);
+      const session = await sm.get(sessionId);
+      if (!session) {
+        console.error(chalk.red(`Session not found: ${sessionId}`));
+        process.exit(1);
+      }
+      if (!session.workspacePath) {
+        console.error(chalk.red(`Session ${sessionId} has no workspace path`));
+        process.exit(1);
+      }
+      const project = config.projects[session.projectId];
+      if (!project?.codeReview?.plugin) {
+        console.error(
+          chalk.red(`Project ${session.projectId} has no codeReview.plugin configured`),
+        );
+        process.exit(1);
+      }
+
+      const manager = buildReviewManager(config, registry);
+      const run = await manager.triggerReview({
+        projectId: session.projectId,
+        linkedSessionId: sessionId,
+        workerWorkspacePath: session.workspacePath,
+        branch: session.branch ?? project.defaultBranch,
+        baseBranch: opts.base ?? project.defaultBranch,
+      });
+
+      console.log(chalk.bold(`\nReview ${run.runId}`));
+      console.log(`  Reviewer: ${run.reviewerSessionId}`);
+      console.log(`  HEAD: ${run.headSha}`);
+      console.log(`  Outcome: ${run.outcome}`);
+      console.log(`  Loop: ${run.loopState}`);
+      if (run.terminationReason) {
+        console.log(`  Terminated: ${run.terminationReason}`);
+      }
+      console.log(`  Findings: ${run.findingCount}`);
+      if (run.overallSummary) {
+        console.log(`\n  ${run.overallSummary}`);
+      }
+    });
+
+  review
+    .command("list")
+    .description("List reviews for a session (or all sessions)")
+    .argument("[session]", "Session ID")
+    .option("-p, --project <id>", "Project ID")
+    .action(async (sessionId: string | undefined, opts: { project?: string }) => {
+      const config = loadConfig();
+      const registry = await getPluginRegistry(config);
+      const manager = buildReviewManager(config, registry);
+
+      const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
+      for (const projectId of projectIds) {
+        const store = manager.getStore(projectId);
+        const runs = sessionId
+          ? store.listRunsForSession(sessionId)
+          : store.listAllRuns();
+        if (runs.length === 0) continue;
+        console.log(chalk.bold(`\n${projectId}:`));
+        for (const run of runs) {
+          const label = `${run.reviewerSessionId} (${run.loopState})`;
+          console.log(
+            `  ${chalk.green(run.runId)}  ${label}  -> ${run.linkedSessionId}  ${
+              run.findingCount
+            } findings`,
+          );
+        }
+      }
+    });
+
+  review
+    .command("show")
+    .description("Show findings for a review run")
+    .argument("<runId>", "Run ID")
+    .option("-p, --project <id>", "Project ID (required if multiple projects)")
+    .action(async (runId: string, opts: { project?: string }) => {
+      const config = loadConfig();
+      const registry = await getPluginRegistry(config);
+      const manager = buildReviewManager(config, registry);
+      const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
+
+      for (const projectId of projectIds) {
+        const store = manager.getStore(projectId);
+        const run = store.getRun(runId);
+        if (!run) continue;
+        console.log(chalk.bold(`\nRun ${run.runId}`));
+        console.log(`  Project: ${projectId}`);
+        console.log(`  Reviewer: ${run.reviewerSessionId}`);
+        console.log(`  HEAD: ${run.headSha}`);
+        console.log(`  Outcome: ${run.outcome}`);
+        console.log(`  Loop: ${run.loopState}`);
+        console.log(`  Findings: ${run.findingCount}`);
+        if (run.overallSummary) {
+          console.log(`\n  ${run.overallSummary}`);
+        }
+        const findings = store.listFindingsForRun(runId);
+        if (findings.length === 0) {
+          console.log(chalk.gray("\n  (no findings)"));
+          return;
+        }
+        console.log();
+        for (const f of findings) {
+          console.log(
+            `  ${formatSeverity(f.severity)} ${formatStatus(f.status)} ${chalk.bold(
+              f.title,
+            )}`,
+          );
+          console.log(`    ${f.filePath}:${f.startLine}-${f.endLine}`);
+          if (f.belowConfidenceThreshold) {
+            console.log(`    ${chalk.gray(`(below confidence threshold: ${f.confidence})`)}`);
+          }
+          console.log(`    ${chalk.gray(f.findingId)}`);
+        }
+        return;
+      }
+      console.error(chalk.red(`Run not found: ${runId}`));
+      process.exit(1);
+    });
+
+  review
+    .command("dismiss")
+    .description("Dismiss a finding")
+    .argument("<runId>", "Run ID")
+    .argument("<findingId>", "Finding ID")
+    .option("-p, --project <id>", "Project ID")
+    .option("--by <user>", "Dismissed by (defaults to $USER)", process.env["USER"] ?? "operator")
+    .action(
+      async (
+        runId: string,
+        findingId: string,
+        opts: { project?: string; by: string },
+      ) => {
+        const config = loadConfig();
+        const registry = await getPluginRegistry(config);
+        const manager = buildReviewManager(config, registry);
+        const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
+        for (const projectId of projectIds) {
+          const store = manager.getStore(projectId);
+          const run = store.getRun(runId);
+          if (!run) continue;
+          const updated = await manager.dismissFinding({
+            projectId,
+            runId,
+            findingId,
+            dismissedBy: opts.by,
+          });
+          console.log(chalk.green(`Dismissed finding ${updated.findingId}`));
+          return;
+        }
+        console.error(chalk.red(`Run not found: ${runId}`));
+        process.exit(1);
+      },
+    );
+
+  review
+    .command("send")
+    .description("Send a finding (or all open findings) to the coding agent")
+    .argument("<runId>", "Run ID")
+    .argument("[findingId]", "Finding ID (omit to send all open findings)")
+    .option("-p, --project <id>", "Project ID")
+    .action(async (runId: string, findingId: string | undefined, opts: { project?: string }) => {
+      const config = loadConfig();
+      const registry = await getPluginRegistry(config);
+      const sm = await getSessionManager(config);
+      const manager = buildReviewManager(config, registry);
+      const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
+
+      for (const projectId of projectIds) {
+        const store = manager.getStore(projectId);
+        const run = store.getRun(runId);
+        if (!run) continue;
+        const findings = store.listFindingsForRun(runId);
+        const target = findingId
+          ? findings.filter((f) => f.findingId === findingId)
+          : findings.filter((f) => f.status === "open");
+        if (target.length === 0) {
+          console.log(chalk.yellow("No matching open findings to send."));
+          return;
+        }
+
+        const message = [
+          `Code review findings on your PR:`,
+          ``,
+          ...target.map(
+            (f) =>
+              `- [${f.severity.toUpperCase()}] ${f.filePath}:${f.startLine}-${f.endLine} — ${f.title}\n    ${f.description.split("\n").join("\n    ")}`,
+          ),
+          ``,
+          `Please address each one, push fixes, and reply.`,
+        ].join("\n");
+
+        try {
+          await sm.send(run.linkedSessionId, message);
+        } catch (err) {
+          console.error(
+            chalk.red(
+              `Failed to deliver to worker ${run.linkedSessionId}: ${
+                err instanceof Error ? err.message : String(err)
+              }`,
+            ),
+          );
+          process.exit(1);
+        }
+
+        await manager.markSentToAgent({
+          projectId,
+          runId,
+          findingIds: target.map((f) => f.findingId),
+        });
+        console.log(chalk.green(`Sent ${target.length} finding(s) to ${run.linkedSessionId}`));
+        return;
+      }
+      console.error(chalk.red(`Run not found: ${runId}`));
+      process.exit(1);
+    });
+
+  review
+    .command("cancel")
+    .description("Cancel a running review")
+    .argument("<runId>", "Run ID")
+    .option("-p, --project <id>", "Project ID")
+    .action(async (runId: string, opts: { project?: string }) => {
+      const config = loadConfig();
+      const registry = await getPluginRegistry(config);
+      const manager = buildReviewManager(config, registry);
+      const projectIds = opts.project ? [opts.project] : Object.keys(config.projects);
+      for (const projectId of projectIds) {
+        const store = manager.getStore(projectId);
+        const run = store.getRun(runId);
+        if (!run) continue;
+        await manager.terminateRun({ projectId, runId, reason: "manual_cancel" });
+        console.log(chalk.green(`Cancelled review ${runId}`));
+        return;
+      }
+      console.error(chalk.red(`Run not found: ${runId}`));
+      process.exit(1);
+    });
+}

--- a/packages/cli/src/lib/plugin-scaffold.ts
+++ b/packages/cli/src/lib/plugin-scaffold.ts
@@ -23,6 +23,8 @@ const SLOT_HINTS: Record<PluginSlot, string> = {
   scm: "Implement an SCM-compatible object from create() for branch, PR, CI, and review operations.",
   notifier: "Implement a Notifier-compatible object from create() for notify() delivery logic.",
   terminal: "Implement a Terminal-compatible object from create() for attach/open UX.",
+  "code-review":
+    "Implement a CodeReview-compatible object from create() for runReview/sendFollowUp — runs in a lightweight reviewer workspace.",
 };
 
 function slugify(value: string): string {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -6,6 +6,7 @@ import { registerSession } from "./commands/session.js";
 import { registerSend } from "./commands/send.js";
 import { registerAcknowledge, registerReport } from "./commands/report.js";
 import { registerReviewCheck } from "./commands/review-check.js";
+import { registerReview } from "./commands/review.js";
 import { registerDashboard } from "./commands/dashboard.js";
 import { registerOpen } from "./commands/open.js";
 import { registerStart, registerStop } from "./commands/start.js";
@@ -36,6 +37,7 @@ export function createProgram(): Command {
   registerAcknowledge(program);
   registerReport(program);
   registerReviewCheck(program);
+  registerReview(program);
   registerDashboard(program);
   registerOpen(program);
   registerVerify(program);

--- a/packages/core/src/__tests__/review-store.test.ts
+++ b/packages/core/src/__tests__/review-store.test.ts
@@ -1,0 +1,291 @@
+/**
+ * Unit tests for ReviewStore + fingerprint + convergence helpers.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  allocateReviewerSessionId,
+  computeFindingFingerprint,
+  createReviewStore,
+  type ReviewStore,
+} from "../review-store.js";
+import {
+  carryForwardTriage,
+  detectStalled,
+  slidingWindowUnion,
+} from "../code-review-fingerprint.js";
+import type { CodeReviewFinding, CodeReviewRun } from "../types.js";
+
+describe("computeFindingFingerprint", () => {
+  it("is stable for identical inputs", () => {
+    const fp1 = computeFindingFingerprint({
+      filePath: "src/foo.ts",
+      category: "bug",
+      severity: "error",
+      anchorSignature: "function foo() {",
+      startLine: 1,
+      endLine: 3,
+    });
+    const fp2 = computeFindingFingerprint({
+      filePath: "src/foo.ts",
+      category: "bug",
+      severity: "error",
+      anchorSignature: "function foo() {",
+      startLine: 1,
+      endLine: 3,
+    });
+    expect(fp1).toBe(fp2);
+  });
+
+  it("differs when any component changes", () => {
+    const base = {
+      filePath: "src/foo.ts",
+      category: "bug" as const,
+      severity: "error" as const,
+      anchorSignature: "function foo() {",
+      startLine: 1,
+      endLine: 3,
+    };
+    const fp = computeFindingFingerprint(base);
+    expect(fp).not.toBe(computeFindingFingerprint({ ...base, filePath: "src/bar.ts" }));
+    expect(fp).not.toBe(computeFindingFingerprint({ ...base, category: "perf" }));
+    expect(fp).not.toBe(computeFindingFingerprint({ ...base, severity: "warning" }));
+    expect(fp).not.toBe(computeFindingFingerprint({ ...base, anchorSignature: "other" }));
+  });
+
+  it("produces a 16-char hex string", () => {
+    const fp = computeFindingFingerprint({
+      filePath: "a",
+      category: "b",
+      severity: "info",
+      anchorSignature: "c",
+      startLine: 1,
+      endLine: 1,
+    });
+    expect(fp).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("falls back to line range when anchor is absent", () => {
+    const fp1 = computeFindingFingerprint({
+      filePath: "a",
+      category: "b",
+      severity: "info",
+      startLine: 10,
+      endLine: 20,
+    });
+    const fp2 = computeFindingFingerprint({
+      filePath: "a",
+      category: "b",
+      severity: "info",
+      startLine: 11,
+      endLine: 20,
+    });
+    expect(fp1).not.toBe(fp2);
+  });
+});
+
+describe("allocateReviewerSessionId", () => {
+  it("starts at 1 when no existing reviewers", () => {
+    expect(allocateReviewerSessionId([], "ao")).toBe("ao-rev-1");
+  });
+
+  it("increments past the max existing number across the whole project", () => {
+    const runs: CodeReviewRun[] = [
+      { reviewerSessionId: "ao-rev-1" } as CodeReviewRun,
+      { reviewerSessionId: "ao-rev-5" } as CodeReviewRun,
+      { reviewerSessionId: "ao-rev-3" } as CodeReviewRun,
+    ];
+    expect(allocateReviewerSessionId(runs, "ao")).toBe("ao-rev-6");
+  });
+
+  it("ignores IDs from other prefixes", () => {
+    const runs: CodeReviewRun[] = [
+      { reviewerSessionId: "other-rev-10" } as CodeReviewRun,
+    ];
+    expect(allocateReviewerSessionId(runs, "ao")).toBe("ao-rev-1");
+  });
+});
+
+describe("ReviewStore", () => {
+  let tempDir: string;
+  let store: ReviewStore;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "ao-review-store-"));
+    store = createReviewStore(tempDir);
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("creates and retrieves runs", () => {
+    const run = store.createRun({
+      reviewerSessionId: "ao-rev-1",
+      reviewerWorkspacePath: "/tmp/ws",
+      linkedSessionId: "ao-1",
+      projectId: "demo",
+      headSha: "abc1234",
+      overallSummary: "",
+    });
+    const fetched = store.getRun(run.runId);
+    expect(fetched?.runId).toBe(run.runId);
+    expect(fetched?.loopState).toBe("reviewing");
+    expect(fetched?.outcome).toBe("completed");
+  });
+
+  it("lists runs for a specific session", () => {
+    store.createRun({
+      reviewerSessionId: "ao-rev-1",
+      reviewerWorkspacePath: null,
+      linkedSessionId: "ao-1",
+      projectId: "demo",
+      headSha: "sha-a",
+    });
+    store.createRun({
+      reviewerSessionId: "ao-rev-2",
+      reviewerWorkspacePath: null,
+      linkedSessionId: "ao-2",
+      projectId: "demo",
+      headSha: "sha-b",
+    });
+    const forOne = store.listRunsForSession("ao-1");
+    expect(forOne.length).toBe(1);
+    expect(forOne[0]?.headSha).toBe("sha-a");
+  });
+
+  it("appends findings and updates status", () => {
+    const run = store.createRun({
+      reviewerSessionId: "ao-rev-1",
+      reviewerWorkspacePath: null,
+      linkedSessionId: "ao-1",
+      projectId: "demo",
+      headSha: "sha-a",
+    });
+    const finding = store.appendFinding(run.runId, {
+      filePath: "src/a.ts",
+      startLine: 1,
+      endLine: 2,
+      title: "t",
+      description: "d",
+      category: "bug",
+      severity: "error",
+      confidence: 0.9,
+    });
+    expect(finding.status).toBe("open");
+
+    const dismissed = store.updateFindingStatus(run.runId, finding.findingId, "dismissed", {
+      dismissedBy: "operator",
+    });
+    expect(dismissed.status).toBe("dismissed");
+    expect(dismissed.dismissedBy).toBe("operator");
+    expect(dismissed.dismissedAt).toBeTypeOf("string");
+  });
+
+  it("appends thread messages per finding", () => {
+    const run = store.createRun({
+      reviewerSessionId: "ao-rev-1",
+      reviewerWorkspacePath: null,
+      linkedSessionId: "ao-1",
+      projectId: "demo",
+      headSha: "sha-a",
+    });
+    const finding = store.appendFinding(run.runId, {
+      filePath: "src/a.ts",
+      startLine: 1,
+      endLine: 1,
+      title: "t",
+      description: "d",
+      category: "bug",
+      severity: "error",
+      confidence: 0.9,
+    });
+    const thread = store.appendThreadMessage(finding.findingId, run.runId, "ao-1", "demo", {
+      role: "human",
+      content: "This is intentional backwards compat.",
+    });
+    expect(thread.messages.length).toBe(1);
+
+    const thread2 = store.appendThreadMessage(finding.findingId, run.runId, "ao-1", "demo", {
+      role: "reviewer",
+      content: "Acknowledged.",
+    });
+    expect(thread2.messages.length).toBe(2);
+  });
+});
+
+describe("carryForwardTriage", () => {
+  it("returns open when there is no prior finding", () => {
+    expect(carryForwardTriage(undefined).status).toBe("open");
+  });
+
+  it("preserves dismissed state with metadata", () => {
+    const prior = {
+      status: "dismissed",
+      dismissedBy: "operator",
+      dismissedAt: "2026-01-01T00:00:00Z",
+    } as unknown as CodeReviewFinding;
+    const result = carryForwardTriage(prior);
+    expect(result.status).toBe("dismissed");
+    expect(result.dismissedBy).toBe("operator");
+    expect(result.dismissedAt).toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("re-opens findings that were previously sent_to_agent", () => {
+    const prior = { status: "sent_to_agent" } as unknown as CodeReviewFinding;
+    expect(carryForwardTriage(prior).status).toBe("open");
+  });
+});
+
+describe("slidingWindowUnion", () => {
+  function f(fp: string, status: CodeReviewFinding["status"] = "open"): CodeReviewFinding {
+    return { fingerprint: fp, status } as CodeReviewFinding;
+  }
+
+  it("unions fingerprints across the window, excluding dismissed", () => {
+    const u = slidingWindowUnion(
+      [[f("a"), f("b", "dismissed")], [f("c")], [f("a"), f("d")]],
+      3,
+    );
+    expect([...u].sort()).toEqual(["a", "c", "d"]);
+  });
+
+  it("respects the window size", () => {
+    const u = slidingWindowUnion([[f("a")], [f("b")], [f("c")]], 2);
+    expect([...u].sort()).toEqual(["b", "c"]);
+  });
+});
+
+describe("detectStalled", () => {
+  function f(fp: string, status: CodeReviewFinding["status"] = "open"): CodeReviewFinding {
+    return { fingerprint: fp, status } as CodeReviewFinding;
+  }
+
+  it("returns converging before hitting maxReviewRounds", () => {
+    expect(detectStalled([[f("a")], [f("a")]], 3, 3)).toBe("converging");
+  });
+
+  it("catches flip-flop loops via window union", () => {
+    // run sequence: {a} -> {b} -> {a}
+    // pairwise superset check would miss this; window union is {a,b} stable.
+    const verdict = detectStalled([[f("a")], [f("b")], [f("a")]], 3, 3);
+    expect(verdict).toBe("stalled");
+  });
+
+  it("treats progress as converging (window=1)", () => {
+    // Latest finding set shrinks relative to prior — window=1 models pure progress.
+    const verdict = detectStalled(
+      [[f("a"), f("b")], [f("a"), f("b")], [f("c")]],
+      3,
+      1,
+    );
+    expect(verdict).toBe("converging");
+  });
+
+  it("treats an empty current window as converging", () => {
+    expect(detectStalled([[f("a")], [f("b")], []], 3, 1)).toBe("converging");
+  });
+});

--- a/packages/core/src/code-review-fingerprint.ts
+++ b/packages/core/src/code-review-fingerprint.ts
@@ -1,0 +1,94 @@
+/**
+ * Code review finding fingerprint + convergence helpers.
+ *
+ * Fingerprints give us stable identity for findings across review runs. When a
+ * human dismisses a finding, we want the same issue to stay dismissed on the
+ * next run even though line numbers may have shifted. The fingerprint relies on
+ * structural anchors (file + category + severity + enclosing scope) rather than
+ * text snippets so small refactors don't invalidate triage state.
+ *
+ * Convergence helpers detect the "stalled" state via a sliding-window union of
+ * open finding fingerprints. This catches flip-flop loops that a pairwise
+ * superset check would miss.
+ */
+
+import { createHash } from "node:crypto";
+import type { CodeReviewFinding, CodeReviewFindingInput } from "./types.js";
+
+/** Truncated sha256 of the fingerprint components, 16 hex chars. */
+export function computeFindingFingerprint(
+  finding: Pick<
+    CodeReviewFindingInput,
+    "filePath" | "category" | "severity" | "anchorSignature" | "startLine" | "endLine"
+  >,
+): string {
+  const anchor =
+    finding.anchorSignature && finding.anchorSignature.length > 0
+      ? finding.anchorSignature
+      : `L${finding.startLine}-${finding.endLine}`;
+  const payload = [finding.filePath, finding.category, finding.severity, anchor].join("\0");
+  return createHash("sha256").update(payload).digest("hex").slice(0, 16);
+}
+
+/**
+ * Sliding-window union of open finding fingerprints across recent runs.
+ * Each run's findings array is filtered to non-dismissed findings before union.
+ */
+export function slidingWindowUnion(
+  runFindings: ReadonlyArray<ReadonlyArray<CodeReviewFinding>>,
+  windowSize: number,
+): Set<string> {
+  const start = Math.max(0, runFindings.length - windowSize);
+  const union = new Set<string>();
+  for (let i = start; i < runFindings.length; i++) {
+    const findings = runFindings[i];
+    if (!findings) continue;
+    for (const f of findings) {
+      if (f.status === "dismissed") continue;
+      union.add(f.fingerprint);
+    }
+  }
+  return union;
+}
+
+/**
+ * Convergence verdict given a history of run findings.
+ * Returns "stalled" when the sliding-window union failed to shrink over the
+ * last `maxReviewRounds` runs; "converging" otherwise.
+ */
+export function detectStalled(
+  runFindings: ReadonlyArray<ReadonlyArray<CodeReviewFinding>>,
+  maxReviewRounds: number,
+  stallWindow: number,
+): "stalled" | "converging" {
+  if (runFindings.length < maxReviewRounds) return "converging";
+  const current = slidingWindowUnion(runFindings, stallWindow);
+  if (current.size === 0) return "converging";
+  const prior = slidingWindowUnion(runFindings.slice(0, -1), stallWindow);
+  if (prior.size === 0) return "converging";
+  return current.size >= prior.size ? "stalled" : "converging";
+}
+
+/**
+ * For a newly produced set of finding inputs, carry forward triage state from
+ * prior stored findings with matching fingerprints. Dismissed findings remain
+ * dismissed; sent_to_agent becomes open again (fresh occurrence worth re-surfacing
+ * if the worker did not fix).
+ */
+export interface CarryForwardResult {
+  status: CodeReviewFinding["status"];
+  dismissedBy?: string;
+  dismissedAt?: string;
+}
+
+export function carryForwardTriage(prior: CodeReviewFinding | undefined): CarryForwardResult {
+  if (!prior) return { status: "open" };
+  if (prior.status === "dismissed") {
+    return {
+      status: "dismissed",
+      dismissedBy: prior.dismissedBy,
+      dismissedAt: prior.dismissedAt,
+    };
+  }
+  return { status: "open" };
+}

--- a/packages/core/src/code-review-trigger.ts
+++ b/packages/core/src/code-review-trigger.ts
@@ -1,0 +1,85 @@
+/**
+ * Bridge between the lifecycle manager and the review manager.
+ *
+ * The lifecycle manager exposes a generic `onSessionPolled` hook. This module
+ * wraps a ReviewManager into a poll-cycle callback that:
+ *   1. Skips sessions without a codeReview configuration or in a non-reviewable
+ *      status.
+ *   2. Reads HEAD SHA from the worker's workspace to detect fresh commits.
+ *   3. Triggers a review if the SHA hasn't been reviewed yet and the project's
+ *      configured trigger flags allow it.
+ *
+ * Kept as a standalone module so the lifecycle manager itself stays agnostic
+ * of the review slot.
+ */
+
+import type {
+  CodeReviewConfig,
+  OrchestratorConfig,
+  Session,
+  SessionStatus,
+} from "./types.js";
+import type { ReviewManager } from "./review-manager.js";
+
+/** Statuses during which we want the reviewer to run. */
+const REVIEW_STATUSES: ReadonlySet<SessionStatus> = new Set([
+  "pr_open",
+  "review_pending",
+  "changes_requested",
+  "ci_failed",
+]);
+
+export interface CreateReviewTriggerDeps {
+  config: OrchestratorConfig;
+  reviewManager: ReviewManager;
+}
+
+export function createReviewTrigger(
+  deps: CreateReviewTriggerDeps,
+): (session: Session, status: SessionStatus) => Promise<void> {
+  const lastReviewedSha = new Map<string, string>();
+
+  return async function onSessionPolled(
+    session: Session,
+    status: SessionStatus,
+  ): Promise<void> {
+    if (!session.workspacePath) return;
+    if (!REVIEW_STATUSES.has(status)) return;
+
+    const project = deps.config.projects[session.projectId];
+    if (!project) return;
+
+    const reviewConfig: CodeReviewConfig | undefined = project.codeReview;
+    if (!reviewConfig || reviewConfig.mode === "disabled") return;
+
+    const trigger = reviewConfig.trigger ?? {};
+    const isPROpenTrigger = status === "pr_open" && trigger.onPullRequestOpen !== false;
+    const isUpdateTrigger =
+      (status === "review_pending" ||
+        status === "changes_requested" ||
+        status === "ci_failed") &&
+      trigger.onPullRequestUpdate !== false;
+
+    if (reviewConfig.mode === "manual-only") return;
+    if (!isPROpenTrigger && !isUpdateTrigger) return;
+
+    const headSha = await deps.reviewManager.readHeadSha(session.workspacePath);
+    if (!headSha) return;
+
+    if (lastReviewedSha.get(session.id) === headSha) return;
+
+    try {
+      await deps.reviewManager.triggerReview({
+        projectId: session.projectId,
+        linkedSessionId: session.id,
+        workerWorkspacePath: session.workspacePath,
+        branch: session.branch ?? project.defaultBranch,
+        baseBranch: project.defaultBranch,
+      });
+      lastReviewedSha.set(session.id, headSha);
+    } catch {
+      // Swallow — next poll cycle will try again. Errors are surfaced via the
+      // review store and dashboards, not by crashing the poll.
+    }
+  };
+}

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -125,6 +125,39 @@ const NotifierConfigSchema = z
   .passthrough()
   .superRefine((value, ctx) => validatePluginConfigFields(value, ctx, "Notifier"));
 
+const CodeReviewConfigSchema = z
+  .object({
+    plugin: z.string().optional(),
+    package: z.string().optional(),
+    path: z.string().optional(),
+    mode: z.enum(["enabled", "disabled", "manual-only"]).default("enabled"),
+    prompt: z.string().optional(),
+    autoSendNewFindingsToAgent: z.boolean().default(true),
+    routing: z
+      .object({
+        publishToScm: z.boolean().default(false),
+      })
+      .default({}),
+    limits: z
+      .object({
+        maxReviewRounds: z.number().int().positive().default(3),
+        maxBudgetPerRun: z.number().positive().optional(),
+        confidenceThreshold: z.number().min(0).max(1).default(0),
+        stallWindow: z.number().int().positive().default(3),
+      })
+      .default({}),
+    severityThreshold: z.enum(["error", "warning", "info"]).default("info"),
+    trigger: z
+      .object({
+        onPullRequestOpen: z.boolean().default(true),
+        onPullRequestUpdate: z.boolean().default(true),
+        manual: z.boolean().default(true),
+      })
+      .default({}),
+  })
+  .passthrough()
+  .superRefine((value, ctx) => validatePluginConfigFields(value, ctx, "CodeReview"));
+
 const AgentPermissionSchema = z
   .enum(["permissionless", "default", "auto-edit", "suggest", "skip"])
   .default("permissionless")
@@ -177,6 +210,7 @@ const ProjectConfigSchema = z.object({
   workspace: z.string().optional(),
   tracker: TrackerConfigSchema.optional(),
   scm: SCMConfigSchema.optional(),
+  codeReview: CodeReviewConfigSchema.optional(),
   symlinks: z.array(z.string()).optional(),
   postCreate: z.array(z.string()).optional(),
   agentConfig: AgentSpecificConfigSchema.default({}),
@@ -393,6 +427,16 @@ export function collectExternalPluginConfigs(config: OrchestratorConfig): Extern
         `projects.${projectId}.scm`,
         { kind: "project", projectId, configType: "scm" },
         "scm",
+      );
+      if (entry) entries.push(entry);
+    }
+
+    if (project.codeReview) {
+      const entry = processExternalPluginConfig(
+        project.codeReview,
+        `projects.${projectId}.codeReview`,
+        { kind: "project", projectId, configType: "codeReview" },
+        "code-review",
       );
       if (entry) entries.push(entry);
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -217,6 +217,17 @@ export type {
   PersistedFeedbackReport,
 } from "./feedback-tools.js";
 
+// Review store — flat-file storage for CodeReview runs + findings + threads
+export { createReviewStore, allocateReviewerSessionId } from "./review-store.js";
+export type { ReviewStore, CreateRunInput } from "./review-store.js";
+export {
+  computeFindingFingerprint,
+  slidingWindowUnion,
+  detectStalled,
+  carryForwardTriage,
+} from "./code-review-fingerprint.js";
+export type { CarryForwardResult } from "./code-review-fingerprint.js";
+
 // Path utilities — hash-based directory structure
 export {
   generateConfigHash,
@@ -229,6 +240,8 @@ export {
   getFeedbackReportsDir,
   getObservabilityBaseDir,
   getArchiveDir,
+  getReviewsDir,
+  getReviewWorkspacesDir,
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -228,6 +228,20 @@ export {
 } from "./code-review-fingerprint.js";
 export type { CarryForwardResult } from "./code-review-fingerprint.js";
 
+// Review manager — orchestrates the code review loop
+export { createReviewManager } from "./review-manager.js";
+export type {
+  ReviewManager,
+  ReviewManagerDeps,
+  TriggerReviewArgs,
+  DismissArgs,
+  ReopenArgs,
+  MarkSentArgs,
+  TerminateRunArgs,
+} from "./review-manager.js";
+export { createReviewTrigger } from "./code-review-trigger.js";
+export type { CreateReviewTriggerDeps } from "./code-review-trigger.js";
+
 // Path utilities — hash-based directory structure
 export {
   generateConfigHash,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -298,6 +298,12 @@ export interface LifecycleManagerDeps {
   sessionManager: SessionManager;
   /** When set, only poll sessions belonging to this project. */
   projectId?: string;
+  /**
+   * Optional hook invoked once per session per poll cycle. Used by the review
+   * manager to opportunistically trigger code reviews without the lifecycle
+   * manager needing to know about the review slot directly.
+   */
+  onSessionPolled?: (session: Session, status: SessionStatus) => Promise<void> | void;
 }
 
 /** Track attempt counts for reactions per session. */
@@ -1787,6 +1793,26 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     // Report watcher: audit agent reports for issues (#140)
     await auditAndReactToReports(session);
+
+    // Code review hook — fires once per session per poll cycle so external
+    // coordinators (e.g. review manager) can trigger reviews without reaching
+    // into lifecycle internals.
+    if (deps.onSessionPolled) {
+      try {
+        await deps.onSessionPolled(session, newStatus);
+      } catch (err) {
+        observer.recordOperation({
+          metric: "lifecycle_poll",
+          operation: "lifecycle.onSessionPolled",
+          outcome: "failure",
+          correlationId: createCorrelationId("lifecycle-on-session-polled"),
+          projectId: session.projectId,
+          durationMs: 0,
+          reason: err instanceof Error ? err.message : String(err),
+          level: "warn",
+        });
+      }
+    }
   }
 
   /**

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -128,6 +128,22 @@ export function getArchiveDir(configPath: string, projectPath: string): string {
 }
 
 /**
+ * Get the code review store directory for a project.
+ * Format: ~/.agent-orchestrator/{hash}-{projectId}/reviews
+ */
+export function getReviewsDir(configPath: string, projectPath: string): string {
+  return join(getProjectBaseDir(configPath, projectPath), "reviews");
+}
+
+/**
+ * Get the reviewer workspaces directory for a project.
+ * Format: ~/.agent-orchestrator/{hash}-{projectId}/review-workspaces
+ */
+export function getReviewWorkspacesDir(configPath: string, projectPath: string): string {
+  return join(getProjectBaseDir(configPath, projectPath), "review-workspaces");
+}
+
+/**
  * Get the .origin file path for a project.
  * This file stores the config path for collision detection.
  */

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -65,6 +65,8 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   // Terminals
   { slot: "terminal", name: "iterm2", pkg: "@aoagents/ao-plugin-terminal-iterm2" },
   { slot: "terminal", name: "web", pkg: "@aoagents/ao-plugin-terminal-web" },
+  // Code reviewers
+  { slot: "code-review", name: "codex", pkg: "@aoagents/ao-plugin-code-review-codex" },
 ];
 
 function matchesNotifierPlugin(
@@ -238,7 +240,11 @@ function updateConfigWithManifestName(
   if (location.kind === "project") {
     const { projectId, configType } = location;
     const project = config.projects[projectId];
-    if (project?.[configType]) {
+    if (configType === "codeReview") {
+      if (project?.codeReview) {
+        project.codeReview.plugin = manifest.name;
+      }
+    } else if (project?.[configType]) {
       project[configType]!.plugin = manifest.name;
     }
   } else if (location.kind === "notifier") {

--- a/packages/core/src/review-manager.ts
+++ b/packages/core/src/review-manager.ts
@@ -1,0 +1,423 @@
+/**
+ * Review manager — orchestrates the code review loop for worker PRs.
+ *
+ * Responsibilities:
+ * - Serialize at most one reviewer workspace per worker session
+ * - Track run lifecycle (reviewing → awaiting_context → done/stalled/terminated)
+ * - Persist runs and findings via the review store
+ * - Carry forward triage state (fingerprint-matched dismissals)
+ * - Detect convergence / stalled loops
+ * - Allocate project-scoped reviewer IDs
+ *
+ * Design choice: the reviewer workspace is a plain git worktree (no tmux, no
+ * agent runtime). The CodeReview plugin runs directly in it. That keeps review
+ * resource overhead tiny compared to a full AO session.
+ */
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import type {
+  CodeReview,
+  CodeReviewConfig,
+  CodeReviewFinding,
+  CodeReviewLoopState,
+  CodeReviewRun,
+  CodeReviewRunOutcome,
+  CodeReviewTerminationReason,
+  ProjectConfig,
+  SessionId,
+} from "./types.js";
+import { carryForwardTriage, detectStalled } from "./code-review-fingerprint.js";
+import {
+  allocateReviewerSessionId,
+  createReviewStore,
+  type ReviewStore,
+} from "./review-store.js";
+import { getReviewsDir, getReviewWorkspacesDir } from "./paths.js";
+
+const GIT_TIMEOUT_MS = 30_000;
+const execFileAsync = promisify(execFile);
+
+export interface ReviewManagerDeps {
+  /** Orchestrator config path — used to locate per-project review dirs. */
+  configPath: string;
+  /** Resolve a project config by ID. */
+  getProject(projectId: string): ProjectConfig | undefined;
+  /** Resolve the configured CodeReview plugin instance for a project. */
+  resolveReviewPlugin(projectId: string): CodeReview | null;
+  /** Resolve the session prefix for allocating reviewer IDs. */
+  getSessionPrefix(projectId: string): string;
+}
+
+export interface ReviewManager {
+  triggerReview(args: TriggerReviewArgs): Promise<CodeReviewRun>;
+  dismissFinding(args: DismissArgs): Promise<CodeReviewFinding>;
+  reopenFinding(args: ReopenArgs): Promise<CodeReviewFinding>;
+  markSentToAgent(args: MarkSentArgs): Promise<CodeReviewFinding[]>;
+  terminateRun(args: TerminateRunArgs): Promise<CodeReviewRun>;
+  cleanupReviewerWorkspace(runId: string): Promise<void>;
+  getStore(projectId: string): ReviewStore;
+  readHeadSha(workspacePath: string): Promise<string | null>;
+}
+
+export interface TriggerReviewArgs {
+  projectId: string;
+  linkedSessionId: SessionId;
+  workerWorkspacePath: string;
+  branch: string;
+  baseBranch?: string;
+  configOverride?: CodeReviewConfig;
+}
+
+export interface DismissArgs {
+  projectId: string;
+  runId: string;
+  findingId: string;
+  dismissedBy: string;
+}
+
+export interface ReopenArgs {
+  projectId: string;
+  runId: string;
+  findingId: string;
+}
+
+export interface MarkSentArgs {
+  projectId: string;
+  runId: string;
+  findingIds: string[];
+}
+
+export interface TerminateRunArgs {
+  projectId: string;
+  runId: string;
+  reason: CodeReviewTerminationReason;
+}
+
+export function createReviewManager(deps: ReviewManagerDeps): ReviewManager {
+  const storeCache = new Map<string, ReviewStore>();
+
+  function storeFor(projectId: string): ReviewStore {
+    const cached = storeCache.get(projectId);
+    if (cached) return cached;
+    const project = deps.getProject(projectId);
+    if (!project) throw new Error(`Unknown project: ${projectId}`);
+    const reviewsDir = getReviewsDir(deps.configPath, project.path);
+    mkdirSync(reviewsDir, { recursive: true });
+    // createReviewStore expects the project base dir; the reviews subdir is appended internally.
+    const store = createReviewStore(join(reviewsDir, ".."));
+    storeCache.set(projectId, store);
+    return store;
+  }
+
+  async function readHeadSha(workspacePath: string): Promise<string | null> {
+    try {
+      const { stdout } = await execFileAsync("git", ["rev-parse", "HEAD"], {
+        cwd: workspacePath,
+        timeout: GIT_TIMEOUT_MS,
+      });
+      const sha = stdout.trim();
+      return sha.length > 0 ? sha : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async function createReviewerWorktree(
+    project: ProjectConfig,
+    reviewerSessionId: string,
+    headSha: string,
+  ): Promise<string> {
+    const baseDir = getReviewWorkspacesDir(deps.configPath, project.path);
+    mkdirSync(baseDir, { recursive: true });
+    const workspacePath = join(baseDir, reviewerSessionId);
+
+    if (existsSync(workspacePath)) {
+      try {
+        await execFileAsync("git", ["worktree", "remove", "--force", workspacePath], {
+          cwd: project.path,
+          timeout: GIT_TIMEOUT_MS,
+        });
+      } catch {
+        // best-effort
+      }
+      try {
+        rmSync(workspacePath, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    }
+
+    // Detached checkout at the exact SHA being reviewed so a misbehaving plugin
+    // can never accidentally commit on top of the worker's branch.
+    await execFileAsync("git", ["worktree", "add", "--detach", workspacePath, headSha], {
+      cwd: resolve(project.path),
+      timeout: GIT_TIMEOUT_MS,
+    });
+    return workspacePath;
+  }
+
+  async function destroyWorktree(project: ProjectConfig, workspacePath: string): Promise<void> {
+    try {
+      await execFileAsync("git", ["worktree", "remove", "--force", workspacePath], {
+        cwd: project.path,
+        timeout: GIT_TIMEOUT_MS,
+      });
+    } catch {
+      if (existsSync(workspacePath)) {
+        try {
+          rmSync(workspacePath, { recursive: true, force: true });
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  function priorFindingsByFingerprint(
+    store: ReviewStore,
+    linkedSessionId: SessionId,
+  ): Map<string, CodeReviewFinding> {
+    const priorFindings = store.listFindingsForSession(linkedSessionId);
+    const map = new Map<string, CodeReviewFinding>();
+    for (const f of priorFindings) {
+      const existing = map.get(f.fingerprint);
+      if (!existing || existing.createdAt < f.createdAt) {
+        map.set(f.fingerprint, f);
+      }
+    }
+    return map;
+  }
+
+  async function markOutdatedRuns(
+    store: ReviewStore,
+    project: ProjectConfig,
+    linkedSessionId: SessionId,
+    newHeadSha: string,
+  ): Promise<void> {
+    const runs = store.listRunsForSession(linkedSessionId);
+    for (const run of runs) {
+      if (run.headSha === newHeadSha) continue;
+      if (run.outcome === "outdated") continue;
+      if (run.outcome === "completed") {
+        store.updateRun(run.runId, { outcome: "outdated" });
+      }
+      if (run.reviewerWorkspacePath) {
+        await destroyWorktree(project, run.reviewerWorkspacePath);
+        store.updateRun(run.runId, { reviewerWorkspacePath: null });
+      }
+    }
+  }
+
+  return {
+    async triggerReview(args: TriggerReviewArgs): Promise<CodeReviewRun> {
+      const project = deps.getProject(args.projectId);
+      if (!project) throw new Error(`Unknown project: ${args.projectId}`);
+      const plugin = deps.resolveReviewPlugin(args.projectId);
+      if (!plugin) throw new Error(`No code-review plugin configured for ${args.projectId}`);
+
+      const sessionPrefix = deps.getSessionPrefix(args.projectId);
+      const store = storeFor(args.projectId);
+
+      const headSha = await readHeadSha(args.workerWorkspacePath);
+      if (!headSha) {
+        throw new Error(
+          `Unable to read HEAD SHA from worker workspace: ${args.workerWorkspacePath}`,
+        );
+      }
+
+      // Serialize: if another run is already in-flight for this worker at this
+      // SHA, reuse it. Queue new reviews — never preempt.
+      const priorRuns = store.listRunsForSession(args.linkedSessionId);
+      for (const run of priorRuns) {
+        if (
+          run.headSha === headSha &&
+          (run.loopState === "reviewing" || run.loopState === "awaiting_context")
+        ) {
+          return run;
+        }
+      }
+
+      await markOutdatedRuns(store, project, args.linkedSessionId, headSha);
+
+      const reviewerSessionId = allocateReviewerSessionId(store.listAllRuns(), sessionPrefix);
+      const workspacePath = await createReviewerWorktree(project, reviewerSessionId, headSha);
+
+      const initialRun = store.createRun({
+        reviewerSessionId,
+        reviewerWorkspacePath: workspacePath,
+        linkedSessionId: args.linkedSessionId,
+        projectId: args.projectId,
+        headSha,
+        overallSummary: "",
+        loopState: "reviewing",
+        outcome: "completed",
+      });
+      const runId = initialRun.runId;
+
+      const reviewConfig = args.configOverride ?? project.codeReview ?? {};
+      const confidenceThreshold = reviewConfig.limits?.confidenceThreshold ?? 0;
+      const severityThreshold = reviewConfig.severityThreshold ?? "info";
+      const baseBranch = args.baseBranch ?? project.defaultBranch;
+
+      let pluginResult;
+      try {
+        pluginResult = await plugin.runReview({
+          reviewerWorkspacePath: workspacePath,
+          baseBranch,
+          headSha,
+          linkedSessionId: args.linkedSessionId,
+          projectId: args.projectId,
+          maxBudgetUsd: reviewConfig.limits?.maxBudgetPerRun,
+          confidenceThreshold,
+          severityThreshold,
+          prompt: reviewConfig.prompt,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const failedRun = store.updateRun(runId, {
+          outcome: "failed",
+          loopState: "terminated",
+          terminationReason: "reviewer_failure",
+          completedAt: new Date().toISOString(),
+          overallSummary: `Reviewer plugin crashed: ${message}`,
+        });
+        await destroyWorktree(project, workspacePath);
+        store.updateRun(runId, { reviewerWorkspacePath: null });
+        return failedRun;
+      }
+
+      const priorByFingerprint = priorFindingsByFingerprint(store, args.linkedSessionId);
+
+      const appended: CodeReviewFinding[] = [];
+      for (const input of pluginResult.findings) {
+        const finding = store.appendFinding(runId, input);
+        const prior = priorByFingerprint.get(finding.fingerprint);
+        const carry = carryForwardTriage(prior);
+        let current = finding;
+        if (carry.status === "dismissed") {
+          current = store.updateFindingStatus(runId, finding.findingId, "dismissed", {
+            dismissedBy: carry.dismissedBy,
+          });
+        }
+        appended.push(current);
+      }
+
+      const openFindings = appended.filter((f) => f.status === "open");
+      const loopStateInit: CodeReviewLoopState =
+        openFindings.length === 0 ? "done" : "awaiting_context";
+      const outcome: CodeReviewRunOutcome = pluginResult.outcome;
+
+      let terminationReason: CodeReviewTerminationReason | undefined;
+      let finalLoopState: CodeReviewLoopState = loopStateInit;
+
+      if (loopStateInit !== "done") {
+        const runs = store.listRunsForSession(args.linkedSessionId);
+        const sortedRuns = [...runs].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+        const recentRunFindings: CodeReviewFinding[][] = [];
+        for (const r of sortedRuns) {
+          if (r.runId === runId) {
+            recentRunFindings.push(appended);
+          } else {
+            recentRunFindings.push(store.listFindingsForRun(r.runId));
+          }
+        }
+        const maxReviewRounds = reviewConfig.limits?.maxReviewRounds ?? 3;
+        const stallWindow = reviewConfig.limits?.stallWindow ?? 3;
+        const verdict = detectStalled(recentRunFindings, maxReviewRounds, stallWindow);
+        if (verdict === "stalled") {
+          finalLoopState = "stalled";
+          terminationReason = "cycle_cap";
+        }
+      }
+
+      const finalRun = store.updateRun(runId, {
+        outcome,
+        loopState: finalLoopState,
+        terminationReason,
+        completedAt: new Date().toISOString(),
+        overallSummary: pluginResult.overallSummary,
+        overallConfidence: pluginResult.overallConfidence,
+        findingCount: appended.length,
+        costUsd: pluginResult.cost?.estimatedCostUsd,
+      });
+
+      // done/stalled/failed/outdated → cleanup the workspace right away.
+      // awaiting_context keeps it so sendFollowUp can chat with the reviewer.
+      if (
+        finalLoopState === "done" ||
+        finalLoopState === "stalled" ||
+        outcome === "failed" ||
+        outcome === "outdated"
+      ) {
+        await destroyWorktree(project, workspacePath);
+        store.updateRun(runId, { reviewerWorkspacePath: null });
+        return { ...finalRun, reviewerWorkspacePath: null };
+      }
+
+      return finalRun;
+    },
+
+    async dismissFinding(args: DismissArgs): Promise<CodeReviewFinding> {
+      const store = storeFor(args.projectId);
+      return store.updateFindingStatus(args.runId, args.findingId, "dismissed", {
+        dismissedBy: args.dismissedBy,
+      });
+    },
+
+    async reopenFinding(args: ReopenArgs): Promise<CodeReviewFinding> {
+      const store = storeFor(args.projectId);
+      return store.updateFindingStatus(args.runId, args.findingId, "open");
+    },
+
+    async markSentToAgent(args: MarkSentArgs): Promise<CodeReviewFinding[]> {
+      const store = storeFor(args.projectId);
+      const updated: CodeReviewFinding[] = [];
+      const now = new Date().toISOString();
+      for (const id of args.findingIds) {
+        updated.push(
+          store.updateFindingStatus(args.runId, id, "sent_to_agent", { sentToAgentAt: now }),
+        );
+      }
+      return updated;
+    },
+
+    async terminateRun(args: TerminateRunArgs): Promise<CodeReviewRun> {
+      const store = storeFor(args.projectId);
+      const run = store.getRun(args.runId);
+      if (!run) throw new Error(`Run not found: ${args.runId}`);
+      if (run.reviewerWorkspacePath) {
+        const project = deps.getProject(args.projectId);
+        if (project) await destroyWorktree(project, run.reviewerWorkspacePath);
+      }
+      return store.updateRun(args.runId, {
+        loopState: "terminated",
+        terminationReason: args.reason,
+        reviewerWorkspacePath: null,
+        completedAt: new Date().toISOString(),
+      });
+    },
+
+    async cleanupReviewerWorkspace(runId: string): Promise<void> {
+      for (const projectId of storeCache.keys()) {
+        const store = storeCache.get(projectId)!;
+        const run = store.getRun(runId);
+        if (!run) continue;
+        if (run.reviewerWorkspacePath) {
+          const project = deps.getProject(projectId);
+          if (project) await destroyWorktree(project, run.reviewerWorkspacePath);
+        }
+        store.updateRun(runId, { reviewerWorkspacePath: null });
+        return;
+      }
+    },
+
+    getStore(projectId: string): ReviewStore {
+      return storeFor(projectId);
+    },
+
+    readHeadSha,
+  };
+}

--- a/packages/core/src/review-store.ts
+++ b/packages/core/src/review-store.ts
@@ -1,0 +1,347 @@
+/**
+ * ReviewStore — flat-file storage for CodeReview runs, findings, and threads.
+ *
+ * Layout (per project):
+ *   {projectBaseDir}/reviews/
+ *     runs/{runId}.json                       CodeReviewRun record
+ *     findings/{runId}/{findingId}.json       CodeReviewFinding records
+ *     threads/{threadId}.json                 CodeReviewThread records
+ *
+ * The store is AO-local-first: findings live here (not on GitHub) so the human
+ * can triage in the Review Workbench and AO can route them to the worker.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { computeFindingFingerprint } from "./code-review-fingerprint.js";
+import type {
+  CodeReviewFinding,
+  CodeReviewFindingInput,
+  CodeReviewFindingStatus,
+  CodeReviewLoopState,
+  CodeReviewRun,
+  CodeReviewRunOutcome,
+  CodeReviewTerminationReason,
+  CodeReviewThread,
+  CodeReviewThreadMessage,
+  SessionId,
+} from "./types.js";
+
+const RUNS_SUBDIR = "runs";
+const FINDINGS_SUBDIR = "findings";
+const THREADS_SUBDIR = "threads";
+
+export interface ReviewStore {
+  /** Base directory, e.g. "{projectBaseDir}/reviews" */
+  readonly baseDir: string;
+
+  // Runs
+  createRun(input: CreateRunInput): CodeReviewRun;
+  getRun(runId: string): CodeReviewRun | null;
+  updateRun(runId: string, patch: Partial<CodeReviewRun>): CodeReviewRun;
+  listAllRuns(): CodeReviewRun[];
+  listRunsForSession(sessionId: SessionId): CodeReviewRun[];
+  deleteRun(runId: string): void;
+
+  // Findings
+  appendFinding(runId: string, input: CodeReviewFindingInput): CodeReviewFinding;
+  getFinding(runId: string, findingId: string): CodeReviewFinding | null;
+  listFindingsForRun(runId: string): CodeReviewFinding[];
+  listFindingsForSession(sessionId: SessionId): CodeReviewFinding[];
+  updateFindingStatus(
+    runId: string,
+    findingId: string,
+    status: CodeReviewFindingStatus,
+    meta?: { dismissedBy?: string; sentToAgentAt?: string },
+  ): CodeReviewFinding;
+
+  // Threads
+  appendThreadMessage(
+    findingId: string,
+    runId: string,
+    linkedSessionId: SessionId,
+    projectId: string,
+    message: Omit<CodeReviewThreadMessage, "timestamp"> & { timestamp?: string },
+  ): CodeReviewThread;
+  getThread(threadId: string): CodeReviewThread | null;
+  getThreadForFinding(findingId: string): CodeReviewThread | null;
+}
+
+export interface CreateRunInput {
+  reviewerSessionId: string;
+  reviewerWorkspacePath: string | null;
+  linkedSessionId: SessionId;
+  projectId: string;
+  headSha: string;
+  overallSummary?: string;
+  loopState?: CodeReviewLoopState;
+  outcome?: CodeReviewRunOutcome;
+  terminationReason?: CodeReviewTerminationReason;
+}
+
+function ensureDir(path: string): void {
+  if (!existsSync(path)) {
+    mkdirSync(path, { recursive: true });
+  }
+}
+
+function readJsonFile<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+function writeJsonFile(path: string, value: unknown): void {
+  writeFileSync(path, JSON.stringify(value, null, 2), "utf-8");
+}
+
+function listJsonFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir).filter((name) => name.endsWith(".json"));
+}
+
+/**
+ * Allocate the next reviewer session ID for a project.
+ * Format: {sessionPrefix}-rev-{N}
+ *
+ * IMPORTANT: Scans ALL runs in the project (not per-linked-session) to prevent
+ * collisions across multiple workers in the same project.
+ */
+export function allocateReviewerSessionId(
+  existingRuns: CodeReviewRun[],
+  sessionPrefix: string,
+): string {
+  let max = 0;
+  const pattern = new RegExp(
+    `^${sessionPrefix.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&")}-rev-(\\d+)$`,
+  );
+  for (const run of existingRuns) {
+    const match = run.reviewerSessionId.match(pattern);
+    if (match?.[1]) {
+      const n = parseInt(match[1], 10);
+      if (n > max) max = n;
+    }
+  }
+  return `${sessionPrefix}-rev-${max + 1}`;
+}
+
+function makeRunId(reviewerSessionId: string, headSha: string): string {
+  const shortSha = headSha.slice(0, 7);
+  return `${reviewerSessionId}-${shortSha}`;
+}
+
+function makeFindingId(runId: string, fingerprint: string): string {
+  return `${runId}-${fingerprint}`;
+}
+
+function makeThreadId(findingId: string): string {
+  return `${findingId}-thread`;
+}
+
+export function createReviewStore(projectBaseDir: string): ReviewStore {
+  const baseDir = join(projectBaseDir, "reviews");
+  const runsDir = (): string => join(baseDir, RUNS_SUBDIR);
+  const findingsRunDir = (runId: string): string => join(baseDir, FINDINGS_SUBDIR, runId);
+  const threadsDir = (): string => join(baseDir, THREADS_SUBDIR);
+
+  function runPath(runId: string): string {
+    return join(runsDir(), `${runId}.json`);
+  }
+  function findingPath(runId: string, findingId: string): string {
+    return join(findingsRunDir(runId), `${findingId}.json`);
+  }
+  function threadPath(threadId: string): string {
+    return join(threadsDir(), `${threadId}.json`);
+  }
+
+  function readAllRuns(): CodeReviewRun[] {
+    ensureDir(runsDir());
+    const files = listJsonFiles(runsDir());
+    const runs: CodeReviewRun[] = [];
+    for (const file of files) {
+      const run = readJsonFile<CodeReviewRun>(join(runsDir(), file));
+      if (run) runs.push(run);
+    }
+    return runs;
+  }
+
+  return {
+    baseDir,
+
+    createRun(input) {
+      ensureDir(runsDir());
+      const runId = makeRunId(input.reviewerSessionId, input.headSha);
+      const now = new Date().toISOString();
+      const run: CodeReviewRun = {
+        runId,
+        reviewerSessionId: input.reviewerSessionId,
+        reviewerWorkspacePath: input.reviewerWorkspacePath,
+        linkedSessionId: input.linkedSessionId,
+        projectId: input.projectId,
+        headSha: input.headSha,
+        outcome: input.outcome ?? "completed",
+        loopState: input.loopState ?? "reviewing",
+        terminationReason: input.terminationReason,
+        createdAt: now,
+        overallSummary: input.overallSummary ?? "",
+        findingCount: 0,
+      };
+      writeJsonFile(runPath(runId), run);
+      return run;
+    },
+
+    getRun(runId) {
+      return readJsonFile<CodeReviewRun>(runPath(runId));
+    },
+
+    updateRun(runId, patch) {
+      const existing = readJsonFile<CodeReviewRun>(runPath(runId));
+      if (!existing) {
+        throw new Error(`Run not found: ${runId}`);
+      }
+      const updated: CodeReviewRun = { ...existing, ...patch };
+      writeJsonFile(runPath(runId), updated);
+      return updated;
+    },
+
+    listAllRuns() {
+      return readAllRuns();
+    },
+
+    listRunsForSession(sessionId) {
+      return readAllRuns().filter((run) => run.linkedSessionId === sessionId);
+    },
+
+    deleteRun(runId) {
+      const path = runPath(runId);
+      if (existsSync(path)) {
+        rmSync(path);
+      }
+      const runFindingsDir = findingsRunDir(runId);
+      if (existsSync(runFindingsDir)) {
+        rmSync(runFindingsDir, { recursive: true, force: true });
+      }
+    },
+
+    appendFinding(runId, input) {
+      const run = readJsonFile<CodeReviewRun>(runPath(runId));
+      if (!run) {
+        throw new Error(`Run not found: ${runId}`);
+      }
+      ensureDir(findingsRunDir(runId));
+      const fingerprint = computeFindingFingerprint(input);
+      const findingId = makeFindingId(runId, fingerprint);
+      const finding: CodeReviewFinding = {
+        ...input,
+        findingId,
+        runId,
+        linkedSessionId: run.linkedSessionId,
+        projectId: run.projectId,
+        fingerprint,
+        status: "open",
+        createdAt: new Date().toISOString(),
+      };
+      writeJsonFile(findingPath(runId, findingId), finding);
+
+      // Update run's finding count
+      writeJsonFile(runPath(runId), { ...run, findingCount: run.findingCount + 1 });
+
+      return finding;
+    },
+
+    getFinding(runId, findingId) {
+      return readJsonFile<CodeReviewFinding>(findingPath(runId, findingId));
+    },
+
+    listFindingsForRun(runId) {
+      const dir = findingsRunDir(runId);
+      const files = listJsonFiles(dir);
+      const findings: CodeReviewFinding[] = [];
+      for (const file of files) {
+        const f = readJsonFile<CodeReviewFinding>(join(dir, file));
+        if (f) findings.push(f);
+      }
+      return findings;
+    },
+
+    listFindingsForSession(sessionId) {
+      const runs = readAllRuns().filter((r) => r.linkedSessionId === sessionId);
+      const findings: CodeReviewFinding[] = [];
+      for (const run of runs) {
+        findings.push(...this.listFindingsForRun(run.runId));
+      }
+      return findings;
+    },
+
+    updateFindingStatus(runId, findingId, status, meta) {
+      const existing = readJsonFile<CodeReviewFinding>(findingPath(runId, findingId));
+      if (!existing) {
+        throw new Error(`Finding not found: ${runId}/${findingId}`);
+      }
+      const now = new Date().toISOString();
+      const updated: CodeReviewFinding = {
+        ...existing,
+        status,
+        dismissedBy:
+          status === "dismissed"
+            ? meta?.dismissedBy ?? existing.dismissedBy
+            : existing.dismissedBy,
+        dismissedAt: status === "dismissed" ? now : existing.dismissedAt,
+        sentToAgentAt:
+          status === "sent_to_agent" ? meta?.sentToAgentAt ?? now : existing.sentToAgentAt,
+      };
+      writeJsonFile(findingPath(runId, findingId), updated);
+      return updated;
+    },
+
+    appendThreadMessage(findingId, runId, linkedSessionId, projectId, message) {
+      ensureDir(threadsDir());
+      const threadId = makeThreadId(findingId);
+      const existing = readJsonFile<CodeReviewThread>(threadPath(threadId));
+      const now = message.timestamp ?? new Date().toISOString();
+      const fullMessage: CodeReviewThreadMessage = {
+        role: message.role,
+        content: message.content,
+        timestamp: now,
+        author: message.author,
+      };
+
+      if (existing) {
+        const updated: CodeReviewThread = {
+          ...existing,
+          messages: [...existing.messages, fullMessage],
+          updatedAt: now,
+        };
+        writeJsonFile(threadPath(threadId), updated);
+        return updated;
+      }
+
+      const thread: CodeReviewThread = {
+        threadId,
+        findingId,
+        runId,
+        linkedSessionId,
+        projectId,
+        messages: [fullMessage],
+        createdAt: now,
+        updatedAt: now,
+      };
+      writeJsonFile(threadPath(threadId), thread);
+      return thread;
+    },
+
+    getThread(threadId) {
+      return readJsonFile<CodeReviewThread>(threadPath(threadId));
+    },
+
+    getThreadForFinding(findingId) {
+      return readJsonFile<CodeReviewThread>(threadPath(makeThreadId(findingId)));
+    },
+  };
+}
+
+// Re-export from fingerprint module so callers can `import { computeFindingFingerprint } from "./review-store.js"`.
+export { computeFindingFingerprint } from "./code-review-fingerprint.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,15 +6,16 @@ import type { ObservabilityLevel } from "./observability.js";
  * This file defines ALL interfaces and types that the system uses.
  * Every plugin, CLI command, and web API route builds against these.
  *
- * Architecture: 8 plugin slots + core services
- *   1. Runtime    — where sessions execute (tmux, docker, k8s, process)
- *   2. Agent      — AI coding tool (claude-code, codex, aider)
- *   3. Workspace  — code isolation (worktree, clone)
- *   4. Tracker    — issue tracking (github, linear, jira)
- *   5. SCM        — source platform + PR/CI/reviews (github, gitlab)
- *   6. Notifier   — push notifications (desktop, slack, webhook)
- *   7. Terminal   — human interaction UI (iterm2, web, none)
- *   8. Lifecycle Manager (core, not pluggable)
+ * Architecture: 9 plugin slots + core services
+ *   1. Runtime     — where sessions execute (tmux, docker, k8s, process)
+ *   2. Agent       — AI coding tool (claude-code, codex, aider)
+ *   3. Workspace   — code isolation (worktree, clone)
+ *   4. Tracker     — issue tracking (github, linear, jira)
+ *   5. SCM         — source platform + PR/CI/reviews (github, gitlab)
+ *   6. Notifier    — push notifications (desktop, slack, webhook)
+ *   7. Terminal    — human interaction UI (iterm2, web, none)
+ *   8. CodeReview  — AI-powered peer review of worker PRs (codex, claude-code)
+ *   9. Lifecycle Manager (core, not pluggable)
  */
 
 // =============================================================================
@@ -1042,6 +1043,165 @@ export interface Terminal {
 }
 
 // =============================================================================
+// CODE REVIEW — Plugin Slot 8
+// =============================================================================
+
+/**
+ * CodeReview plugin — AI-powered peer review of worker PRs.
+ *
+ * Unlike other plugins, reviewers run as lightweight workspaces (a git worktree only,
+ * with no runtime/agent/tmux). The CodeReview plugin IS the reviewer: it reads the
+ * diff, produces findings, and optionally handles conversational follow-up.
+ */
+export interface CodeReview {
+  readonly name: string;
+
+  /** Run a code review pass on the given workspace and return findings. */
+  runReview(config: CodeReviewRunConfig): Promise<CodeReviewResult>;
+
+  /** Optional: send a follow-up message to the persistent reviewer session. */
+  sendFollowUp?(config: CodeReviewFollowUpConfig): Promise<CodeReviewFollowUpResult>;
+
+  /** Optional: cleanup any plugin-managed state for a reviewer workspace. */
+  destroy?(reviewerWorkspacePath: string): Promise<void>;
+}
+
+export interface CodeReviewRunConfig {
+  reviewerWorkspacePath: string;
+  baseBranch: string;
+  headSha: string;
+  linkedSessionId: SessionId;
+  projectId: string;
+  maxBudgetUsd?: number;
+  confidenceThreshold?: number;
+  severityThreshold?: CodeReviewFindingSeverity;
+  prompt?: string;
+}
+
+export interface CodeReviewResult {
+  outcome: CodeReviewRunOutcome;
+  findings: CodeReviewFindingInput[];
+  overallSummary: string;
+  overallConfidence?: number;
+  errorMessage?: string;
+  cost?: CostEstimate;
+}
+
+export interface CodeReviewFollowUpConfig {
+  reviewerWorkspacePath: string;
+  findingId?: string;
+  message: string;
+}
+
+export interface CodeReviewFollowUpResult {
+  response: string;
+  statusChange?: "acknowledged" | "unchanged";
+}
+
+export type CodeReviewFindingSeverity = "error" | "warning" | "info";
+export type CodeReviewFindingStatus = "open" | "dismissed" | "sent_to_agent" | "acknowledged";
+export type CodeReviewRunOutcome = "completed" | "failed" | "outdated";
+export type CodeReviewLoopState =
+  | "reviewing"
+  | "awaiting_context"
+  | "done"
+  | "stalled"
+  | "terminated";
+export type CodeReviewTerminationReason =
+  | "cycle_cap"
+  | "worker_dead"
+  | "reviewer_failure"
+  | "manual_cancel"
+  | "config_change";
+
+export interface CodeReviewFindingInput {
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  title: string;
+  description: string;
+  category: string;
+  severity: CodeReviewFindingSeverity;
+  confidence: number;
+  anchorSignature?: string;
+}
+
+export interface CodeReviewFinding extends CodeReviewFindingInput {
+  findingId: string;
+  runId: string;
+  linkedSessionId: SessionId;
+  projectId: string;
+  fingerprint: string;
+  status: CodeReviewFindingStatus;
+  belowConfidenceThreshold?: boolean;
+  dismissedBy?: string;
+  dismissedAt?: string;
+  sentToAgentAt?: string;
+  createdAt: string;
+}
+
+export interface CodeReviewRun {
+  runId: string;
+  reviewerSessionId: string;
+  reviewerWorkspacePath: string | null;
+  linkedSessionId: SessionId;
+  projectId: string;
+  headSha: string;
+  outcome: CodeReviewRunOutcome;
+  loopState: CodeReviewLoopState;
+  terminationReason?: CodeReviewTerminationReason;
+  createdAt: string;
+  completedAt?: string;
+  overallSummary: string;
+  overallConfidence?: number;
+  findingCount: number;
+  costUsd?: number;
+}
+
+export interface CodeReviewThread {
+  threadId: string;
+  findingId: string;
+  runId: string;
+  linkedSessionId: SessionId;
+  projectId: string;
+  messages: CodeReviewThreadMessage[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CodeReviewThreadMessage {
+  role: "human" | "reviewer";
+  content: string;
+  timestamp: string;
+  author?: string;
+}
+
+export interface CodeReviewConfig {
+  plugin?: string;
+  package?: string;
+  path?: string;
+  mode?: "enabled" | "disabled" | "manual-only";
+  prompt?: string;
+  autoSendNewFindingsToAgent?: boolean;
+  routing?: {
+    publishToScm?: boolean;
+  };
+  limits?: {
+    maxReviewRounds?: number;
+    maxBudgetPerRun?: number;
+    confidenceThreshold?: number;
+    stallWindow?: number;
+  };
+  severityThreshold?: CodeReviewFindingSeverity;
+  trigger?: {
+    onPullRequestOpen?: boolean;
+    onPullRequestUpdate?: boolean;
+    manual?: boolean;
+  };
+  [key: string]: unknown;
+}
+
+// =============================================================================
 // EVENTS
 // =============================================================================
 
@@ -1213,7 +1373,7 @@ export interface OrchestratorConfig {
  * Used to update config with manifest.name after loading (avoids parsing dotted strings).
  */
 export type ExternalPluginLocation =
-  | { kind: "project"; projectId: string; configType: "tracker" | "scm" }
+  | { kind: "project"; projectId: string; configType: "tracker" | "scm" | "codeReview" }
   | { kind: "notifier"; notifierId: string };
 
 /**
@@ -1226,7 +1386,7 @@ export interface ExternalPluginEntryRef {
   /** Structured location for updating config (avoids parsing source string) */
   location: ExternalPluginLocation;
   /** The slot this plugin fills */
-  slot: "tracker" | "scm" | "notifier";
+  slot: "tracker" | "scm" | "notifier" | "code-review";
   /** npm package name (if specified) */
   package?: string;
   /** Local path (if specified) */
@@ -1325,6 +1485,9 @@ export interface ProjectConfig {
 
   /** SCM configuration (usually inferred from repo) */
   scm?: SCMConfig;
+
+  /** CodeReview plugin configuration (AI-powered peer review) */
+  codeReview?: CodeReviewConfig;
 
   /** Files/dirs to symlink into workspaces */
   symlinks?: string[];
@@ -1491,7 +1654,8 @@ export type PluginSlot =
   | "tracker"
   | "scm"
   | "notifier"
-  | "terminal";
+  | "terminal"
+  | "code-review";
 
 /** Plugin manifest — what every plugin exports */
 export interface PluginManifest {

--- a/packages/plugins/code-review-codex/package.json
+++ b/packages/plugins/code-review-codex/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-code-review-codex",
+  "version": "0.2.5",
+  "description": "CodeReview plugin: OpenAI Codex (codex exec review)",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/code-review-codex"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/code-review-codex/src/__tests__/index.test.ts
+++ b/packages/plugins/code-review-codex/src/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import pluginModule, { extractJsonPayload, normalizeFinding } from "../index.js";
+
+describe("code-review-codex plugin", () => {
+  it("exposes a valid manifest", () => {
+    expect(pluginModule.manifest.name).toBe("codex");
+    expect(pluginModule.manifest.slot).toBe("code-review");
+    expect(pluginModule.manifest.version).toBeTypeOf("string");
+  });
+
+  it("creates an instance with required methods", () => {
+    const instance = pluginModule.create();
+    expect(instance.name).toBe("codex");
+    expect(typeof instance.runReview).toBe("function");
+    expect(typeof instance.sendFollowUp).toBe("function");
+  });
+});
+
+describe("extractJsonPayload", () => {
+  it("parses whole-stdout JSON", () => {
+    const raw = JSON.stringify({ overallSummary: "ok", findings: [] });
+    expect(extractJsonPayload(raw)).toEqual({ overallSummary: "ok", findings: [] });
+  });
+
+  it("returns null for non-JSON output", () => {
+    expect(extractJsonPayload("hello world")).toBe(null);
+  });
+
+  it("picks up a final JSON line", () => {
+    const raw = [
+      "[info] running review...",
+      "[info] 3 files changed",
+      JSON.stringify({ findings: [{ file: "a.ts", line: 1, title: "t" }] }),
+    ].join("\n");
+    const payload = extractJsonPayload(raw);
+    expect(payload?.findings?.[0]?.title).toBe("t");
+  });
+});
+
+describe("normalizeFinding", () => {
+  it("normalizes flexible codex shapes", () => {
+    const f = normalizeFinding({
+      file: "src/a.ts",
+      line: 10,
+      title: "t",
+      body: "b",
+      severity: "warning",
+      confidence: 0.9,
+    });
+    expect(f).toMatchObject({
+      filePath: "src/a.ts",
+      startLine: 10,
+      endLine: 10,
+      severity: "warning",
+      confidence: 0.9,
+    });
+  });
+
+  it("rejects findings without a file path", () => {
+    expect(normalizeFinding({ title: "x" })).toBe(null);
+  });
+
+  it("clamps 0-100 confidence into 0-1", () => {
+    const f = normalizeFinding({ file: "a", line: 1, title: "t", confidence: 80 });
+    expect(f?.confidence).toBeCloseTo(0.8, 2);
+  });
+
+  it("maps priority strings to severity", () => {
+    expect(normalizeFinding({ file: "a", line: 1, title: "t", priority: "high" })?.severity).toBe(
+      "error",
+    );
+    expect(
+      normalizeFinding({ file: "a", line: 1, title: "t", priority: "medium" })?.severity,
+    ).toBe("warning");
+    expect(normalizeFinding({ file: "a", line: 1, title: "t", priority: "low" })?.severity).toBe(
+      "info",
+    );
+  });
+});

--- a/packages/plugins/code-review-codex/src/index.ts
+++ b/packages/plugins/code-review-codex/src/index.ts
@@ -1,0 +1,373 @@
+/**
+ * CodeReview plugin — OpenAI Codex.
+ *
+ * Wraps `codex exec review --base <base>` to produce structured findings.
+ * The plugin runs directly in a reviewer workspace — no runtime, no tmux,
+ * no separate agent. The Codex CLI does the actual review; this plugin is
+ * thin plumbing that maps its JSON output into AO's domain model.
+ *
+ * The Codex session intentionally persists inside the reviewer workspace so
+ * conversational follow-up via sendFollowUp can reattach to the same review
+ * context. `--ephemeral` is NOT used.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import type {
+  CodeReview,
+  CodeReviewFindingInput,
+  CodeReviewFindingSeverity,
+  CodeReviewFollowUpConfig,
+  CodeReviewFollowUpResult,
+  CodeReviewResult,
+  CodeReviewRunConfig,
+  PluginModule,
+} from "@aoagents/ao-core";
+
+export const manifest = {
+  name: "codex",
+  slot: "code-review" as const,
+  description: "CodeReview plugin: OpenAI Codex (native review command)",
+  version: "0.2.5",
+  displayName: "Codex Reviewer",
+};
+
+interface CodexPluginConfig {
+  /** Path to codex binary. Defaults to `codex` (resolved via PATH). */
+  binary?: string;
+  /** Extra CLI args appended after the review subcommand. */
+  extraArgs?: string[];
+  /** Working timeout in milliseconds. Default 10 minutes. */
+  timeoutMs?: number;
+}
+
+interface CodexReviewFindingRaw {
+  filePath?: string;
+  file?: string;
+  path?: string;
+  startLine?: number;
+  start_line?: number;
+  endLine?: number;
+  end_line?: number;
+  line?: number;
+  title?: string;
+  summary?: string;
+  description?: string;
+  body?: string;
+  message?: string;
+  category?: string;
+  severity?: string;
+  priority?: string;
+  confidence?: number;
+  anchorSignature?: string;
+  anchor?: string;
+}
+
+interface CodexReviewPayload {
+  findings?: CodexReviewFindingRaw[];
+  issues?: CodexReviewFindingRaw[];
+  overallSummary?: string;
+  summary?: string;
+  overallConfidence?: number;
+  confidence?: number;
+  cost?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    estimatedCostUsd?: number;
+    amountUsd?: number;
+  };
+  errorMessage?: string;
+  error?: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+
+export function create(rawConfig?: Record<string, unknown>): CodeReview {
+  const config = normalizeConfig(rawConfig);
+
+  return {
+    name: manifest.name,
+
+    async runReview(runConfig: CodeReviewRunConfig): Promise<CodeReviewResult> {
+      if (!existsSync(runConfig.reviewerWorkspacePath)) {
+        throw new Error(
+          `Reviewer workspace does not exist: ${runConfig.reviewerWorkspacePath}`,
+        );
+      }
+
+      const args = buildReviewArgs(runConfig, config);
+      const { stdout, stderr, exitCode } = await runCodex({
+        binary: config.binary,
+        args,
+        cwd: runConfig.reviewerWorkspacePath,
+        timeoutMs: config.timeoutMs,
+      });
+
+      if (exitCode !== 0) {
+        return {
+          outcome: "failed",
+          findings: [],
+          overallSummary: "",
+          errorMessage: stderr.trim() || `codex exited with code ${exitCode}`,
+        };
+      }
+
+      const payload = extractJsonPayload(stdout);
+      if (!payload) {
+        return {
+          outcome: "failed",
+          findings: [],
+          overallSummary: "",
+          errorMessage: "Could not parse codex review output as JSON",
+        };
+      }
+
+      const findings = (payload.findings ?? payload.issues ?? [])
+        .map((raw) => normalizeFinding(raw))
+        .filter((f): f is CodeReviewFindingInput => f !== null);
+
+      const estimatedCostUsd = payload.cost?.estimatedCostUsd ?? payload.cost?.amountUsd;
+      return {
+        outcome: "completed",
+        findings,
+        overallSummary: payload.overallSummary ?? payload.summary ?? "",
+        overallConfidence: payload.overallConfidence ?? payload.confidence,
+        errorMessage: payload.errorMessage ?? payload.error,
+        cost:
+          typeof estimatedCostUsd === "number"
+            ? {
+                inputTokens: payload.cost?.inputTokens ?? 0,
+                outputTokens: payload.cost?.outputTokens ?? 0,
+                estimatedCostUsd,
+              }
+            : undefined,
+      };
+    },
+
+    async sendFollowUp(
+      followUp: CodeReviewFollowUpConfig,
+    ): Promise<CodeReviewFollowUpResult> {
+      if (!existsSync(followUp.reviewerWorkspacePath)) {
+        throw new Error(
+          `Reviewer workspace does not exist: ${followUp.reviewerWorkspacePath}`,
+        );
+      }
+
+      const args = ["exec", "--json", followUp.message];
+      const { stdout, stderr, exitCode } = await runCodex({
+        binary: config.binary,
+        args,
+        cwd: followUp.reviewerWorkspacePath,
+        timeoutMs: config.timeoutMs,
+      });
+
+      if (exitCode !== 0) {
+        throw new Error(stderr.trim() || `codex follow-up exited with code ${exitCode}`);
+      }
+
+      return {
+        response: stdout.trim(),
+        statusChange: "unchanged",
+      };
+    },
+
+    async destroy(): Promise<void> {
+      // No persistent plugin state — reviewer workspaces are managed by the lifecycle layer.
+    },
+  };
+}
+
+function normalizeConfig(raw?: Record<string, unknown>): Required<CodexPluginConfig> {
+  const binary = typeof raw?.["binary"] === "string" ? (raw["binary"] as string) : "codex";
+  const extraArgs = Array.isArray(raw?.["extraArgs"])
+    ? (raw["extraArgs"] as unknown[]).filter((a): a is string => typeof a === "string")
+    : [];
+  const timeoutMs =
+    typeof raw?.["timeoutMs"] === "number" && raw["timeoutMs"] > 0
+      ? (raw["timeoutMs"] as number)
+      : DEFAULT_TIMEOUT_MS;
+  return { binary, extraArgs, timeoutMs };
+}
+
+function buildReviewArgs(
+  runConfig: CodeReviewRunConfig,
+  config: Required<CodexPluginConfig>,
+): string[] {
+  const args = ["exec", "review", "--base", runConfig.baseBranch, "--json"];
+
+  if (runConfig.prompt) {
+    args.push("--prompt", runConfig.prompt);
+  }
+  if (typeof runConfig.maxBudgetUsd === "number") {
+    args.push("--max-budget-usd", String(runConfig.maxBudgetUsd));
+  }
+  if (typeof runConfig.confidenceThreshold === "number") {
+    args.push("--confidence-threshold", String(runConfig.confidenceThreshold));
+  }
+  if (runConfig.severityThreshold) {
+    args.push("--severity-threshold", runConfig.severityThreshold);
+  }
+
+  args.push(...config.extraArgs);
+  return args;
+}
+
+interface RunOptions {
+  binary: string;
+  args: string[];
+  cwd: string;
+  timeoutMs: number;
+}
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number | null;
+}
+
+function runCodex(options: RunOptions): Promise<RunResult> {
+  return new Promise((resolvePromise) => {
+    const child = spawn(options.binary, options.args, {
+      cwd: options.cwd,
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, options.timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf-8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
+
+    child.on("error", (err: Error) => {
+      clearTimeout(timer);
+      resolvePromise({
+        stdout,
+        stderr: stderr || err.message,
+        exitCode: 1,
+      });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (timedOut) {
+        resolvePromise({
+          stdout,
+          stderr: stderr + `\ncodex review timed out after ${options.timeoutMs}ms`,
+          exitCode: 124,
+        });
+        return;
+      }
+      resolvePromise({ stdout, stderr, exitCode: code });
+    });
+  });
+}
+
+/**
+ * Extract a JSON payload from codex stdout. Codex may emit log lines
+ * before a final JSON block — we take the last top-level JSON object.
+ */
+export function extractJsonPayload(stdout: string): CodexReviewPayload | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) return null;
+
+  const whole = tryParseJson(trimmed);
+  if (whole) return whole;
+
+  const lines = trimmed.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]?.trim();
+    if (!line) continue;
+    if (line.startsWith("{") && line.endsWith("}")) {
+      const parsed = tryParseJson(line);
+      if (parsed) return parsed;
+    }
+  }
+
+  const firstBrace = trimmed.indexOf("{");
+  const lastBrace = trimmed.lastIndexOf("}");
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    return tryParseJson(trimmed.slice(firstBrace, lastBrace + 1));
+  }
+
+  return null;
+}
+
+function tryParseJson(raw: string): CodexReviewPayload | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as CodexReviewPayload;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function normalizeFinding(raw: CodexReviewFindingRaw): CodeReviewFindingInput | null {
+  const filePath = raw.filePath ?? raw.file ?? raw.path;
+  if (!filePath) return null;
+
+  const startLine = raw.startLine ?? raw.start_line ?? raw.line ?? 1;
+  const endLine = raw.endLine ?? raw.end_line ?? startLine;
+
+  const title = raw.title ?? raw.summary ?? raw.message ?? "Untitled finding";
+  const description = raw.description ?? raw.body ?? raw.message ?? raw.summary ?? "";
+  const category = raw.category ?? "general";
+  const severity = normalizeSeverity(raw.severity ?? raw.priority);
+  const confidence = clampConfidence(raw.confidence);
+  const anchorSignature = raw.anchorSignature ?? raw.anchor;
+
+  return {
+    filePath,
+    startLine,
+    endLine,
+    title,
+    description,
+    category,
+    severity,
+    confidence,
+    anchorSignature,
+  };
+}
+
+function normalizeSeverity(value: string | undefined): CodeReviewFindingSeverity {
+  if (!value) return "info";
+  const lower = value.toLowerCase();
+  if (lower === "error" || lower === "critical" || lower === "high" || lower === "blocker") {
+    return "error";
+  }
+  if (lower === "warning" || lower === "medium" || lower === "warn") {
+    return "warning";
+  }
+  return "info";
+}
+
+function clampConfidence(value: number | undefined): number {
+  if (typeof value !== "number" || Number.isNaN(value)) return 0.5;
+  if (value < 0) return 0;
+  if (value <= 1) return value;
+  // Accept 0-100 scores and scale them down
+  if (value <= 100) return value / 100;
+  return 1;
+}
+
+export function detect(): boolean {
+  // Lightweight detection: presence of codex binary hint in PATH
+  const path = process.env["PATH"] ?? "";
+  return path.length > 0;
+}
+
+const pluginModule: PluginModule<CodeReview> = { manifest, create, detect };
+export default pluginModule;

--- a/packages/plugins/code-review-codex/tsconfig.json
+++ b/packages/plugins/code-review-codex/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,6 +33,7 @@
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
+    "@aoagents/ao-plugin-code-review-codex": "workspace:*",
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",

--- a/packages/web/src/app/api/reviews/findings/[runId]/[findingId]/route.ts
+++ b/packages/web/src/app/api/reviews/findings/[runId]/[findingId]/route.ts
@@ -1,0 +1,95 @@
+/**
+ * PATCH /api/reviews/findings/[runId]/[findingId]
+ *
+ * Body: { action: "dismiss" | "reopen" | "send", dismissedBy?: string }
+ *
+ * - dismiss: marks the finding dismissed (human triage); dismissals persist via
+ *   fingerprint across future reviewer runs.
+ * - reopen: clears dismissal.
+ * - send: delivers this finding to the worker's coding agent via the session
+ *   manager's send() and marks the finding as sent_to_agent.
+ */
+
+import { getServices } from "@/lib/services";
+
+interface PatchBody {
+  action?: "dismiss" | "reopen" | "send";
+  dismissedBy?: string;
+  projectId?: string;
+}
+
+export async function PATCH(
+  request: Request,
+  ctx: { params: Promise<{ runId: string; findingId: string }> },
+): Promise<Response> {
+  const { runId, findingId } = await ctx.params;
+  let body: PatchBody;
+  try {
+    body = (await request.json()) as PatchBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  if (!body.action) {
+    return Response.json({ error: "action is required" }, { status: 400 });
+  }
+
+  const { config, reviewManager, sessionManager } = await getServices();
+  const projectIds = body.projectId ? [body.projectId] : Object.keys(config.projects);
+
+  for (const projectId of projectIds) {
+    let store;
+    try {
+      store = reviewManager.getStore(projectId);
+    } catch {
+      continue;
+    }
+    const run = store.getRun(runId);
+    if (!run) continue;
+
+    try {
+      if (body.action === "dismiss") {
+        const finding = await reviewManager.dismissFinding({
+          projectId,
+          runId,
+          findingId,
+          dismissedBy: body.dismissedBy ?? "operator",
+        });
+        return Response.json({ finding });
+      }
+      if (body.action === "reopen") {
+        const finding = await reviewManager.reopenFinding({ projectId, runId, findingId });
+        return Response.json({ finding });
+      }
+      if (body.action === "send") {
+        const finding = store.getFinding(runId, findingId);
+        if (!finding) {
+          return Response.json({ error: `Finding not found` }, { status: 404 });
+        }
+        const message = [
+          `Code review finding on your PR:`,
+          ``,
+          `- [${finding.severity.toUpperCase()}] ${finding.filePath}:${finding.startLine}-${finding.endLine} — ${finding.title}`,
+          `    ${finding.description.split("\n").join("\n    ")}`,
+          ``,
+          `Please address it, push a fix, and reply.`,
+        ].join("\n");
+
+        await sessionManager.send(run.linkedSessionId, message);
+        const [updated] = await reviewManager.markSentToAgent({
+          projectId,
+          runId,
+          findingIds: [findingId],
+        });
+        return Response.json({ finding: updated });
+      }
+    } catch (err) {
+      return Response.json(
+        { error: err instanceof Error ? err.message : String(err) },
+        { status: 500 },
+      );
+    }
+    return Response.json({ error: `Unknown action: ${body.action}` }, { status: 400 });
+  }
+
+  return Response.json({ error: `Run not found: ${runId}` }, { status: 404 });
+}

--- a/packages/web/src/app/api/reviews/route.ts
+++ b/packages/web/src/app/api/reviews/route.ts
@@ -1,0 +1,45 @@
+/**
+ * GET /api/reviews — list review runs with findings, grouped by worker session.
+ *
+ * Query params:
+ *   ?project=<id>    filter to a specific project
+ *   ?session=<id>    filter to a specific worker session
+ */
+
+import { getServices } from "@/lib/services";
+import type { CodeReviewRun, CodeReviewFinding } from "@aoagents/ao-core";
+
+export async function GET(request: Request): Promise<Response> {
+  const { searchParams } = new URL(request.url);
+  const projectFilter = searchParams.get("project");
+  const sessionFilter = searchParams.get("session");
+
+  const { config, reviewManager } = await getServices();
+  const projectIds = projectFilter
+    ? [projectFilter].filter((id) => config.projects[id])
+    : Object.keys(config.projects);
+
+  const runs: Array<
+    CodeReviewRun & { findings: CodeReviewFinding[]; projectId: string }
+  > = [];
+
+  for (const projectId of projectIds) {
+    let store;
+    try {
+      store = reviewManager.getStore(projectId);
+    } catch {
+      continue;
+    }
+    const projectRuns = sessionFilter
+      ? store.listRunsForSession(sessionFilter)
+      : store.listAllRuns();
+    for (const run of projectRuns) {
+      const findings = store.listFindingsForRun(run.runId);
+      runs.push({ ...run, findings, projectId });
+    }
+  }
+
+  runs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+
+  return Response.json({ runs });
+}

--- a/packages/web/src/app/api/reviews/runs/route.ts
+++ b/packages/web/src/app/api/reviews/runs/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/reviews/runs — manually trigger a review for a worker session.
+ *
+ * Body: { sessionId: string, projectId?: string, baseBranch?: string }
+ */
+
+import { getServices } from "@/lib/services";
+
+interface TriggerBody {
+  sessionId?: string;
+  projectId?: string;
+  baseBranch?: string;
+}
+
+export async function POST(request: Request): Promise<Response> {
+  let body: TriggerBody;
+  try {
+    body = (await request.json()) as TriggerBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  if (!body.sessionId) {
+    return Response.json({ error: "sessionId is required" }, { status: 400 });
+  }
+
+  const { config, sessionManager, reviewManager } = await getServices();
+  const session = await sessionManager.get(body.sessionId);
+  if (!session) {
+    return Response.json({ error: `Session not found: ${body.sessionId}` }, { status: 404 });
+  }
+  if (!session.workspacePath) {
+    return Response.json(
+      { error: `Session ${body.sessionId} has no workspace path` },
+      { status: 400 },
+    );
+  }
+
+  const projectId = body.projectId ?? session.projectId;
+  const project = config.projects[projectId];
+  if (!project) {
+    return Response.json({ error: `Project not found: ${projectId}` }, { status: 404 });
+  }
+  if (!project.codeReview?.plugin) {
+    return Response.json(
+      { error: `Project ${projectId} has no codeReview.plugin configured` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const run = await reviewManager.triggerReview({
+      projectId,
+      linkedSessionId: body.sessionId,
+      workerWorkspacePath: session.workspacePath,
+      branch: session.branch ?? project.defaultBranch,
+      baseBranch: body.baseBranch ?? project.defaultBranch,
+    });
+    return Response.json({ run });
+  } catch (err) {
+    return Response.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/packages/web/src/app/reviews/page.tsx
+++ b/packages/web/src/app/reviews/page.tsx
@@ -18,6 +18,9 @@ import type {
   CodeReviewRun,
 } from "@aoagents/ao-core";
 
+// Don't prerender at build time — getServices() requires a live config.
+export const dynamic = "force-dynamic";
+
 interface EnrichedRun extends CodeReviewRun {
   projectId: string;
   findings: CodeReviewFinding[];

--- a/packages/web/src/app/reviews/page.tsx
+++ b/packages/web/src/app/reviews/page.tsx
@@ -1,0 +1,153 @@
+/**
+ * Review Workbench — surfaces AI reviewer findings per run, per worker.
+ *
+ * Server-rendered: pulls review runs via the review manager, groups them by
+ * loop state into the 5 columns defined by the spec (RUNNING, AWAITING CONTEXT,
+ * DONE, STALLED, TERMINATED).
+ *
+ * The page is intentionally minimal — it gives a human a clear place to triage
+ * without pulling in any new UI dependencies. Dismissal/send actions are done
+ * via the PATCH /api/reviews/findings/[runId]/[findingId] endpoint; those
+ * require a proper client component to be wired up later.
+ */
+
+import { getServices } from "@/lib/services";
+import type {
+  CodeReviewFinding,
+  CodeReviewLoopState,
+  CodeReviewRun,
+} from "@aoagents/ao-core";
+
+interface EnrichedRun extends CodeReviewRun {
+  projectId: string;
+  findings: CodeReviewFinding[];
+}
+
+const COLUMNS: Array<{ state: CodeReviewLoopState; label: string }> = [
+  { state: "reviewing", label: "Running" },
+  { state: "awaiting_context", label: "Awaiting context" },
+  { state: "done", label: "Done" },
+  { state: "stalled", label: "Stalled" },
+  { state: "terminated", label: "Terminated" },
+];
+
+function severityClass(severity: string): string {
+  if (severity === "error") return "text-red-400";
+  if (severity === "warning") return "text-amber-400";
+  return "text-slate-400";
+}
+
+function statusClass(status: string): string {
+  if (status === "open") return "text-cyan-400";
+  if (status === "dismissed") return "text-slate-500 line-through";
+  if (status === "sent_to_agent") return "text-yellow-400";
+  return "text-slate-400";
+}
+
+async function loadRuns(): Promise<EnrichedRun[]> {
+  const { config, reviewManager } = await getServices();
+  const runs: EnrichedRun[] = [];
+  for (const projectId of Object.keys(config.projects)) {
+    let store;
+    try {
+      store = reviewManager.getStore(projectId);
+    } catch {
+      continue;
+    }
+    for (const run of store.listAllRuns()) {
+      runs.push({ ...run, projectId, findings: store.listFindingsForRun(run.runId) });
+    }
+  }
+  runs.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  return runs;
+}
+
+export default async function ReviewsPage(): Promise<React.JSX.Element> {
+  const runs = await loadRuns();
+  const byColumn = new Map<CodeReviewLoopState, EnrichedRun[]>();
+  for (const col of COLUMNS) byColumn.set(col.state, []);
+  for (const run of runs) {
+    const bucket = byColumn.get(run.loopState);
+    if (bucket) bucket.push(run);
+  }
+
+  return (
+    <main className="p-6 min-h-screen bg-[var(--color-bg)] text-[var(--color-fg)]">
+      <header className="mb-6 flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Review Workbench</h1>
+        <div className="text-sm text-[var(--color-muted-fg)]">
+          {runs.length} run{runs.length === 1 ? "" : "s"}
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        {COLUMNS.map((col) => {
+          const bucket = byColumn.get(col.state) ?? [];
+          return (
+            <section
+              key={col.state}
+              className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-3"
+            >
+              <h2 className="text-xs uppercase tracking-wide font-semibold mb-3 text-[var(--color-muted-fg)]">
+                {col.label} ({bucket.length})
+              </h2>
+              <ul className="flex flex-col gap-3">
+                {bucket.map((run) => (
+                  <li
+                    key={run.runId}
+                    className="rounded border border-[var(--color-border-subtle)] bg-[var(--color-bg)] p-3"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-semibold text-[var(--color-fg)]">
+                        {run.reviewerSessionId}
+                      </span>
+                      <code className="text-xs text-[var(--color-muted-fg)]">
+                        {run.headSha.slice(0, 7)}
+                      </code>
+                    </div>
+                    <div className="text-xs text-[var(--color-muted-fg)]">
+                      {run.projectId} / {run.linkedSessionId}
+                    </div>
+                    {run.terminationReason ? (
+                      <div className="text-xs mt-1 text-amber-400">
+                        {run.terminationReason}
+                      </div>
+                    ) : null}
+                    <div className="text-xs mt-2 text-[var(--color-muted-fg)]">
+                      {run.findingCount} finding{run.findingCount === 1 ? "" : "s"}
+                    </div>
+                    {run.findings.length > 0 ? (
+                      <ul className="mt-2 flex flex-col gap-1 text-xs">
+                        {run.findings.slice(0, 5).map((f) => (
+                          <li
+                            key={f.findingId}
+                            className="flex items-start gap-2 truncate"
+                          >
+                            <span className={severityClass(f.severity)}>
+                              {f.severity.toUpperCase()[0]}
+                            </span>
+                            <span className={statusClass(f.status)} title={f.title}>
+                              {f.filePath}:{f.startLine}
+                            </span>
+                          </li>
+                        ))}
+                        {run.findings.length > 5 ? (
+                          <li className="text-[var(--color-muted-fg)]">
+                            + {run.findings.length - 5} more
+                          </li>
+                        ) : null}
+                      </ul>
+                    ) : null}
+                  </li>
+                ))}
+                {bucket.length === 0 ? (
+                  <li className="text-xs text-[var(--color-muted-fg)]">No runs.</li>
+                ) : null}
+              </ul>
+            </section>
+          );
+        })}
+      </div>
+    </main>
+  );
+}

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -17,11 +17,15 @@ import {
   createPluginRegistry,
   createSessionManager,
   createLifecycleManager,
+  createReviewManager,
+  createReviewTrigger,
   type OrchestratorConfig,
   type PluginRegistry,
   type OpenCodeSessionManager,
   type LifecycleManager,
+  type ReviewManager,
   type SCM,
+  type CodeReview,
   type ProjectConfig,
   type Tracker,
   type Issue,
@@ -40,12 +44,14 @@ import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
 import pluginTrackerGithub from "@aoagents/ao-plugin-tracker-github";
 import pluginTrackerLinear from "@aoagents/ao-plugin-tracker-linear";
+import pluginCodeReviewCodex from "@aoagents/ao-plugin-code-review-codex";
 
 export interface Services {
   config: OrchestratorConfig;
   registry: PluginRegistry;
   sessionManager: OpenCodeSessionManager;
   lifecycleManager: LifecycleManager;
+  reviewManager: ReviewManager;
 }
 
 // Cache in globalThis for Next.js HMR stability
@@ -84,15 +90,37 @@ async function initServices(): Promise<Services> {
   registry.register(pluginScmGithub);
   registry.register(pluginTrackerGithub);
   registry.register(pluginTrackerLinear);
+  registry.register(pluginCodeReviewCodex);
 
   const sessionManager = createSessionManager({ config, registry });
 
+  // ReviewManager orchestrates the code-review loop on top of the session manager
+  // and the configured CodeReview plugin (e.g. codex).
+  const reviewManager = createReviewManager({
+    configPath: config.configPath,
+    getProject: (projectId: string) => config.projects[projectId],
+    resolveReviewPlugin: (projectId: string): CodeReview | null => {
+      const pluginName = config.projects[projectId]?.codeReview?.plugin;
+      if (!pluginName) return null;
+      return registry.get<CodeReview>("code-review", pluginName);
+    },
+    getSessionPrefix: (projectId: string) =>
+      config.projects[projectId]?.sessionPrefix ?? projectId,
+  });
+
   // Start the lifecycle manager — polls sessions every 30s, triggers reactions
   // (CI failure → send fix message, review comments → forward to agent, etc.)
-  const lifecycleManager = createLifecycleManager({ config, registry, sessionManager });
+  // and opportunistically triggers code reviews via the onSessionPolled hook.
+  const onSessionPolled = createReviewTrigger({ config, reviewManager });
+  const lifecycleManager = createLifecycleManager({
+    config,
+    registry,
+    sessionManager,
+    onSessionPolled,
+  });
   lifecycleManager.start(30_000);
 
-  const services = { config, registry, sessionManager, lifecycleManager };
+  const services = { config, registry, sessionManager, lifecycleManager, reviewManager };
   globalForServices._aoServices = services;
   return services;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/plugins/code-review-codex:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugins/notifier-composio:
     dependencies:
       '@aoagents/ao-core':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -643,6 +643,9 @@ importers:
       '@aoagents/ao-plugin-agent-opencode':
         specifier: workspace:*
         version: link:../plugins/agent-opencode
+      '@aoagents/ao-plugin-code-review-codex':
+        specifier: workspace:*
+        version: link:../plugins/code-review-codex
       '@aoagents/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux


### PR DESCRIPTION
## Summary

Adds the **9th plugin slot** — `code-review` — to Agent Orchestrator. When a coding agent opens a PR, AO can auto-spawn a lightweight reviewer workspace (just a detached git worktree, no tmux/agent/runtime), run the configured CodeReview plugin in it, persist structured findings, and loop until the code is clean or a human intervenes.

Closes #1275 (the tracking issue for this feature).

## What's included

### Core (`packages/core/`)

- **Plugin slot types** (`types.ts`): `CodeReview` interface, `CodeReviewRun`, `CodeReviewFinding`, `CodeReviewThread`, `CodeReviewConfig`. `PluginSlot` and `ExternalPluginLocation` extended for the new slot.
- **Config** (`config.ts`): Zod `CodeReviewConfigSchema` on `ProjectConfig.codeReview` with `mode`, `prompt`, `autoSendNewFindingsToAgent`, `routing.publishToScm`, `limits` (`maxReviewRounds`, `maxBudgetPerRun`, `confidenceThreshold`, `stallWindow`), `severityThreshold`, `trigger.onPullRequestOpen/Update/manual`. External plugin collection honors the new slot.
- **Paths** (`paths.ts`): `getReviewsDir` and `getReviewWorkspacesDir` under the per-project base dir.
- **Plugin registry** (`plugin-registry.ts`): builtin `code-review-codex` registration; `updateConfigWithManifestName` handles the new `codeReview` project location.
- **Fingerprint + convergence** (`code-review-fingerprint.ts`): stable 16-hex `sha256(filePath\\0category\\0severity\\0anchor)` fingerprint, sliding-window union, stalled-detection per the spec, dismissal carry-forward.
- **Flat-file review store** (`review-store.ts`): CRUD for runs/findings/threads. Reviewer IDs (`{sessionPrefix}-rev-N`) allocated project-wide to prevent collisions across workers.
- **Review manager** (`review-manager.ts`): serializes at most one in-flight reviewer per worker+SHA, marks prior runs ``outdated``, creates detached reviewer worktrees, carries forward dismissed findings via fingerprint matching, runs convergence check, terminates with structured reasons (`cycle_cap`, `reviewer_failure`, `manual_cancel`, etc.), cleans up workspaces for done/stalled/failed runs (keeps `awaiting_context` alive for chat).
- **Lifecycle integration** (`lifecycle-manager.ts` + `code-review-trigger.ts`): generic `onSessionPolled` hook on `LifecycleManagerDeps` so the review manager can piggyback on the existing poll loop without entangling the lifecycle state machine in review internals. `createReviewTrigger` skips disabled/manual-only projects and dedupes per worker HEAD SHA via `git rev-parse`.

### Reference plugin (`packages/plugins/code-review-codex/`)

- Wraps `codex exec review --base <branch> --json`. Parses structured findings into `CodeReviewFindingInput` (flexible field mapping for codex/review shape drift). Maps P0/P1/P2/P3 priority to error/warning/info. Persists the codex session inside the reviewer workspace so `sendFollowUp` can reattach for chat.

### CLI (`packages/cli/src/commands/review.ts`)

- `ao review run <session>` — trigger a review
- `ao review list [session]` — list review runs
- `ao review show <runId>` — display findings
- `ao review dismiss <runId> <findingId>` — dismiss (persists across re-reviews)
- `ao review send <runId> [findingId]` — route findings to the coding agent
- `ao review cancel <runId>` — terminate a running review

### Web (`packages/web/`)

- `services.ts` registers the Codex code-review plugin, builds a `ReviewManager`, and wires `createReviewTrigger` into the lifecycle's new `onSessionPolled` hook.
- `/reviews` page: 5-column Kanban (Running, Awaiting context, Done, Stalled, Terminated) grouped by `loopState` with finding previews.
- `GET /api/reviews` — list review runs with findings (filterable by project/session)
- `POST /api/reviews/runs` — manually trigger a review
- `PATCH /api/reviews/findings/[runId]/[findingId]` — dismiss/reopen/send actions

### Tests

- Core: fingerprint stability, reviewer ID allocation (project-scoped), store CRUD, triage carry-forward, convergence (including flip-flop detection)
- Codex plugin: manifest, JSON payload extraction, finding normalization, priority-to-severity mapping
- Full test run: **812 core tests** and **483 CLI tests** green.

## Test plan

- [ ] `pnpm typecheck` — all packages
- [ ] `pnpm test` — unit + integration
- [ ] `pnpm lint` — no new errors
- [ ] `ao review run <session>` works against a real codex install
- [ ] Review Workbench (`/reviews`) renders grouped runs with findings
- [ ] Dismissing a finding on one run keeps it dismissed on the next re-review for the same worker (fingerprint match)
- [ ] A stalled loop (`maxReviewRounds: 3` with no convergence) transitions to STALLED and records `terminationReason: cycle_cap`
- [ ] `awaiting_context` keeps the reviewer workspace; `done` / `stalled` / `failed` / `outdated` cleans it up