### PR TITLE
fix: add ground truth verification before CI/review lifecycle transitions

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -841,7 +841,12 @@ describe("check (single session)", () => {
   });
 
   it("detects PR states from SCM", async () => {
-    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "failed", conclusion: "FAILURE" },
+      ]),
+    });
     const registry = createMockRegistry({
       runtime: plugins.runtime,
       agent: plugins.agent,
@@ -855,6 +860,194 @@ describe("check (single session)", () => {
 
     await lm.check("app-1");
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
+  });
+
+  it("blocks ci_failed transition when fresh checks show no actual failures", async () => {
+    // getCISummary reports "failing" (e.g., fail-closed fallback on API error)
+    // but getCIChecks reveals no checks have actually failed — all pending.
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "pending", conclusion: undefined },
+        { name: "lint", status: "running", conclusion: undefined },
+      ]),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Should NOT transition to ci_failed — ground truth shows checks are pending
+    expect(lm.getStates().get("app-1")).not.toBe("ci_failed");
+  });
+
+  it("blocks ci_failed transition when getCIChecks verification call fails", async () => {
+    // getCISummary reports "failing" but getCIChecks throws (API error).
+    // For a NEW transition, we don't trust the fail-closed fallback.
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockRejectedValue(new Error("API rate limit")),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Should NOT transition to ci_failed when verification fails
+    expect(lm.getStates().get("app-1")).not.toBe("ci_failed");
+  });
+
+  it("allows ci_failed transition when fresh checks confirm actual failures", async () => {
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "passed", conclusion: "SUCCESS" },
+        { name: "lint", status: "failed", conclusion: "FAILURE" },
+      ]),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Transition IS allowed — fresh checks confirm a real failure
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+  });
+
+  it("skips CI verification when session is already in ci_failed", async () => {
+    const getCIChecksMock = vi.fn().mockResolvedValue([
+      { name: "lint", status: "failed", conclusion: "FAILURE" },
+    ]);
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: getCIChecksMock,
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "ci_failed", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // When already in ci_failed, getCIChecks should not be called for verification
+    // (getCISummary itself may call it internally, but the verification step is skipped)
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+  });
+
+  it("blocks changes_requested transition when no unresolved review comments exist", async () => {
+    // GitHub reviewDecision says "changes_requested" but all threads are resolved
+    const mockSCM = createMockSCM({
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      getPendingComments: vi.fn().mockResolvedValue([]),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Should NOT transition to changes_requested — no unresolved comments
+    expect(lm.getStates().get("app-1")).not.toBe("changes_requested");
+  });
+
+  it("allows changes_requested transition when unresolved comments exist", async () => {
+    const mockSCM = createMockSCM({
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      getPendingComments: vi.fn().mockResolvedValue([
+        {
+          id: "c1",
+          author: "reviewer",
+          body: "Please fix this",
+          isResolved: false,
+          createdAt: new Date(),
+          url: "https://example.com/comment/1",
+        },
+      ]),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Transition IS allowed — there are real unresolved comments
+    expect(lm.getStates().get("app-1")).toBe("changes_requested");
+  });
+
+  it("blocks ci_failed from batch enrichment when ciChecks show no failures", async () => {
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            "org/repo#42",
+            {
+              state: "open" as const,
+              ciStatus: "failing" as const,
+              reviewDecision: "none" as const,
+              mergeable: false,
+              hasConflicts: false,
+              // Batch reports "failing" but individual checks are all passing
+              ciChecks: [
+                { name: "build", status: "passed" as const, conclusion: "SUCCESS" },
+                { name: "lint", status: "passed" as const, conclusion: "SUCCESS" },
+              ],
+            },
+          ],
+        ]),
+      ),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    // Batch enrichment CI status is overridden by check-level verification
+    expect(lm.getStates().get("app-1")).not.toBe("ci_failed");
   });
 
   it("keeps canonical session state idle while waiting on external review", async () => {
@@ -1221,7 +1414,12 @@ describe("reactions", () => {
       },
     };
 
-    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "failed", conclusion: "FAILURE" },
+      ]),
+    });
     const registry = createMockRegistry({
       runtime: plugins.runtime,
       agent: plugins.agent,
@@ -1242,7 +1440,12 @@ describe("reactions", () => {
       "ci-failed": { auto: false, action: "send-to-agent", message: "CI is failing." },
     };
 
-    const mockSCM = createMockSCM({ getCISummary: vi.fn().mockResolvedValue("failing") });
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "failed", conclusion: "FAILURE" },
+      ]),
+    });
     const registry = createMockRegistry({
       runtime: plugins.runtime,
       agent: plugins.agent,
@@ -1262,6 +1465,9 @@ describe("reactions", () => {
     const notifier = createMockNotifier();
     const mockSCM = createMockSCM({
       getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIChecks: vi.fn().mockResolvedValue([
+        { name: "build", status: "failed", conclusion: "FAILURE" },
+      ]),
     });
 
     const registry: PluginRegistry = {

--- a/packages/core/src/__tests__/plugin-integration.test.ts
+++ b/packages/core/src/__tests__/plugin-integration.test.ts
@@ -494,6 +494,8 @@ describe("plugin integration", () => {
       mockGh({ state: "OPEN" });
       // 2. getCISummary → failing (pr checks returns array of checks with correct field names)
       mockGh([{ name: "lint", state: "FAILURE", link: "", startedAt: "", completedAt: "" }]);
+      // 3. verifyCIStatusForTransition → getCIChecks confirms the failure is real
+      mockGh([{ name: "lint", state: "FAILURE", link: "", startedAt: "", completedAt: "" }]);
 
       await lm.check("app-1");
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -37,6 +37,8 @@ import {
   type ProjectConfig as _ProjectConfig,
   type PREnrichmentData,
   type CICheck,
+  type CIStatus,
+  type ReviewDecision,
 } from "./types.js";
 import { buildLifecycleMetadataPatch, cloneLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
 import { updateMetadata } from "./metadata.js";
@@ -461,6 +463,149 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
   }
 
+  /**
+   * Verify CI status before a NEW transition to ci_failed.
+   *
+   * When getCISummary reports "failing" (which may be from a fail-closed
+   * fallback on API error or stale batch data), fetch individual CI checks
+   * to confirm at least one check has actually failed. This prevents false
+   * ci_failed transitions when checks are passing or pending.
+   *
+   * Skips verification when the session is already in ci_failed (no
+   * transition will occur, so the extra API call is unnecessary).
+   */
+  async function verifyCIStatusForTransition(
+    ciStatus: CIStatus,
+    session: Session,
+    scm: SCM,
+  ): Promise<CIStatus> {
+    if (ciStatus !== CI_STATUS.FAILING) return ciStatus;
+    if (session.status === SESSION_STATUS.CI_FAILED) return ciStatus;
+    if (!session.pr) return ciStatus;
+
+    try {
+      const checks = await scm.getCIChecks(session.pr);
+      const hasFailing = checks.some((c) => c.status === "failed");
+      if (!hasFailing) {
+        // No actual failures — override the stale/erroneous CI status
+        const hasPending = checks.some(
+          (c) => c.status === "pending" || c.status === "running",
+        );
+        if (hasPending) return CI_STATUS.PENDING;
+        const hasPassing = checks.some((c) => c.status === "passed");
+        return hasPassing ? CI_STATUS.PASSING : CI_STATUS.NONE;
+      }
+    } catch {
+      // Verification call itself failed — don't trust the original
+      // fail-closed "failing" for a NEW transition. Return pending so
+      // the lifecycle stays in its current state rather than falsely
+      // moving to ci_failed.
+      return CI_STATUS.PENDING;
+    }
+    return ciStatus;
+  }
+
+  /**
+   * Verify review decision before a NEW transition to changes_requested.
+   *
+   * GitHub's reviewDecision field can stay "CHANGES_REQUESTED" even after
+   * the agent addresses comments and pushes new code (the reviewer hasn't
+   * re-reviewed yet). Before transitioning, check whether there are actually
+   * unresolved review comments. If all threads are resolved (or there are
+   * none), the transition is stale and should be suppressed.
+   *
+   * Skips verification when the session is already in changes_requested.
+   */
+  async function verifyReviewDecisionForTransition(
+    reviewDecision: ReviewDecision,
+    session: Session,
+    scm: SCM,
+  ): Promise<ReviewDecision> {
+    if (reviewDecision !== "changes_requested") return reviewDecision;
+    if (session.status === SESSION_STATUS.CHANGES_REQUESTED) return reviewDecision;
+    if (!session.pr) return reviewDecision;
+
+    try {
+      const pendingComments = await scm.getPendingComments(session.pr);
+      if (pendingComments.length === 0) {
+        // No unresolved human review comments — the review decision is stale.
+        // Downgrade to "pending" so the PR shows as awaiting re-review rather
+        // than falsely routing the agent to address already-resolved comments.
+        return "pending";
+      }
+    } catch {
+      // Verification failed — preserve the original decision since we can't
+      // confirm it's stale. This is conservative: the agent may get a
+      // redundant notification, but won't miss a real review request.
+    }
+    return reviewDecision;
+  }
+
+  /**
+   * Verify batch enrichment data before a NEW ci_failed or changes_requested
+   * transition. Returns a shallow copy of the enrichment data with corrected
+   * ciStatus and/or reviewDecision when the ground truth disagrees.
+   *
+   * For CI: when `ciChecks` is included in the batch data (self-contained),
+   * validates the top-level ciStatus against individual checks without an
+   * extra API call. When `ciChecks` is absent (truncated), falls back to
+   * fetching fresh checks via getCIChecks().
+   */
+  async function verifyPREnrichmentForTransition(
+    cachedData: PREnrichmentData,
+    session: Session,
+    scm: SCM,
+  ): Promise<PREnrichmentData> {
+    const needsCIVerification =
+      cachedData.ciStatus === CI_STATUS.FAILING &&
+      session.status !== SESSION_STATUS.CI_FAILED;
+    const needsReviewVerification =
+      cachedData.reviewDecision === "changes_requested" &&
+      session.status !== SESSION_STATUS.CHANGES_REQUESTED;
+
+    if (!needsCIVerification && !needsReviewVerification) {
+      return cachedData;
+    }
+
+    let verifiedCI = cachedData.ciStatus;
+    let verifiedReview = cachedData.reviewDecision;
+
+    if (needsCIVerification) {
+      if (cachedData.ciChecks !== undefined) {
+        // Batch data includes individual checks — verify self-consistency
+        // without an extra API call.
+        const hasFailing = cachedData.ciChecks.some((c) => c.status === "failed");
+        if (!hasFailing) {
+          const hasPending = cachedData.ciChecks.some(
+            (c) => c.status === "pending" || c.status === "running",
+          );
+          if (hasPending) {
+            verifiedCI = CI_STATUS.PENDING;
+          } else {
+            const hasPassing = cachedData.ciChecks.some((c) => c.status === "passed");
+            verifiedCI = hasPassing ? CI_STATUS.PASSING : CI_STATUS.NONE;
+          }
+        }
+      } else {
+        // ciChecks was truncated — fall back to fresh API call
+        verifiedCI = await verifyCIStatusForTransition(cachedData.ciStatus, session, scm);
+      }
+    }
+    if (needsReviewVerification) {
+      verifiedReview = await verifyReviewDecisionForTransition(
+        cachedData.reviewDecision,
+        session,
+        scm,
+      );
+    }
+
+    if (verifiedCI === cachedData.ciStatus && verifiedReview === cachedData.reviewDecision) {
+      return cachedData;
+    }
+
+    return { ...cachedData, ciStatus: verifiedCI, reviewDecision: verifiedReview };
+  }
+
   /** Check if idle time exceeds the agent-stuck threshold. */
   function isIdleBeyondThreshold(session: Session, idleTimestamp: Date): boolean {
     const stuckReaction = getReactionConfigForSession(session, "agent-stuck");
@@ -754,8 +899,16 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             : false;
 
         if (cachedData) {
+          // Ground truth verification: before accepting a ci_failed or
+          // changes_requested transition from batch cache, confirm with fresh
+          // data. Batch enrichment can be stale (fetched at poll-cycle start).
+          const verifiedData = await verifyPREnrichmentForTransition(
+            cachedData,
+            session,
+            scm,
+          );
           return commit(
-            resolvePREnrichmentDecision(cachedData, {
+            resolvePREnrichmentDecision(verifiedData, {
               shouldEscalateIdleToStuck,
               idleWasBlocked,
               activityEvidence,
@@ -779,11 +932,19 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
 
         const ciStatus = await scm.getCISummary(session.pr);
-        if (ciStatus === CI_STATUS.FAILING) {
+        // Ground truth verification: when getCISummary reports failing (which
+        // may come from a fail-closed fallback on API error), verify there are
+        // actual failed checks before transitioning to ci_failed.
+        const verifiedCIStatus = await verifyCIStatusForTransition(
+          ciStatus,
+          session,
+          scm,
+        );
+        if (verifiedCIStatus === CI_STATUS.FAILING) {
           return commit(
             resolvePRLiveDecision({
               prState,
-              ciStatus,
+              ciStatus: verifiedCIStatus,
               reviewDecision: "none",
               mergeable: false,
               shouldEscalateIdleToStuck,
@@ -794,15 +955,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
 
         const reviewDecision = await scm.getReviewDecision(session.pr);
+        // Ground truth verification: when reviewDecision says changes_requested,
+        // verify there are actually unresolved review comments before transitioning.
+        const verifiedReviewDecision = await verifyReviewDecisionForTransition(
+          reviewDecision,
+          session,
+          scm,
+        );
         const mergeReady =
-          reviewDecision === "approved" || reviewDecision === "none"
+          verifiedReviewDecision === "approved" || verifiedReviewDecision === "none"
             ? await scm.getMergeability(session.pr)
             : { mergeable: false };
         return commit(
           resolvePRLiveDecision({
             prState,
-            ciStatus,
-            reviewDecision,
+            ciStatus: verifiedCIStatus,
+            reviewDecision: verifiedReviewDecision,
             mergeable: mergeReady.mergeable,
             shouldEscalateIdleToStuck,
             idleWasBlocked,

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -495,11 +495,21 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         const hasPassing = checks.some((c) => c.status === "passed");
         return hasPassing ? CI_STATUS.PASSING : CI_STATUS.NONE;
       }
-    } catch {
+    } catch (err) {
       // Verification call itself failed — don't trust the original
-      // fail-closed "failing" for a NEW transition. Return pending so
-      // the lifecycle stays in its current state rather than falsely
-      // moving to ci_failed.
+      // fail-closed "failing" for a NEW transition. Record the error for
+      // diagnosability, then return pending so the lifecycle stays in its
+      // current state rather than falsely moving to ci_failed.
+      observer?.recordOperation?.({
+        metric: "lifecycle_poll",
+        operation: "verification.ci_checks",
+        outcome: "failure",
+        correlationId: createCorrelationId("lifecycle-verify"),
+        projectId: session.projectId,
+        sessionId: session.id,
+        reason: err instanceof Error ? err.message : String(err),
+        level: "warn",
+      });
       return CI_STATUS.PENDING;
     }
     return ciStatus;
@@ -514,7 +524,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
    * unresolved review comments. If all threads are resolved (or there are
    * none), the transition is stale and should be suppressed.
    *
-   * Skips verification when the session is already in changes_requested.
+   * Skips verification when the session is already in changes_requested or
+   * review_pending (the latter means a prior verification already ran and
+   * found no actionable comments — re-checking every poll would bypass the
+   * existing review backlog throttle).
+   *
+   * Note: this checks review threads only. A body-only "Request Changes"
+   * review without inline threads will still be surfaced because we preserve
+   * the original decision when getPendingComments returns non-empty OR when
+   * verification fails. The edge case where a reviewer requests changes
+   * with ONLY a body comment and no threads is accepted — the review will
+   * be caught by maybeDispatchReviewBacklog on the next throttle cycle.
    */
   async function verifyReviewDecisionForTransition(
     reviewDecision: ReviewDecision,
@@ -523,6 +543,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   ): Promise<ReviewDecision> {
     if (reviewDecision !== "changes_requested") return reviewDecision;
     if (session.status === SESSION_STATUS.CHANGES_REQUESTED) return reviewDecision;
+    if (session.status === SESSION_STATUS.REVIEW_PENDING) return reviewDecision;
     if (!session.pr) return reviewDecision;
 
     try {
@@ -533,10 +554,20 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         // than falsely routing the agent to address already-resolved comments.
         return "pending";
       }
-    } catch {
+    } catch (err) {
       // Verification failed — preserve the original decision since we can't
       // confirm it's stale. This is conservative: the agent may get a
       // redundant notification, but won't miss a real review request.
+      observer?.recordOperation?.({
+        metric: "lifecycle_poll",
+        operation: "verification.pending_comments",
+        outcome: "failure",
+        correlationId: createCorrelationId("lifecycle-verify"),
+        projectId: session.projectId,
+        sessionId: session.id,
+        reason: err instanceof Error ? err.message : String(err),
+        level: "warn",
+      });
     }
     return reviewDecision;
   }


### PR DESCRIPTION
## Summary

- Adds ground truth verification in the lifecycle manager before transitioning sessions to `ci_failed` or `changes_requested`, preventing false positive notifications to agents
- For CI: fetches fresh `getCIChecks` to confirm at least one check has actually failed before accepting a `ci_failed` transition (catches `getCISummary` fail-closed fallback and stale batch cache)
- For reviews: calls `getPendingComments` to verify unresolved human review threads exist before accepting a `changes_requested` transition (catches stale GitHub `reviewDecision` field)
- Verification is skipped when the session is already in the target state (no extra API calls on steady-state polls)

Fixes #1325
Fixes #1375

## Test plan

- [x] New test: blocks `ci_failed` transition when fresh checks show no actual failures
- [x] New test: blocks `ci_failed` transition when `getCIChecks` verification call fails
- [x] New test: allows `ci_failed` transition when fresh checks confirm actual failures
- [x] New test: skips CI verification when session is already in `ci_failed`
- [x] New test: blocks `changes_requested` transition when no unresolved review comments exist
- [x] New test: allows `changes_requested` transition when unresolved comments exist
- [x] New test: blocks `ci_failed` from batch enrichment when `ciChecks` show no failures
- [x] All 96 lifecycle-manager tests pass
- [x] All 13 plugin-integration tests pass
- [x] Typecheck passes across all packages
- [x] Lint passes (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)