### PR TITLE
fix(web): resolve dashboard issue URLs from tracker

### DIFF
--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -872,7 +872,11 @@ describe("enrichSessionsMetadata", () => {
         labels: [],
       }),
       isCompleted: vi.fn().mockResolvedValue(false),
-      issueUrl: vi.fn().mockReturnValue(`${urlBase}-default`),
+      issueUrl: vi.fn().mockImplementation((identifier: string) =>
+        identifier.startsWith("http://") || identifier.startsWith("https://")
+          ? identifier
+          : `${urlBase}-${identifier}`,
+      ),
       issueLabel: vi.fn().mockReturnValue("#42"),
       branchName: vi.fn().mockReturnValue("feat/issue-42"),
       generatePrompt: vi.fn().mockResolvedValue("prompt"),
@@ -946,6 +950,23 @@ describe("enrichSessionsMetadata", () => {
     // Summary enriched (async)
     expect(dashboard.summary).toBe("Implementing auth fix");
     // Issue title enriched (async, depends on issueLabel from sync step)
+    expect(dashboard.issueTitle).toBe("Fix auth bug");
+  });
+
+  it("should derive issue URL from issue identifier via tracker", async () => {
+    const tracker = mockTracker("Fix auth bug");
+    const agent = mockAgent("Implementing auth fix");
+    const registry = mockRegistry(tracker, agent);
+
+    const core = createCoreSession({ issueId: "42" });
+    const dashboard = sessionToDashboard(core);
+    expect(dashboard.issueUrl).toBeNull();
+
+    await enrichSessionsMetadata([core], [dashboard], testConfig, registry);
+
+    expect(tracker.issueUrl).toHaveBeenCalledWith("42", testProject);
+    expect(dashboard.issueUrl).toBe(`${urlBase}-42`);
+    expect(dashboard.issueLabel).toBe("#42");
     expect(dashboard.issueTitle).toBe("Fix auth bug");
   });
 

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -18,6 +18,7 @@ import {
   sessionToDashboard,
   resolveProject,
   enrichSessionPR,
+  enrichSessionIssue,
   enrichSessionAgentSummary,
   enrichSessionIssueTitle,
   enrichSessionsMetadata,
@@ -840,6 +841,25 @@ describe("enrichSessionIssueTitle", () => {
     expect(dashboard.issueTitle).toBeNull();
   });
 
+  it("should avoid repeated issue lookups after a recent failure", async () => {
+    const issueUrl = "https://github.com/test/repo/issues/failure-cache";
+    const dashboard = makeDashboard({
+      issueUrl,
+      issueLabel: "#failure-cache",
+    });
+    const tracker: Tracker = {
+      ...createMockTracker(),
+      getIssue: vi.fn().mockRejectedValue(new Error("API error")),
+    };
+    const project = makeProject();
+
+    await enrichSessionIssueTitle(dashboard, tracker, project);
+    await enrichSessionIssueTitle(dashboard, tracker, project);
+
+    expect(tracker.getIssue).toHaveBeenCalledTimes(1);
+    expect(dashboard.issueTitle).toBeNull();
+  });
+
   it("should cache results across calls", async () => {
     // Unique URL to avoid cache from other tests
     const issueUrl = "https://github.com/test/repo/issues/cache-test";
@@ -872,11 +892,7 @@ describe("enrichSessionsMetadata", () => {
         labels: [],
       }),
       isCompleted: vi.fn().mockResolvedValue(false),
-      issueUrl: vi.fn().mockImplementation((identifier: string) =>
-        identifier.startsWith("http://") || identifier.startsWith("https://")
-          ? identifier
-          : `${urlBase}-${identifier}`,
-      ),
+      issueUrl: vi.fn().mockImplementation((identifier: string) => `${urlBase}-${identifier}`),
       issueLabel: vi.fn().mockReturnValue("#42"),
       branchName: vi.fn().mockReturnValue("feat/issue-42"),
       generatePrompt: vi.fn().mockResolvedValue("prompt"),
@@ -968,6 +984,47 @@ describe("enrichSessionsMetadata", () => {
     expect(dashboard.issueUrl).toBe(`${urlBase}-42`);
     expect(dashboard.issueLabel).toBe("#42");
     expect(dashboard.issueTitle).toBe("Fix auth bug");
+  });
+
+  it("preserves URL-shaped issueId without passing it through tracker.issueUrl", async () => {
+    const tracker = mockTracker("Fix auth bug");
+    const agent = mockAgent("Implementing auth fix");
+    const registry = mockRegistry(tracker, agent);
+    const originalUrl = "https://github.com/acme/repo/issues/99";
+    const core = createCoreSession({ issueId: originalUrl });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], testConfig, registry);
+
+    expect(dashboard.issueUrl).toBe(originalUrl);
+    expect(tracker.issueUrl).not.toHaveBeenCalledWith(originalUrl, testProject);
+  });
+
+  it("does not create synthetic URLs for free-text issueId", async () => {
+    const tracker = mockTracker();
+    const agent = mockAgent();
+    const registry = mockRegistry(tracker, agent);
+    const core = createCoreSession({ issueId: "fix login bug" });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], testConfig, registry);
+
+    expect(dashboard.issueUrl).toBeNull();
+    expect(dashboard.issueLabel).toBeNull();
+    expect(tracker.getIssue).not.toHaveBeenCalled();
+  });
+
+  it("keeps URL unset when tracker.issueUrl throws", async () => {
+    const tracker = mockTracker();
+    tracker.issueUrl = vi.fn().mockImplementation(() => {
+      throw new Error("bad template");
+    });
+    const dashboard = sessionToDashboard(createCoreSession({ issueId: "42" }));
+
+    enrichSessionIssue(dashboard, tracker, testProject);
+
+    expect(dashboard.issueUrl).toBeNull();
+    expect(dashboard.issueLabel).toBeNull();
   });
 
   it("starts issue-title fetches before agent summaries finish", async () => {

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -29,6 +29,8 @@ import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 
 /** Cache for issue titles (5 min TTL — issue titles rarely change) */
 const issueTitleCache = new TTLCache<string>(300_000);
+/** Cache failed issue-title lookups to avoid repeated tracker API calls. */
+const issueTitleMissCache = new TTLCache<boolean>(120_000);
 
 function isAbsoluteUrl(value: string): boolean {
   try {
@@ -433,7 +435,7 @@ export async function enrichSessionPR(
   return true;
 }
 
-/** Enrich a DashboardSession's issue label using the tracker plugin. */
+/** Enrich a DashboardSession's issue URL and label using the tracker plugin. */
 export function enrichSessionIssue(
   dashboard: DashboardSession,
   tracker: Tracker,
@@ -442,13 +444,31 @@ export function enrichSessionIssue(
   const issueReference = dashboard.issueId ?? dashboard.issueUrl;
   if (!issueReference) return;
 
-  if (tracker.issueUrl) {
+  if (isAbsoluteUrl(issueReference)) {
+    dashboard.issueUrl = issueReference;
+  } else if (/\s/.test(issueReference)) {
+    // Free-text issue IDs are user notes, not tracker identifiers.
+    dashboard.issueUrl = null;
+  } else if (tracker.issueUrl) {
     try {
-      dashboard.issueUrl = tracker.issueUrl(issueReference, project);
-    } catch {
-      // Keep existing values if URL generation fails.
+      const candidateUrl = tracker.issueUrl(issueReference, project);
+      if (candidateUrl && isAbsoluteUrl(candidateUrl)) {
+        dashboard.issueUrl = candidateUrl;
+      } else {
+        console.warn("[enrichSessionIssue] tracker.issueUrl() returned a non-absolute URL", {
+          tracker: tracker.name,
+          issueReference,
+          candidateUrl,
+        });
+      }
+    } catch (error) {
+      console.warn("[enrichSessionIssue] tracker.issueUrl() failed", {
+        tracker: tracker.name,
+        issueReference,
+        error: String(error),
+      });
     }
-  } else if (!dashboard.issueUrl) {
+  } else if (!dashboard.issueUrl && isAbsoluteUrl(issueReference)) {
     dashboard.issueUrl = issueReference;
   }
 
@@ -510,6 +530,9 @@ export async function enrichSessionIssueTitle(
     dashboard.issueTitle = cached;
     return;
   }
+  if (issueTitleMissCache.get(dashboard.issueUrl)) {
+    return;
+  }
 
   try {
     // Strip "#" prefix from GitHub-style labels to get the identifier
@@ -520,6 +543,7 @@ export async function enrichSessionIssueTitle(
       issueTitleCache.set(dashboard.issueUrl, issue.title);
     }
   } catch {
+    issueTitleMissCache.set(dashboard.issueUrl, true);
     // Can't fetch issue — keep issueTitle null
   }
 }

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -30,6 +30,15 @@ import { TTLCache, prCache, prCacheKey, type PREnrichmentData } from "./cache";
 /** Cache for issue titles (5 min TTL — issue titles rarely change) */
 const issueTitleCache = new TTLCache<string>(300_000);
 
+function isAbsoluteUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
 /** Resolve which project a session belongs to. */
 export function resolveProject(
   core: Session,
@@ -176,7 +185,7 @@ export function sessionToDashboard(session: Session): DashboardSession {
     lifecycle: buildDashboardLifecycle(session),
     branch: session.branch,
     issueId: session.issueId, // Deprecated: kept for backwards compatibility
-    issueUrl: session.issueId, // issueId is actually the full URL
+    issueUrl: session.issueId && isAbsoluteUrl(session.issueId) ? session.issueId : null,
     issueLabel: null, // Will be enriched by enrichSessionIssue()
     issueTitle: null, // Will be enriched by enrichSessionIssueTitle()
     userPrompt: session.metadata["userPrompt"] ?? null,
@@ -430,6 +439,19 @@ export function enrichSessionIssue(
   tracker: Tracker,
   project: ProjectConfig,
 ): void {
+  const issueReference = dashboard.issueId ?? dashboard.issueUrl;
+  if (!issueReference) return;
+
+  if (tracker.issueUrl) {
+    try {
+      dashboard.issueUrl = tracker.issueUrl(issueReference, project);
+    } catch {
+      // Keep existing values if URL generation fails.
+    }
+  } else if (!dashboard.issueUrl) {
+    dashboard.issueUrl = issueReference;
+  }
+
   if (!dashboard.issueUrl) return;
 
   // Use tracker plugin to extract human-readable label from URL
@@ -535,7 +557,9 @@ function prepareSessionMetadataEnrichment(
 
   // Issue labels (synchronous string parsing, no API calls)
   projects.forEach((project, i) => {
-    if (!dashboardSessions[i].issueUrl || !project?.tracker?.plugin) return;
+    if ((!dashboardSessions[i].issueUrl && !dashboardSessions[i].issueId) || !project?.tracker?.plugin) {
+      return;
+    }
     const tracker = registry.get<Tracker>("tracker", project.tracker.plugin);
     if (!tracker) return;
     enrichSessionIssue(dashboardSessions[i], tracker, project);

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -468,8 +468,6 @@ export function enrichSessionIssue(
         error: String(error),
       });
     }
-  } else if (!dashboard.issueUrl && isAbsoluteUrl(issueReference)) {
-    dashboard.issueUrl = issueReference;
   }
 
   if (!dashboard.issueUrl) return;


### PR DESCRIPTION
## Summary
- resolve issue links from tracker metadata when sessions only store issue identifiers (for example `42`)
- keep existing absolute URLs unchanged and continue to enrich `issueLabel`/`issueTitle` from the resolved URL
- add regression coverage for identifier-only issue IDs in dashboard metadata enrichment

## Root cause
`sessionToDashboard()` treated `session.issueId` as a URL. For GitHub sessions spawned with an identifier, this produced invalid links like `/42` and broke downstream issue enrichment assumptions.

## What changed
- `sessionToDashboard()` now only initializes `issueUrl` when `issueId` is already an absolute URL.
- `enrichSessionIssue()` now resolves `dashboard.issueUrl` via `tracker.issueUrl()` using the available issue reference (`issueId` or existing `issueUrl`).
- metadata enrichment now runs issue enrichment when either `issueUrl` or `issueId` exists.
- tests updated to verify numeric issue identifiers are converted into valid tracker URLs.

## Why this approach
This keeps backward compatibility for sessions already storing full URLs while fixing identifier-only sessions at the existing enrichment boundary, avoiding schema changes or broader refactors.

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/lib/__tests__/serialize.test.ts`

Closes #1213.