### PR TITLE
deploy-vps: run deploy as aoagent instead of root

### DIFF
--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -81,13 +81,13 @@ jobs:
         uses: appleboy/ssh-action@v1.2.2
         with:
           host: ${{ secrets.VPS_HOST }}
-          username: root
+          username: aoagent
           key: ${{ secrets.VPS_SSH_KEY }}
           fingerprint: ${{ secrets.VPS_HOST_FINGERPRINT }}
           envs: DEPLOY_SHA,FETCH_REF
           script: |
             set -e
-            cd /root/agent-orchestrator
+            cd /home/aoagent/agent-orchestrator
             echo "==> Ensuring full worktree..."
             if [ "$(git config --bool core.sparseCheckout || echo false)" = "true" ]; then
               git sparse-checkout disable


### PR DESCRIPTION
## Summary

- Change the `appleboy/ssh-action` SSH user in `.github/workflows/deploy-vps.yml` from `root` to `aoagent`, and update the working directory in the same step from `/root/agent-orchestrator` to `/home/aoagent/agent-orchestrator`.

## Why

The VPS deploy currently SSHes in as `root` but operates on files owned by `aoagent` through the `/root/agent-orchestrator` → `/home/aoagent/agent-orchestrator` symlink. Every `pnpm install` / `pnpm build` run then creates new cache entries (`.pnpm`, `.bun`, `.cache`, `node_modules`) owned by `root` inside an otherwise aoagent-owned subtree, leaking root ownership on each deploy. Running the deploy as `aoagent` removes that drift at the source.

## Notes

- No secret rotation needed — the existing `VPS_SSH_KEY` pubkey (`dhruv-ao-openclaw`, `SHA256:0i7ttaeLL1ZMDwKcvdnpoyTosX38+xLjJ0fuJgGZLlI`) is already present in `/home/aoagent/.ssh/authorized_keys` on the VPS, so the same key authenticates for `aoagent`.
- Working-tree path change is cosmetic: `/root/agent-orchestrator` is a symlink to `/home/aoagent/agent-orchestrator`, so we point the deploy at the canonical path.
- Diff is scoped to those two lines in `deploy-vps.yml`; no other workflows or infra files are touched.

## Test plan

- [ ] Verified post-merge when the `workflow_run` trigger fires on the first CI-passing push to `main` (out of scope for this PR; workflow is only exercised in production CI).