### PR TITLE
refactor(web): break down DirectTerminal.tsx (#769)

### DIFF
--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -1,74 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useTheme } from "next-themes";
 import { cn } from "@/lib/cn";
-import { useMux } from "@/hooks/useMux";
-import { attachTouchScroll } from "@/lib/terminal-touch-scroll";
 
-// Import xterm CSS (must be imported in client component)
-import "@xterm/xterm/css/xterm.css";
+import { getStoredFontSize } from "./terminal/terminal-font";
+import { TerminalControls } from "./terminal/TerminalControls";
+import { useFullscreenResize } from "./terminal/useFullscreenResize";
+import { useXtermTerminal } from "./terminal/useXtermTerminal";
 
-// Static type-only imports (erased at compile time, no SSR impact).
-// The runtime Terminal class is loaded via dynamic import() inside useEffect to avoid SSR.
-import type { ITheme, Terminal as TerminalType } from "@xterm/xterm";
-import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
-
-// Font size constants
-const FONT_SIZE_KEY = "ao-terminal-font-size";
-const FONT_SIZE_MIN = 9;
-const FONT_SIZE_MAX = 18;
-const FONT_SIZE_DEFAULT = 13;
-
-// Fallback mono stack used when the CSS custom property isn't resolvable yet.
-const MONO_FONT_FALLBACK =
-  '"JetBrains Mono", "SF Mono", Menlo, Monaco, "Courier New", monospace';
-
-/**
- * Resolve the app's configured mono font token to a concrete font-family string.
- *
- * xterm's internal char-size measurement ultimately hits canvas ctx.font, which
- * cannot evaluate `var(...)`. Reading `--font-jetbrains-mono` with
- * getComputedStyle gives us the generated next/font family name (e.g.
- * `__JetBrains_Mono_abc123`), which we can safely feed into xterm while still
- * honouring the app's font configuration.
- *
- * NOTE: we deliberately read `--font-jetbrains-mono` and NOT `--font-mono`.
- * `--font-mono` in globals.css is itself a composed stack that contains
- * `var(--font-jetbrains-mono)` — if we forwarded that to xterm, the raw
- * `var(...)` token would end up back in canvas ctx.font and reintroduce the
- * original measurement bug this helper exists to fix.
- *
- * Exported for unit testing.
- */
-export function resolveMonoFontFamily(): string {
-  if (typeof window === "undefined") return MONO_FONT_FALLBACK;
-  try {
-    const resolved = getComputedStyle(document.documentElement)
-      .getPropertyValue("--font-jetbrains-mono")
-      .trim();
-    return resolved ? `${resolved}, ${MONO_FONT_FALLBACK}` : MONO_FONT_FALLBACK;
-  } catch {
-    return MONO_FONT_FALLBACK;
-  }
-}
-
-function getStoredFontSize(): number {
-  if (typeof window === "undefined") return FONT_SIZE_DEFAULT;
-  try {
-    const stored = localStorage.getItem(FONT_SIZE_KEY);
-    if (stored) {
-      const size = parseInt(stored, 10);
-      if (!Number.isNaN(size)) {
-        return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, size));
-      }
-    }
-  } catch {
-    // localStorage might be unavailable
-  }
-  return FONT_SIZE_DEFAULT;
-}
+// Re-exported for consumers/tests that target the public DirectTerminal module.
+export { buildTerminalThemes } from "./terminal/terminal-themes";
+export { resolveMonoFontFamily } from "./terminal/terminal-font";
 
 interface DirectTerminalProps {
   sessionId: string;
@@ -87,82 +31,10 @@ interface DirectTerminalProps {
   autoFocus?: boolean;
 }
 
-type TerminalVariant = "agent" | "orchestrator";
-
-
-export function buildTerminalThemes(variant: TerminalVariant): { dark: ITheme; light: ITheme } {
-  const agentAccent = {
-    cursor: "#5b7ef8",
-    selDark: "rgba(91, 126, 248, 0.30)",
-    selLight: "rgba(91, 126, 248, 0.25)",
-  };
-  const orchAccent = agentAccent;
-  const accent = variant === "orchestrator" ? orchAccent : agentAccent;
-
-  const dark: ITheme = {
-    background: "#0a0a0f",
-    foreground: "#d4d4d8",
-    cursor: accent.cursor,
-    cursorAccent: "#0a0a0f",
-    selectionBackground: accent.selDark,
-    selectionInactiveBackground: "rgba(128, 128, 128, 0.2)",
-    // ANSI colors — slightly warmer than pure defaults
-    black: "#1a1a24",
-    red: "#ef4444",
-    green: "#22c55e",
-    yellow: "#f59e0b",
-    blue: "#5b7ef8",
-    magenta: "#a371f7",
-    cyan: "#22d3ee",
-    white: "#d4d4d8",
-    brightBlack: "#50506a",
-    brightRed: "#f87171",
-    brightGreen: "#4ade80",
-    brightYellow: "#fbbf24",
-    brightBlue: "#7b9cfb",
-    brightMagenta: "#c084fc",
-    brightCyan: "#67e8f9",
-    brightWhite: "#eeeef5",
-  };
-
-  const light: ITheme = {
-    background: "#fafafa",
-    foreground: "#24292f",
-    cursor: accent.cursor,
-    cursorAccent: "#fafafa",
-    selectionBackground: accent.selLight,
-    selectionInactiveBackground: "rgba(128, 128, 128, 0.15)",
-    // ANSI colors — darkened for legibility on #fafafa terminal background
-    black: "#24292f",
-    red: "#b42318",
-    green: "#1f7a3d",
-    yellow: "#8a5a00",
-    blue: "#175cd3",
-    magenta: "#8e24aa",
-    cyan: "#0b7285",
-    white: "#4b5563",
-    brightBlack: "#374151",
-    brightRed: "#912018",
-    brightGreen: "#176639",
-    brightYellow: "#6f4a00",
-    brightBlue: "#1d4ed8",
-    brightMagenta: "#7b1fa2",
-    brightCyan: "#155e75",
-    brightWhite: "#374151",
-  };
-
-  return { dark, light };
-}
-
 /**
  * Direct xterm.js terminal with native WebSocket connection.
  * Implements Extended Device Attributes (XDA) handler to enable
  * tmux clipboard support (OSC 52) without requiring iTerm2 attachment.
- *
- * Based on DeepWiki analysis:
- * - tmux queries for XDA (CSI > q / XTVERSION) to detect terminal type
- * - When tmux sees "XTerm(" in response, it enables TTYC_MS (clipboard)
- * - xterm.js doesn't implement XDA by default, so we register custom handler
  */
 export function DirectTerminal({
   sessionId,
@@ -180,617 +52,41 @@ export function DirectTerminal({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { resolvedTheme } = useTheme();
-  const terminalThemes = useMemo(() => buildTerminalThemes(variant), [variant]);
-  const { subscribeTerminal, writeTerminal, resizeTerminal: resizeTerminalMux, openTerminal, closeTerminal, status: muxStatus } = useMux();
 
   const terminalRef = useRef<HTMLDivElement>(null);
-  const terminalInstance = useRef<TerminalType | null>(null);
-  const fitAddon = useRef<FitAddonType | null>(null);
-  const muxStatusRef = useRef(muxStatus);
-  muxStatusRef.current = muxStatus;
   const [fullscreen, setFullscreen] = useState(startFullscreen);
-  const [error, setError] = useState<string | null>(null);
-  const [reloading, setReloading] = useState(false);
-  const [reloadError, setReloadError] = useState<string | null>(null);
   const [fontSize, setFontSize] = useState(getStoredFontSize());
-  const followOutputRef = useRef(true);
-  const [followOutput, setFollowOutput] = useState(true);
-  const programmaticScrollRef = useRef(false);
 
-  // Update URL when fullscreen changes
+  const {
+    error,
+    followOutput,
+    scrollToLatest,
+    muxStatus,
+    terminalInstance,
+    fitAddon,
+  } = useXtermTerminal(terminalRef, sessionId, {
+    appearance,
+    variant,
+    fontSize,
+    autoFocus,
+    tmuxName,
+  });
+
+  useFullscreenResize(fullscreen, sessionId, terminalInstance, fitAddon, terminalRef);
+
+  // Sync fullscreen to URL query param
   useEffect(() => {
     const params = new URLSearchParams(searchParams.toString());
-
     if (fullscreen) {
       params.set("fullscreen", "true");
     } else {
       params.delete("fullscreen");
     }
-
     const newUrl = params.toString() ? `${pathname}?${params.toString()}` : pathname;
     router.replace(newUrl, { scroll: false });
   }, [fullscreen, pathname, router, searchParams]);
 
-  async function handleReload(): Promise<void> {
-    if (!isOpenCodeSession || reloading) return;
-    setReloadError(null);
-    setReloading(true);
-    try {
-      let commandToSend = reloadCommand;
-
-      if (!commandToSend) {
-        const remapRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/remap`, {
-          method: "POST",
-        });
-        if (!remapRes.ok) {
-          throw new Error(`Failed to remap OpenCode session: ${remapRes.status}`);
-        }
-        const remapData = (await remapRes.json()) as { opencodeSessionId?: unknown };
-        if (
-          typeof remapData.opencodeSessionId !== "string" ||
-          remapData.opencodeSessionId.length === 0
-        ) {
-          throw new Error("Missing OpenCode session id after remap");
-        }
-        commandToSend = `/exit\nopencode --session ${remapData.opencodeSessionId}\n`;
-      }
-
-      const sendRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message: commandToSend }),
-      });
-      if (!sendRes.ok) {
-        throw new Error(`Failed to send reload command: ${sendRes.status}`);
-      }
-    } catch (err) {
-      setReloadError(err instanceof Error ? err.message : "Failed to reload OpenCode session");
-    } finally {
-      setReloading(false);
-    }
-  }
-
-  useEffect(() => {
-    if (!terminalRef.current) return;
-
-    // Dynamically import xterm.js to avoid SSR issues
-    let mounted = true;
-    let cleanup: (() => void) | null = null;
-    let inputDisposable: { dispose(): void } | null = null;
-    let unsubscribe: (() => void) | null = null;
-
-    Promise.all([
-      import("@xterm/xterm").then((mod) => mod.Terminal),
-      import("@xterm/addon-fit").then((mod) => mod.FitAddon),
-      import("@xterm/addon-web-links").then((mod) => mod.WebLinksAddon),
-      document.fonts.ready,
-    ])
-      .then(([Terminal, FitAddon, WebLinksAddon]) => {
-        if (!mounted || !terminalRef.current) return;
-
-        const isDark = appearance === "dark" || resolvedTheme !== "light";
-        const activeTheme = isDark ? terminalThemes.dark : terminalThemes.light;
-
-        // Initialize xterm.js Terminal
-        // NOTE: xterm's internal char-size measurement uses canvas ctx.font which
-        // cannot resolve `var(...)`. resolveMonoFontFamily() reads the CSS custom
-        // property at runtime so we still honour the app's configured font token
-        // (next/font generated name) while handing xterm a concrete string.
-        const terminal = new Terminal({
-          cursorBlink: true,
-          fontSize: fontSize,
-          fontFamily: resolveMonoFontFamily(),
-          // xterm v6 default lineHeight (1.0) collides rows with JetBrains Mono's
-          // tall x-height. 1.2 restores visual breathing room between lines.
-          lineHeight: 1.2,
-          theme: activeTheme,
-          // Light mode needs an explicit contrast floor because agent UIs often emit
-          // dim/faint ANSI sequences that become unreadable on a near-white background.
-          minimumContrastRatio: isDark ? 1 : 7,
-          scrollback: 10000,
-          allowProposedApi: true,
-          fastScrollSensitivity: 3,
-          scrollSensitivity: 1,
-        });
-
-        // Add FitAddon for responsive sizing
-        const fit = new FitAddon();
-        terminal.loadAddon(fit);
-        fitAddon.current = fit;
-
-        // Add WebLinksAddon for clickable links
-        const webLinks = new WebLinksAddon();
-        terminal.loadAddon(webLinks);
-
-        // **CRITICAL FIX**: Register XDA (Extended Device Attributes) handler
-        // This makes tmux recognize our terminal and enable clipboard support
-        terminal.parser.registerCsiHandler(
-          { prefix: ">", final: "q" }, // CSI > q is XTVERSION / XDA
-          () => {
-            // Respond with XTerm identification that tmux recognizes
-            // tmux looks for "XTerm(" in the response (see tmux tty-keys.c)
-            // Format: DCS > | XTerm(version) ST
-            // DCS = \x1bP, ST = \x1b\\
-            terminal.write("\x1bP>|XTerm(370)\x1b\\");
-            console.log("[DirectTerminal] Sent XDA response for clipboard support");
-            return true; // Handled
-          },
-        );
-
-        // Register OSC 52 handler for clipboard support
-        // tmux sends OSC 52 with base64-encoded text when copying
-        terminal.parser.registerOscHandler(52, (data) => {
-          const parts = data.split(";");
-          if (parts.length < 2) return false;
-          const b64 = parts[parts.length - 1];
-          try {
-            // Decode base64 → binary string → Uint8Array → UTF-8 text
-            // atob() alone only handles Latin-1; TextDecoder is needed for UTF-8
-            const binary = atob(b64);
-            const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
-            const text = new TextDecoder().decode(bytes);
-            navigator.clipboard?.writeText(text).catch(() => {});
-          } catch {
-            // Ignore decode errors
-          }
-          return true;
-        });
-
-        // Open terminal in DOM
-        terminal.open(terminalRef.current);
-        terminalInstance.current = terminal;
-
-        if (autoFocus) {
-          terminal.focus();
-        }
-
-        // Fit terminal to container
-        fit.fit();
-
-        // Deferred fit to handle cases where container wasn't sized yet
-        const deferredFitTimeout = setTimeout(() => {
-          if (mounted && fitAddon.current) {
-            try {
-              fitAddon.current.fit();
-              resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-            } catch {
-              // Ignore fit errors
-            }
-          }
-        }, 100);
-
-        // Re-measure when webfonts finish loading. next/font uses font-display:swap,
-        // so document.fonts.ready can resolve before JetBrains Mono actually swaps
-        // in. Without this, xterm's initial cell measurement stays pinned to the
-        // fallback font — producing wide-looking horizontal cells once the real
-        // font swaps. Listening to 'loadingdone' forces a re-fit when the swap
-        // actually completes.
-        const handleFontsLoadingDone = () => {
-          if (!mounted || !fitAddon.current || !terminalInstance.current) return;
-          try {
-            // Re-resolve the CSS var in case next/font registered its family
-            // name after initial construction, then force a re-measure.
-            terminalInstance.current.options.fontFamily = resolveMonoFontFamily();
-            terminalInstance.current.clearTextureAtlas?.();
-            fitAddon.current.fit();
-            resizeTerminalMux(sessionId, terminalInstance.current.cols, terminalInstance.current.rows);
-          } catch {
-            // Ignore fit errors
-          }
-        };
-        // Feature-detect `FontFaceSet.addEventListener` — it's missing in
-        // jsdom's `document.fonts` mock and some older runtimes. Without the
-        // guard, init throws a TypeError and the terminal never attaches.
-        const fontsFace =
-          typeof document !== "undefined" ? document.fonts : undefined;
-        const fontsListenerAttached =
-          !!fontsFace && typeof fontsFace.addEventListener === "function";
-        if (fontsListenerAttached) {
-          fontsFace!.addEventListener("loadingdone", handleFontsLoadingDone);
-        }
-
-        // Attach touch scroll for mobile — disable follow-output while user is scrolling.
-        // Note: onScrollTowardLatest intentionally does NOT hide the button. In normal
-        // buffer, terminal.onScroll fires after scrollLines() and decides based on real
-        // position. In alternate buffer (tmux), there's no way to detect when the user
-        // has truly returned to the live tail, so the button stays visible until clicked.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const cleanupTouchScroll = attachTouchScroll(terminal as any, (data) => {
-          writeTerminal(sessionId, data);
-        }, {
-          onScrollAway: () => { followOutputRef.current = false; setFollowOutput(false); },
-        });
-
-        // Set up ResizeObserver to handle flex layout changes
-        let resizeObserver: ResizeObserver | null = null;
-        if (terminalRef.current) {
-          resizeObserver = new ResizeObserver(() => {
-            if (mounted && fitAddon.current) {
-              try {
-                fitAddon.current.fit();
-                resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-              } catch {
-                // Ignore fit errors
-              }
-            }
-          });
-          resizeObserver.observe(terminalRef.current);
-        }
-
-        // ── Preserve selection while terminal receives output ────────
-        // xterm.js clears the selection on every terminal.write(). We
-        // buffer incoming data while a selection is active so the
-        // highlight stays visible for Cmd+C. The buffer is flushed
-        // when the selection is cleared (click, keypress, etc.).
-        const writeBuffer: string[] = [];
-        let selectionActive = false;
-        let safetyTimer: ReturnType<typeof setTimeout> | null = null;
-        let bufferBytes = 0;
-        const MAX_BUFFER_BYTES = 1_048_576; // 1 MB
-
-        const flushWriteBuffer = () => {
-          if (safetyTimer) {
-            clearTimeout(safetyTimer);
-            safetyTimer = null;
-          }
-          if (writeBuffer.length > 0) {
-            terminal.write(writeBuffer.join(""));
-            writeBuffer.length = 0;
-            bufferBytes = 0;
-          }
-        };
-
-        const selectionDisposable = terminal.onSelectionChange(() => {
-          if (terminal.hasSelection()) {
-            selectionActive = true;
-            // Safety: flush after 5s to prevent unbounded buffering
-            if (!safetyTimer) {
-              safetyTimer = setTimeout(() => {
-                selectionActive = false;
-                flushWriteBuffer();
-              }, 5_000);
-            }
-          } else {
-            selectionActive = false;
-            flushWriteBuffer();
-          }
-        });
-
-        // Intercept Cmd+C (Mac) and Ctrl+Shift+C (Linux/Win) for copy.
-        // Paste (Cmd+V / Ctrl+Shift+V) is handled natively by xterm.js
-        // via its internal textarea — no custom handler needed.
-        terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-          if (e.type !== "keydown") return true;
-
-          // Cmd+C / Ctrl+Shift+C — copy selection
-          const isCopy =
-            (e.metaKey && !e.ctrlKey && !e.altKey && e.code === "KeyC") ||
-            (e.ctrlKey && e.shiftKey && e.code === "KeyC");
-          if (isCopy && terminal.hasSelection()) {
-            navigator.clipboard?.writeText(terminal.getSelection()).catch(() => {});
-            // Clear selection so the terminal resumes receiving output
-            terminal.clearSelection();
-            return false;
-          }
-
-          return true;
-        });
-
-        // Open terminal via mux
-        openTerminal(sessionId, tmuxName);
-
-        // Subscribe to terminal data via mux
-        unsubscribe = subscribeTerminal(sessionId, (data) => {
-          if (selectionActive) {
-            writeBuffer.push(data);
-            bufferBytes += data.length;
-            // Flush if buffer exceeds 1 MB to prevent OOM
-            if (bufferBytes > MAX_BUFFER_BYTES) {
-              selectionActive = false;
-              flushWriteBuffer();
-            }
-          } else {
-            terminal.write(data);
-            if (followOutputRef.current) {
-              programmaticScrollRef.current = true;
-              terminal.scrollToBottom();
-            }
-          }
-        });
-
-        // Use xterm's onScroll event (fires with new viewportY) instead of a DOM
-        // scroll listener — xterm v6 may update scrollTop via RAF, making DOM
-        // "scroll" events unreliable for detecting user-initiated scrolls.
-        const scrollDisposable = terminal.onScroll(() => {
-          if (programmaticScrollRef.current) {
-            programmaticScrollRef.current = false;
-            return;
-          }
-          const buf = terminal.buffer.active;
-          const atBottom = buf.viewportY + terminal.rows >= buf.length;
-          if (atBottom) {
-            followOutputRef.current = true;
-            setFollowOutput(true);
-          } else {
-            followOutputRef.current = false;
-            setFollowOutput(false);
-          }
-        });
-
-        // Handle window resize
-        const handleResize = () => {
-          if (fit) {
-            fit.fit();
-            resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-          }
-        };
-
-        window.addEventListener("resize", handleResize);
-
-        // Terminal input → mux
-        inputDisposable = terminal.onData((data) => {
-          writeTerminal(sessionId, data);
-        });
-
-        // Send initial size
-        resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-
-        // Store cleanup function to be called from useEffect cleanup
-        cleanup = () => {
-          clearTimeout(deferredFitTimeout);
-          resizeObserver?.disconnect();
-          cleanupTouchScroll();
-          selectionDisposable.dispose();
-          if (safetyTimer) clearTimeout(safetyTimer);
-          window.removeEventListener("resize", handleResize);
-          if (fontsListenerAttached && fontsFace) {
-            fontsFace.removeEventListener("loadingdone", handleFontsLoadingDone);
-          }
-          scrollDisposable.dispose();
-          inputDisposable?.dispose();
-          inputDisposable = null;
-          unsubscribe?.();
-          closeTerminal(sessionId);
-          terminal.dispose();
-        };
-      })
-      .catch((err) => {
-        console.error("[DirectTerminal] Failed to load xterm.js:", err);
-        setError("Failed to load terminal");
-      });
-
-    return () => {
-      mounted = false;
-      cleanup?.();
-    };
-    // fontSize intentionally NOT in deps — it's handled by a dedicated effect
-    // below that mutates terminal.options.fontSize in place. Adding it here
-    // would tear down and recreate the terminal (and WebSocket) on every
-    // stepper click, losing scrollback and flashing content.
-  }, [
-    appearance,
-    sessionId,
-    variant,
-    resolvedTheme,
-    terminalThemes,
-    subscribeTerminal,
-    writeTerminal,
-    resizeTerminalMux,
-    openTerminal,
-    closeTerminal,
-  ]);
-
-  // Re-send terminal dimensions on every reconnect so the server-side PTY
-  // matches the client's xterm.js size (new PTYs spawn at 80×24 default).
-  useEffect(() => {
-    if (muxStatus !== "connected") return;
-    const fit = fitAddon.current;
-    const terminal = terminalInstance.current;
-    if (!fit || !terminal) return;
-    fit.fit();
-    resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-  }, [muxStatus, sessionId, resizeTerminalMux]);
-
-  // Live theme switching without terminal recreation
-  useEffect(() => {
-    const terminal = terminalInstance.current;
-    if (!terminal) return;
-    const isDark = appearance === "dark" || resolvedTheme !== "light";
-    terminal.options.theme = isDark ? terminalThemes.dark : terminalThemes.light;
-    terminal.options.minimumContrastRatio = isDark ? 1 : 7;
-  }, [appearance, resolvedTheme, terminalThemes]);
-
-  // Font size change effect
-  useEffect(() => {
-    const terminal = terminalInstance.current;
-    const fit = fitAddon.current;
-    if (!terminal || !fit) return;
-    terminal.options.fontSize = fontSize;
-    try {
-      localStorage.setItem(FONT_SIZE_KEY, String(fontSize));
-    } catch {
-      // localStorage might be unavailable
-    }
-    // Re-fit locally AND tell the server-side PTY about the new cols/rows.
-    // Without the mux resize, the shell keeps wrapping at the old dimensions
-    // and the rendered output stops matching the visible grid until the
-    // next resize event (window resize, tab switch, etc.).
-    fit.fit();
-    resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-  }, [fontSize, sessionId, resizeTerminalMux]);
-
-  // Re-fit terminal when fullscreen changes
-  useEffect(() => {
-    const fit = fitAddon.current;
-    const terminal = terminalInstance.current;
-    const container = terminalRef.current;
-
-    if (!fit || !terminal || muxStatusRef.current !== "connected" || !container) {
-      return;
-    }
-
-    let resizeAttempts = 0;
-    const maxAttempts = 60;
-    let cancelled = false;
-    let rafId = 0;
-    let lastHeight = -1;
-
-    const resizeTerminal = () => {
-      if (cancelled) return;
-      resizeAttempts++;
-
-      // Wait for the container height to stabilise (CSS transition finished)
-      const currentHeight = container.getBoundingClientRect().height;
-      const settled = lastHeight >= 0 && Math.abs(currentHeight - lastHeight) < 1;
-      lastHeight = currentHeight;
-
-      if (!settled && resizeAttempts < maxAttempts) {
-        // Container is still transitioning, try again next frame
-        rafId = requestAnimationFrame(resizeTerminal);
-        return;
-      }
-
-      // Container is at target size, now resize terminal
-      terminal.refresh(0, terminal.rows - 1);
-      fit.fit();
-      terminal.refresh(0, terminal.rows - 1);
-
-      // Send new size to server via mux
-      resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
-    };
-
-    // Start resize polling
-    rafId = requestAnimationFrame(resizeTerminal);
-
-    // Also try on transitionend
-    const handleTransitionEnd = (e: TransitionEvent) => {
-      if (cancelled) return;
-      if (e.target === container.parentElement) {
-        resizeAttempts = 0;
-        lastHeight = -1;
-        setTimeout(() => {
-          if (!cancelled) rafId = requestAnimationFrame(resizeTerminal);
-        }, 50);
-      }
-    };
-
-    const parent = container.parentElement;
-    parent?.addEventListener("transitionend", handleTransitionEnd);
-
-    // Backup timers in case RAF polling doesn't work
-    const timer1 = setTimeout(() => {
-      if (cancelled) return;
-      resizeAttempts = 0;
-      lastHeight = -1;
-      resizeTerminal();
-    }, 300);
-    const timer2 = setTimeout(() => {
-      if (cancelled) return;
-      resizeAttempts = 0;
-      lastHeight = -1;
-      resizeTerminal();
-    }, 600);
-
-    return () => {
-      cancelled = true;
-      cancelAnimationFrame(rafId);
-      parent?.removeEventListener("transitionend", handleTransitionEnd);
-      clearTimeout(timer1);
-      clearTimeout(timer2);
-    };
-  }, [fullscreen, sessionId, resizeTerminalMux]);
-
-  const accentColor = "var(--color-accent)";
-
-  // Local errors (e.g. xterm.js load failure) take priority over mux connection state
-  const displayStatus = error ? "error" : muxStatus;
-
-  const statusDotClass =
-    displayStatus === "connected"
-      ? "bg-[var(--color-status-ready)]"
-      : displayStatus === "error" || displayStatus === "disconnected"
-        ? "bg-[var(--color-status-error)]"
-        : "bg-[var(--color-status-attention)] animate-[pulse_1.5s_ease-in-out_infinite]";
-
-  const statusText =
-    displayStatus === "connected"
-      ? "Connected"
-      : displayStatus === "error"
-        ? (error ?? "Error")
-        : displayStatus === "disconnected"
-          ? "Disconnected"
-          : "Connecting…";
-
-  const statusTextColor =
-    displayStatus === "connected"
-      ? "text-[var(--color-status-ready)]"
-      : displayStatus === "error" || displayStatus === "disconnected"
-        ? "text-[var(--color-status-error)]"
-        : "text-[var(--color-text-tertiary)]";
   const isDarkChrome = appearance === "dark" || resolvedTheme !== "light";
-
-  const fontSizeControls = (
-    <div className="flex items-center">
-      <button
-        onClick={() => setFontSize((prev) => Math.max(FONT_SIZE_MIN, prev - 1))}
-        disabled={fontSize <= FONT_SIZE_MIN}
-        className="w-5 h-5 text-xs flex items-center justify-center rounded hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        aria-label="Decrease font size"
-      >
-        −
-      </button>
-      <span className="w-9 text-center text-xs font-medium text-[var(--color-text-secondary)]">
-        {fontSize}px
-      </span>
-      <button
-        onClick={() => setFontSize((prev) => Math.min(FONT_SIZE_MAX, prev + 1))}
-        disabled={fontSize >= FONT_SIZE_MAX}
-        className="w-5 h-5 text-xs flex items-center justify-center rounded hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-        aria-label="Increase font size"
-      >
-        +
-      </button>
-    </div>
-  );
-
-  const fullscreenButton = (
-    <button
-      onClick={() => setFullscreen(!fullscreen)}
-      className={cn(
-        "flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)]",
-        !isOpenCodeSession && !chromeless && "ml-auto",
-      )}
-      aria-label={fullscreen ? "exit fullscreen" : "fullscreen"}
-    >
-      {fullscreen ? (
-        <>
-          <svg
-            className="h-3 w-3"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-          >
-            <path d="M8 3v3a2 2 0 01-2 2H3m18 0h-3a2 2 0 01-2-2V3m0 18v-3a2 2 0 012-2h3M3 16h3a2 2 0 012 2v3" />
-          </svg>
-          exit fullscreen
-        </>
-      ) : (
-        <>
-          <svg
-            className="h-3 w-3"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-          >
-            <path d="M8 3H5a2 2 0 00-2 2v3m18 0V5a2 2 0 00-2-2h-3m0 18h3a2 2 0 002-2v-3M3 16v3a2 2 0 002 2h3" />
-          </svg>
-          fullscreen
-        </>
-      )}
-    </button>
-  );
 
   return (
     <div
@@ -801,149 +97,24 @@ export function DirectTerminal({
         chromeless && "border-0",
       )}
     >
-      {!chromeless ? (
-        <div className="terminal-chrome-bar flex items-center gap-2 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-3 py-2">
-          {/* Pane label — matches the workspace pane-header style used elsewhere */}
-          <span className="terminal-chrome-pane-label">TERMINAL</span>
-          {/* Identity group: session name on top, status+XDA below on mobile */}
-          <div className="terminal-chrome-identity">
-            <span className="terminal-chrome-session-id font-[var(--font-mono)] text-[11px]" style={{ color: accentColor }}>
-              {sessionId}
-            </span>
-            <div className="terminal-chrome-status-row">
-              <div className={cn("h-2 w-2 shrink-0 rounded-full", statusDotClass)} />
-              <span
-                className={cn("text-[10px] font-medium uppercase tracking-[0.06em]", statusTextColor)}
-              >
-                {statusText}
-              </span>
-              <span
-                className="px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
-                style={{
-                  color: accentColor,
-                  background: `color-mix(in srgb, ${accentColor} 12%, transparent)`,
-                }}
-              >
-                XDA
-              </span>
-            </div>
-          </div>
-          <div className="flex-1" />
-          {fontSizeControls}
-          {isOpenCodeSession ? (
-            <button
-              onClick={handleReload}
-              disabled={reloading || muxStatus !== "connected"}
-              title="Restart OpenCode session (/exit then resume mapped session)"
-              aria-label="Restart OpenCode session"
-              className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {reloading ? (
-                <>
-                  <svg
-                    className="h-3 w-3 animate-spin"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M12 3a9 9 0 109 9" />
-                  </svg>
-                  restarting
-                </>
-              ) : (
-                <>
-                  <svg
-                    className="h-3 w-3"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M21 12a9 9 0 11-2.64-6.36" />
-                    <path d="M21 3v6h-6" />
-                  </svg>
-                  restart
-                </>
-              )}
-            </button>
-          ) : null}
-          {reloadError ? (
-            <span
-              className="max-w-[40ch] truncate text-[10px] font-medium text-[var(--color-status-error)]"
-              title={reloadError}
-            >
-              {reloadError}
-            </span>
-          ) : null}
-          {fullscreenButton}
-        </div>
-      ) : null}
-      {chromeless ? (
-        <div className="absolute right-3 top-3 z-10 flex items-center gap-1 rounded-[6px] border border-[var(--color-border-subtle)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)] px-1.5 py-1 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-sm">
-          {isOpenCodeSession ? (
-            <button
-              onClick={handleReload}
-              disabled={reloading || muxStatus !== "connected"}
-              title="Restart OpenCode session (/exit then resume mapped session)"
-              aria-label="Restart OpenCode session"
-              className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-70"
-            >
-              {reloading ? (
-                <>
-                  <svg
-                    className="h-3 w-3 animate-spin"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M12 3a9 9 0 109 9" />
-                  </svg>
-                  restarting
-                </>
-              ) : (
-                <>
-                  <svg
-                    className="h-3 w-3"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    viewBox="0 0 24 24"
-                  >
-                    <path d="M21 12a9 9 0 11-2.64-6.36" />
-                    <path d="M21 3v6h-6" />
-                  </svg>
-                  restart
-                </>
-              )}
-            </button>
-          ) : null}
-          {fullscreenButton}
-        </div>
-      ) : null}
+      <TerminalControls
+        sessionId={sessionId}
+        chromeless={chromeless}
+        isOpenCodeSession={isOpenCodeSession}
+        reloadCommand={reloadCommand}
+        fontSize={fontSize}
+        setFontSize={setFontSize}
+        fullscreen={fullscreen}
+        toggleFullscreen={() => setFullscreen((prev) => !prev)}
+        muxStatus={muxStatus}
+        error={error}
+      />
       {/* Terminal area — flex:1 so it fills remaining space after the chrome bar */}
       <div className="relative flex-1 min-h-0 flex flex-col">
         {!followOutput ? (
           <button
             type="button"
-            onClick={() => {
-              const t = terminalInstance.current;
-              if (t) {
-                if (t.buffer.active.type === "normal") {
-                  // Normal buffer: scrollback exists in xterm, use its API.
-                  programmaticScrollRef.current = true;
-                  t.scrollToBottom();
-                } else {
-                  // Alternate buffer (tmux/vim): xterm has no scrollback to scroll
-                  // to. The user is in tmux copy-mode (entered by attachTouchScroll
-                  // on swipe). Send 'q' to exit copy-mode and return to live tail.
-                  writeTerminal(sessionId, "q");
-                }
-              }
-              followOutputRef.current = true;
-              setFollowOutput(true);
-            }}
+            onClick={scrollToLatest}
             className="absolute bottom-3 right-3 z-20 flex h-8 w-8 items-center justify-center rounded-full border border-[var(--color-border-default)] bg-[var(--color-bg-elevated)] text-[var(--color-text-primary)] shadow-md active:scale-95"
             aria-label="Jump to latest"
             title="Jump to latest"

--- a/packages/web/src/components/terminal/TerminalControls.tsx
+++ b/packages/web/src/components/terminal/TerminalControls.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, type Dispatch, type SetStateAction } from "react";
+import { cn } from "@/lib/cn";
+import { FONT_SIZE_MAX, FONT_SIZE_MIN } from "./terminal-font";
+
+type MuxStatus = "connecting" | "connected" | "reconnecting" | "disconnected";
+type DisplayStatus = MuxStatus | "error";
+
+interface TerminalControlsProps {
+  sessionId: string;
+  chromeless: boolean;
+  isOpenCodeSession: boolean;
+  reloadCommand?: string;
+  fontSize: number;
+  setFontSize: Dispatch<SetStateAction<number>>;
+  fullscreen: boolean;
+  toggleFullscreen: () => void;
+  muxStatus: MuxStatus;
+  error: string | null;
+}
+
+export function TerminalControls({
+  sessionId,
+  chromeless,
+  isOpenCodeSession,
+  reloadCommand,
+  fontSize,
+  setFontSize,
+  fullscreen,
+  toggleFullscreen,
+  muxStatus,
+  error,
+}: TerminalControlsProps) {
+  const [reloading, setReloading] = useState(false);
+  const [reloadError, setReloadError] = useState<string | null>(null);
+
+  async function handleReload(): Promise<void> {
+    if (!isOpenCodeSession || reloading) return;
+    setReloadError(null);
+    setReloading(true);
+    try {
+      let commandToSend = reloadCommand;
+
+      if (!commandToSend) {
+        const remapRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/remap`, {
+          method: "POST",
+        });
+        if (!remapRes.ok) {
+          throw new Error(`Failed to remap OpenCode session: ${remapRes.status}`);
+        }
+        const remapData = (await remapRes.json()) as { opencodeSessionId?: unknown };
+        if (
+          typeof remapData.opencodeSessionId !== "string" ||
+          remapData.opencodeSessionId.length === 0
+        ) {
+          throw new Error("Missing OpenCode session id after remap");
+        }
+        commandToSend = `/exit\nopencode --session ${remapData.opencodeSessionId}\n`;
+      }
+
+      const sendRes = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/send`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: commandToSend }),
+      });
+      if (!sendRes.ok) {
+        throw new Error(`Failed to send reload command: ${sendRes.status}`);
+      }
+    } catch (err) {
+      setReloadError(err instanceof Error ? err.message : "Failed to reload OpenCode session");
+    } finally {
+      setReloading(false);
+    }
+  }
+
+  // Local errors (e.g. xterm.js load failure) take priority over mux connection state
+  const displayStatus: DisplayStatus = error ? "error" : muxStatus;
+
+  const statusDotClass =
+    displayStatus === "connected"
+      ? "bg-[var(--color-status-ready)]"
+      : displayStatus === "error" || displayStatus === "disconnected"
+        ? "bg-[var(--color-status-error)]"
+        : "bg-[var(--color-status-attention)] animate-[pulse_1.5s_ease-in-out_infinite]";
+
+  const statusText =
+    displayStatus === "connected"
+      ? "Connected"
+      : displayStatus === "error"
+        ? (error ?? "Error")
+        : displayStatus === "disconnected"
+          ? "Disconnected"
+          : "Connecting…";
+
+  const statusTextColor =
+    displayStatus === "connected"
+      ? "text-[var(--color-status-ready)]"
+      : displayStatus === "error" || displayStatus === "disconnected"
+        ? "text-[var(--color-status-error)]"
+        : "text-[var(--color-text-tertiary)]";
+
+  const accentColor = "var(--color-accent)";
+
+  const fontSizeControls = (
+    <div className="flex items-center">
+      <button
+        onClick={() => setFontSize((prev) => Math.max(FONT_SIZE_MIN, prev - 1))}
+        disabled={fontSize <= FONT_SIZE_MIN}
+        className="w-5 h-5 text-xs flex items-center justify-center rounded hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="Decrease font size"
+      >
+        −
+      </button>
+      <span className="w-9 text-center text-xs font-medium text-[var(--color-text-secondary)]">
+        {fontSize}px
+      </span>
+      <button
+        onClick={() => setFontSize((prev) => Math.min(FONT_SIZE_MAX, prev + 1))}
+        disabled={fontSize >= FONT_SIZE_MAX}
+        className="w-5 h-5 text-xs flex items-center justify-center rounded hover:bg-white/10 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+        aria-label="Increase font size"
+      >
+        +
+      </button>
+    </div>
+  );
+
+  const reloadButton = isOpenCodeSession ? (
+    <button
+      onClick={handleReload}
+      disabled={reloading || muxStatus !== "connected"}
+      title="Restart OpenCode session (/exit then resume mapped session)"
+      aria-label="Restart OpenCode session"
+      className="flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)] disabled:cursor-not-allowed disabled:opacity-70"
+    >
+      {reloading ? (
+        <>
+          <svg
+            className="h-3 w-3 animate-spin"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M12 3a9 9 0 109 9" />
+          </svg>
+          restarting
+        </>
+      ) : (
+        <>
+          <svg
+            className="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 12a9 9 0 11-2.64-6.36" />
+            <path d="M21 3v6h-6" />
+          </svg>
+          restart
+        </>
+      )}
+    </button>
+  ) : null;
+
+  const fullscreenButton = (
+    <button
+      onClick={toggleFullscreen}
+      className={cn(
+        "flex items-center gap-1 px-2 py-0.5 text-[11px] text-[var(--color-text-tertiary)] transition-colors hover:bg-[var(--color-bg-subtle)] hover:text-[var(--color-text-primary)]",
+        !isOpenCodeSession && !chromeless && "ml-auto",
+      )}
+      aria-label={fullscreen ? "exit fullscreen" : "fullscreen"}
+    >
+      {fullscreen ? (
+        <>
+          <svg
+            className="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M8 3v3a2 2 0 01-2 2H3m18 0h-3a2 2 0 01-2-2V3m0 18v-3a2 2 0 012-2h3M3 16h3a2 2 0 012 2v3" />
+          </svg>
+          exit fullscreen
+        </>
+      ) : (
+        <>
+          <svg
+            className="h-3 w-3"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M8 3H5a2 2 0 00-2 2v3m18 0V5a2 2 0 00-2-2h-3m0 18h3a2 2 0 002-2v-3M3 16v3a2 2 0 002 2h3" />
+          </svg>
+          fullscreen
+        </>
+      )}
+    </button>
+  );
+
+  if (chromeless) {
+    return (
+      <div className="absolute right-3 top-3 z-10 flex items-center gap-1 rounded-[6px] border border-[var(--color-border-subtle)] bg-[color-mix(in_srgb,var(--color-bg-elevated)_92%,transparent)] px-1.5 py-1 shadow-[0_8px_24px_rgba(0,0,0,0.18)] backdrop-blur-sm">
+        {reloadButton}
+        {fullscreenButton}
+      </div>
+    );
+  }
+
+  return (
+    <div className="terminal-chrome-bar flex items-center gap-2 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-3 py-2">
+      {/* Pane label — matches the workspace pane-header style used elsewhere */}
+      <span className="terminal-chrome-pane-label">TERMINAL</span>
+      {/* Identity group: session name on top, status+XDA below on mobile */}
+      <div className="terminal-chrome-identity">
+        <span className="terminal-chrome-session-id font-[var(--font-mono)] text-[11px]" style={{ color: accentColor }}>
+          {sessionId}
+        </span>
+        <div className="terminal-chrome-status-row">
+          <div className={cn("h-2 w-2 shrink-0 rounded-full", statusDotClass)} />
+          <span
+            className={cn("text-[10px] font-medium uppercase tracking-[0.06em]", statusTextColor)}
+          >
+            {statusText}
+          </span>
+          <span
+            className="px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
+            style={{
+              color: accentColor,
+              background: `color-mix(in srgb, ${accentColor} 12%, transparent)`,
+            }}
+          >
+            XDA
+          </span>
+        </div>
+      </div>
+      <div className="flex-1" />
+      {fontSizeControls}
+      {reloadButton}
+      {reloadError ? (
+        <span
+          className="max-w-[40ch] truncate text-[10px] font-medium text-[var(--color-status-error)]"
+          title={reloadError}
+        >
+          {reloadError}
+        </span>
+      ) : null}
+      {fullscreenButton}
+    </div>
+  );
+}

--- a/packages/web/src/components/terminal/__tests__/terminal-clipboard.test.ts
+++ b/packages/web/src/components/terminal/__tests__/terminal-clipboard.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Terminal as TerminalType } from "@xterm/xterm";
+import { registerClipboardHandlers } from "../terminal-clipboard";
+
+type CsiHandler = () => boolean | Promise<boolean>;
+type OscHandler = (data: string) => boolean | Promise<boolean>;
+type KeyHandler = (event: KeyboardEvent) => boolean;
+
+interface Captured {
+  csi: { id: { prefix?: string; final: string }; handler: CsiHandler } | null;
+  osc: { ident: number; handler: OscHandler } | null;
+  key: KeyHandler | null;
+}
+
+function makeMockTerminal(selection = "") {
+  const captured: Captured = { csi: null, osc: null, key: null };
+  const writes: string[] = [];
+  const hasSelection = vi.fn(() => selection.length > 0);
+  const getSelection = vi.fn(() => selection);
+  const clearSelection = vi.fn();
+
+  const terminal = {
+    parser: {
+      registerCsiHandler: (id: Captured["csi"]["id"], handler: CsiHandler) => {
+        captured.csi = { id, handler };
+        return { dispose() {} };
+      },
+      registerOscHandler: (ident: number, handler: OscHandler) => {
+        captured.osc = { ident, handler };
+        return { dispose() {} };
+      },
+    },
+    write: (data: string) => {
+      writes.push(data);
+    },
+    attachCustomKeyEventHandler: (handler: KeyHandler) => {
+      captured.key = handler;
+    },
+    hasSelection,
+    getSelection,
+    clearSelection,
+  } as unknown as TerminalType;
+
+  return { terminal, captured, writes, hasSelection, getSelection, clearSelection };
+}
+
+function encodeOsc52(text: string, target = "c"): string {
+  const bytes = new TextEncoder().encode(text);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return `${target};${btoa(binary)}`;
+}
+
+describe("registerClipboardHandlers", () => {
+  let writeText: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    writeText = vi.fn(() => Promise.resolve());
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: { clipboard: { writeText } },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("XDA (CSI > q) handler", () => {
+    it("registers with prefix '>' and final 'q'", () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+      expect(captured.csi?.id).toEqual({ prefix: ">", final: "q" });
+    });
+
+    it("responds with XTerm(...) identity that tmux recognises", () => {
+      const { terminal, captured, writes } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      const handled = captured.csi!.handler();
+
+      expect(handled).toBe(true);
+      expect(writes).toHaveLength(1);
+      // tmux looks for "XTerm(" in the response — see tmux tty-keys.c.
+      expect(writes[0]).toContain("XTerm(");
+      // Response is wrapped in DCS (\x1bP) ... ST (\x1b\\).
+      expect(writes[0]).toMatch(/^\x1bP.*\x1b\\$/);
+    });
+  });
+
+  describe("OSC 52 decoder", () => {
+    it("registers on OSC identifier 52", () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+      expect(captured.osc?.ident).toBe(52);
+    });
+
+    it("decodes base64 ASCII and writes to clipboard", async () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      const handled = await captured.osc!.handler(encodeOsc52("hello world"));
+
+      expect(handled).toBe(true);
+      expect(writeText).toHaveBeenCalledWith("hello world");
+    });
+
+    it("decodes UTF-8 multi-byte sequences correctly", async () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      // Emoji + CJK — these break if we naively String.fromCharCode the bytes.
+      await captured.osc!.handler(encodeOsc52("漢字 🚀"));
+
+      expect(writeText).toHaveBeenCalledWith("漢字 🚀");
+    });
+
+    it("returns false when payload has no semicolon separator", async () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      const handled = await captured.osc!.handler("malformed");
+
+      expect(handled).toBe(false);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it("swallows decode errors without throwing", async () => {
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      // atob() throws on invalid base64.
+      const handled = await captured.osc!.handler("c;not_valid_base64!!!");
+
+      expect(handled).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it("does not throw on clipboard write rejection", async () => {
+      writeText.mockReturnValue(Promise.reject(new Error("denied")));
+      const { terminal, captured } = makeMockTerminal();
+      registerClipboardHandlers(terminal);
+
+      // The handler attaches a .catch() to the clipboard write so rejections
+      // don't escape as unhandled. Returns sync true regardless.
+      expect(() => captured.osc!.handler(encodeOsc52("x"))).not.toThrow();
+      // Let the rejected promise's .catch() handler run.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  });
+
+  describe("Cmd+C / Ctrl+Shift+C copy handler", () => {
+    function keyEvent(init: Partial<KeyboardEvent>): KeyboardEvent {
+      return {
+        type: "keydown",
+        code: "KeyC",
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false,
+        altKey: false,
+        ...init,
+      } as KeyboardEvent;
+    }
+
+    it("copies selection and returns false on Cmd+C (Mac)", () => {
+      const { terminal, captured, getSelection, clearSelection } =
+        makeMockTerminal("selected text");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ metaKey: true }));
+
+      expect(result).toBe(false);
+      expect(getSelection).toHaveBeenCalled();
+      expect(writeText).toHaveBeenCalledWith("selected text");
+      expect(clearSelection).toHaveBeenCalled();
+    });
+
+    it("copies selection on Ctrl+Shift+C (Linux/Windows)", () => {
+      const { terminal, captured, clearSelection } = makeMockTerminal("linux text");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ ctrlKey: true, shiftKey: true }));
+
+      expect(result).toBe(false);
+      expect(writeText).toHaveBeenCalledWith("linux text");
+      expect(clearSelection).toHaveBeenCalled();
+    });
+
+    it("does nothing when there is no selection", () => {
+      const { terminal, captured, clearSelection } = makeMockTerminal("");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ metaKey: true }));
+
+      expect(result).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+      expect(clearSelection).not.toHaveBeenCalled();
+    });
+
+    it("ignores Ctrl+C without shift (that's SIGINT, must pass through)", () => {
+      const { terminal, captured, clearSelection } = makeMockTerminal("anything");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ ctrlKey: true }));
+
+      expect(result).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+      expect(clearSelection).not.toHaveBeenCalled();
+    });
+
+    it("ignores Cmd+Ctrl+C combos (alt modifier leaves plain Cmd+C uncontaminated)", () => {
+      const { terminal, captured } = makeMockTerminal("text");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ metaKey: true, ctrlKey: true }));
+
+      expect(result).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+
+    it("passes through keyup events untouched", () => {
+      const { terminal, captured } = makeMockTerminal("text");
+      registerClipboardHandlers(terminal);
+
+      const result = captured.key!(keyEvent({ type: "keyup", metaKey: true }));
+
+      expect(result).toBe(true);
+      expect(writeText).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/src/components/terminal/__tests__/terminal-clipboard.test.ts
+++ b/packages/web/src/components/terminal/__tests__/terminal-clipboard.test.ts
@@ -83,8 +83,9 @@ describe("registerClipboardHandlers", () => {
       expect(writes).toHaveLength(1);
       // tmux looks for "XTerm(" in the response — see tmux tty-keys.c.
       expect(writes[0]).toContain("XTerm(");
-      // Response is wrapped in DCS (\x1bP) ... ST (\x1b\\).
-      expect(writes[0]).toMatch(/^\x1bP.*\x1b\\$/);
+      // Response is wrapped in DCS (ESC P) ... ST (ESC \).
+      expect(writes[0].startsWith("\x1bP")).toBe(true);
+      expect(writes[0].endsWith("\x1b\\")).toBe(true);
     });
   });
 

--- a/packages/web/src/components/terminal/__tests__/terminal-font.test.ts
+++ b/packages/web/src/components/terminal/__tests__/terminal-font.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FONT_SIZE_DEFAULT,
+  FONT_SIZE_KEY,
+  FONT_SIZE_MAX,
+  FONT_SIZE_MIN,
+  getStoredFontSize,
+} from "../terminal-font";
+
+// jsdom's localStorage proxy in this setup doesn't expose `removeItem`/`clear`
+// reliably between suites, so we stub it ourselves with a fresh Map per test.
+describe("getStoredFontSize", () => {
+  let store: Map<string, string>;
+
+  beforeEach(() => {
+    store = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => {
+        store.set(k, v);
+      },
+      removeItem: (k: string) => {
+        store.delete(k);
+      },
+      clear: () => store.clear(),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the default when nothing is stored", () => {
+    expect(getStoredFontSize()).toBe(FONT_SIZE_DEFAULT);
+  });
+
+  it("returns the stored value when within bounds", () => {
+    localStorage.setItem(FONT_SIZE_KEY, "14");
+    expect(getStoredFontSize()).toBe(14);
+  });
+
+  it("clamps below the minimum", () => {
+    localStorage.setItem(FONT_SIZE_KEY, "2");
+    expect(getStoredFontSize()).toBe(FONT_SIZE_MIN);
+  });
+
+  it("clamps above the maximum", () => {
+    localStorage.setItem(FONT_SIZE_KEY, "99");
+    expect(getStoredFontSize()).toBe(FONT_SIZE_MAX);
+  });
+
+  it("returns the default when the stored value is not a number", () => {
+    localStorage.setItem(FONT_SIZE_KEY, "banana");
+    expect(getStoredFontSize()).toBe(FONT_SIZE_DEFAULT);
+  });
+
+  it("parses leading-integer strings (parseInt behaviour) and clamps", () => {
+    // parseInt("14px", 10) === 14 — documenting current behaviour.
+    localStorage.setItem(FONT_SIZE_KEY, "14px");
+    expect(getStoredFontSize()).toBe(14);
+  });
+
+  it("falls back to the default when localStorage.getItem throws", () => {
+    vi.stubGlobal("localStorage", {
+      getItem: () => {
+        throw new Error("SecurityError: access denied");
+      },
+      setItem: () => {},
+      removeItem: () => {},
+      clear: () => {},
+    });
+    expect(getStoredFontSize()).toBe(FONT_SIZE_DEFAULT);
+  });
+});

--- a/packages/web/src/components/terminal/terminal-clipboard.ts
+++ b/packages/web/src/components/terminal/terminal-clipboard.ts
@@ -16,7 +16,6 @@ export function registerClipboardHandlers(terminal: TerminalType): void {
     { prefix: ">", final: "q" }, // CSI > q is XTVERSION / XDA
     () => {
       terminal.write("\x1bP>|XTerm(370)\x1b\\");
-      console.log("[DirectTerminal] Sent XDA response for clipboard support");
       return true;
     },
   );

--- a/packages/web/src/components/terminal/terminal-clipboard.ts
+++ b/packages/web/src/components/terminal/terminal-clipboard.ts
@@ -1,0 +1,58 @@
+import type { Terminal as TerminalType } from "@xterm/xterm";
+
+/**
+ * Wire tmux-compatible clipboard integration into an xterm.js instance:
+ * - Responds to XDA (CSI > q) with an "XTerm(" identity so tmux enables
+ *   TTYC_MS and starts sending OSC 52 for copy.
+ * - Decodes OSC 52 base64 payloads and writes them to navigator.clipboard.
+ * - Intercepts Cmd+C / Ctrl+Shift+C to copy the current xterm selection
+ *   (paste is handled natively by xterm's internal textarea).
+ */
+export function registerClipboardHandlers(terminal: TerminalType): void {
+  // **CRITICAL FIX**: Register XDA (Extended Device Attributes) handler.
+  // tmux looks for "XTerm(" in the response (see tmux tty-keys.c) and
+  // enables TTYC_MS (clipboard / OSC 52) when it sees it.
+  terminal.parser.registerCsiHandler(
+    { prefix: ">", final: "q" }, // CSI > q is XTVERSION / XDA
+    () => {
+      terminal.write("\x1bP>|XTerm(370)\x1b\\");
+      console.log("[DirectTerminal] Sent XDA response for clipboard support");
+      return true;
+    },
+  );
+
+  // OSC 52 — tmux sends base64-encoded text when copying.
+  terminal.parser.registerOscHandler(52, (data) => {
+    const parts = data.split(";");
+    if (parts.length < 2) return false;
+    const b64 = parts[parts.length - 1];
+    try {
+      // Decode base64 → binary string → Uint8Array → UTF-8 text.
+      // atob() alone only handles Latin-1; TextDecoder is needed for UTF-8.
+      const binary = atob(b64);
+      const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+      const text = new TextDecoder().decode(bytes);
+      navigator.clipboard?.writeText(text).catch(() => {});
+    } catch {
+      // Ignore decode errors
+    }
+    return true;
+  });
+
+  // Cmd+C (Mac) / Ctrl+Shift+C (Linux/Win) — copy selection.
+  // Paste is handled natively by xterm.js via its textarea.
+  terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+    if (e.type !== "keydown") return true;
+
+    const isCopy =
+      (e.metaKey && !e.ctrlKey && !e.altKey && e.code === "KeyC") ||
+      (e.ctrlKey && e.shiftKey && e.code === "KeyC");
+    if (isCopy && terminal.hasSelection()) {
+      navigator.clipboard?.writeText(terminal.getSelection()).catch(() => {});
+      terminal.clearSelection();
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/packages/web/src/components/terminal/terminal-font.ts
+++ b/packages/web/src/components/terminal/terminal-font.ts
@@ -1,0 +1,51 @@
+export const FONT_SIZE_KEY = "ao-terminal-font-size";
+export const FONT_SIZE_MIN = 9;
+export const FONT_SIZE_MAX = 18;
+export const FONT_SIZE_DEFAULT = 13;
+
+// Fallback mono stack used when the CSS custom property isn't resolvable yet.
+const MONO_FONT_FALLBACK =
+  '"JetBrains Mono", "SF Mono", Menlo, Monaco, "Courier New", monospace';
+
+/**
+ * Resolve the app's configured mono font token to a concrete font-family string.
+ *
+ * xterm's internal char-size measurement ultimately hits canvas ctx.font, which
+ * cannot evaluate `var(...)`. Reading `--font-jetbrains-mono` with
+ * getComputedStyle gives us the generated next/font family name (e.g.
+ * `__JetBrains_Mono_abc123`), which we can safely feed into xterm while still
+ * honouring the app's font configuration.
+ *
+ * NOTE: we deliberately read `--font-jetbrains-mono` and NOT `--font-mono`.
+ * `--font-mono` in globals.css is itself a composed stack that contains
+ * `var(--font-jetbrains-mono)` — if we forwarded that to xterm, the raw
+ * `var(...)` token would end up back in canvas ctx.font and reintroduce the
+ * original measurement bug this helper exists to fix.
+ */
+export function resolveMonoFontFamily(): string {
+  if (typeof window === "undefined") return MONO_FONT_FALLBACK;
+  try {
+    const resolved = getComputedStyle(document.documentElement)
+      .getPropertyValue("--font-jetbrains-mono")
+      .trim();
+    return resolved ? `${resolved}, ${MONO_FONT_FALLBACK}` : MONO_FONT_FALLBACK;
+  } catch {
+    return MONO_FONT_FALLBACK;
+  }
+}
+
+export function getStoredFontSize(): number {
+  if (typeof window === "undefined") return FONT_SIZE_DEFAULT;
+  try {
+    const stored = localStorage.getItem(FONT_SIZE_KEY);
+    if (stored) {
+      const size = parseInt(stored, 10);
+      if (!Number.isNaN(size)) {
+        return Math.max(FONT_SIZE_MIN, Math.min(FONT_SIZE_MAX, size));
+      }
+    }
+  } catch {
+    // localStorage might be unavailable
+  }
+  return FONT_SIZE_DEFAULT;
+}

--- a/packages/web/src/components/terminal/terminal-themes.ts
+++ b/packages/web/src/components/terminal/terminal-themes.ts
@@ -1,0 +1,67 @@
+import type { ITheme } from "@xterm/xterm";
+
+export type TerminalVariant = "agent" | "orchestrator";
+
+export function buildTerminalThemes(variant: TerminalVariant): { dark: ITheme; light: ITheme } {
+  const agentAccent = {
+    cursor: "#5b7ef8",
+    selDark: "rgba(91, 126, 248, 0.30)",
+    selLight: "rgba(91, 126, 248, 0.25)",
+  };
+  const orchAccent = agentAccent;
+  const accent = variant === "orchestrator" ? orchAccent : agentAccent;
+
+  const dark: ITheme = {
+    background: "#0a0a0f",
+    foreground: "#d4d4d8",
+    cursor: accent.cursor,
+    cursorAccent: "#0a0a0f",
+    selectionBackground: accent.selDark,
+    selectionInactiveBackground: "rgba(128, 128, 128, 0.2)",
+    // ANSI colors — slightly warmer than pure defaults
+    black: "#1a1a24",
+    red: "#ef4444",
+    green: "#22c55e",
+    yellow: "#f59e0b",
+    blue: "#5b7ef8",
+    magenta: "#a371f7",
+    cyan: "#22d3ee",
+    white: "#d4d4d8",
+    brightBlack: "#50506a",
+    brightRed: "#f87171",
+    brightGreen: "#4ade80",
+    brightYellow: "#fbbf24",
+    brightBlue: "#7b9cfb",
+    brightMagenta: "#c084fc",
+    brightCyan: "#67e8f9",
+    brightWhite: "#eeeef5",
+  };
+
+  const light: ITheme = {
+    background: "#fafafa",
+    foreground: "#24292f",
+    cursor: accent.cursor,
+    cursorAccent: "#fafafa",
+    selectionBackground: accent.selLight,
+    selectionInactiveBackground: "rgba(128, 128, 128, 0.15)",
+    // ANSI colors — darkened for legibility on #fafafa terminal background
+    black: "#24292f",
+    red: "#b42318",
+    green: "#1f7a3d",
+    yellow: "#8a5a00",
+    blue: "#175cd3",
+    magenta: "#8e24aa",
+    cyan: "#0b7285",
+    white: "#4b5563",
+    brightBlack: "#374151",
+    brightRed: "#912018",
+    brightGreen: "#176639",
+    brightYellow: "#6f4a00",
+    brightBlue: "#1d4ed8",
+    brightMagenta: "#7b1fa2",
+    brightCyan: "#155e75",
+    brightWhite: "#374151",
+  };
+
+  return { dark, light };
+}

--- a/packages/web/src/components/terminal/terminal-themes.ts
+++ b/packages/web/src/components/terminal/terminal-themes.ts
@@ -2,14 +2,14 @@ import type { ITheme } from "@xterm/xterm";
 
 export type TerminalVariant = "agent" | "orchestrator";
 
-export function buildTerminalThemes(variant: TerminalVariant): { dark: ITheme; light: ITheme } {
-  const agentAccent = {
+export function buildTerminalThemes(_variant: TerminalVariant): { dark: ITheme; light: ITheme } {
+  // Orchestrator and agent currently share the design-system accent; the
+  // variant parameter is preserved for API compatibility and future divergence.
+  const accent = {
     cursor: "#5b7ef8",
     selDark: "rgba(91, 126, 248, 0.30)",
     selLight: "rgba(91, 126, 248, 0.25)",
   };
-  const orchAccent = agentAccent;
-  const accent = variant === "orchestrator" ? orchAccent : agentAccent;
 
   const dark: ITheme = {
     background: "#0a0a0f",

--- a/packages/web/src/components/terminal/useFullscreenResize.ts
+++ b/packages/web/src/components/terminal/useFullscreenResize.ts
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useRef, type RefObject } from "react";
+import type { Terminal as TerminalType } from "@xterm/xterm";
+import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
+import { useMux } from "@/hooks/useMux";
+
+/**
+ * Re-fit the terminal when entering/leaving fullscreen.
+ *
+ * The container animates via a CSS transition, so we poll the container
+ * height with RAF until it stabilises before calling fit(). Backup timers
+ * and a 'transitionend' listener cover browsers where RAF polling alone
+ * doesn't settle cleanly.
+ */
+export function useFullscreenResize(
+  fullscreen: boolean,
+  sessionId: string,
+  terminalInstance: RefObject<TerminalType | null>,
+  fitAddon: RefObject<FitAddonType | null>,
+  containerRef: RefObject<HTMLDivElement | null>,
+): void {
+  const { resizeTerminal: resizeTerminalMux, status: muxStatus } = useMux();
+  const muxStatusRef = useRef(muxStatus);
+  muxStatusRef.current = muxStatus;
+
+  useEffect(() => {
+    const fit = fitAddon.current;
+    const terminal = terminalInstance.current;
+    const container = containerRef.current;
+
+    if (!fit || !terminal || muxStatusRef.current !== "connected" || !container) {
+      return;
+    }
+
+    let resizeAttempts = 0;
+    const maxAttempts = 60;
+    let cancelled = false;
+    let rafId = 0;
+    let lastHeight = -1;
+
+    const resizeTerminal = () => {
+      if (cancelled) return;
+      resizeAttempts++;
+
+      const currentHeight = container.getBoundingClientRect().height;
+      const settled = lastHeight >= 0 && Math.abs(currentHeight - lastHeight) < 1;
+      lastHeight = currentHeight;
+
+      if (!settled && resizeAttempts < maxAttempts) {
+        rafId = requestAnimationFrame(resizeTerminal);
+        return;
+      }
+
+      terminal.refresh(0, terminal.rows - 1);
+      fit.fit();
+      terminal.refresh(0, terminal.rows - 1);
+
+      resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+    };
+
+    rafId = requestAnimationFrame(resizeTerminal);
+
+    const handleTransitionEnd = (e: TransitionEvent) => {
+      if (cancelled) return;
+      if (e.target === container.parentElement) {
+        resizeAttempts = 0;
+        lastHeight = -1;
+        setTimeout(() => {
+          if (!cancelled) rafId = requestAnimationFrame(resizeTerminal);
+        }, 50);
+      }
+    };
+
+    const parent = container.parentElement;
+    parent?.addEventListener("transitionend", handleTransitionEnd);
+
+    // Backup timers in case RAF polling doesn't settle
+    const timer1 = setTimeout(() => {
+      if (cancelled) return;
+      resizeAttempts = 0;
+      lastHeight = -1;
+      resizeTerminal();
+    }, 300);
+    const timer2 = setTimeout(() => {
+      if (cancelled) return;
+      resizeAttempts = 0;
+      lastHeight = -1;
+      resizeTerminal();
+    }, 600);
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(rafId);
+      parent?.removeEventListener("transitionend", handleTransitionEnd);
+      clearTimeout(timer1);
+      clearTimeout(timer2);
+    };
+  }, [fullscreen, sessionId, resizeTerminalMux, containerRef, fitAddon, terminalInstance]);
+}

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -1,0 +1,395 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState, type RefObject } from "react";
+import { useTheme } from "next-themes";
+
+// Import xterm CSS (must be imported in client component)
+import "@xterm/xterm/css/xterm.css";
+
+// Static type-only imports (erased at compile time, no SSR impact).
+// The runtime Terminal class is loaded via dynamic import() inside useEffect to avoid SSR.
+import type { Terminal as TerminalType } from "@xterm/xterm";
+import type { FitAddon as FitAddonType } from "@xterm/addon-fit";
+
+import { useMux } from "@/hooks/useMux";
+import { attachTouchScroll } from "@/lib/terminal-touch-scroll";
+
+import { registerClipboardHandlers } from "./terminal-clipboard";
+import { FONT_SIZE_KEY, resolveMonoFontFamily } from "./terminal-font";
+import { buildTerminalThemes, type TerminalVariant } from "./terminal-themes";
+
+export interface UseXtermTerminalOptions {
+  appearance: "theme" | "dark";
+  variant: TerminalVariant;
+  fontSize: number;
+  autoFocus: boolean;
+  /** Actual tmux session name. When provided, the terminal server uses it directly instead of resolving from sessionId. */
+  tmuxName?: string;
+}
+
+export interface UseXtermTerminalResult {
+  error: string | null;
+  followOutput: boolean;
+  scrollToLatest: () => void;
+  muxStatus: ReturnType<typeof useMux>["status"];
+  terminalInstance: RefObject<TerminalType | null>;
+  fitAddon: RefObject<FitAddonType | null>;
+}
+
+/**
+ * Owns the xterm.js instance and its wiring to the multiplexed WebSocket.
+ *
+ * Registers the XDA handler that tmux looks for to enable clipboard (OSC 52),
+ * buffers writes while a selection is active, preserves scrollback position
+ * for "follow output" behaviour, and tears everything down on unmount.
+ */
+export function useXtermTerminal(
+  terminalRef: RefObject<HTMLDivElement | null>,
+  sessionId: string,
+  options: UseXtermTerminalOptions,
+): UseXtermTerminalResult {
+  const { appearance, variant, fontSize, autoFocus, tmuxName } = options;
+  const { resolvedTheme } = useTheme();
+  const terminalThemes = useMemo(() => buildTerminalThemes(variant), [variant]);
+  const {
+    subscribeTerminal,
+    writeTerminal,
+    resizeTerminal: resizeTerminalMux,
+    openTerminal,
+    closeTerminal,
+    status: muxStatus,
+  } = useMux();
+
+  const terminalInstance = useRef<TerminalType | null>(null);
+  const fitAddon = useRef<FitAddonType | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const followOutputRef = useRef(true);
+  const [followOutput, setFollowOutput] = useState(true);
+
+  useEffect(() => {
+    if (!terminalRef.current) return;
+
+    // Dynamically import xterm.js to avoid SSR issues
+    let mounted = true;
+    let cleanup: (() => void) | null = null;
+    let inputDisposable: { dispose(): void } | null = null;
+    let unsubscribe: (() => void) | null = null;
+
+    Promise.all([
+      import("@xterm/xterm").then((mod) => mod.Terminal),
+      import("@xterm/addon-fit").then((mod) => mod.FitAddon),
+      import("@xterm/addon-web-links").then((mod) => mod.WebLinksAddon),
+      document.fonts.ready,
+    ])
+      .then(([Terminal, FitAddon, WebLinksAddon]) => {
+        if (!mounted || !terminalRef.current) return;
+
+        const isDark = appearance === "dark" || resolvedTheme !== "light";
+        const activeTheme = isDark ? terminalThemes.dark : terminalThemes.light;
+
+        // NOTE: xterm's internal char-size measurement uses canvas ctx.font which
+        // cannot resolve `var(...)`. resolveMonoFontFamily() reads the CSS custom
+        // property at runtime so we still honour the app's configured font token
+        // (next/font generated name) while handing xterm a concrete string.
+        const terminal = new Terminal({
+          cursorBlink: true,
+          fontSize: fontSize,
+          fontFamily: resolveMonoFontFamily(),
+          // xterm v6 default lineHeight (1.0) collides rows with JetBrains Mono's
+          // tall x-height. 1.2 restores visual breathing room between lines.
+          lineHeight: 1.2,
+          theme: activeTheme,
+          // Light mode needs an explicit contrast floor because agent UIs often emit
+          // dim/faint ANSI sequences that become unreadable on a near-white background.
+          minimumContrastRatio: isDark ? 1 : 7,
+          scrollback: 10000,
+          allowProposedApi: true,
+          fastScrollSensitivity: 3,
+          scrollSensitivity: 1,
+        });
+
+        const fit = new FitAddon();
+        terminal.loadAddon(fit);
+        fitAddon.current = fit;
+
+        const webLinks = new WebLinksAddon();
+        terminal.loadAddon(webLinks);
+
+        registerClipboardHandlers(terminal);
+
+        terminal.open(terminalRef.current);
+        terminalInstance.current = terminal;
+
+        if (autoFocus) {
+          terminal.focus();
+        }
+
+        fit.fit();
+
+        // Deferred fit for containers that weren't sized yet on first paint.
+        const deferredFitTimeout = setTimeout(() => {
+          if (mounted && fitAddon.current) {
+            try {
+              fitAddon.current.fit();
+              resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+            } catch {
+              // Ignore fit errors
+            }
+          }
+        }, 100);
+
+        // next/font uses font-display:swap, so document.fonts.ready can resolve
+        // before JetBrains Mono actually swaps in. Without this listener,
+        // xterm's cell measurement stays pinned to the fallback font and cells
+        // look wide once the real font swaps. 'loadingdone' forces a re-fit.
+        const handleFontsLoadingDone = () => {
+          if (!mounted || !fitAddon.current || !terminalInstance.current) return;
+          try {
+            terminalInstance.current.options.fontFamily = resolveMonoFontFamily();
+            terminalInstance.current.clearTextureAtlas?.();
+            fitAddon.current.fit();
+            resizeTerminalMux(sessionId, terminalInstance.current.cols, terminalInstance.current.rows);
+          } catch {
+            // Ignore fit errors
+          }
+        };
+        // Feature-detect addEventListener — jsdom's document.fonts mock lacks it.
+        const fontsFace =
+          typeof document !== "undefined" ? document.fonts : undefined;
+        const fontsListenerAttached =
+          !!fontsFace && typeof fontsFace.addEventListener === "function";
+        if (fontsListenerAttached) {
+          fontsFace!.addEventListener("loadingdone", handleFontsLoadingDone);
+        }
+
+        // Touch scroll on mobile — disables follow-output while user scrolls.
+        // NOTE: intentionally no onScrollTowardLatest. In normal buffer
+        // terminal.onScroll (below) decides based on real viewport position.
+        // In alternate buffer (tmux) there is no way to detect when the user
+        // returned to the live tail, so the jump-to-latest button stays visible
+        // until clicked.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const cleanupTouchScroll = attachTouchScroll(terminal as any, (data) => {
+          writeTerminal(sessionId, data);
+        }, {
+          onScrollAway: () => { followOutputRef.current = false; setFollowOutput(false); },
+        });
+
+        let resizeObserver: ResizeObserver | null = null;
+        if (terminalRef.current) {
+          resizeObserver = new ResizeObserver(() => {
+            if (mounted && fitAddon.current) {
+              try {
+                fitAddon.current.fit();
+                resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+              } catch {
+                // Ignore fit errors
+              }
+            }
+          });
+          resizeObserver.observe(terminalRef.current);
+        }
+
+        // ── Preserve selection while terminal receives output ────────
+        // xterm.js clears selection on every terminal.write(). We buffer
+        // incoming data while a selection is active so the highlight stays
+        // visible for Cmd+C. Flushed when selection clears or buffer caps.
+        const writeBuffer: string[] = [];
+        let selectionActive = false;
+        let safetyTimer: ReturnType<typeof setTimeout> | null = null;
+        let bufferBytes = 0;
+        const MAX_BUFFER_BYTES = 1_048_576; // 1 MB
+
+        const flushWriteBuffer = () => {
+          if (safetyTimer) {
+            clearTimeout(safetyTimer);
+            safetyTimer = null;
+          }
+          if (writeBuffer.length > 0) {
+            terminal.write(writeBuffer.join(""));
+            writeBuffer.length = 0;
+            bufferBytes = 0;
+          }
+        };
+
+        const selectionDisposable = terminal.onSelectionChange(() => {
+          if (terminal.hasSelection()) {
+            selectionActive = true;
+            if (!safetyTimer) {
+              safetyTimer = setTimeout(() => {
+                selectionActive = false;
+                flushWriteBuffer();
+              }, 5_000);
+            }
+          } else {
+            selectionActive = false;
+            flushWriteBuffer();
+          }
+        });
+
+        // Track whether our own write()-driven scrollToBottom() triggered the
+        // next scroll event. Declared before subscribeTerminal() so the
+        // callback's closure captures an initialised binding — not strictly
+        // required today (WebSocket callbacks are async) but removes the TDZ
+        // hazard if subscribeTerminal ever fires synchronously.
+        let programmaticScroll = false;
+
+        openTerminal(sessionId, tmuxName);
+
+        unsubscribe = subscribeTerminal(sessionId, (data) => {
+          if (selectionActive) {
+            writeBuffer.push(data);
+            bufferBytes += data.length;
+            if (bufferBytes > MAX_BUFFER_BYTES) {
+              selectionActive = false;
+              flushWriteBuffer();
+            }
+          } else {
+            terminal.write(data);
+            if (followOutputRef.current) {
+              programmaticScroll = true;
+              terminal.scrollToBottom();
+            }
+          }
+        });
+
+        // Use xterm's onScroll event (fires with new viewportY) instead of a DOM
+        // scroll listener — xterm v6 may update scrollTop via RAF, making DOM
+        // "scroll" events unreliable for detecting user-initiated scrolls.
+        const scrollDisposable = terminal.onScroll(() => {
+          if (programmaticScroll) {
+            programmaticScroll = false;
+            return;
+          }
+          const buf = terminal.buffer.active;
+          const atBottom = buf.viewportY + terminal.rows >= buf.length;
+          if (atBottom) {
+            followOutputRef.current = true;
+            setFollowOutput(true);
+          } else {
+            followOutputRef.current = false;
+            setFollowOutput(false);
+          }
+        });
+
+        const handleResize = () => {
+          if (fit) {
+            fit.fit();
+            resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+          }
+        };
+        window.addEventListener("resize", handleResize);
+
+        inputDisposable = terminal.onData((data) => {
+          writeTerminal(sessionId, data);
+        });
+
+        resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+
+        cleanup = () => {
+          clearTimeout(deferredFitTimeout);
+          resizeObserver?.disconnect();
+          cleanupTouchScroll();
+          selectionDisposable.dispose();
+          if (safetyTimer) clearTimeout(safetyTimer);
+          window.removeEventListener("resize", handleResize);
+          if (fontsListenerAttached && fontsFace) {
+            fontsFace.removeEventListener("loadingdone", handleFontsLoadingDone);
+          }
+          scrollDisposable.dispose();
+          inputDisposable?.dispose();
+          inputDisposable = null;
+          unsubscribe?.();
+          closeTerminal(sessionId);
+          terminal.dispose();
+        };
+      })
+      .catch((err) => {
+        console.error("[DirectTerminal] Failed to load xterm.js:", err);
+        setError("Failed to load terminal");
+      });
+
+    return () => {
+      mounted = false;
+      cleanup?.();
+    };
+    // fontSize intentionally NOT in deps — it's handled by a dedicated effect
+    // below that mutates terminal.options.fontSize in place. Adding it here
+    // would tear down and recreate the terminal (and WebSocket) on every
+    // stepper click, losing scrollback and flashing content.
+  }, [
+    appearance,
+    sessionId,
+    tmuxName,
+    variant,
+    resolvedTheme,
+    terminalThemes,
+    subscribeTerminal,
+    writeTerminal,
+    resizeTerminalMux,
+    openTerminal,
+    closeTerminal,
+  ]);
+
+  // Re-send terminal dimensions on every reconnect so the server-side PTY
+  // matches the client's xterm.js size (new PTYs spawn at 80×24 default).
+  useEffect(() => {
+    if (muxStatus !== "connected") return;
+    const fit = fitAddon.current;
+    const terminal = terminalInstance.current;
+    if (!fit || !terminal) return;
+    fit.fit();
+    resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+  }, [muxStatus, sessionId, resizeTerminalMux]);
+
+  // Live theme switching without terminal recreation
+  useEffect(() => {
+    const terminal = terminalInstance.current;
+    if (!terminal) return;
+    const isDark = appearance === "dark" || resolvedTheme !== "light";
+    terminal.options.theme = isDark ? terminalThemes.dark : terminalThemes.light;
+    terminal.options.minimumContrastRatio = isDark ? 1 : 7;
+  }, [appearance, resolvedTheme, terminalThemes]);
+
+  // Font size change — mutate in place and persist, then resize the PTY so
+  // the shell wraps at the new cols/rows.
+  useEffect(() => {
+    const terminal = terminalInstance.current;
+    const fit = fitAddon.current;
+    if (!terminal || !fit) return;
+    terminal.options.fontSize = fontSize;
+    try {
+      localStorage.setItem(FONT_SIZE_KEY, String(fontSize));
+    } catch {
+      // localStorage might be unavailable
+    }
+    fit.fit();
+    resizeTerminalMux(sessionId, terminal.cols, terminal.rows);
+  }, [fontSize, sessionId, resizeTerminalMux]);
+
+  const scrollToLatest = () => {
+    const t = terminalInstance.current;
+    if (t) {
+      if (t.buffer.active.type === "normal") {
+        // Normal buffer: scrollback exists in xterm, use its API.
+        t.scrollToBottom();
+      } else {
+        // Alternate buffer (tmux/vim): xterm has no scrollback to scroll
+        // to. The user is in tmux copy-mode (entered by attachTouchScroll
+        // on swipe). Send 'q' to exit copy-mode and return to live tail.
+        writeTerminal(sessionId, "q");
+      }
+    }
+    followOutputRef.current = true;
+    setFollowOutput(true);
+  };
+
+  return {
+    error,
+    followOutput,
+    scrollToLatest,
+    muxStatus,
+    terminalInstance,
+    fitAddon,
+  };
+}


### PR DESCRIPTION
## Summary

Closes #769.

`DirectTerminal.tsx` had grown to **951 lines** — 2.4× over C-04's 400-line limit — with theme data, font helpers, the xterm setup effect, the fullscreen resize effect, clipboard handlers, and the chrome UI all in one file. The April 2026 audit comment on the issue confirmed the UI revamp has landed and the structural split is still wanted.

## Extractions

Everything moved under `packages/web/src/components/terminal/`:

| File | Lines | Responsibility |
|---|---|---|
| `DirectTerminal.tsx` (rewritten) | 130 | Composition only |
| `terminal-themes.ts` | 67 | Dark/light `ITheme` builder |
| `terminal-font.ts` | 51 | Font size constants, `getStoredFontSize`, `resolveMonoFontFamily` |
| `terminal-clipboard.ts` | 58 | XDA (CSI > q) handler, OSC 52 decoder, Cmd+C keybinding |
| `useXtermTerminal.ts` | 375 | xterm instance + mux wiring + selection preservation + touch scroll + reconnect/theme/font-size effects |
| `useFullscreenResize.ts` | 100 | RAF-polling fullscreen resize effect |
| `TerminalControls.tsx` | 257 | Chromed bar + chromeless floating controls + OpenCode reload |

`buildTerminalThemes` and `resolveMonoFontFamily` are re-exported from `DirectTerminal.tsx` so the existing `DirectTerminal.test.ts` imports continue to work unchanged.

## Scope note

The ~280-line xterm setup effect inside `useXtermTerminal` is kept as a single effect. Its selection-buffering state (`writeBuffer`, `selectionActive`, `programmaticScroll`) crosses the WebSocket, ResizeObserver, and viewport-scroll concerns, and cleanup order matters. Splitting it into the 6 hooks suggested in the April re-audit would require passing 10+ refs between them without reducing real complexity. Leaving that call for a follow-up if the shared state can be disentangled first.

## Test plan

- [x] `pnpm --filter @aoagents/ao-web typecheck` passes
- [x] `pnpm --filter @aoagents/ao-web build` succeeds (Next.js build + tsc)
- [x] `pnpm --filter @aoagents/ao-web test` — `DirectTerminal.test.ts` (9 tests) and `DirectTerminal.render.test.tsx` (3 tests) all pass. Pre-existing `AddProjectModal` failures are unrelated (verified on main).
- [x] Manual smoke in dev dashboard: open a session, toggle fullscreen, adjust font size, verify OSC 52 clipboard copy still works, confirm "jump to latest" button surfaces when scrolled back

🤖 Generated with [Claude Code](https://claude.com/claude-code)