### PR TITLE
ci(web): detect unused CSS custom properties in globals.css (warn-only)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
       - run: pnpm -r --filter '!@aoagents/ao-web' build
       - run: pnpm test
 
+  css-tokens:
+    name: CSS Tokens (warn-only)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      # Warn-only: report dead/duplicate design tokens in globals.css without
+      # failing the build. Flip to --strict once the baseline is clean.
+      # See packages/web/scripts/check-css-tokens.mjs and #1431.
+      - name: Audit CSS design tokens
+        run: node packages/web/scripts/check-css-tokens.mjs
+        continue-on-error: true
+
   test-web:
     name: Test (Web)
     runs-on: ubuntu-latest

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -21,6 +21,7 @@
     "start:all": "node dist-server/start-all.js",
     "dev:optimized": "rimraf .next dist-server && next build && tsc -p tsconfig.server.json && node dist-server/start-all.js",
     "typecheck": "tsc --noEmit",
+    "lint:css-tokens": "node scripts/check-css-tokens.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rimraf .next dist-server",

--- a/packages/web/scripts/check-css-tokens.mjs
+++ b/packages/web/scripts/check-css-tokens.mjs
@@ -165,7 +165,10 @@ function findDuplicateValues(defs) {
   for (const [key, names] of byScopeValue) {
     const unique = [...new Set(names)];
     if (unique.length > 1) {
-      const [scope, value] = key.split("::");
+      // Use indexOf-based split so values containing "::" don't get truncated.
+      const sepIdx = key.indexOf("::");
+      const scope = key.slice(0, sepIdx);
+      const value = key.slice(sepIdx + 2);
       duplicates.push({ scope, value, tokens: unique.sort() });
     }
   }
@@ -177,8 +180,8 @@ function main() {
   const defs = parseTokenDefinitions(cssText);
   const tokenNames = [...defs.keys()].sort();
 
+  // walkFiles(SOURCE_DIR) already includes globals.css; don't scan it twice.
   const searchFiles = walkFiles(SOURCE_DIR);
-  searchFiles.push(CSS_FILE);
   try {
     if (statSync(DESIGN_DOC).isFile()) searchFiles.push(DESIGN_DOC);
   } catch {

--- a/packages/web/scripts/check-css-tokens.mjs
+++ b/packages/web/scripts/check-css-tokens.mjs
@@ -49,7 +49,6 @@ function parseTokenDefinitions(cssText) {
   // Track which scope block we're in so duplicate-value detection can be
   // scoped (light vs dark) instead of bleeding across modes.
   const scopeStack = ["root"];
-  let depth = 0;
 
   // Strip comments to avoid false matches inside doc examples.
   const stripped = cssText.replace(/\/\*[\s\S]*?\*\//g, "");
@@ -63,18 +62,14 @@ function parseTokenDefinitions(cssText) {
     // Detect block openers (e.g. ":root {", ".dark {", "@theme {", "@theme inline {")
     const openerMatch = trimmed.match(/^(@theme(?:\s+inline)?|:root|\.dark|@media[^{]*)\s*\{/);
     if (openerMatch) {
-      depth += 1;
       scopeStack.push(openerMatch[1].startsWith(".dark") ? "dark" : "root");
       continue;
     }
 
-    // Count braces to track nesting generically.
+    // Pop when a block closes so the scope stack tracks nesting.
     const opens = (trimmed.match(/\{/g) || []).length;
     const closes = (trimmed.match(/\}/g) || []).length;
-    if (opens !== closes) {
-      depth += opens - closes;
-      if (closes > opens && scopeStack.length > 1) scopeStack.pop();
-    }
+    if (closes > opens && scopeStack.length > 1) scopeStack.pop();
 
     const defMatch = trimmed.match(/^(--[a-zA-Z0-9-]+)\s*:\s*([^;]+);/);
     if (!defMatch) continue;

--- a/packages/web/scripts/check-css-tokens.mjs
+++ b/packages/web/scripts/check-css-tokens.mjs
@@ -14,7 +14,6 @@
  *   node scripts/check-css-tokens.mjs            # warn-only, always exits 0
  *   node scripts/check-css-tokens.mjs --strict   # exit 1 on dead/duplicate
  *   node scripts/check-css-tokens.mjs --all      # scan every --* token
- *   node scripts/check-css-tokens.mjs --json     # emit machine-readable JSON
  */
 
 import { readFileSync, readdirSync, statSync } from "node:fs";
@@ -37,7 +36,6 @@ const IGNORE_DIRS = new Set(["node_modules", ".next", "dist", "dist-server", "co
 const args = new Set(process.argv.slice(2));
 const STRICT = args.has("--strict");
 const ALL_TOKENS = args.has("--all");
-const JSON_OUT = args.has("--json");
 
 const TOKEN_PREFIX = ALL_TOKENS ? "--" : "--color-";
 
@@ -196,18 +194,7 @@ function main() {
   const dead = tokenNames.filter((name) => (refs.get(name) ?? 0) === 0);
   const duplicates = findDuplicateValues(defs);
 
-  if (JSON_OUT) {
-    const counts = Object.fromEntries(refs);
-    process.stdout.write(
-      JSON.stringify(
-        { total: tokenNames.length, dead, duplicates, referenceCounts: counts },
-        null,
-        2,
-      ) + "\n",
-    );
-  } else {
-    printHuman({ total: tokenNames.length, dead, duplicates, refs });
-  }
+  printHuman({ total: tokenNames.length, dead, duplicates, refs });
 
   const hasIssues = dead.length > 0 || duplicates.length > 0;
   if (STRICT && hasIssues) {

--- a/packages/web/scripts/check-css-tokens.mjs
+++ b/packages/web/scripts/check-css-tokens.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * check-css-tokens.mjs
+ * -----------------------------------------------------------------------------
+ * Scan packages/web/src/app/globals.css for `--color-*` (and optionally any
+ * `--*`) custom-property definitions and report tokens that are never
+ * referenced anywhere in the web package source or DESIGN.md.
+ *
+ * Also flags multiple tokens that resolve to the same literal value (likely
+ * duplicates). Intentionally dependency-free (pure Node stdlib) so it can run
+ * in CI without extra install overhead.
+ *
+ * Usage:
+ *   node scripts/check-css-tokens.mjs            # warn-only, always exits 0
+ *   node scripts/check-css-tokens.mjs --strict   # exit 1 on dead/duplicate
+ *   node scripts/check-css-tokens.mjs --all      # scan every --* token
+ *   node scripts/check-css-tokens.mjs --json     # emit machine-readable JSON
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, extname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const WEB_ROOT = resolve(__dirname, "..");
+const REPO_ROOT = resolve(WEB_ROOT, "..", "..");
+
+const CSS_FILE = resolve(WEB_ROOT, "src/app/globals.css");
+const SOURCE_DIR = resolve(WEB_ROOT, "src");
+const DESIGN_DOC = resolve(REPO_ROOT, "DESIGN.md");
+
+const SEARCH_EXTS = new Set([".tsx", ".ts", ".jsx", ".js", ".mjs", ".css", ".md"]);
+const IGNORE_DIRS = new Set(["node_modules", ".next", "dist", "dist-server", "coverage"]);
+
+const args = new Set(process.argv.slice(2));
+const STRICT = args.has("--strict");
+const ALL_TOKENS = args.has("--all");
+const JSON_OUT = args.has("--json");
+
+const TOKEN_PREFIX = ALL_TOKENS ? "--" : "--color-";
+
+/**
+ * Parse `--foo: value;` definitions from CSS, returning a map of
+ * token name -> array of { value, scope } entries (because a token can be
+ * redefined under :root vs .dark vs @theme).
+ */
+function parseTokenDefinitions(cssText) {
+  const defs = new Map();
+  // Track which scope block we're in so duplicate-value detection can be
+  // scoped (light vs dark) instead of bleeding across modes.
+  const scopeStack = ["root"];
+  let depth = 0;
+
+  // Strip comments to avoid false matches inside doc examples.
+  const stripped = cssText.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // Walk line by line; good enough since the file uses one declaration
+  // per line and blocks open/close on their own lines.
+  const lines = stripped.split("\n");
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Detect block openers (e.g. ":root {", ".dark {", "@theme {", "@theme inline {")
+    const openerMatch = trimmed.match(/^(@theme(?:\s+inline)?|:root|\.dark|@media[^{]*)\s*\{/);
+    if (openerMatch) {
+      depth += 1;
+      scopeStack.push(openerMatch[1].startsWith(".dark") ? "dark" : "root");
+      continue;
+    }
+
+    // Count braces to track nesting generically.
+    const opens = (trimmed.match(/\{/g) || []).length;
+    const closes = (trimmed.match(/\}/g) || []).length;
+    if (opens !== closes) {
+      depth += opens - closes;
+      if (closes > opens && scopeStack.length > 1) scopeStack.pop();
+    }
+
+    const defMatch = trimmed.match(/^(--[a-zA-Z0-9-]+)\s*:\s*([^;]+);/);
+    if (!defMatch) continue;
+    const [, name, rawValue] = defMatch;
+    if (!name.startsWith(TOKEN_PREFIX)) continue;
+    const scope = scopeStack[scopeStack.length - 1] || "root";
+    const value = rawValue.trim();
+    if (!defs.has(name)) defs.set(name, []);
+    defs.get(name).push({ value, scope });
+  }
+  return defs;
+}
+
+function walkFiles(startPath) {
+  const out = [];
+  const stat = statSync(startPath, { throwIfNoEntry: false });
+  if (!stat) return out;
+  if (stat.isFile()) {
+    if (SEARCH_EXTS.has(extname(startPath))) out.push(startPath);
+    return out;
+  }
+  for (const entry of readdirSync(startPath, { withFileTypes: true })) {
+    if (entry.name.startsWith(".")) continue;
+    if (IGNORE_DIRS.has(entry.name)) continue;
+    const full = join(startPath, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkFiles(full));
+    } else if (entry.isFile() && SEARCH_EXTS.has(extname(entry.name))) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * Count references to each token across the given files, excluding the
+ * token's own definition lines in globals.css (a token defining itself
+ * does not count as "used").
+ */
+function countReferences(tokenNames, files) {
+  const refs = new Map();
+  for (const name of tokenNames) refs.set(name, 0);
+
+  for (const file of files) {
+    const text = readFileSync(file, "utf8");
+    const isCssTokens = file === CSS_FILE;
+    for (const name of tokenNames) {
+      // Find every occurrence of the token name in the file.
+      let idx = 0;
+      let count = 0;
+      while ((idx = text.indexOf(name, idx)) !== -1) {
+        // Ensure word-boundary-like behaviour so `--color-bg` doesn't match
+        // `--color-bg-surface`.
+        const nextChar = text[idx + name.length];
+        const isBoundary = !nextChar || !/[a-zA-Z0-9_-]/.test(nextChar);
+        if (isBoundary) {
+          if (isCssTokens) {
+            // Skip self-definition lines: `  --name: value;`
+            const lineStart = text.lastIndexOf("\n", idx) + 1;
+            const lineEnd = text.indexOf("\n", idx);
+            const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
+            const isDefLine = new RegExp(`^\\s*${name}\\s*:`).test(line);
+            if (!isDefLine) count += 1;
+          } else {
+            count += 1;
+          }
+        }
+        idx += name.length;
+      }
+      refs.set(name, refs.get(name) + count);
+    }
+  }
+  return refs;
+}
+
+function findDuplicateValues(defs) {
+  // Group by (scope, normalizedValue). A token that resolves to var(--other)
+  // is an alias, not a duplicate — skip those.
+  const byScopeValue = new Map();
+  for (const [name, entries] of defs) {
+    for (const { value, scope } of entries) {
+      const normalized = value.replace(/\s+/g, "").toLowerCase();
+      if (normalized.startsWith("var(")) continue;
+      if (normalized === "transparent" || normalized === "inherit" || normalized === "none") {
+        continue;
+      }
+      const key = `${scope}::${normalized}`;
+      if (!byScopeValue.has(key)) byScopeValue.set(key, []);
+      byScopeValue.get(key).push(name);
+    }
+  }
+  const duplicates = [];
+  for (const [key, names] of byScopeValue) {
+    const unique = [...new Set(names)];
+    if (unique.length > 1) {
+      const [scope, value] = key.split("::");
+      duplicates.push({ scope, value, tokens: unique.sort() });
+    }
+  }
+  return duplicates;
+}
+
+function main() {
+  const cssText = readFileSync(CSS_FILE, "utf8");
+  const defs = parseTokenDefinitions(cssText);
+  const tokenNames = [...defs.keys()].sort();
+
+  const searchFiles = walkFiles(SOURCE_DIR);
+  searchFiles.push(CSS_FILE);
+  try {
+    if (statSync(DESIGN_DOC).isFile()) searchFiles.push(DESIGN_DOC);
+  } catch {
+    // DESIGN.md is optional.
+  }
+
+  const refs = countReferences(tokenNames, searchFiles);
+  const dead = tokenNames.filter((name) => (refs.get(name) ?? 0) === 0);
+  const duplicates = findDuplicateValues(defs);
+
+  if (JSON_OUT) {
+    const counts = Object.fromEntries(refs);
+    process.stdout.write(
+      JSON.stringify(
+        { total: tokenNames.length, dead, duplicates, referenceCounts: counts },
+        null,
+        2,
+      ) + "\n",
+    );
+  } else {
+    printHuman({ total: tokenNames.length, dead, duplicates, refs });
+  }
+
+  const hasIssues = dead.length > 0 || duplicates.length > 0;
+  if (STRICT && hasIssues) {
+    process.exit(1);
+  }
+}
+
+function printHuman({ total, dead, duplicates, refs }) {
+  const out = process.stdout;
+  out.write(`CSS token audit — ${CSS_FILE.replace(REPO_ROOT + "/", "")}\n`);
+  out.write(`  Scanned ${total} tokens matching "${TOKEN_PREFIX}*"\n`);
+  out.write(`  Dead tokens: ${dead.length}\n`);
+  out.write(`  Duplicate-value groups: ${duplicates.length}\n\n`);
+
+  if (dead.length) {
+    out.write("── Dead tokens (defined, zero references) ─────────────────────\n");
+    for (const name of dead) out.write(`  ${name}\n`);
+    out.write("\n");
+  }
+
+  if (duplicates.length) {
+    out.write("── Duplicate values (possible consolidation targets) ──────────\n");
+    for (const { scope, value, tokens } of duplicates) {
+      out.write(`  [${scope}] ${value}\n`);
+      for (const t of tokens) out.write(`      ${t} (refs: ${refs.get(t) ?? 0})\n`);
+    }
+    out.write("\n");
+  }
+
+  if (!dead.length && !duplicates.length) {
+    out.write("✓ No dead or duplicate color tokens found.\n");
+  } else if (!STRICT) {
+    out.write(
+      "ℹ  Warn-only mode. Re-run with --strict to fail on findings once the baseline is clean.\n",
+    );
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds `packages/web/scripts/check-css-tokens.mjs`, a dependency-free Node audit that parses `--color-*` token definitions out of `packages/web/src/app/globals.css` and reports dead tokens (zero references across `packages/web/src/**` and `DESIGN.md`) plus multi-token groups that resolve to the same literal value (likely duplicates).
- Exposes it as `pnpm --filter @aoagents/ao-web lint:css-tokens`.
- Wires a new `css-tokens` CI job with `continue-on-error: true` so the audit is warn-only until the baseline is cleaned up.

## Flags
- `--all` — audit every `--*` token, not just `--color-*` (the issue explicitly calls this out as optional).
- `--strict` — exit non-zero on findings, for flipping to failing once the baseline is clean.

## Notable behaviour
- Groups duplicate-value detection by scope (`:root` vs `.dark`) so light/dark redefinitions of the same token don't appear as false positives.
- Skips `var(--…)` aliases and no-ops (`transparent`, `inherit`, `none`) when hunting for duplicate values.
- Self-definition lines in `globals.css` don't count as references, but cross-token references inside `globals.css` (e.g. `--color-bg-primary: var(--color-bg-base)`) do — so backward-compat aliases that reference another token stay "used" on the alias target side but the alias itself is flagged dead if nobody else reads it.

## Initial findings (reproducible via `pnpm --filter @aoagents/ao-web lint:css-tokens`)
- 7 dead `--color-*` tokens: `--color-accent-purple`, `--color-accent-violet`, `--color-alert-ci-unknown`, `--color-border-emphasis`, `--color-border-muted`, `--color-column-header`, `--color-tint-violet`.
- 23 duplicate-value groups pointing at likely consolidation candidates (e.g. `--color-accent-green` / `--color-ci-pass` / `--color-status-merge` / `--color-status-working` all resolve to the same green).

These are intentionally surfaced but not enforced yet, per the issue.

## Test plan
- [x] `node packages/web/scripts/check-css-tokens.mjs` — prints a human-readable report and exits 0.
- [x] `node packages/web/scripts/check-css-tokens.mjs --strict` — exits 1 while findings exist.
- [x] `pnpm --filter @aoagents/ao-web lint:css-tokens` runs the script via the new npm script.
- [x] `node --check` on the script.
- [x] CI run on this branch — confirm the new `css-tokens` job is reported and does not fail the build.

Closes #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)