### PR TITLE
fix(web): treat exited sessions as restorable in detail view

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -3,7 +3,16 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
-import { type DashboardSession, TERMINAL_STATUSES, NON_RESTORABLE_STATUSES } from "@/lib/types";
+import {
+  type DashboardSession,
+  type DashboardPR,
+  TERMINAL_STATUSES,
+  TERMINAL_ACTIVITIES,
+  NON_RESTORABLE_STATUSES,
+  isPRMergeReady,
+} from "@/lib/types";
+import { CI_STATUS } from "@aoagents/ao-core/types";
+import { cn } from "@/lib/cn";
 import dynamic from "next/dynamic";
 import { getSessionTitle } from "@/lib/format";
 import type { ProjectInfo } from "@/lib/project-name";
@@ -63,7 +72,8 @@ export function SessionDetail({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [showTerminal, setShowTerminal] = useState(false);
   const pr = session.pr;
-  const terminalEnded = TERMINAL_STATUSES.has(session.status);
+  const terminalEnded =
+    TERMINAL_STATUSES.has(session.status) || TERMINAL_ACTIVITIES.has(session.activity);
   const isRestorable = terminalEnded && !NON_RESTORABLE_STATUSES.has(session.status);
   const activity = (session.activity && sessionActivityMeta[session.activity]) ?? {
     label: session.activity ?? "unknown",

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -73,7 +73,8 @@ export function SessionDetail({
   const [showTerminal, setShowTerminal] = useState(false);
   const pr = session.pr;
   const terminalEnded =
-    TERMINAL_STATUSES.has(session.status) || TERMINAL_ACTIVITIES.has(session.activity);
+    TERMINAL_STATUSES.has(session.status) ||
+    (session.activity !== null && TERMINAL_ACTIVITIES.has(session.activity));
   const isRestorable = terminalEnded && !NON_RESTORABLE_STATUSES.has(session.status);
   const activity = (session.activity && sessionActivityMeta[session.activity]) ?? {
     label: session.activity ?? "unknown",

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -5,14 +5,10 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import {
   type DashboardSession,
-  type DashboardPR,
   TERMINAL_STATUSES,
   TERMINAL_ACTIVITIES,
   NON_RESTORABLE_STATUSES,
-  isPRMergeReady,
 } from "@/lib/types";
-import { CI_STATUS } from "@aoagents/ao-core/types";
-import { cn } from "@/lib/cn";
 import dynamic from "next/dynamic";
 import { getSessionTitle } from "@/lib/format";
 import type { ProjectInfo } from "@/lib/project-name";

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -225,6 +225,24 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
   });
 
+  it("shows restore action when activity is exited but status is still working", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-crashed",
+          projectId: "my-app",
+          status: "working",
+          activity: "exited",
+          pr: null,
+        })}
+      />,
+    );
+
+    expect(screen.getByText(/Terminal session has ended/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Restore" })).toBeInTheDocument();
+    expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
+  });
+
   it("shows restore for restorable orchestrator sessions", () => {
     render(
       <SessionDetail

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -238,7 +238,7 @@ describe("SessionDetail desktop layout", () => {
       />,
     );
 
-    expect(screen.getByText(/Terminal session has ended/i)).toBeInTheDocument();
+    expect(screen.getByText("Terminal ended")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Restore" })).toBeInTheDocument();
     expect(screen.queryByTestId("direct-terminal")).not.toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- treat `activity: exited` as a terminal condition in `SessionDetail`, even when lifecycle status is still non-terminal
- keep restore eligibility gated by existing `NON_RESTORABLE_STATUSES`
- add desktop regression coverage for crashed workers that still report `status: working`

## Root cause
`SessionDetail` only used `TERMINAL_STATUSES` to decide if a session had ended. Sessions that crashed and emitted `activity: exited` before status convergence were rendered as live and had no restore affordance.

## What changed
- include `TERMINAL_ACTIVITIES` in the detail-page terminal-ended predicate
- add a test that verifies ended placeholder + restore button for `status=working` + `activity=exited`

## Why this approach
The rest of the dashboard already uses status-or-activity terminal semantics. Aligning the detail page avoids behavioral drift without changing backend lifecycle logic.

## Testing
- `pnpm --filter @aoagents/ao-web test -- src/components/__tests__/SessionDetail.desktop.test.tsx`

Closes #1225.