### PR TITLE
refactor(core): extract hasRecentCommits helper into @aoagents/ao-core

### DIFF
--- a/packages/core/src/__tests__/git-activity.test.ts
+++ b/packages/core/src/__tests__/git-activity.test.ts
@@ -42,19 +42,23 @@ describe("hasRecentCommits", () => {
     }
   });
 
-  it("respects a custom window", async () => {
+  it("respects a custom window — excludes commits outside it, includes them inside it", async () => {
     await writeFile(join(repoDir, "a.txt"), "hello");
     execFileSync("git", ["add", "."], { cwd: repoDir });
-    // Backdate the commit well outside any short window.
-    execFileSync("git", ["commit", "-q", "-m", "old"], {
+    // Backdate the commit by ~2 minutes so a 30s window excludes it but a
+    // 10-minute window includes it — this discriminates between "parameter
+    // forwarded" and "parameter silently ignored / hardcoded".
+    const twoMinAgo = new Date(Date.now() - 120_000).toISOString();
+    execFileSync("git", ["commit", "-q", "-m", "two-min-ago"], {
       cwd: repoDir,
       env: {
         ...process.env,
-        GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
-        GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+        GIT_AUTHOR_DATE: twoMinAgo,
+        GIT_COMMITTER_DATE: twoMinAgo,
       },
     });
 
-    expect(await hasRecentCommits(repoDir, 60)).toBe(false);
+    expect(await hasRecentCommits(repoDir, 30)).toBe(false);
+    expect(await hasRecentCommits(repoDir, 600)).toBe(true);
   });
 });

--- a/packages/core/src/__tests__/git-activity.test.ts
+++ b/packages/core/src/__tests__/git-activity.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { hasRecentCommits } from "../git-activity.js";
+
+describe("hasRecentCommits", () => {
+  let repoDir: string;
+
+  beforeEach(() => {
+    repoDir = mkdtempSync(join(tmpdir(), "ao-git-activity-"));
+    execFileSync("git", ["init", "-q", "-b", "main"], { cwd: repoDir });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: repoDir });
+    execFileSync("git", ["config", "user.name", "Test"], { cwd: repoDir });
+    execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd: repoDir });
+  });
+
+  afterEach(() => {
+    if (repoDir) rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  it("returns true when a commit exists within the default 60s window", async () => {
+    await writeFile(join(repoDir, "a.txt"), "hello");
+    execFileSync("git", ["add", "."], { cwd: repoDir });
+    execFileSync("git", ["commit", "-q", "-m", "initial"], { cwd: repoDir });
+
+    expect(await hasRecentCommits(repoDir)).toBe(true);
+  });
+
+  it("returns false when no commits have been made", async () => {
+    expect(await hasRecentCommits(repoDir)).toBe(false);
+  });
+
+  it("returns false when the path is not a git repo", async () => {
+    const notARepo = mkdtempSync(join(tmpdir(), "ao-git-activity-notrepo-"));
+    try {
+      expect(await hasRecentCommits(notARepo)).toBe(false);
+    } finally {
+      rmSync(notARepo, { recursive: true, force: true });
+    }
+  });
+
+  it("respects a custom window", async () => {
+    await writeFile(join(repoDir, "a.txt"), "hello");
+    execFileSync("git", ["add", "."], { cwd: repoDir });
+    // Backdate the commit well outside any short window.
+    execFileSync("git", ["commit", "-q", "-m", "old"], {
+      cwd: repoDir,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_DATE: "2000-01-01T00:00:00Z",
+        GIT_COMMITTER_DATE: "2000-01-01T00:00:00Z",
+      },
+    });
+
+    expect(await hasRecentCommits(repoDir, 60)).toBe(false);
+  });
+});

--- a/packages/core/src/git-activity.ts
+++ b/packages/core/src/git-activity.ts
@@ -1,0 +1,34 @@
+/**
+ * Git-commit-based activity detection helpers for agent plugins.
+ *
+ * Agents without native JSONL introspection (Aider, Cursor, etc.) can use
+ * recent git commits as a signal that the agent has been actively working.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Check whether the given workspace has any git commits within the last
+ * `windowSeconds` seconds. Swallows errors (e.g. not a git repo, git missing)
+ * and returns `false` so callers can use this as a best-effort liveness signal.
+ *
+ * @param workspacePath Absolute path to the workspace (must be a git repo).
+ * @param windowSeconds How far back to look for commits. Defaults to 60s.
+ */
+export async function hasRecentCommits(
+  workspacePath: string,
+  windowSeconds = 60,
+): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      "git",
+      ["log", `--since=${windowSeconds} seconds ago`, "--format=%H"],
+      { cwd: workspacePath, timeout: 5_000 },
+    );
+    return stdout.trim().length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -189,6 +189,9 @@ export {
   buildAgentPath,
   PREFERRED_GH_PATH,
 } from "./agent-workspace-hooks.js";
+
+// Git-based activity helpers — recent-commit liveness signal for agent plugins
+export { hasRecentCommits } from "./git-activity.js";
 export type { NormalizedOrchestratorSessionStrategy } from "./orchestrator-session-strategy.js";
 
 export {

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -5,6 +5,7 @@ import {
   checkActivityLogState,
   getActivityFallbackState,
   recordTerminalActivity,
+  hasRecentCommits,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   type Agent,
@@ -28,22 +29,6 @@ const execFileAsync = promisify(execFile);
 // =============================================================================
 // Aider Activity Detection Helpers
 // =============================================================================
-
-/**
- * Check if Aider has made recent commits (within last 60 seconds).
- */
-async function hasRecentCommits(workspacePath: string): Promise<boolean> {
-  try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["log", "--since=60 seconds ago", "--format=%H"],
-      { cwd: workspacePath, timeout: 5_000 },
-    );
-    return stdout.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Get modification time of Aider chat history file.

--- a/packages/plugins/agent-cursor/src/index.ts
+++ b/packages/plugins/agent-cursor/src/index.ts
@@ -5,6 +5,7 @@ import {
   checkActivityLogState,
   getActivityFallbackState,
   recordTerminalActivity,
+  hasRecentCommits,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   type Agent,
@@ -29,22 +30,6 @@ const execFileAsync = promisify(execFile);
 // =============================================================================
 // Cursor Activity Detection Helpers
 // =============================================================================
-
-/**
- * Check if Cursor has made recent commits (within last 60 seconds).
- */
-async function hasRecentCommits(workspacePath: string): Promise<boolean> {
-  try {
-    const { stdout } = await execFileAsync(
-      "git",
-      ["log", "--since=60 seconds ago", "--format=%H"],
-      { cwd: workspacePath, timeout: 5_000 },
-    );
-    return stdout.trim().length > 0;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Get modification time of Cursor session file if it exists.


### PR DESCRIPTION
## Summary

- Extract the byte-identical `hasRecentCommits(workspacePath)` helper that was copy-pasted between `agent-aider` and `agent-cursor` into `@aoagents/ao-core`.
- Parameterize the window (`windowSeconds = 60`) so future agent plugins using git-commit-based activity detection aren't locked into a 60s window.
- Update both plugins to import from core and delete the local helpers.

No behavior change — the extracted helper preserves the original signature, args, 5s timeout, and swallow-error-return-false semantics. Net -27 lines across the plugin layer.

Closes #1423

## Test plan

- [x] `pnpm --filter @aoagents/ao-core test` (812 passed, incl. 4 new `git-activity` tests)
- [x] `pnpm --filter @aoagents/ao-plugin-agent-aider --filter @aoagents/ao-plugin-agent-cursor test` (110 passed)
- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-plugin-agent-aider --filter @aoagents/ao-plugin-agent-cursor typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)