### PR TITLE
feat(web): enable tmux status bar in web terminal

### DIFF
--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -284,10 +284,10 @@ class TerminalManager {
       console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
     });
 
-    // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
+    // Enable the status bar for session context visibility
+    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "on"]);
     statusProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
+      console.error(`[MuxServer] Failed to enable status bar for ${tmuxSessionId}:`, err.message);
     });
 
     // Build environment


### PR DESCRIPTION
## What

Enables the tmux status bar in the web terminal. Currently it is explicitly forced off when a PTY attaches.

## Change

`packages/web/server/mux-websocket.ts` — `set-option status off` → `set-option status on`

One-line change, no new dependencies.

## Why

The status bar provides useful at-a-glance context — session name, window list, datetime — especially when working with multiple tmux sessions or sub-sessions. Both CLI and web terminal users benefit from seeing it.

Requested by @yyovil during SubSession design iteration.

## Testing

- No test file asserts on the tmux `set-option` value (the test suite for `mux-websocket.ts` covers `SessionBroadcaster`, not PTY setup)
- Verified no other files reference `status off` for tmux

Closes #1469