### PR TITLE
fix(cli): stop all project sessions on ao stop

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1455,10 +1455,8 @@ describe("stop command", () => {
     });
   }
 
-  it("stops the actual numbered orchestrator session and dashboard", async () => {
+  it("stops all project sessions and dashboard", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
-    // Issue #1048: ao stop must look up the real numbered orchestrator id
-    // (e.g. app-orchestrator-3) via sm.list — never the phantom `${prefix}-orchestrator`.
     mockSessionManager.list.mockResolvedValue([
       {
         id: "app-orchestrator-3",
@@ -1469,13 +1467,25 @@ describe("stop command", () => {
         lastActivityAt: new Date(),
         runtimeHandle: { id: "tmux-3" },
       },
+      {
+        id: "app-1147",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "worker" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-4" },
+      },
     ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-3", {
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-3", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-1147", {
       purgeOpenCode: false,
     });
     const output = vi
@@ -1484,9 +1494,10 @@ describe("stop command", () => {
       .join("\n");
     expect(output).toContain("Orchestrator stopped");
     expect(output).toContain("app-orchestrator-3");
+    expect(output).toContain("app-1147");
   });
 
-  it("kills the most-recently-active orchestrator when multiple exist", async () => {
+  it("kills every returned project session", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     const now = Date.now();
     mockSessionManager.list.mockResolvedValue([
@@ -1500,11 +1511,11 @@ describe("stop command", () => {
         runtimeHandle: { id: "tmux-1" },
       },
       {
-        id: "app-orchestrator-2",
+        id: "app-2",
         projectId: "my-app",
         status: "working",
         activity: "active",
-        metadata: { role: "orchestrator" },
+        metadata: { role: "worker" },
         lastActivityAt: new Date(now),
         runtimeHandle: { id: "tmux-2" },
       },
@@ -1513,7 +1524,11 @@ describe("stop command", () => {
 
     await program.parseAsync(["node", "test", "stop"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-2", {
+    expect(mockSessionManager.kill).toHaveBeenCalledTimes(2);
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-1", {
+      purgeOpenCode: false,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-2", {
       purgeOpenCode: false,
     });
   });
@@ -1530,10 +1545,10 @@ describe("stop command", () => {
       .mocked(console.log)
       .mock.calls.map((c) => c.join(" "))
       .join("\n");
-    expect(output).toContain("No running orchestrator session found");
+    expect(output).toContain("No running project sessions found");
   });
 
-  it("passes purge flag when stopping orchestrator with --purge-session", async () => {
+  it("passes purge flag when stopping project sessions with --purge-session", async () => {
     mockConfigRef.current = makeConfig({ "my-app": makeProject() });
     mockSessionManager.list.mockResolvedValue([
       {
@@ -1545,13 +1560,25 @@ describe("stop command", () => {
         lastActivityAt: new Date(),
         runtimeHandle: { id: "tmux-1" },
       },
+      {
+        id: "app-1",
+        projectId: "my-app",
+        status: "working",
+        activity: "active",
+        metadata: { role: "worker" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-2" },
+      },
     ]);
     mockSessionManager.kill.mockResolvedValue(undefined);
     mockDashboardOnPort(3000);
 
     await program.parseAsync(["node", "test", "stop", "--purge-session"]);
 
-    expect(mockSessionManager.kill).toHaveBeenCalledWith("app-orchestrator-1", {
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(1, "app-orchestrator-1", {
+      purgeOpenCode: true,
+    });
+    expect(mockSessionManager.kill).toHaveBeenNthCalledWith(2, "app-1", {
       purgeOpenCode: true,
     });
   });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1740,53 +1740,44 @@ export function registerStop(program: Command): void {
 
           console.log(chalk.bold(`\nStopping orchestrator for ${chalk.cyan(project.name)}\n`));
 
-          // Resolve the actual orchestrator session id by listing the project's sessions
-          // and finding the most-recently-active orchestrator. This avoids relying on the
-          // legacy `${prefix}-orchestrator` (no-N) phantom id, which never matches a real
-          // numbered session and causes ao stop to silently no-op.
+          // Stop every live session for the project so worker tmux sessions and
+          // worktrees do not survive after the orchestrator shuts down.
           const sm = await getSessionManager(config);
-          const allSessionPrefixes = Object.entries(config.projects).map(
-            ([, p]) => p.sessionPrefix ?? generateSessionPrefix(p.name ?? ""),
-          );
-          let orchestratorToKill: { id: string } | null = null;
+          let sessionsToKill: Session[] = [];
           let lookupFailed = false;
           try {
-            const projectSessions = await sm.list(_projectId);
-            const orchestrators = projectSessions
-              .filter((s) =>
-                isOrchestratorSession(s, project.sessionPrefix ?? _projectId, allSessionPrefixes),
-              )
-              .filter((s) => !isTerminalSession(s));
-            const sorted = [...orchestrators].sort(
-              (a, b) =>
-                (b.lastActivityAt?.getTime() ?? 0) - (a.lastActivityAt?.getTime() ?? 0),
-            );
-            orchestratorToKill = sorted[0] ?? null;
+            sessionsToKill = await sm.list(_projectId);
           } catch (err) {
             lookupFailed = true;
             console.log(
               chalk.yellow(
-                `  Could not list sessions to locate orchestrator: ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
+                `  Could not list project sessions: ${err instanceof Error ? err.message : String(err)}`,
               ),
             );
           }
 
-          if (orchestratorToKill) {
-            const spinner = ora("Stopping orchestrator session").start();
+          if (sessionsToKill.length > 0) {
+            const spinner = ora(
+              `Stopping ${sessionsToKill.length} project session${sessionsToKill.length === 1 ? "" : "s"}`,
+            ).start();
             const purgeOpenCode = opts?.purgeSession === true;
-            await sm.kill(orchestratorToKill.id, { purgeOpenCode });
-            spinner.succeed(`Orchestrator session stopped (${orchestratorToKill.id})`);
-            // Also log to console.log so the killed id is visible in non-TTY callers
-            // (CI, scripts) and in test capture, since spinner output is suppressed.
-            console.log(chalk.green(`  Stopped orchestrator session: ${orchestratorToKill.id}`));
+            for (const session of sessionsToKill) {
+              await sm.kill(session.id, { purgeOpenCode });
+            }
+            spinner.succeed(
+              `Stopped ${sessionsToKill.length} project session${sessionsToKill.length === 1 ? "" : "s"}`,
+            );
+            console.log(
+              chalk.green(
+                `  Stopped project sessions: ${sessionsToKill.map((session) => session.id).join(", ")}`,
+              ),
+            );
           } else if (!lookupFailed) {
-            // Suppress the "no orchestrator found" message when sm.list threw —
+            // Suppress the "no sessions found" message when sm.list threw —
             // the catch above already explained the real reason and adding a
             // second message would falsely imply the lookup succeeded.
             console.log(
-              chalk.yellow(`No running orchestrator session found for "${project.name}"`),
+              chalk.yellow(`No running project sessions found for "${project.name}"`),
             );
           }
 


### PR DESCRIPTION
## Summary
- change `ao stop` to kill every session returned by `sessionManager.list(projectId)` instead of only the orchestrator
- keep the existing dashboard shutdown flow while reporting all stopped session ids
- extend stop command tests to cover worker-session cleanup and purge propagation

Closes #1129

## Testing
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm --filter @aoagents/ao-cli test -- --run __tests__/commands/start.test.ts
- pnpm test *(fails in pre-existing `packages/core` timeout tests: `src/__tests__/session-manager/spawn.test.ts` and `src/__tests__/orchestrator-prompt.dist.test.ts`)*