### PR TITLE
fix: clear stale CI blocker on session detail page

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -599,7 +599,12 @@ export function SessionDetail({
 
               {prPopoverOpen && (
                 <div className="topbar-pr-popover">
-                  <SessionDetailPRCard pr={pr} sessionId={session.id} metadata={session.metadata} />
+                  <SessionDetailPRCard
+                    pr={pr}
+                    sessionId={session.id}
+                    metadata={session.metadata}
+                    lifecyclePrReason={session.lifecycle?.prReason}
+                  />
                 </div>
               )}
             </div>
@@ -729,7 +734,17 @@ export function SessionDetail({
 
 // ── Session detail PR card ────────────────────────────────────────────
 
-function SessionDetailPRCard({ pr, sessionId, metadata }: { pr: DashboardPR; sessionId: string; metadata: Record<string, string> }) {
+function SessionDetailPRCard({
+  pr,
+  sessionId,
+  metadata,
+  lifecyclePrReason,
+}: {
+  pr: DashboardPR;
+  sessionId: string;
+  metadata: Record<string, string>;
+  lifecyclePrReason?: string;
+}) {
   const [sendingComments, setSendingComments] = useState<Set<string>>(new Set());
   const [sentComments, setSentComments] = useState<Set<string>>(new Set());
   const [errorComments, setErrorComments] = useState<Set<string>>(new Set());
@@ -801,7 +816,7 @@ function SessionDetailPRCard({ pr, sessionId, metadata }: { pr: DashboardPR; ses
   };
 
   const allGreen = isPRMergeReady(pr);
-  const blockerIssues = buildBlockerChips(pr, metadata);
+  const blockerIssues = buildBlockerChips(pr, metadata, lifecyclePrReason);
   const fileCount = pr.changedFiles ?? 0;
 
   const mergeabilityReliable = !isPRUnenriched(pr) && !isPRRateLimited(pr);
@@ -1045,7 +1060,11 @@ interface BlockerChip {
   notified?: boolean;
 }
 
-function buildBlockerChips(pr: DashboardPR, metadata: Record<string, string>): BlockerChip[] {
+function buildBlockerChips(
+  pr: DashboardPR,
+  metadata: Record<string, string>,
+  lifecyclePrReason?: string,
+): BlockerChip[] {
   const chips: BlockerChip[] = [];
 
   const ciNotified = Boolean(metadata["lastCIFailureDispatchHash"]);
@@ -1053,7 +1072,10 @@ function buildBlockerChips(pr: DashboardPR, metadata: Record<string, string>): B
   const reviewNotified = Boolean(metadata["lastPendingReviewDispatchHash"]);
   const lifecycleStatus = metadata["status"];
 
-  const ciIsFailing = pr.ciStatus === CI_STATUS.FAILING || lifecycleStatus === "ci_failed";
+  const ciIsFailing =
+    lifecyclePrReason !== undefined
+      ? lifecyclePrReason === "ci_failing"
+      : pr.ciStatus === CI_STATUS.FAILING;
   const hasChangesRequested =
     pr.reviewDecision === "changes_requested" || lifecycleStatus === "changes_requested";
   const mergeabilityReliable = !isPRUnenriched(pr) && !isPRRateLimited(pr);

--- a/packages/web/src/components/SessionDetailPRCard.tsx
+++ b/packages/web/src/components/SessionDetailPRCard.tsx
@@ -37,9 +37,9 @@ function buildBlockerChips(
   const lifecycleStatus = metadata["status"];
 
   const ciIsFailing =
-    pr.ciStatus === CI_STATUS.FAILING ||
-    lifecyclePrReason === "ci_failing" ||
-    lifecycleStatus === "ci_failed";
+    lifecyclePrReason !== undefined
+      ? lifecyclePrReason === "ci_failing"
+      : pr.ciStatus === CI_STATUS.FAILING;
   const hasChangesRequested =
     pr.reviewDecision === "changes_requested" ||
     lifecyclePrReason === "changes_requested" ||

--- a/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.desktop.test.tsx
@@ -146,6 +146,43 @@ describe("SessionDetail desktop layout", () => {
     expect(screen.getByText("The empty state text needs to be shorter.")).toBeInTheDocument();
   });
 
+  it("does not show a stale CI blocker when the PR lifecycle has recovered", () => {
+    render(
+      <SessionDetail
+        session={makeSession({
+          id: "worker-ci-recovered",
+          projectId: "my-app",
+          pr: makePR({
+            number: 312,
+            title: "Recovered CI should not stay red",
+            ciStatus: "passing",
+            ciChecks: [
+              { name: "build", status: "passed" },
+              { name: "test", status: "passed" },
+            ],
+            reviewDecision: "approved",
+            mergeability: {
+              mergeable: true,
+              ciPassing: true,
+              approved: true,
+              noConflicts: true,
+              blockers: [],
+            },
+          }),
+          metadata: {
+            status: "ci_failed",
+            lastCIFailureDispatchHash: "stale-dispatch-hash",
+          },
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "PR #312" }));
+
+    expect(screen.getByText("Ready to merge")).toBeInTheDocument();
+    expect(screen.queryByText("CI failing")).not.toBeInTheDocument();
+  });
+
   it("sends unresolved comments back to the agent and shows sent state", async () => {
     vi.useFakeTimers();
 

--- a/packages/web/src/lib/cache.ts
+++ b/packages/web/src/lib/cache.ts
@@ -2,7 +2,7 @@
  * Simple in-memory TTL cache for SCM API data.
  *
  * Reduces GitHub API rate limit exhaustion by caching PR enrichment data.
- * Default TTL: 60 seconds (data is fresh enough for dashboard refresh).
+ * Default TTL: 5 minutes.
  */
 
 interface CacheEntry<T> {
@@ -105,7 +105,7 @@ export interface PREnrichmentData {
   }>;
 }
 
-/** Global PR enrichment cache (60s TTL) */
+/** Global PR enrichment cache (5 min TTL) */
 export const prCache = new TTLCache<PREnrichmentData>();
 
 /** Generate cache key for a PR: `owner/repo#123` */


### PR DESCRIPTION
## Summary
- use the lifecycle PR reason as the session detail CI blocker signal instead of OR-ing in stale legacy metadata
- keep the duplicate SessionDetailPRCard helper aligned with the active detail view logic
- add a regression test covering recovered CI with stale `metadata.status`, and fix the web PR cache comments to match the real 5 minute TTL

Closes #1360.

## Validation
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (passes with existing repo warnings)
- `pnpm --filter @aoagents/ao-web test -- --run src/components/__tests__/SessionDetail.desktop.test.tsx`
- `pnpm --filter @aoagents/ao-web test -- --run src/lib/__tests__/cache.test.ts`
- `pnpm test` currently hits existing `packages/core` timeouts in `src/__tests__/plugin-registry.test.ts` and `src/__tests__/orchestrator-prompt.dist.test.ts`
