### PR TITLE
fix(cli): stop all project sessions on ao stop

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1431,10 +1431,8 @@ describe("stop command", () => {
     });
   }
 
-  it("stops the actual numbered orchestrator session and dashboard", async () => {
+  it("stops all live project sessions and dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    // Issue #1048: ao stop must look up the real numbered orchestrator id
-    // (e.g. app-orchestrator-3) via sm.list — never the phantom `${prefix}-orchestrator`.
     mockSessionManager.list.mockResolvedValue([
       {
         id: "app-orchestrator-3",
@@ -1445,24 +1443,47 @@ describe("stop command", () => {
         lastActivityAt: new Date(),
         runtimeHandle: { id: "tmux-3" },
       },
+      {
+        id: "app-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: {},
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-1" },
+      },
+      {
+        id: "app-2",
+        projectId: "my-app",
+        status: "killed",
+        activity: "inactive",
+        metadata: {},
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-2" },
+      },
     ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-3", {
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-3", {
       purgeOpenCode: false,
     });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-1", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenCalledTimes(2);
     const output = vi
       .mocked(console.log)
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
     expect(output).toContain("Orchestrator stopped");
     expect(output).toContain("app-orchestrator-3");
+    expect(output).toContain("app-1");
   });
 
-  it("kills the most-recently-active orchestrator when multiple exist", async () => {
+  it("kills multiple orchestrators and workers when they exist", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     const now = Date.now();
     mockSessionManager.list.mockResolvedValue([
@@ -1484,12 +1505,27 @@ describe("stop command", () => {
         lastActivityAt: new Date(now),
         runtimeHandle: { id: "tmux-2" },
       },
+      {
+        id: "app-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: {},
+        lastActivityAt: new Date(now - 5_000),
+        runtimeHandle: { id: "tmux-worker" },
+      },
     ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-2", {
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-1", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-orchestrator-2", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(3, "app-1", {
       purgeOpenCode: false,
     });
   });
@@ -1506,10 +1542,10 @@ describe("stop command", () => {
       .mocked(console.log)
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
-    expect(output).toContain("No running orchestrator session found");
+    expect(output).toContain("No running project sessions found");
   });
 
-  it("passes purge flag when stopping orchestrator with --purge-session", async () => {
+  it("passes purge flag when stopping all project sessions with --purge-session", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     mockSessionManager.list.mockResolvedValue([
       {
@@ -1521,13 +1557,25 @@ describe("stop command", () => {
         lastActivityAt: new Date(),
         runtimeHandle: { id: "tmux-1" },
       },
+      {
+        id: "app-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: {},
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-worker" },
+      },
     ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop", "--purge-session"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-1", {
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-1", {
+      purgeOpenCode: true,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-1", {
       purgeOpenCode: true,
     });
   });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1667,53 +1667,55 @@ export function registerStop(program: Command): void {
 
           console.log(chalk.bold(`\nStopping orchestrator for ${chalk.cyan(project.name)}\n`));
 
-          // Resolve the actual orchestrator session id by listing the project's sessions
-          // and finding the most-recently-active orchestrator. This avoids relying on the
-          // legacy `${prefix}-orchestrator` (no-N) phantom id, which never matches a real
-          // numbered session and causes ao stop to silently no-op.
           const sm = await getSessionManager(config);
           const allSessionPrefixes = Object.entries(config.projects).map(
-            ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
+            ([, configuredProject]) =>
+              configuredProject.sessionPrefix ?? generateSessionPrefix(configuredProject.name ?? ""),
           );
-          let orchestratorToKill: { id: string } | null = null;
+          let sessionsToKill: Session[] = [];
           let lookupFailed = false;
           try {
             const projectSessions = await sm.list(_projectId);
-            const orchestrators = projectSessions
-              .filter((s) =>
-                isOrchestratorSession(s, project.sessionPrefix ?? _projectId, allSessionPrefixes),
-              )
-              .filter((s) => !isTerminalSession(s));
-            const sorted = [...orchestrators].sort(
-              (a, b) =>
-                (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
-            );
-            orchestratorToKill = sorted[0] ?? null;
+            sessionsToKill = projectSessions.filter((session) => !isTerminalSession(session));
           } catch (err) {
             lookupFailed = true;
             console.log(
               chalk.yellow(
-                `  Could not list sessions to locate orchestrator: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
+                `  Could not list project sessions: ${err instanceof Error ? err.message : String(err)}`,
               ),
             );
           }
 
-          if (orchestratorToKill) {
-            const spinner = ora("Stopping orchestrator session").start();
+          if (sessionsToKill.length > 0) {
+            const spinner = ora("Stopping project sessions").start();
             const purgeOpenCode = opts?.purgeSession === true;
-            await sm.kill(orchestratorToKill.id, { purgeOpenCode });
-            spinner.succeed(`Orchestrator session stopped (${orchestratorToKill.id})`);
-            // Also log to console.log so the killed id is visible in non-TTY callers
-            // (CI, scripts) and in test capture, since spinner output is suppressed.
-            console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorToKill.id}`));
-          } else if (!lookupFailed) {
-            // Suppress the "no orchestrator found" message when sm.list threw —
-            // the catch above already explained the real reason and adding a
-            // second message would falsely imply the lookup succeeded.
+            const orchestratorSessions = sessionsToKill.filter((session) =>
+              isOrchestratorSession(
+                session,
+                project.sessionPrefix ?? _projectId,
+                allSessionPrefixes,
+              ),
+            );
+            const workerSessions = sessionsToKill.filter(
+              (session) => !orchestratorSessions.some((candidate) => candidate.id === session.id),
+            );
+            const orderedSessions = [...orchestratorSessions, ...workerSessions];
+
+            for (const session of orderedSessions) {
+              await sm.kill(session.id, { purgeOpenCode });
+            }
+
+            spinner.succeed(
+              `Stopped ${orderedSessions.length} project session${orderedSessions.length === 1 ? "" : "s"}`,
+            );
             console.log(
-              chalk.yellow(`No running orchestrator session found for "${project.name}"`),
+              chalk.green(
+                `  Stopped project sessions: ${orderedSessions.map((session) => session.id).join(", ")}`,
+              ),
+            );
+          } else if (!lookupFailed) {
+            console.log(
+              chalk.yellow(`No running project sessions found for "${project.name}"`),
             );
           }
 


### PR DESCRIPTION
Fixes #1129
Refs #1147

## Summary
- list all live sessions for the target project during `ao stop`
- kill orchestrator and worker sessions instead of only the orchestrator
- extend stop-command tests to cover multi-session shutdown and purge propagation

## Testing
- `pnpm build`
- `pnpm --filter @aoagents/ao-cli test -- --run __tests__/commands/start.test.ts`
- `pnpm typecheck` _(fails in existing baseline: `packages/plugins/terminal-iterm2` cannot resolve `@aoagents/ao-core`)_
- `pnpm lint`
- `pnpm test` _(fails in existing baseline: two timed out `packages/core` tests unrelated to this change)_