### PR TITLE
feat: add built-in Jira tracker plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "@aoagents/ao-plugin-terminal-iterm2": "workspace:*",
     "@aoagents/ao-plugin-terminal-web": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
+    "@aoagents/ao-plugin-tracker-jira": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",
     "@aoagents/ao-plugin-workspace-clone": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",

--- a/packages/cli/src/assets/plugin-registry.json
+++ b/packages/cli/src/assets/plugin-registry.json
@@ -41,6 +41,14 @@
     "latestVersion": "0.1.0"
   },
   {
+    "id": "tracker-jira",
+    "package": "@aoagents/ao-plugin-tracker-jira",
+    "slot": "tracker",
+    "description": "Tracker plugin: Jira issues",
+    "source": "registry",
+    "latestVersion": "0.1.0"
+  },
+  {
     "id": "tracker-gitlab",
     "package": "@aoagents/ao-plugin-tracker-gitlab",
     "slot": "tracker",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -86,7 +86,12 @@ projects:
 
     # ── Issue tracker (optional) ──────────────────────────────────
     tracker:
-      plugin: github          # github | linear | gitlab
+      plugin: github          # github | jira | linear | gitlab
+      # Jira-specific:
+      # projectKey: APP
+      # baseUrl: https://acme.atlassian.net
+      # email: engineer@acme.com
+      # jql: project = APP AND statusCategory != Done ORDER BY updated DESC
       # Linear-specific:
       # teamId: TEAM-123
       # projectId: PROJECT-456

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -91,6 +91,7 @@ projects:
       # projectKey: APP
       # baseUrl: https://acme.atlassian.net
       # email: engineer@acme.com
+      # issueTypeName: Task
       # jql: project = APP AND statusCategory != Done ORDER BY updated DESC
       # Linear-specific:
       # teamId: TEAM-123

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -69,6 +69,10 @@ export default defineConfig({
         find: "@aoagents/ao-plugin-scm-github",
         replacement: resolve(__dirname, "../plugins/scm-github/src/index.ts"),
       },
+      {
+        find: "@aoagents/ao-plugin-tracker-jira",
+        replacement: resolve(__dirname, "../plugins/tracker-jira/src/index.ts"),
+      },
     ],
   },
 });

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -50,6 +50,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "workspace", name: "clone", pkg: "@aoagents/ao-plugin-workspace-clone" },
   // Trackers
   { slot: "tracker", name: "github", pkg: "@aoagents/ao-plugin-tracker-github" },
+  { slot: "tracker", name: "jira", pkg: "@aoagents/ao-plugin-tracker-jira" },
   { slot: "tracker", name: "linear", pkg: "@aoagents/ao-plugin-tracker-linear" },
   { slot: "tracker", name: "gitlab", pkg: "@aoagents/ao-plugin-tracker-gitlab" },
   // SCM

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
         __dirname,
         "../plugins/tracker-github/src/index.ts",
       ),
+      "@aoagents/ao-plugin-tracker-jira": resolve(
+        __dirname,
+        "../plugins/tracker-jira/src/index.ts",
+      ),
       "@aoagents/ao-plugin-scm-github": resolve(__dirname, "../plugins/scm-github/src/index.ts"),
     },
     coverage: {

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -19,6 +19,7 @@
     "@aoagents/ao-plugin-runtime-process": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@aoagents/ao-plugin-workspace-clone": "workspace:*",
+    "@aoagents/ao-plugin-tracker-jira": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*"
   },
   "devDependencies": {

--- a/packages/plugins/tracker-jira/CHANGELOG.md
+++ b/packages/plugins/tracker-jira/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @composio/ao-plugin-tracker-jira
+
+## 0.1.0
+
+- Add initial Jira tracker plugin with read-only issue fetching and listing.

--- a/packages/plugins/tracker-jira/README.md
+++ b/packages/plugins/tracker-jira/README.md
@@ -29,5 +29,6 @@ Notes:
 - `baseUrl` and `email` in `tracker:` override the environment values.
 - `listIssues()` uses `tracker.jql` when provided, otherwise it builds a query from `projectKey` and AO filters.
 - `createIssue()` requires `projectKey` and creates Jira issues as `Task` by default, or `tracker.issueTypeName` when set.
-- `updateIssue()` supports state transitions, additive label updates with removals, comments, and best-effort assignee lookup.
+- `updateIssue()` supports state transitions, additive label updates with removals, comments, and best-effort assignee lookup. Jira's common `204 No Content` success responses are treated as success for transitions and field updates.
+- Done-category statuses still preserve `Canceled`/`Cancelled` as AO `cancelled` instead of collapsing every done status to `closed`.
 - Jira priorities are normalized to AO's 1-4 scale (`Highest`, `High`, `Medium`, `Low`).

--- a/packages/plugins/tracker-jira/README.md
+++ b/packages/plugins/tracker-jira/README.md
@@ -21,10 +21,13 @@ projects:
       # Optional overrides:
       # baseUrl: https://acme.atlassian.net
       # email: engineer@acme.com
+      # issueTypeName: Bug
       # jql: project = APP AND statusCategory != Done ORDER BY updated DESC
 ```
 
 Notes:
 - `baseUrl` and `email` in `tracker:` override the environment values.
 - `listIssues()` uses `tracker.jql` when provided, otherwise it builds a query from `projectKey` and AO filters.
-- The plugin currently supports read paths only: fetch, inspect, prompt generation, and list/search.
+- `createIssue()` requires `projectKey` and creates Jira issues as `Task` by default, or `tracker.issueTypeName` when set.
+- `updateIssue()` supports state transitions, additive label updates with removals, comments, and best-effort assignee lookup.
+- Jira priorities are normalized to AO's 1-4 scale (`Highest`, `High`, `Medium`, `Low`).

--- a/packages/plugins/tracker-jira/README.md
+++ b/packages/plugins/tracker-jira/README.md
@@ -29,6 +29,6 @@ Notes:
 - `baseUrl` and `email` in `tracker:` override the environment values.
 - `listIssues()` uses `tracker.jql` when provided, otherwise it builds a query from `projectKey` and AO filters.
 - `createIssue()` requires `projectKey` and creates Jira issues as `Task` by default, or `tracker.issueTypeName` when set.
-- `updateIssue()` supports state transitions, additive label updates with removals, comments, and best-effort assignee lookup. Jira's common `204 No Content` success responses are treated as success for transitions and field updates.
+- `updateIssue()` supports state transitions, additive label updates with removals, comments, and best-effort assignee lookup. Assignees are only written when Jira user search returns a single exact match on display name, email, or account ID. Jira's common `204 No Content` success responses are treated as success for transitions and field updates.
 - Done-category statuses still preserve `Canceled`/`Cancelled` as AO `cancelled` instead of collapsing every done status to `closed`.
 - Jira priorities are normalized to AO's 1-4 scale (`Highest`, `High`, `Medium`, `Low`).

--- a/packages/plugins/tracker-jira/README.md
+++ b/packages/plugins/tracker-jira/README.md
@@ -1,0 +1,30 @@
+# Jira tracker plugin
+
+Built-in Jira Cloud tracker support for AO.
+
+## Configuration
+
+Set auth with environment variables:
+
+- `JIRA_BASE_URL`, for example `https://acme.atlassian.net`
+- `JIRA_EMAIL`
+- `JIRA_API_TOKEN`
+
+Then configure a project tracker:
+
+```yaml
+projects:
+  app:
+    tracker:
+      plugin: jira
+      projectKey: APP
+      # Optional overrides:
+      # baseUrl: https://acme.atlassian.net
+      # email: engineer@acme.com
+      # jql: project = APP AND statusCategory != Done ORDER BY updated DESC
+```
+
+Notes:
+- `baseUrl` and `email` in `tracker:` override the environment values.
+- `listIssues()` uses `tracker.jql` when provided, otherwise it builds a query from `projectKey` and AO filters.
+- The plugin currently supports read paths only: fetch, inspect, prompt generation, and list/search.

--- a/packages/plugins/tracker-jira/package.json
+++ b/packages/plugins/tracker-jira/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-tracker-jira",
+  "version": "0.1.0",
+  "description": "Tracker plugin: Jira issues",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/tracker-jira"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/tracker-jira/src/index.ts
+++ b/packages/plugins/tracker-jira/src/index.ts
@@ -1,0 +1,316 @@
+import { request } from "node:https";
+import type { IncomingHttpHeaders } from "node:http";
+import type { PluginModule, ProjectConfig, Issue, IssueFilters, Tracker } from "@aoagents/ao-core";
+
+interface JiraConfig {
+  baseUrl: string;
+  email: string;
+  apiToken: string;
+  projectKey?: string;
+  jql?: string;
+}
+
+interface JiraIssueResponse {
+  id: string;
+  key: string;
+  self?: string;
+  fields: {
+    summary?: string | null;
+    description?: unknown;
+    labels?: string[];
+    assignee?: {
+      displayName?: string | null;
+      emailAddress?: string | null;
+      accountId?: string | null;
+    } | null;
+    priority?: {
+      id?: string | null;
+      name?: string | null;
+    } | null;
+    status?: {
+      name?: string | null;
+      statusCategory?: {
+        key?: string | null;
+        name?: string | null;
+      } | null;
+    } | null;
+  };
+}
+
+interface JiraSearchResponse {
+  issues: JiraIssueResponse[];
+}
+
+interface JiraApiResponse<T> {
+  body: T;
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+}
+
+const ISSUE_FIELDS = ["summary", "description", "labels", "assignee", "priority", "status"].join(",");
+
+function getTrackerConfig(project: ProjectConfig): Record<string, unknown> {
+  return (project.tracker ?? {}) as Record<string, unknown>;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export function resolveJiraConfig(project: ProjectConfig): JiraConfig {
+  const tracker = getTrackerConfig(project);
+  const baseUrl = readString(tracker.baseUrl) ?? readString(process.env["JIRA_BASE_URL"]);
+  const email = readString(tracker.email) ?? readString(process.env["JIRA_EMAIL"]);
+  const apiToken = readString(tracker.apiToken) ?? readString(process.env["JIRA_API_TOKEN"]);
+  const projectKey = readString(tracker.projectKey);
+  const jql = readString(tracker.jql);
+
+  if (!baseUrl) {
+    throw new Error("Jira tracker requires JIRA_BASE_URL or tracker.baseUrl");
+  }
+  if (!email) {
+    throw new Error("Jira tracker requires JIRA_EMAIL or tracker.email");
+  }
+  if (!apiToken) {
+    throw new Error("Jira tracker requires JIRA_API_TOKEN or tracker.apiToken");
+  }
+
+  return {
+    baseUrl: baseUrl.replace(/\/+$/, ""),
+    email,
+    apiToken,
+    projectKey,
+    jql,
+  };
+}
+
+export function extractDocumentText(node: unknown): string {
+  if (!node) return "";
+  if (typeof node === "string") return node;
+  if (Array.isArray(node)) {
+    return node.map((item) => extractDocumentText(item)).filter(Boolean).join("\n").trim();
+  }
+  if (typeof node !== "object") return "";
+
+  const record = node as { type?: string; text?: string; content?: unknown[] };
+  if (record.type === "text") return record.text ?? "";
+
+  const content = Array.isArray(record.content) ? record.content : [];
+  const parts = content.map((item) => extractDocumentText(item)).filter(Boolean);
+  if (parts.length === 0) return "";
+
+  if (["paragraph", "heading", "blockquote", "listItem"].includes(record.type ?? "")) {
+    return parts.join("").trim();
+  }
+  if (["bulletList", "orderedList"].includes(record.type ?? "")) {
+    return parts.map((part) => `- ${part}`).join("\n").trim();
+  }
+  if (record.type === "hardBreak") return "\n";
+
+  return parts.join("\n").trim();
+}
+
+function mapJiraState(status: JiraIssueResponse["fields"]["status"]): Issue["state"] {
+  const categoryKey = status?.statusCategory?.key?.toLowerCase();
+  if (categoryKey === "done") return "closed";
+  if (categoryKey === "indeterminate") return "in_progress";
+  if (categoryKey === "new") return "open";
+
+  const name = status?.name?.toLowerCase() ?? "";
+  if (["done", "closed", "resolved"].includes(name)) return "closed";
+  if (["cancelled", "canceled"].includes(name)) return "cancelled";
+  if (["in progress", "in review", "selected for development", "implementing"].includes(name)) {
+    return "in_progress";
+  }
+  return "open";
+}
+
+function mapPriority(priority: JiraIssueResponse["fields"]["priority"]): number | undefined {
+  const name = priority?.name?.toLowerCase();
+  if (!name) return undefined;
+  if (name.includes("highest")) return 1;
+  if (name.includes("high")) return 2;
+  if (name.includes("medium")) return 3;
+  if (name.includes("low")) return 4;
+  if (name.includes("lowest")) return 5;
+  return undefined;
+}
+
+export function mapJiraIssue(issue: JiraIssueResponse, config: JiraConfig): Issue {
+  const description = extractDocumentText(issue.fields.description);
+  const assignee = issue.fields.assignee?.displayName ?? issue.fields.assignee?.emailAddress ?? issue.fields.assignee?.accountId ?? undefined;
+
+  return {
+    id: issue.key,
+    title: issue.fields.summary ?? issue.key,
+    description,
+    url: `${config.baseUrl}/browse/${issue.key}`,
+    state: mapJiraState(issue.fields.status),
+    labels: issue.fields.labels ?? [],
+    assignee,
+    priority: mapPriority(issue.fields.priority),
+    branchName: `feat/${issue.key.toLowerCase()}`,
+  };
+}
+
+function buildAuthHeader(config: JiraConfig): string {
+  return `Basic ${Buffer.from(`${config.email}:${config.apiToken}`).toString("base64")}`;
+}
+
+function jiraRequest<T>(config: JiraConfig, path: string): Promise<JiraApiResponse<T>> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(path, config.baseUrl);
+    const req = request(
+      url,
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+          Authorization: buildAuthHeader(config),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("error", reject);
+        res.on("end", () => {
+          try {
+            const text = Buffer.concat(chunks).toString("utf8");
+            const statusCode = res.statusCode ?? 0;
+            if (statusCode < 200 || statusCode >= 300) {
+              reject(new Error(`Jira API request failed (${statusCode}): ${text.slice(0, 300)}`));
+              return;
+            }
+            resolve({
+              body: JSON.parse(text) as T,
+              statusCode,
+              headers: res.headers,
+            });
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    req.setTimeout(30_000, () => req.destroy(new Error("Jira API request timed out after 30s")));
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function buildListJql(filters: IssueFilters, config: JiraConfig): string {
+  if (config.jql) return config.jql;
+  if (!config.projectKey) {
+    throw new Error("Jira tracker listIssues requires tracker.projectKey or tracker.jql");
+  }
+
+  const clauses = [`project = ${JSON.stringify(config.projectKey)}`];
+
+  if (filters.state === "closed") {
+    clauses.push("statusCategory = Done");
+  } else if (filters.state !== "all") {
+    clauses.push("statusCategory != Done");
+  }
+
+  if (filters.assignee) {
+    clauses.push(`assignee = ${JSON.stringify(filters.assignee)}`);
+  }
+
+  if (filters.labels && filters.labels.length > 0) {
+    for (const label of filters.labels) {
+      clauses.push(`labels = ${JSON.stringify(label)}`);
+    }
+  }
+
+  return `${clauses.join(" AND ")} ORDER BY updated DESC`;
+}
+
+function normalizeIdentifier(identifier: string): string {
+  return identifier.trim().replace(/^#/, "").toUpperCase();
+}
+
+function createJiraTracker(): Tracker {
+  return {
+    name: "jira",
+
+    async getIssue(identifier: string, project: ProjectConfig): Promise<Issue> {
+      const config = resolveJiraConfig(project);
+      const key = normalizeIdentifier(identifier);
+      const response = await jiraRequest<JiraIssueResponse>(
+        config,
+        `/rest/api/3/issue/${encodeURIComponent(key)}?fields=${encodeURIComponent(ISSUE_FIELDS)}`,
+      );
+      return mapJiraIssue(response.body, config);
+    },
+
+    async isCompleted(identifier: string, project: ProjectConfig): Promise<boolean> {
+      const issue = await this.getIssue(identifier, project);
+      return issue.state === "closed" || issue.state === "cancelled";
+    },
+
+    issueUrl(identifier: string, project: ProjectConfig): string {
+      const config = resolveJiraConfig(project);
+      return `${config.baseUrl}/browse/${normalizeIdentifier(identifier)}`;
+    },
+
+    issueLabel(url: string): string {
+      const browseMatch = url.match(/\/browse\/([A-Z][A-Z0-9]+-\d+)/i);
+      if (browseMatch?.[1]) return browseMatch[1].toUpperCase();
+      const issueKey = url.split("/").pop();
+      return issueKey?.toUpperCase() ?? url;
+    },
+
+    branchName(identifier: string): string {
+      return `feat/${normalizeIdentifier(identifier).toLowerCase()}`;
+    },
+
+    async generatePrompt(identifier: string, project: ProjectConfig): Promise<string> {
+      const issue = await this.getIssue(identifier, project);
+      const lines = [
+        `You are working on Jira issue ${issue.id}: ${issue.title}`,
+        `Issue URL: ${issue.url}`,
+        "",
+      ];
+
+      if (issue.labels.length > 0) {
+        lines.push(`Labels: ${issue.labels.join(", ")}`);
+      }
+
+      if (issue.description) {
+        lines.push("## Description", "", issue.description);
+      }
+
+      lines.push(
+        "",
+        "Please implement the changes described in this issue. When done, commit and push your changes.",
+      );
+
+      return lines.join("\n");
+    },
+
+    async listIssues(filters: IssueFilters, project: ProjectConfig): Promise<Issue[]> {
+      const config = resolveJiraConfig(project);
+      const jql = buildListJql(filters, config);
+      const maxResults = String(filters.limit ?? 30);
+      const response = await jiraRequest<JiraSearchResponse>(
+        config,
+        `/rest/api/3/search/jql?jql=${encodeURIComponent(jql)}&maxResults=${encodeURIComponent(maxResults)}&fields=${encodeURIComponent(ISSUE_FIELDS)}`,
+      );
+      return response.body.issues.map((issue) => mapJiraIssue(issue, config));
+    },
+  };
+}
+
+export const manifest = {
+  name: "jira",
+  slot: "tracker" as const,
+  description: "Tracker plugin: Jira issues",
+  version: "0.1.0",
+};
+
+export function create(): Tracker {
+  return createJiraTracker();
+}
+
+export default { manifest, create } satisfies PluginModule<Tracker>;

--- a/packages/plugins/tracker-jira/src/index.ts
+++ b/packages/plugins/tracker-jira/src/index.ts
@@ -8,6 +8,7 @@ interface JiraConfig {
   apiToken: string;
   projectKey?: string;
   jql?: string;
+  issueTypeName?: string;
 }
 
 interface JiraIssueResponse {
@@ -47,6 +48,31 @@ interface JiraApiResponse<T> {
   headers: IncomingHttpHeaders;
 }
 
+interface JiraTransitionResponse {
+  transitions: Array<{
+    id: string;
+    name?: string | null;
+    to?: {
+      name?: string | null;
+      statusCategory?: {
+        key?: string | null;
+        name?: string | null;
+      } | null;
+    } | null;
+  }>;
+}
+
+interface JiraCreateIssueResponse {
+  id: string;
+  key: string;
+}
+
+interface JiraUserResponse {
+  accountId?: string | null;
+  displayName?: string | null;
+  emailAddress?: string | null;
+}
+
 const ISSUE_FIELDS = ["summary", "description", "labels", "assignee", "priority", "status"].join(",");
 
 function getTrackerConfig(project: ProjectConfig): Record<string, unknown> {
@@ -64,6 +90,7 @@ export function resolveJiraConfig(project: ProjectConfig): JiraConfig {
   const apiToken = readString(tracker.apiToken) ?? readString(process.env["JIRA_API_TOKEN"]);
   const projectKey = readString(tracker.projectKey);
   const jql = readString(tracker.jql);
+  const issueTypeName = readString(tracker.issueTypeName);
 
   if (!baseUrl) {
     throw new Error("Jira tracker requires JIRA_BASE_URL or tracker.baseUrl");
@@ -81,6 +108,7 @@ export function resolveJiraConfig(project: ProjectConfig): JiraConfig {
     apiToken,
     projectKey,
     jql,
+    issueTypeName,
   };
 }
 
@@ -88,24 +116,28 @@ export function extractDocumentText(node: unknown): string {
   if (!node) return "";
   if (typeof node === "string") return node;
   if (Array.isArray(node)) {
-    return node.map((item) => extractDocumentText(item)).filter(Boolean).join("\n").trim();
+    return node
+      .map((item) => extractDocumentText(item))
+      .filter((item) => item !== "")
+      .join("\n")
+      .trim();
   }
   if (typeof node !== "object") return "";
 
   const record = node as { type?: string; text?: string; content?: unknown[] };
   if (record.type === "text") return record.text ?? "";
+  if (record.type === "hardBreak") return "\n";
 
   const content = Array.isArray(record.content) ? record.content : [];
-  const parts = content.map((item) => extractDocumentText(item)).filter(Boolean);
+  const parts = content.map((item) => extractDocumentText(item)).filter((item) => item !== "");
   if (parts.length === 0) return "";
 
   if (["paragraph", "heading", "blockquote", "listItem"].includes(record.type ?? "")) {
-    return parts.join("").trim();
+    return parts.join("").replace(/\n{3,}/g, "\n\n").trim();
   }
   if (["bulletList", "orderedList"].includes(record.type ?? "")) {
     return parts.map((part) => `- ${part}`).join("\n").trim();
   }
-  if (record.type === "hardBreak") return "\n";
 
   return parts.join("\n").trim();
 }
@@ -131,9 +163,17 @@ function mapPriority(priority: JiraIssueResponse["fields"]["priority"]): number 
   if (name.includes("highest")) return 1;
   if (name.includes("high")) return 2;
   if (name.includes("medium")) return 3;
+  if (name.includes("lowest")) return 4;
   if (name.includes("low")) return 4;
-  if (name.includes("lowest")) return 5;
   return undefined;
+}
+
+function mapAoPriority(priority: number | undefined): string | undefined {
+  if (priority === undefined) return undefined;
+  if (priority <= 1) return "Highest";
+  if (priority === 2) return "High";
+  if (priority === 3) return "Medium";
+  return "Low";
 }
 
 export function mapJiraIssue(issue: JiraIssueResponse, config: JiraConfig): Issue {
@@ -157,16 +197,26 @@ function buildAuthHeader(config: JiraConfig): string {
   return `Basic ${Buffer.from(`${config.email}:${config.apiToken}`).toString("base64")}`;
 }
 
-function jiraRequest<T>(config: JiraConfig, path: string): Promise<JiraApiResponse<T>> {
+function jiraRequest<T>(
+  config: JiraConfig,
+  path: string,
+  options?: {
+    method?: "GET" | "POST" | "PUT";
+    body?: unknown;
+  },
+): Promise<JiraApiResponse<T>> {
   return new Promise((resolve, reject) => {
     const url = new URL(path, config.baseUrl);
+    const method = options?.method ?? "GET";
+    const body = options?.body === undefined ? undefined : JSON.stringify(options.body);
     const req = request(
       url,
       {
-        method: "GET",
+        method,
         headers: {
           Accept: "application/json",
           Authorization: buildAuthHeader(config),
+          ...(body ? { "Content-Type": "application/json", "Content-Length": Buffer.byteLength(body).toString() } : {}),
         },
       },
       (res) => {
@@ -195,8 +245,71 @@ function jiraRequest<T>(config: JiraConfig, path: string): Promise<JiraApiRespon
 
     req.setTimeout(30_000, () => req.destroy(new Error("Jira API request timed out after 30s")));
     req.on("error", reject);
+    if (body) {
+      req.write(body);
+    }
     req.end();
   });
+}
+
+async function resolveIssueForUpdate(
+  tracker: Tracker,
+  identifier: string,
+  project: ProjectConfig,
+): Promise<Issue> {
+  return tracker.getIssue(identifier, project);
+}
+
+async function findTransitionId(
+  config: JiraConfig,
+  identifier: string,
+  state: NonNullable<Issue["state"]>,
+): Promise<string | undefined> {
+  const response = await jiraRequest<JiraTransitionResponse>(
+    config,
+    `/rest/api/3/issue/${encodeURIComponent(identifier)}/transitions`,
+  );
+
+  const target = response.body.transitions.find((transition) => {
+    const toName = transition.to?.name?.toLowerCase() ?? "";
+    const transitionName = transition.name?.toLowerCase() ?? "";
+    const category = transition.to?.statusCategory?.key?.toLowerCase() ?? "";
+
+    if (state === "closed") {
+      return category === "done" || [toName, transitionName].some((name) => ["done", "closed", "resolved"].includes(name));
+    }
+
+    if (state === "in_progress") {
+      return (
+        category === "indeterminate" ||
+        [toName, transitionName].some((name) =>
+          ["in progress", "in review", "selected for development", "implementing"].includes(name),
+        )
+      );
+    }
+
+    return category === "new" || [toName, transitionName].some((name) => ["open", "to do", "todo", "backlog"].includes(name));
+  });
+
+  return target?.id;
+}
+
+async function resolveAssigneeAccountId(
+  config: JiraConfig,
+  assignee: string,
+): Promise<string | undefined> {
+  const response = await jiraRequest<JiraUserResponse[]>(
+    config,
+    `/rest/api/3/user/search?query=${encodeURIComponent(assignee)}`,
+  );
+  const lower = assignee.toLowerCase();
+  const exact = response.body.find(
+    (user) =>
+      user.displayName?.toLowerCase() === lower ||
+      user.emailAddress?.toLowerCase() === lower ||
+      user.accountId?.toLowerCase() === lower,
+  );
+  return exact?.accountId ?? response.body[0]?.accountId ?? undefined;
 }
 
 function buildListJql(filters: IssueFilters, config: JiraConfig): string {
@@ -298,6 +411,113 @@ function createJiraTracker(): Tracker {
         `/rest/api/3/search/jql?jql=${encodeURIComponent(jql)}&maxResults=${encodeURIComponent(maxResults)}&fields=${encodeURIComponent(ISSUE_FIELDS)}`,
       );
       return response.body.issues.map((issue) => mapJiraIssue(issue, config));
+    },
+
+    async updateIssue(identifier: string, update, project: ProjectConfig): Promise<void> {
+      const config = resolveJiraConfig(project);
+      const key = normalizeIdentifier(identifier);
+
+      if (update.state) {
+        const transitionId = await findTransitionId(config, key, update.state);
+        if (!transitionId) {
+          throw new Error(`No Jira transition found for state \"${update.state}\" on ${key}`);
+        }
+        await jiraRequest(
+          config,
+          `/rest/api/3/issue/${encodeURIComponent(key)}/transitions`,
+          { method: "POST", body: { transition: { id: transitionId } } },
+        );
+      }
+
+      const fieldUpdates: Record<string, unknown> = {};
+
+      if (update.labels || update.removeLabels) {
+        const currentIssue = await resolveIssueForUpdate(this, key, project);
+        const labels = new Set(currentIssue.labels);
+        for (const label of update.labels ?? []) labels.add(label);
+        for (const label of update.removeLabels ?? []) labels.delete(label);
+        fieldUpdates["labels"] = [...labels];
+      }
+
+      if (update.assignee) {
+        const accountId = await resolveAssigneeAccountId(config, update.assignee);
+        if (accountId) {
+          fieldUpdates["assignee"] = { id: accountId };
+        }
+      }
+
+      if (Object.keys(fieldUpdates).length > 0) {
+        await jiraRequest(config, `/rest/api/3/issue/${encodeURIComponent(key)}`, {
+          method: "PUT",
+          body: { fields: fieldUpdates },
+        });
+      }
+
+      if (update.comment) {
+        await jiraRequest(config, `/rest/api/3/issue/${encodeURIComponent(key)}/comment`, {
+          method: "POST",
+          body: {
+            body: {
+              type: "doc",
+              version: 1,
+              content: [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: update.comment }],
+                },
+              ],
+            },
+          },
+        });
+      }
+    },
+
+    async createIssue(input, project: ProjectConfig): Promise<Issue> {
+      const config = resolveJiraConfig(project);
+      if (!config.projectKey) {
+        throw new Error("Jira tracker createIssue requires tracker.projectKey");
+      }
+
+      const fields: Record<string, unknown> = {
+        project: { key: config.projectKey },
+        summary: input.title,
+        description: {
+          type: "doc",
+          version: 1,
+          content: input.description
+            ? [
+                {
+                  type: "paragraph",
+                  content: [{ type: "text", text: input.description }],
+                },
+              ]
+            : [],
+        },
+        issuetype: { name: config.issueTypeName ?? "Task" },
+      };
+
+      if (input.labels && input.labels.length > 0) {
+        fields["labels"] = input.labels;
+      }
+
+      const mappedPriority = mapAoPriority(input.priority);
+      if (mappedPriority) {
+        fields["priority"] = { name: mappedPriority };
+      }
+
+      if (input.assignee) {
+        const accountId = await resolveAssigneeAccountId(config, input.assignee);
+        if (accountId) {
+          fields["assignee"] = { id: accountId };
+        }
+      }
+
+      const created = await jiraRequest<JiraCreateIssueResponse>(config, "/rest/api/3/issue", {
+        method: "POST",
+        body: { fields },
+      });
+
+      return this.getIssue(created.body.key, project);
     },
   };
 }

--- a/packages/plugins/tracker-jira/src/index.ts
+++ b/packages/plugins/tracker-jira/src/index.ts
@@ -48,6 +48,12 @@ interface JiraApiResponse<T> {
   headers: IncomingHttpHeaders;
 }
 
+interface JiraRequestOptions {
+  method?: "GET" | "POST" | "PUT";
+  body?: unknown;
+  allowEmptyBody?: boolean;
+}
+
 interface JiraTransitionResponse {
   transitions: Array<{
     id: string;
@@ -142,15 +148,16 @@ export function extractDocumentText(node: unknown): string {
   return parts.join("\n").trim();
 }
 
-function mapJiraState(status: JiraIssueResponse["fields"]["status"]): Issue["state"] {
+export function mapJiraState(status: JiraIssueResponse["fields"]["status"]): Issue["state"] {
+  const name = status?.name?.toLowerCase() ?? "";
+  if (["cancelled", "canceled"].includes(name)) return "cancelled";
+
   const categoryKey = status?.statusCategory?.key?.toLowerCase();
   if (categoryKey === "done") return "closed";
   if (categoryKey === "indeterminate") return "in_progress";
   if (categoryKey === "new") return "open";
 
-  const name = status?.name?.toLowerCase() ?? "";
   if (["done", "closed", "resolved"].includes(name)) return "closed";
-  if (["cancelled", "canceled"].includes(name)) return "cancelled";
   if (["in progress", "in review", "selected for development", "implementing"].includes(name)) {
     return "in_progress";
   }
@@ -200,10 +207,7 @@ function buildAuthHeader(config: JiraConfig): string {
 function jiraRequest<T>(
   config: JiraConfig,
   path: string,
-  options?: {
-    method?: "GET" | "POST" | "PUT";
-    body?: unknown;
-  },
+  options?: JiraRequestOptions,
 ): Promise<JiraApiResponse<T>> {
   return new Promise((resolve, reject) => {
     const url = new URL(path, config.baseUrl);
@@ -231,8 +235,16 @@ function jiraRequest<T>(
               reject(new Error(`Jira API request failed (${statusCode}): ${text.slice(0, 300)}`));
               return;
             }
+            const canBeEmpty = options?.allowEmptyBody === true || statusCode === 204;
+            const body = text.trim()
+              ? (JSON.parse(text) as T)
+              : canBeEmpty
+                ? (undefined as T)
+                : (() => {
+                    throw new Error(`Jira API request returned an empty body (${statusCode}) for ${method} ${url.pathname}`);
+                  })();
             resolve({
-              body: JSON.parse(text) as T,
+              body,
               statusCode,
               headers: res.headers,
             });
@@ -276,7 +288,8 @@ async function findTransitionId(
     const category = transition.to?.statusCategory?.key?.toLowerCase() ?? "";
 
     if (state === "closed") {
-      return category === "done" || [toName, transitionName].some((name) => ["done", "closed", "resolved"].includes(name));
+      const cancelled = [toName, transitionName].some((name) => ["cancelled", "canceled"].includes(name));
+      return !cancelled && (category === "done" || [toName, transitionName].some((name) => ["done", "closed", "resolved"].includes(name)));
     }
 
     if (state === "in_progress") {

--- a/packages/plugins/tracker-jira/src/index.ts
+++ b/packages/plugins/tracker-jira/src/index.ts
@@ -79,6 +79,13 @@ interface JiraUserResponse {
   emailAddress?: string | null;
 }
 
+function matchesAssigneeQuery(user: JiraUserResponse, query: string): boolean {
+  const lower = query.toLowerCase();
+  return [user.displayName, user.emailAddress, user.accountId].some(
+    (value) => typeof value === "string" && value.toLowerCase() === lower,
+  );
+}
+
 const ISSUE_FIELDS = ["summary", "description", "labels", "assignee", "priority", "status"].join(",");
 
 function getTrackerConfig(project: ProjectConfig): Record<string, unknown> {
@@ -315,14 +322,13 @@ async function resolveAssigneeAccountId(
     config,
     `/rest/api/3/user/search?query=${encodeURIComponent(assignee)}`,
   );
-  const lower = assignee.toLowerCase();
-  const exact = response.body.find(
-    (user) =>
-      user.displayName?.toLowerCase() === lower ||
-      user.emailAddress?.toLowerCase() === lower ||
-      user.accountId?.toLowerCase() === lower,
-  );
-  return exact?.accountId ?? response.body[0]?.accountId ?? undefined;
+
+  const exactMatches = response.body.filter((user) => matchesAssigneeQuery(user, assignee));
+  if (exactMatches.length !== 1) {
+    return undefined;
+  }
+
+  return exactMatches[0]?.accountId ?? undefined;
 }
 
 function buildListJql(filters: IssueFilters, config: JiraConfig): string {
@@ -455,7 +461,7 @@ function createJiraTracker(): Tracker {
       if (update.assignee) {
         const accountId = await resolveAssigneeAccountId(config, update.assignee);
         if (accountId) {
-          fieldUpdates["assignee"] = { id: accountId };
+          fieldUpdates["assignee"] = { accountId };
         }
       }
 
@@ -521,7 +527,7 @@ function createJiraTracker(): Tracker {
       if (input.assignee) {
         const accountId = await resolveAssigneeAccountId(config, input.assignee);
         if (accountId) {
-          fields["assignee"] = { id: accountId };
+          fields["assignee"] = { accountId };
         }
       }
 

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -10,6 +10,13 @@ vi.mock("node:https", () => ({ request: requestMock }));
 import { create, manifest, resolveJiraConfig, extractDocumentText, mapJiraIssue } from "../src/index.js";
 import type { ProjectConfig } from "@aoagents/ao-core";
 
+type MockRequest = EventEmitter & {
+  setTimeout: (ms: number, handler: () => void) => void;
+  end: () => void;
+  destroy: (err?: Error) => void;
+  write: ReturnType<typeof vi.fn>;
+};
+
 const project: ProjectConfig = {
   name: "test",
   path: "/tmp/repo",
@@ -31,7 +38,11 @@ const sampleIssue = {
       content: [
         {
           type: "paragraph",
-          content: [{ type: "text", text: "Users cannot sign in." }],
+          content: [
+            { type: "text", text: "Users cannot sign in." },
+            { type: "hardBreak" },
+            { type: "text", text: "Reset link also fails." },
+          ],
         },
         {
           type: "bulletList",
@@ -48,37 +59,51 @@ const sampleIssue = {
   },
 };
 
-function mockJiraResponse(body: unknown, statusCode = 200) {
-  requestMock.mockImplementationOnce((url: URL | string, options: unknown, callback: (res: EventEmitter & { statusCode?: number; headers: Record<string, string> }) => void) => {
-    const res = new EventEmitter() as EventEmitter & { statusCode?: number; headers: Record<string, string> };
-    res.statusCode = statusCode;
-    res.headers = {};
+function installJiraMock() {
+  const responses: Array<{ body: unknown; statusCode?: number }> = [];
 
-    queueMicrotask(() => {
-      callback(res);
-      res.emit("data", Buffer.from(JSON.stringify(body)));
-      res.emit("end");
-    });
+  requestMock.mockImplementation(
+    (_url: URL | string, _options: unknown, callback: (res: EventEmitter & { statusCode?: number; headers: Record<string, string> }) => void) => {
+      const response = responses.shift();
+      if (!response) {
+        throw new Error("No mock Jira response queued");
+      }
 
-    const req = new EventEmitter() as EventEmitter & {
-      setTimeout: (ms: number, handler: () => void) => void;
-      end: () => void;
-      destroy: (err?: Error) => void;
-    };
-    req.setTimeout = (_ms, _handler) => {};
-    req.end = () => {};
-    req.destroy = (err?: Error) => {
-      if (err) req.emit("error", err);
-    };
-    return req;
-  });
+      const req = new EventEmitter() as MockRequest;
+      req.setTimeout = (_ms, _handler) => {};
+      req.write = vi.fn();
+      req.end = () => {
+        const res = new EventEmitter() as EventEmitter & { statusCode?: number; headers: Record<string, string> };
+        res.statusCode = response.statusCode ?? 200;
+        res.headers = {};
+
+        queueMicrotask(() => {
+          callback(res);
+          res.emit("data", Buffer.from(JSON.stringify(response.body)));
+          res.emit("end");
+        });
+      };
+      req.destroy = (err?: Error) => {
+        if (err) req.emit("error", err);
+      };
+      return req;
+    },
+  );
+
+  return {
+    queue(body: unknown, statusCode = 200) {
+      responses.push({ body, statusCode });
+    },
+  };
 }
 
 describe("tracker-jira plugin", () => {
   const env = { ...process.env };
+  let jira: ReturnType<typeof installJiraMock>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    jira = installJiraMock();
     process.env["JIRA_BASE_URL"] = "https://acme.atlassian.net";
     process.env["JIRA_EMAIL"] = "jira-bot@acme.com";
     process.env["JIRA_API_TOKEN"] = "secret-token";
@@ -104,6 +129,7 @@ describe("tracker-jira plugin", () => {
         projectKey: "APP",
         baseUrl: "https://custom.atlassian.net/",
         email: "owner@acme.com",
+        issueTypeName: "Bug",
       },
     });
 
@@ -113,6 +139,7 @@ describe("tracker-jira plugin", () => {
       apiToken: "secret-token",
       projectKey: "APP",
       jql: undefined,
+      issueTypeName: "Bug",
     });
   });
 
@@ -121,9 +148,10 @@ describe("tracker-jira plugin", () => {
     expect(() => resolveJiraConfig(project)).toThrow("JIRA_API_TOKEN");
   });
 
-  it("extracts text from Atlassian document format", () => {
-    expect(extractDocumentText(sampleIssue.fields.description)).toContain("Users cannot sign in.");
-    expect(extractDocumentText(sampleIssue.fields.description)).toContain("Repro on mobile");
+  it("extracts text from Atlassian document format, including hard breaks", () => {
+    const text = extractDocumentText(sampleIssue.fields.description);
+    expect(text).toContain("Users cannot sign in.\nReset link also fails.");
+    expect(text).toContain("Repro on mobile");
   });
 
   it("maps Jira issues into AO Issue shape", () => {
@@ -131,7 +159,7 @@ describe("tracker-jira plugin", () => {
     expect(issue).toEqual({
       id: "APP-123",
       title: "Fix login flow",
-      description: expect.stringContaining("Users cannot sign in."),
+      description: expect.stringContaining("Users cannot sign in.\nReset link also fails."),
       url: "https://acme.atlassian.net/browse/APP-123",
       state: "in_progress",
       labels: ["bug", "urgent"],
@@ -141,8 +169,21 @@ describe("tracker-jira plugin", () => {
     });
   });
 
+  it("maps Jira 'Lowest' priority to AO low priority", () => {
+    const issue = mapJiraIssue(
+      {
+        ...sampleIssue,
+        key: "APP-124",
+        fields: { ...sampleIssue.fields, priority: { name: "Lowest" } },
+      },
+      resolveJiraConfig(project),
+    );
+
+    expect(issue.priority).toBe(4);
+  });
+
   it("fetches a single Jira issue", async () => {
-    mockJiraResponse(sampleIssue);
+    jira.queue(sampleIssue);
     const tracker = create();
 
     const issue = await tracker.getIssue("app-123", project);
@@ -155,7 +196,7 @@ describe("tracker-jira plugin", () => {
   });
 
   it("lists Jira issues using projectKey-derived JQL", async () => {
-    mockJiraResponse({ issues: [sampleIssue] });
+    jira.queue({ issues: [sampleIssue] });
     const tracker = create();
 
     const issues = await tracker.listIssues!({ state: "open", labels: ["bug"], limit: 10 }, project);
@@ -169,7 +210,7 @@ describe("tracker-jira plugin", () => {
   });
 
   it("respects explicit tracker.jql for listIssues", async () => {
-    mockJiraResponse({ issues: [sampleIssue] });
+    jira.queue({ issues: [sampleIssue] });
     const tracker = create();
 
     await tracker.listIssues!(
@@ -185,5 +226,88 @@ describe("tracker-jira plugin", () => {
 
     const [url] = requestMock.mock.calls[0] as [URL];
     expect(decodeURIComponent(String(url))).toContain("project = APP ORDER BY created DESC");
+  });
+
+  it("updates state, labels, removes labels, and posts a comment", async () => {
+    jira.queue({ transitions: [{ id: "31", to: { name: "Done", statusCategory: { key: "done" } } }] });
+    jira.queue({});
+    jira.queue(sampleIssue);
+    jira.queue({});
+    jira.queue({ id: "comment-1" });
+    const tracker = create();
+
+    await tracker.updateIssue!(
+      "APP-123",
+      {
+        state: "closed",
+        labels: ["verified", "agent:done"],
+        removeLabels: ["urgent"],
+        comment: "Verified on staging.",
+      },
+      project,
+    );
+
+    expect(requestMock).toHaveBeenCalledTimes(5);
+
+    const transitionWrite = (requestMock.mock.results[1].value as MockRequest).write.mock.calls[0][0];
+    expect(JSON.parse(transitionWrite)).toEqual({ transition: { id: "31" } });
+
+    const issueUpdateWrite = (requestMock.mock.results[3].value as MockRequest).write.mock.calls[0][0];
+    expect(JSON.parse(issueUpdateWrite)).toEqual({ fields: { labels: ["bug", "verified", "agent:done"] } });
+
+    const commentWrite = (requestMock.mock.results[4].value as MockRequest).write.mock.calls[0][0];
+    expect(JSON.parse(commentWrite).body.content[0].content[0].text).toBe("Verified on staging.");
+  });
+
+  it("creates an issue with priority, labels, assignee, and custom issue type", async () => {
+    jira.queue([{ accountId: "acct-123", displayName: "Alice Doe" }]);
+    jira.queue({ id: "10002", key: "APP-456" });
+    jira.queue({
+      ...sampleIssue,
+      key: "APP-456",
+      fields: {
+        ...sampleIssue.fields,
+        summary: "New login bug",
+        labels: ["agent:backlog"],
+        assignee: { displayName: "Alice Doe" },
+        priority: { name: "Highest" },
+      },
+    });
+    const tracker = create();
+
+    const issue = await tracker.createIssue!(
+      {
+        title: "New login bug",
+        description: "Freshly reported",
+        labels: ["agent:backlog"],
+        assignee: "Alice Doe",
+        priority: 1,
+      },
+      {
+        ...project,
+        tracker: {
+          plugin: "jira",
+          projectKey: "APP",
+          issueTypeName: "Bug",
+        },
+      },
+    );
+
+    expect(issue.id).toBe("APP-456");
+    expect(requestMock).toHaveBeenCalledTimes(3);
+
+    const createWrite = (requestMock.mock.results[1].value as MockRequest).write.mock.calls[0][0];
+    const createBody = JSON.parse(createWrite);
+    expect(createBody.fields.issuetype).toEqual({ name: "Bug" });
+    expect(createBody.fields.priority).toEqual({ name: "Highest" });
+    expect(createBody.fields.labels).toEqual(["agent:backlog"]);
+    expect(createBody.fields.assignee).toEqual({ id: "acct-123" });
+  });
+
+  it("requires projectKey for createIssue", async () => {
+    const tracker = create();
+    await expect(
+      tracker.createIssue!({ title: "Missing key", description: "" }, { ...project, tracker: { plugin: "jira" } }),
+    ).rejects.toThrow("projectKey");
   });
 });

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { EventEmitter } from "node:events";
+
+const { requestMock } = vi.hoisted(() => ({
+  requestMock: vi.fn(),
+}));
+
+vi.mock("node:https", () => ({ request: requestMock }));
+
+import { create, manifest, resolveJiraConfig, extractDocumentText, mapJiraIssue } from "../src/index.js";
+import type { ProjectConfig } from "@aoagents/ao-core";
+
+const project: ProjectConfig = {
+  name: "test",
+  path: "/tmp/repo",
+  defaultBranch: "main",
+  sessionPrefix: "test",
+  tracker: {
+    plugin: "jira",
+    projectKey: "APP",
+  },
+};
+
+const sampleIssue = {
+  id: "10001",
+  key: "APP-123",
+  fields: {
+    summary: "Fix login flow",
+    description: {
+      type: "doc",
+      content: [
+        {
+          type: "paragraph",
+          content: [{ type: "text", text: "Users cannot sign in." }],
+        },
+        {
+          type: "bulletList",
+          content: [
+            { type: "listItem", content: [{ type: "paragraph", content: [{ type: "text", text: "Repro on mobile" }] }] },
+          ],
+        },
+      ],
+    },
+    labels: ["bug", "urgent"],
+    assignee: { displayName: "Alice Doe", emailAddress: "alice@example.com" },
+    priority: { name: "High" },
+    status: { name: "In Progress", statusCategory: { key: "indeterminate" } },
+  },
+};
+
+function mockJiraResponse(body: unknown, statusCode = 200) {
+  requestMock.mockImplementationOnce((url: URL | string, options: unknown, callback: (res: EventEmitter & { statusCode?: number; headers: Record<string, string> }) => void) => {
+    const res = new EventEmitter() as EventEmitter & { statusCode?: number; headers: Record<string, string> };
+    res.statusCode = statusCode;
+    res.headers = {};
+
+    queueMicrotask(() => {
+      callback(res);
+      res.emit("data", Buffer.from(JSON.stringify(body)));
+      res.emit("end");
+    });
+
+    const req = new EventEmitter() as EventEmitter & {
+      setTimeout: (ms: number, handler: () => void) => void;
+      end: () => void;
+      destroy: (err?: Error) => void;
+    };
+    req.setTimeout = (_ms, _handler) => {};
+    req.end = () => {};
+    req.destroy = (err?: Error) => {
+      if (err) req.emit("error", err);
+    };
+    return req;
+  });
+}
+
+describe("tracker-jira plugin", () => {
+  const env = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env["JIRA_BASE_URL"] = "https://acme.atlassian.net";
+    process.env["JIRA_EMAIL"] = "jira-bot@acme.com";
+    process.env["JIRA_API_TOKEN"] = "secret-token";
+  });
+
+  afterEach(() => {
+    process.env = { ...env };
+  });
+
+  it("exports the expected manifest", () => {
+    expect(manifest).toMatchObject({
+      name: "jira",
+      slot: "tracker",
+      version: "0.1.0",
+    });
+  });
+
+  it("resolves config from tracker overrides and env", () => {
+    const config = resolveJiraConfig({
+      ...project,
+      tracker: {
+        plugin: "jira",
+        projectKey: "APP",
+        baseUrl: "https://custom.atlassian.net/",
+        email: "owner@acme.com",
+      },
+    });
+
+    expect(config).toEqual({
+      baseUrl: "https://custom.atlassian.net",
+      email: "owner@acme.com",
+      apiToken: "secret-token",
+      projectKey: "APP",
+      jql: undefined,
+    });
+  });
+
+  it("fails fast when auth config is missing", () => {
+    delete process.env["JIRA_API_TOKEN"];
+    expect(() => resolveJiraConfig(project)).toThrow("JIRA_API_TOKEN");
+  });
+
+  it("extracts text from Atlassian document format", () => {
+    expect(extractDocumentText(sampleIssue.fields.description)).toContain("Users cannot sign in.");
+    expect(extractDocumentText(sampleIssue.fields.description)).toContain("Repro on mobile");
+  });
+
+  it("maps Jira issues into AO Issue shape", () => {
+    const issue = mapJiraIssue(sampleIssue, resolveJiraConfig(project));
+    expect(issue).toEqual({
+      id: "APP-123",
+      title: "Fix login flow",
+      description: expect.stringContaining("Users cannot sign in."),
+      url: "https://acme.atlassian.net/browse/APP-123",
+      state: "in_progress",
+      labels: ["bug", "urgent"],
+      assignee: "Alice Doe",
+      priority: 2,
+      branchName: "feat/app-123",
+    });
+  });
+
+  it("fetches a single Jira issue", async () => {
+    mockJiraResponse(sampleIssue);
+    const tracker = create();
+
+    const issue = await tracker.getIssue("app-123", project);
+
+    expect(issue.id).toBe("APP-123");
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    const [url, options] = requestMock.mock.calls[0] as [URL, { headers: Record<string, string> }];
+    expect(String(url)).toContain("/rest/api/3/issue/APP-123");
+    expect(options.headers.Authorization).toContain("Basic ");
+  });
+
+  it("lists Jira issues using projectKey-derived JQL", async () => {
+    mockJiraResponse({ issues: [sampleIssue] });
+    const tracker = create();
+
+    const issues = await tracker.listIssues!({ state: "open", labels: ["bug"], limit: 10 }, project);
+
+    expect(issues).toHaveLength(1);
+    const [url] = requestMock.mock.calls[0] as [URL];
+    expect(String(url)).toContain("/rest/api/3/search/jql?");
+    expect(decodeURIComponent(String(url))).toContain('project = "APP"');
+    expect(decodeURIComponent(String(url))).toContain('labels = "bug"');
+    expect(decodeURIComponent(String(url))).toContain("statusCategory != Done");
+  });
+
+  it("respects explicit tracker.jql for listIssues", async () => {
+    mockJiraResponse({ issues: [sampleIssue] });
+    const tracker = create();
+
+    await tracker.listIssues!(
+      { state: "closed" },
+      {
+        ...project,
+        tracker: {
+          plugin: "jira",
+          jql: "project = APP ORDER BY created DESC",
+        },
+      },
+    );
+
+    const [url] = requestMock.mock.calls[0] as [URL];
+    expect(decodeURIComponent(String(url))).toContain("project = APP ORDER BY created DESC");
+  });
+});

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -7,7 +7,7 @@ const { requestMock } = vi.hoisted(() => ({
 
 vi.mock("node:https", () => ({ request: requestMock }));
 
-import { create, manifest, resolveJiraConfig, extractDocumentText, mapJiraIssue } from "../src/index.js";
+import { create, manifest, resolveJiraConfig, extractDocumentText, mapJiraIssue, mapJiraState } from "../src/index.js";
 import type { ProjectConfig } from "@aoagents/ao-core";
 
 type MockRequest = EventEmitter & {
@@ -60,7 +60,7 @@ const sampleIssue = {
 };
 
 function installJiraMock() {
-  const responses: Array<{ body: unknown; statusCode?: number }> = [];
+  const responses: Array<{ body?: unknown; rawBody?: string; statusCode?: number }> = [];
 
   requestMock.mockImplementation(
     (_url: URL | string, _options: unknown, callback: (res: EventEmitter & { statusCode?: number; headers: Record<string, string> }) => void) => {
@@ -79,7 +79,10 @@ function installJiraMock() {
 
         queueMicrotask(() => {
           callback(res);
-          res.emit("data", Buffer.from(JSON.stringify(response.body)));
+          const rawBody = response.rawBody ?? (response.body === undefined ? "" : JSON.stringify(response.body));
+          if (rawBody) {
+            res.emit("data", Buffer.from(rawBody));
+          }
           res.emit("end");
         });
       };
@@ -93,6 +96,9 @@ function installJiraMock() {
   return {
     queue(body: unknown, statusCode = 200) {
       responses.push({ body, statusCode });
+    },
+    queueEmpty(statusCode = 204) {
+      responses.push({ rawBody: "", statusCode });
     },
   };
 }
@@ -182,6 +188,11 @@ describe("tracker-jira plugin", () => {
     expect(issue.priority).toBe(4);
   });
 
+  it("preserves canceled semantics for done-category statuses", () => {
+    expect(mapJiraState({ name: "Canceled", statusCategory: { key: "done" } })).toBe("cancelled");
+    expect(mapJiraState({ name: "Cancelled", statusCategory: { key: "done" } })).toBe("cancelled");
+  });
+
   it("fetches a single Jira issue", async () => {
     jira.queue(sampleIssue);
     const tracker = create();
@@ -229,10 +240,15 @@ describe("tracker-jira plugin", () => {
   });
 
   it("updates state, labels, removes labels, and posts a comment", async () => {
-    jira.queue({ transitions: [{ id: "31", to: { name: "Done", statusCategory: { key: "done" } } }] });
-    jira.queue({});
+    jira.queue({
+      transitions: [
+        { id: "41", name: "Cancel", to: { name: "Canceled", statusCategory: { key: "done" } } },
+        { id: "31", name: "Resolve", to: { name: "Done", statusCategory: { key: "done" } } },
+      ],
+    });
+    jira.queueEmpty(204);
     jira.queue(sampleIssue);
-    jira.queue({});
+    jira.queueEmpty(204);
     jira.queue({ id: "comment-1" });
     const tracker = create();
 

--- a/packages/plugins/tracker-jira/test/index.test.ts
+++ b/packages/plugins/tracker-jira/test/index.test.ts
@@ -275,6 +275,71 @@ describe("tracker-jira plugin", () => {
     expect(JSON.parse(commentWrite).body.content[0].content[0].text).toBe("Verified on staging.");
   });
 
+  it("updates assignee using Jira Cloud accountId payload", async () => {
+    jira.queue([{ accountId: "acct-456", displayName: "Bob Roe" }]);
+    jira.queueEmpty(204);
+    const tracker = create();
+
+    await tracker.updateIssue!("APP-123", { assignee: "Bob Roe" }, project);
+
+    expect(requestMock).toHaveBeenCalledTimes(2);
+    const updateWrite = (requestMock.mock.results[1].value as MockRequest).write.mock.calls[0][0];
+    expect(JSON.parse(updateWrite)).toEqual({ fields: { assignee: { accountId: "acct-456" } } });
+  });
+
+  it("skips assignee update when Jira user search is ambiguous", async () => {
+    jira.queue([
+      { accountId: "acct-123", displayName: "Alice Doe" },
+      { accountId: "acct-456", displayName: "Alice Doe" },
+    ]);
+    const tracker = create();
+
+    await tracker.updateIssue!("APP-123", { assignee: "Alice Doe" }, project);
+
+    expect(requestMock).toHaveBeenCalledTimes(1);
+    expect((requestMock.mock.results[0].value as MockRequest).write).not.toHaveBeenCalled();
+  });
+
+  it("skips assignee create when Jira user search has no exact match", async () => {
+    jira.queue([{ accountId: "acct-123", displayName: "Alice Doe" }]);
+    jira.queue({ id: "10002", key: "APP-456" });
+    jira.queue({
+      ...sampleIssue,
+      key: "APP-456",
+      fields: {
+        ...sampleIssue.fields,
+        summary: "New login bug",
+        labels: ["agent:backlog"],
+        assignee: null,
+        priority: { name: "Highest" },
+      },
+    });
+    const tracker = create();
+
+    const issue = await tracker.createIssue!(
+      {
+        title: "New login bug",
+        description: "Freshly reported",
+        labels: ["agent:backlog"],
+        assignee: "Alice",
+        priority: 1,
+      },
+      {
+        ...project,
+        tracker: {
+          plugin: "jira",
+          projectKey: "APP",
+          issueTypeName: "Bug",
+        },
+      },
+    );
+
+    expect(issue.id).toBe("APP-456");
+    const createWrite = (requestMock.mock.results[1].value as MockRequest).write.mock.calls[0][0];
+    const createBody = JSON.parse(createWrite);
+    expect(createBody.fields.assignee).toBeUndefined();
+  });
+
   it("creates an issue with priority, labels, assignee, and custom issue type", async () => {
     jira.queue([{ accountId: "acct-123", displayName: "Alice Doe" }]);
     jira.queue({ id: "10002", key: "APP-456" });
@@ -317,7 +382,7 @@ describe("tracker-jira plugin", () => {
     expect(createBody.fields.issuetype).toEqual({ name: "Bug" });
     expect(createBody.fields.priority).toEqual({ name: "Highest" });
     expect(createBody.fields.labels).toEqual(["agent:backlog"]);
-    expect(createBody.fields.assignee).toEqual({ id: "acct-123" });
+    expect(createBody.fields.assignee).toEqual({ accountId: "acct-123" });
   });
 
   it("requires projectKey for createIssue", async () => {

--- a/packages/plugins/tracker-jira/tsconfig.json
+++ b/packages/plugins/tracker-jira/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -8,6 +8,7 @@ const nextConfig = {
     "@aoagents/ao-plugin-runtime-tmux",
     "@aoagents/ao-plugin-scm-github",
     "@aoagents/ao-plugin-tracker-github",
+    "@aoagents/ao-plugin-tracker-jira",
     "@aoagents/ao-plugin-tracker-linear",
     "@aoagents/ao-plugin-workspace-worktree",
   ],

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
     "@aoagents/ao-plugin-runtime-tmux": "workspace:*",
     "@aoagents/ao-plugin-scm-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
+    "@aoagents/ao-plugin-tracker-jira": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@xterm/addon-fit": "^0.11.0",

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -12,6 +12,7 @@ const {
   worktreePlugin,
   scmPlugin,
   trackerGithubPlugin,
+  trackerJiraPlugin,
   trackerLinearPlugin,
 } = vi.hoisted(() => {
   const mockLoadConfig = vi.fn();
@@ -37,6 +38,7 @@ const {
     worktreePlugin: { manifest: { name: "worktree" } },
     scmPlugin: { manifest: { name: "github" } },
     trackerGithubPlugin: { manifest: { name: "github" } },
+    trackerJiraPlugin: { manifest: { name: "jira" } },
     trackerLinearPlugin: { manifest: { name: "linear" } },
   };
 });
@@ -57,10 +59,12 @@ vi.mock("@aoagents/ao-core", () => ({
 vi.mock("@aoagents/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
 vi.mock("@aoagents/ao-plugin-agent-codex", () => ({ default: codexPlugin }));
+vi.mock("@aoagents/ao-plugin-agent-cursor", () => ({ default: { manifest: { name: "cursor" } } }));
 vi.mock("@aoagents/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));
 vi.mock("@aoagents/ao-plugin-workspace-worktree", () => ({ default: worktreePlugin }));
 vi.mock("@aoagents/ao-plugin-scm-github", () => ({ default: scmPlugin }));
 vi.mock("@aoagents/ao-plugin-tracker-github", () => ({ default: trackerGithubPlugin }));
+vi.mock("@aoagents/ao-plugin-tracker-jira", () => ({ default: trackerJiraPlugin }));
 vi.mock("@aoagents/ao-plugin-tracker-linear", () => ({ default: trackerLinearPlugin }));
 
 describe("services", () => {
@@ -103,6 +107,14 @@ describe("services", () => {
     await getServices();
 
     expect(mockRegister).toHaveBeenCalledWith(codexPlugin);
+  });
+
+  it("registers the Jira tracker plugin with web services", async () => {
+    const { getServices } = await import("../lib/services");
+
+    await getServices();
+
+    expect(mockRegister).toHaveBeenCalledWith(trackerJiraPlugin);
   });
 
   it("caches initialized services across repeated calls", async () => {

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -39,6 +39,7 @@ import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
 import pluginTrackerGithub from "@aoagents/ao-plugin-tracker-github";
+import pluginTrackerJira from "@aoagents/ao-plugin-tracker-jira";
 import pluginTrackerLinear from "@aoagents/ao-plugin-tracker-linear";
 
 export interface Services {
@@ -83,6 +84,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);
   registry.register(pluginTrackerGithub);
+  registry.register(pluginTrackerJira);
   registry.register(pluginTrackerLinear);
 
   const sessionManager = createSessionManager({ config, registry });

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -49,6 +49,10 @@ export default defineConfig({
         replacement: resolve(__dirname, "../plugins/agent-codex/src/index.ts"),
       },
       {
+        find: "@aoagents/ao-plugin-agent-cursor",
+        replacement: resolve(__dirname, "../plugins/agent-cursor/src/index.ts"),
+      },
+      {
         find: "@aoagents/ao-plugin-agent-opencode",
         replacement: resolve(__dirname, "../plugins/agent-opencode/src/index.ts"),
       },
@@ -63,6 +67,10 @@ export default defineConfig({
       {
         find: "@aoagents/ao-plugin-tracker-github",
         replacement: resolve(__dirname, "../plugins/tracker-github/src/index.ts"),
+      },
+      {
+        find: "@aoagents/ao-plugin-tracker-jira",
+        replacement: resolve(__dirname, "../plugins/tracker-jira/src/index.ts"),
       },
       {
         find: "@aoagents/ao-plugin-tracker-linear",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       '@aoagents/ao-plugin-tracker-github':
         specifier: workspace:*
         version: link:../plugins/tracker-github
+      '@aoagents/ao-plugin-tracker-jira':
+        specifier: workspace:*
+        version: link:../plugins/tracker-jira
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
@@ -205,6 +208,9 @@ importers:
       '@aoagents/ao-plugin-runtime-tmux':
         specifier: workspace:*
         version: link:../plugins/runtime-tmux
+      '@aoagents/ao-plugin-tracker-jira':
+        specifier: workspace:*
+        version: link:../plugins/tracker-jira
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear
@@ -562,6 +568,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/plugins/tracker-jira:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
   packages/plugins/tracker-linear:
     dependencies:
       '@aoagents/ao-core':
@@ -636,6 +658,9 @@ importers:
       '@aoagents/ao-plugin-tracker-github':
         specifier: workspace:*
         version: link:../plugins/tracker-github
+      '@aoagents/ao-plugin-tracker-jira':
+        specifier: workspace:*
+        version: link:../plugins/tracker-jira
       '@aoagents/ao-plugin-tracker-linear':
         specifier: workspace:*
         version: link:../plugins/tracker-linear


### PR DESCRIPTION
## Summary
- add a built-in Jira tracker plugin for AO
- support issue read and minimal write flows for Jira Cloud
- harden Jira Cloud-specific behavior for transitions, empty success responses, and assignee handling
- add tests and docs for the new plugin

## Included
- new `packages/plugins/tracker-jira`
- built-in plugin wiring in core/web/CLI config docs
- Jira Cloud config via env and tracker overrides
- `getIssue`, `listIssues`, `createIssue`, `updateIssue`, `isCompleted`, `issueUrl`, `issueLabel`, `branchName`, `generatePrompt`
- safer assignee resolution using exact-match only + `accountId` payloads
- regression tests for 204 responses, cancelled mapping, assignee ambiguity, and write payload shape

## Validation
- `pnpm --filter @aoagents/ao-plugin-tracker-jira test`
- `pnpm --filter @aoagents/ao-plugin-tracker-jira typecheck`
- earlier local validation in this branch also covered core/cli/web wiring

## Notes
- assignee writes are best-effort and intentionally skipped when Jira user search is ambiguous or has no exact match
- this is a practical first upstreamable slice, not a full Jira workflow implementation
