### PR TITLE
fix(core): make opencode worker prompt delivery reliable

### DIFF
--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1288,6 +1288,52 @@ describe("spawn", () => {
     vi.useRealTimers();
   }, 20_000);
 
+  it("delivers worker prompts post-launch for opencode sessions", async () => {
+    vi.useFakeTimers();
+    const opencodeAgent: Agent = {
+      ...mockAgent,
+      name: "opencode",
+    };
+    const registryWithOpenCode: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return opencodeAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const configWithOpenCode: OrchestratorConfig = {
+      ...config,
+      defaults: { ...config.defaults, agent: "opencode" },
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          agent: "opencode",
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithOpenCode, registry: registryWithOpenCode });
+    const spawnPromise = sm.spawn({ projectId: "my-app", prompt: "Fix the authentication bug" });
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    const session = await spawnPromise;
+
+    expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: undefined,
+      }),
+    );
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ id: expect.any(String) }),
+      expect.stringContaining("Fix the authentication bug"),
+    );
+    expect(session.metadata.promptDelivered).toBe("true");
+    vi.useRealTimers();
+  });
+
   describe("rollback on failure", () => {
     it("cleans up reserved metadata when workspace creation fails", async () => {
       (mockWorkspace.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
@@ -1501,8 +1547,6 @@ describe("spawn", () => {
       const meta = readMetadataRaw(sessionsDir, "app-1");
       expect(meta?.["displayName"]).toBeUndefined();
     });
-  });
-
   describe("spawnOrchestrator", () => {
     it("throws when no workspace plugin is configured", async () => {
       const registryNoWorkspace: PluginRegistry = {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1334,6 +1334,66 @@ describe("spawn", () => {
     vi.useRealTimers();
   });
 
+  it("keeps AO guidance in the opencode config when there is no explicit prompt", async () => {
+    vi.useFakeTimers();
+    const workspacePath = join(tmpDir, "opencode-guidance-ws");
+    vi.mocked(mockWorkspace.create).mockResolvedValueOnce({
+      path: workspacePath,
+      branch: "session/app-1",
+      sessionId: "app-1",
+      projectId: "my-app",
+    });
+    const opencodeAgent: Agent = {
+      ...mockAgent,
+      name: "opencode",
+    };
+    const registryWithOpenCode: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return opencodeAgent;
+        if (slot === "workspace") return mockWorkspace;
+        return null;
+      }),
+    };
+    const configWithOpenCode: OrchestratorConfig = {
+      ...config,
+      defaults: { ...config.defaults, agent: "opencode" },
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...config.projects["my-app"],
+          agent: "opencode",
+          opencodeIssueSessionStrategy: "ignore",
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithOpenCode, registry: registryWithOpenCode });
+    const spawnPromise = sm.spawn({ projectId: "my-app" });
+
+    await vi.advanceTimersByTimeAsync(3_000);
+    const session = await spawnPromise;
+
+    expect(opencodeAgent.getLaunchCommand).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: undefined,
+      }),
+    );
+    expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
+    expect(session.metadata.promptDelivered).toBeUndefined();
+
+    const runtimeCreateCall = vi.mocked(mockRuntime.create).mock.calls[0][0];
+    const opencodeConfigPath = runtimeCreateCall.environment.OPENCODE_CONFIG;
+    expect(opencodeConfigPath).toBeTruthy();
+    const opencodeConfig = JSON.parse(readFileSync(opencodeConfigPath, "utf-8")) as {
+      instructions: string[];
+    };
+    const systemPrompt = readFileSync(opencodeConfig.instructions[0]!, "utf-8");
+    expect(systemPrompt).toContain("ao session claim-pr");
+    vi.useRealTimers();
+  });
+
   describe("rollback on failure", () => {
     it("cleans up reserved metadata when workspace creation fails", async () => {
       (mockWorkspace.create as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
@@ -1547,6 +1607,8 @@ describe("spawn", () => {
       const meta = readMetadataRaw(sessionsDir, "app-1");
       expect(meta?.["displayName"]).toBeUndefined();
     });
+  });
+
   describe("spawnOrchestrator", () => {
     it("throws when no workspace plugin is configured", async () => {
       const registryNoWorkspace: PluginRegistry = {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1265,6 +1265,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
               strategy: opencodeIssueSessionStrategy,
             })
           : undefined;
+      const shouldUsePostLaunchPromptDelivery =
+        plugins.agent.promptDelivery === "post-launch" || plugins.agent.name === "opencode";
+      const promptForLaunchCommand = plugins.agent.name === "opencode" ? undefined : taskPrompt;
 
       const agentLaunchConfig = {
         sessionId,
@@ -1277,7 +1280,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         },
         workspacePath,
         issueId: spawnConfig.issueId,
-        prompt: taskPrompt,
+        prompt: promptForLaunchCommand,
         systemPromptFile,
         permissions: selection.permissions,
         model: selection.model,
@@ -1416,8 +1419,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // (e.g. Claude Code exits after -p, so we send the prompt after it starts
       // in interactive mode). Prompt delivery failure must NOT destroy the
       // session — the agent is running; user can retry with `ao send`.
+      const promptForPostLaunch =
+        plugins.agent.name === "opencode" ? taskPrompt : agentLaunchConfig.prompt;
       let promptDelivered = false;
-      if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+      if (shouldUsePostLaunchPromptDelivery && promptForPostLaunch) {
         const maxRetries = 3;
         const baseDelayMs = 3_000;
         let lastError: Error | undefined;
@@ -1427,7 +1432,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             // Wait for agent to start and be ready for input
             // Use exponential backoff: 3s, 6s, 9s between attempts
             await new Promise((resolve) => setTimeout(resolve, baseDelayMs * attempt));
-            await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+            await plugins.runtime.sendMessage(handle, promptForPostLaunch);
             promptDelivered = true;
             break;
           } catch (err) {


### PR DESCRIPTION
## Summary
- deliver OpenCode worker prompts via post-launch runtime messaging with retries
- stop inlining worker prompt payload into the OpenCode launch command path
- add regression coverage proving prompt delivery + metadata state for OpenCode workers

## Root cause
OpenCode worker spawns relied on inline launch-command prompt delivery. If the OpenCode startup flow did not complete cleanly, the prompt could be dropped while AO still marked it as delivered.

## What changed
- in worker `spawn()`, treat OpenCode as a post-launch prompt-delivery flow
- pass `prompt: undefined` to OpenCode launch config so launch only establishes session/runtime
- send the composed prompt through `runtime.sendMessage()` using existing retry logic
- preserve existing behavior for other agent plugins
- add test coverage for OpenCode worker prompt delivery and `promptDelivered` metadata

## Why this approach
This reuses an existing, battle-tested delivery path and keeps the fix tightly scoped to OpenCode worker spawning without changing plugin contracts or broader session lifecycle behavior.

## Testing
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/spawn.test.ts`

Closes #1304.