### PR TITLE
fix(core): prevent stale reaction dispatch on status oscillation

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1994,7 +1994,7 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     vi.mocked(mockSessionManager.send).mockClear();
 
-    // Second: conflicts resolved
+    // Second: conflicts resolved (first clear poll — debounce count = 1)
     getMergeabilityMock.mockResolvedValue({
       mergeable: true,
       ciPassing: true,
@@ -2005,10 +2005,12 @@ describe("reactions", () => {
     await lm.check("app-1");
     expect(mockSessionManager.send).not.toHaveBeenCalled();
 
+    // Third: still resolved (second clear poll — debounce count = 2 → flag cleared)
+    await lm.check("app-1");
     const metadata = readMetadataRaw(env.sessionsDir, "app-1");
     expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
 
-    // Third: conflicts recur — should re-dispatch
+    // Fourth: conflicts recur — should re-dispatch
     getMergeabilityMock.mockResolvedValue({
       mergeable: false,
       ciPassing: true,
@@ -2894,6 +2896,7 @@ describe("reaction tracker oscillation protection (#1409)", () => {
   const pr = makePR();
 
   it("does not re-dispatch CI failure on status oscillation (ci_failed → working → ci_failed)", async () => {
+    vi.useFakeTimers();
     config.reactions = {
       "ci-failed": {
         auto: true,
@@ -2983,6 +2986,7 @@ describe("reaction tracker oscillation protection (#1409)", () => {
   });
 
   it("does not re-dispatch merge conflicts when enrichment cache oscillates", async () => {
+    vi.useFakeTimers();
     config.reactions = {
       "merge-conflicts": {
         auto: true,
@@ -3067,6 +3071,7 @@ describe("reaction tracker oscillation protection (#1409)", () => {
   });
 
   it("re-dispatches merge conflicts after genuine resolution followed by new conflicts", async () => {
+    vi.useFakeTimers();
     config.reactions = {
       "merge-conflicts": {
         auto: true,

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -3034,7 +3034,10 @@ describe("reaction tracker oscillation protection (#1409)", () => {
 
     vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
 
-    const session = makeSession({ id: "s-osc-2", status: "working", pr });
+    // Start in pr_open — an eligible status for maybeDispatchMergeConflicts.
+    // The enrichment data (ciStatus: passing, reviewDecision: none, mergeable: false)
+    // keeps the session in pr_open across polls, so conflict checks always run.
+    const session = makeSession({ id: "s-osc-2", status: "pr_open", pr });
     vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
 
     const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
@@ -3120,7 +3123,8 @@ describe("reaction tracker oscillation protection (#1409)", () => {
 
     vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
 
-    const session = makeSession({ id: "s-osc-3", status: "working", pr });
+    // Start in pr_open — directly eligible for maybeDispatchMergeConflicts.
+    const session = makeSession({ id: "s-osc-3", status: "pr_open", pr });
     vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
 
     const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -3047,10 +3047,11 @@ describe("reaction tracker oscillation protection (#1409)", () => {
     );
     expect(firstCalls.length).toBe(1);
 
-    // Poll 2: enrichment says no conflicts — should NOT clear dispatch flag
+    // Poll 2: enrichment says no conflicts — should NOT clear dispatch flag (debounce)
     await vi.advanceTimersByTimeAsync(60_000);
 
     // Poll 3: enrichment says conflicts again — should NOT re-dispatch
+    // (flag wasn't cleared because debounce requires 2 consecutive clear polls)
     vi.mocked(mockSessionManager.send).mockClear();
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -3058,6 +3059,104 @@ describe("reaction tracker oscillation protection (#1409)", () => {
       (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
     );
     expect(reDispatchCalls.length).toBe(0);
+
+    lm.stop();
+  });
+
+  it("re-dispatches merge conflicts after genuine resolution followed by new conflicts", async () => {
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
+      },
+    };
+
+    const conflictEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "passing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: true,
+        },
+      ],
+    ]);
+
+    const noConflictEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "passing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: false,
+        },
+      ],
+    ]);
+
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: vi.fn()
+        // Poll 1: conflicts → dispatch
+        .mockResolvedValueOnce(conflictEnrichment)
+        // Poll 2: no conflicts → first clear (debounce count = 1)
+        .mockResolvedValueOnce(noConflictEnrichment)
+        // Poll 3: no conflicts → second clear (debounce count >= 2) → flag cleared
+        .mockResolvedValueOnce(noConflictEnrichment)
+        // Poll 4: new conflicts → should dispatch again
+        .mockResolvedValueOnce(conflictEnrichment)
+        // Poll 5: conflicts still — should NOT dispatch again
+        .mockResolvedValue(conflictEnrichment),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const session = makeSession({ id: "s-osc-3", status: "working", pr });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+
+    // Poll 1: conflicts detected → dispatch
+    await vi.advanceTimersByTimeAsync(0);
+    expect(
+      vi.mocked(mockSessionManager.send).mock.calls.filter(
+        (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
+      ).length,
+    ).toBe(1);
+
+    // Poll 2: no conflicts → debounce count = 1
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Poll 3: no conflicts → debounce count = 2 → flag cleared
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Poll 4: new conflicts → should dispatch again!
+    vi.mocked(mockSessionManager.send).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(
+      vi.mocked(mockSessionManager.send).mock.calls.filter(
+        (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
+      ).length,
+    ).toBe(1);
+
+    // Poll 5: conflicts persist → should NOT dispatch again
+    vi.mocked(mockSessionManager.send).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(
+      vi.mocked(mockSessionManager.send).mock.calls.filter(
+        (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
+      ).length,
+    ).toBe(0);
 
     lm.stop();
   });

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2889,3 +2889,176 @@ describe("auto-cleanup on merge (#1309)", () => {
     expect(meta?.["mergedPendingCleanupSince"]).toMatch(/\d{4}-\d{2}-\d{2}T/);
   });
 });
+
+describe("reaction tracker oscillation protection (#1409)", () => {
+  const pr = makePR();
+
+  it("does not re-dispatch CI failure on status oscillation (ci_failed → working → ci_failed)", async () => {
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 2,
+        message: "CI is failing on your PR. Run `gh pr checks` to see the failures, fix them, and push.",
+      },
+    };
+
+    // Enrichment data that says CI is failing — simulates stale cache
+    const failingEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "failing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: false,
+          ciChecks: [
+            { name: "lint", status: "failed" as const, conclusion: "FAILURE" },
+          ],
+        },
+      ],
+    ]);
+
+    // Enrichment data that says CI is passing — simulates oscillation
+    const passingEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "passing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: false,
+        },
+      ],
+    ]);
+
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: vi.fn()
+        .mockResolvedValueOnce(failingEnrichment)
+        .mockResolvedValueOnce(passingEnrichment)
+        .mockResolvedValue(failingEnrichment),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    // Start with pr_open so first poll triggers ci_failed
+    const session = makeSession({ id: "s-osc-1", status: "pr_open", pr });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+
+    // Poll 1: pr_open → ci_failed — dispatches CI failure reaction
+    await vi.advanceTimersByTimeAsync(0);
+    const firstDispatchCount = vi.mocked(mockSessionManager.send).mock.calls.length;
+    expect(firstDispatchCount).toBeGreaterThanOrEqual(1);
+
+    // Poll 2: ci_failed → working (stale cache says passing) — should NOT re-dispatch on next failure
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Poll 3: working → ci_failed (stale cache flips back) — should NOT dispatch again,
+    // because the tracker was preserved across oscillation and retries budget is consumed
+    vi.mocked(mockSessionManager.send).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // The transition reaction fires once per oscillation but should hit the retry limit.
+    // The key assertion: no additional CI failure details should be dispatched.
+    const sendCalls = vi.mocked(mockSessionManager.send).mock.calls;
+    const ciFailureMessages = sendCalls.filter(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("CI is failing"),
+    );
+    // Should not dispatch the detailed follow-up on every oscillation
+    // (the transition reaction at most fires retries+1 times total)
+    expect(ciFailureMessages.length).toBeLessThanOrEqual(1);
+
+    lm.stop();
+  });
+
+  it("does not re-dispatch merge conflicts when enrichment cache oscillates", async () => {
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Your branch has merge conflicts. Rebase on the default branch and resolve them.",
+      },
+    };
+
+    // Enrichment that says conflicts exist
+    const conflictEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "passing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: true,
+        },
+      ],
+    ]);
+
+    // Enrichment that says no conflicts
+    const noConflictEnrichment = new Map([
+      [
+        `${pr.owner}/${pr.repo}#${pr.number}`,
+        {
+          state: "open" as const,
+          ciStatus: "passing" as const,
+          reviewDecision: "none" as const,
+          mergeable: false,
+          hasConflicts: false,
+        },
+      ],
+    ]);
+
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: vi.fn()
+        .mockResolvedValueOnce(conflictEnrichment)
+        .mockResolvedValueOnce(noConflictEnrichment)
+        .mockResolvedValue(conflictEnrichment),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const session = makeSession({ id: "s-osc-2", status: "working", pr });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+
+    // Poll 1: dispatches merge conflict
+    await vi.advanceTimersByTimeAsync(0);
+    const firstCalls = vi.mocked(mockSessionManager.send).mock.calls.filter(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
+    );
+    expect(firstCalls.length).toBe(1);
+
+    // Poll 2: enrichment says no conflicts — should NOT clear dispatch flag
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    // Poll 3: enrichment says conflicts again — should NOT re-dispatch
+    vi.mocked(mockSessionManager.send).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    const reDispatchCalls = vi.mocked(mockSessionManager.send).mock.calls.filter(
+      (c) => typeof c[1] === "string" && (c[1] as string).includes("merge conflicts"),
+    );
+    expect(reDispatchCalls.length).toBe(0);
+
+    lm.stop();
+  });
+});

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -316,6 +316,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+  // Reaction keys that survive status transitions — their trackers are not cleared
+  // on exit to prevent stale prEnrichmentCache oscillation from resetting retry budgets.
+  const persistentReactionKeys = new Set(["ci-failed", "merge-conflicts"]);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -1745,11 +1748,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // that are genuinely resolved, not for conditions that may be stale-cached.
       // CI failure and merge conflict trackers survive oscillation so the retry
       // budget is not reset when stale prEnrichmentCache causes status to flap.
-      const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
       const oldEventType = statusToEventType(undefined, oldStatus);
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
-        if (oldReactionKey && !PERSISTENT_REACTION_KEYS.has(oldReactionKey)) {
+        if (oldReactionKey && !persistentReactionKeys.has(oldReactionKey)) {
           clearReactionTracker(session.id, oldReactionKey);
         }
       }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1332,10 +1332,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     // Only dispatch CI details when in ci_failed state
     if (newStatus !== "ci_failed") {
-      // CI is no longer failing — clear tracking so next failure is dispatched fresh
+      // CI is no longer failing — but don't clear the reaction tracker here.
+      // The transition handler already protects against clearing ci-failed
+      // trackers on oscillation (stale cache flapping). Only clear fingerprint
+      // metadata so stale data doesn't pollute the next genuine failure.
       const lastFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
       if (lastFingerprint) {
-        clearReactionTracker(session.id, ciReactionKey);
         updateSessionMetadata(session, {
           lastCIFailureFingerprint: "",
           lastCIFailureDispatchHash: "",
@@ -1527,11 +1529,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
       }
     } else if (lastDispatched === "true") {
-      // Conflicts resolved — clear so we can re-dispatch if they recur
-      clearReactionTracker(session.id, conflictReactionKey);
-      updateSessionMetadata(session, {
-        lastMergeConflictDispatched: "",
-      });
+      // Conflicts appear resolved — but only clear tracking if we have
+      // authoritative data (live API call), not stale batch enrichment.
+      // Batch enrichment data can oscillate, causing repeated dispatch cycles.
+      if (!cachedData) {
+        clearReactionTracker(session.id, conflictReactionKey);
+        updateSessionMetadata(session, {
+          lastMergeConflictDispatched: "",
+        });
+      }
     }
   }
 
@@ -1726,11 +1732,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         allCompleteEmitted = false;
       }
 
-      // Clear reaction trackers for the old status so retries reset on state changes
+      // Clear reaction trackers for the old status — but only for reactions
+      // that are genuinely resolved, not for conditions that may be stale-cached.
+      // CI failure and merge conflict trackers survive oscillation so the retry
+      // budget is not reset when stale prEnrichmentCache causes status to flap.
+      const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
       const oldEventType = statusToEventType(undefined, oldStatus);
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
-        if (oldReactionKey) {
+        if (oldReactionKey && !PERSISTENT_REACTION_KEYS.has(oldReactionKey)) {
           clearReactionTracker(session.id, oldReactionKey);
         }
       }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1457,6 +1457,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       clearReactionTracker(session.id, conflictReactionKey);
       updateSessionMetadata(session, {
         lastMergeConflictDispatched: "",
+        conflictClearCount: "0",
       });
       return;
     }
@@ -1495,8 +1496,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     const lastDispatched = session.metadata["lastMergeConflictDispatched"] ?? "";
+    const conflictClearCount = parseInt(session.metadata["conflictClearCount"] ?? "0", 10);
 
     if (hasConflicts) {
+      // Conflicts detected — reset clear counter since they're still present
+      if (conflictClearCount > 0) {
+        updateSessionMetadata(session, { conflictClearCount: "0" });
+      }
       // Already dispatched for current conflict state — skip
       if (lastDispatched === "true") return;
 
@@ -1529,14 +1535,17 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
       }
     } else if (lastDispatched === "true") {
-      // Conflicts appear resolved — but only clear tracking if we have
-      // authoritative data (live API call), not stale batch enrichment.
-      // Batch enrichment data can oscillate, causing repeated dispatch cycles.
-      if (!cachedData) {
+      // No conflicts detected — require 2 consecutive clear polls before clearing
+      // the dispatch flag. This debounces against single-cycle stale cache oscillation
+      // while still allowing genuine conflict resolution to clear through.
+      if (conflictClearCount >= 1) {
         clearReactionTracker(session.id, conflictReactionKey);
         updateSessionMetadata(session, {
           lastMergeConflictDispatched: "",
+          conflictClearCount: "0",
         });
+      } else {
+        updateSessionMetadata(session, { conflictClearCount: String(conflictClearCount + 1) });
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #1409

When `prEnrichmentCache` returns stale data that oscillates between CI failing/passing or conflicts/no-conflicts, the lifecycle manager was re-dispatching CI failure and merge conflict messages to agent sessions infinitely. The agent would dismiss them as "stale orchestrator noise" but they kept coming every 5 seconds.

## Root cause

Three reinforcing problems:

1. **Transition handler clears reaction trackers on status exit** (line ~1729): When status oscillates `ci_failed → working → ci_failed`, the `ci-failed` tracker is cleared on exit, creating a fresh tracker with `attempts: 0` on re-entry — resetting the retry budget every cycle.

2. **`maybeDispatchCIFailureDetails` clears tracker when leaving `ci_failed`** (line ~1338): Double-clears the tracker from a different code path, same effect.

3. **`maybeDispatchMergeConflicts` clears `lastMergeConflictDispatched` based on stale batch data** (line ~1531): When enrichment cache flips to `hasConflicts: false`, it clears the dedup flag. Next cycle when cache flips back to `hasConflicts: true`, the flag is gone and it dispatches again.

## Changes

| File | Change |
|---|---|
| `lifecycle-manager.ts` | Transition handler: skip clearing `ci-failed` and `merge-conflicts` trackers on status exit |
| `lifecycle-manager.ts` | `maybeDispatchCIFailureDetails`: clear fingerprint metadata but preserve tracker when leaving `ci_failed` |
| `lifecycle-manager.ts` | `maybeDispatchMergeConflicts`: only clear dispatch flag when mergeability is from live API call, not stale batch enrichment |
| `lifecycle-manager.test.ts` | 2 new tests: CI failure oscillation and merge conflict oscillation |

## Test plan

- [x] New tests cover both oscillation scenarios
- [ ] Existing lifecycle tests pass (`pnpm --filter @aoagents/ao-core test`)
- [ ] Manual verification: run a session with stale CI data, confirm no repeated dispatch

## Relationship to #1347

This is the companion fix to PR #1347 (issue #1290). That PR fixes the "CI signal never reaches dead sessions" gap in the webhook path. This PR fixes the "CI signal won't stop reaching live sessions" gap in the lifecycle polling path. Together they ensure CI signals are delivered exactly once to the right session.