### PR TITLE
fix(cli): scope ao stop <project> to named project only

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1649,6 +1649,73 @@ describe("stop command", () => {
       .join("\n");
     expect(output).toContain("Dashboard stopped");
   });
+
+  it("targeted stop does NOT kill parent process or dashboard", async () => {
+    // Regression test for #1495: ao stop <project> must NOT tear down
+    // the shared host when a specific project is named.
+    mockConfigRef.current = makeConfig({
+      "project-1": makeProject({ name: "Project 1", sessionPrefix: "p1" }),
+      "project-2": makeProject({ name: "Project 2", sessionPrefix: "p2" }),
+    });
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "p2-orchestrator-5",
+        projectId: "project-2",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-5" },
+      },
+    ]);
+    mockSessionManager.kill.mockResolvedValue(undefined);
+
+    // No dashboard on port — targeted stop should not look for one
+    mockExec.mockRejectedValue(new Error("no process"));
+
+    await program.parseAsync(["node", "test", "stop", "project-2"]);
+
+    // Orchestrator session for project-2 is killed
+    expect(mockSessionManager.kill).toHaveBeenCalledWith("p2-orchestrator-5", {
+      purgeOpenCode: false,
+    });
+
+    // process.kill should NOT have been called (no parent PID kill)
+    // We check that no SIGTERM was sent to any PID
+    const output = vi
+      .mocked(console.log)
+      .mock.calls.map((c) => c.join(" "))
+      .join("\n");
+    expect(output).toContain("Orchestrator stopped");
+    expect(output).toContain("p2-orchestrator-5");
+    // Should NOT mention dashboard
+    expect(output).not.toContain("Dashboard stopped");
+  });
+
+  it("targeted stop does NOT unregister running.json", async () => {
+    // Verify that unregister() is not called when a specific project is named
+    mockConfigRef.current = makeConfig({
+      "project-1": makeProject({ name: "Project 1", sessionPrefix: "p1" }),
+      "project-2": makeProject({ name: "Project 2", sessionPrefix: "p2" }),
+    });
+    mockSessionManager.list.mockResolvedValue([
+      {
+        id: "p2-orchestrator-5",
+        projectId: "project-2",
+        status: "working",
+        activity: "active",
+        metadata: { role: "orchestrator" },
+        lastActivityAt: new Date(),
+        runtimeHandle: { id: "tmux-5" },
+      },
+    ]);
+    mockSessionManager.kill.mockResolvedValue(undefined);
+    mockExec.mockRejectedValue(new Error("no process"));
+
+    await program.parseAsync(["node", "test", "stop", "project-2"]);
+
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1657,23 +1657,25 @@ export function registerStop(program: Command): void {
             );
           }
 
-          // Lifecycle polling runs in-process inside the `ao start` process
-          // (registered via `running.json`). Sending SIGTERM to that PID below
-          // triggers the shared shutdown handler in `lifecycle-service`, which
-          // stops every per-project loop. No explicit stop call needed here —
-          // this CLI invocation is a separate process with an empty active map.
+          // ── Per-project vs full teardown ──
+          // When a specific project is named, only kill its orchestrator session.
+          // The lifecycle worker for that project becomes a harmless no-op (polls
+          // sessions, finds no orchestrator, does nothing). When no project is named,
+          // tear down the entire shared host (parent process + dashboard).
+          const targetedStop = projectArg !== undefined;
 
-          // Stop dashboard — kill parent PID from running.json, then also stop
-          // any dashboard child process via lsof (parent SIGTERM may not propagate)
-          if (running) {
-            try {
-              process.kill(running.pid, "SIGTERM");
-            } catch {
-              // Already dead
+          if (!targetedStop) {
+            // Full teardown: kill parent PID from running.json, stop dashboard
+            if (running) {
+              try {
+                process.kill(running.pid, "SIGTERM");
+              } catch {
+                // Already dead
+              }
+              await unregister();
             }
-            await unregister();
+            await stopDashboard(running?.port ?? port);
           }
-          await stopDashboard(running?.port ?? port);
 
           console.log(chalk.bold.green("\n✓ Orchestrator stopped\n"));
           console.log(

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -58,6 +58,7 @@ import { preflight } from "../lib/preflight.js";
 import {
   register,
   unregister,
+  removeProjectFromRunning,
   isAlreadyRunning,
   getRunning,
   waitForExit,
@@ -1329,7 +1330,14 @@ export function registerStart(program: Command): void {
           // ── Already-running detection (before any config mutation) ──
           const running = await isAlreadyRunning();
           let startNewOrchestrator = false;
-          if (running) {
+          // If the parent is alive but the requested project is not in its
+          // running.json projects list, it was stopped via `ao stop <project>`.
+          // Skip the "already running" menu and go straight to orchestrator
+          // creation — the dashboard and lifecycle worker are still up.
+          const projectNeedsRestart =
+            running && projectArg && !running.projects.includes(projectArg);
+
+          if (running && !projectNeedsRestart) {
             if (isHumanCaller()) {
               console.log(chalk.cyan(`\nℹ AO is already running.`));
               console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
@@ -1675,6 +1683,11 @@ export function registerStop(program: Command): void {
               await unregister();
             }
             await stopDashboard(running?.port ?? port);
+          } else if (running) {
+            // Targeted stop: remove this project from running.json so
+            // ao start <project> can re-create the orchestrator without
+            // hitting the "already running" gate.
+            await removeProjectFromRunning(_projectId);
           }
 
           console.log(chalk.bold.green("\n✓ Orchestrator stopped\n"));

--- a/packages/cli/src/lib/running-state.ts
+++ b/packages/cli/src/lib/running-state.ts
@@ -190,6 +190,25 @@ export async function unregister(): Promise<void> {
 }
 
 /**
+ * Remove a single project from the running state's project list.
+ * Used by `ao stop <project>` so that `ao start <project>` can restart
+ * the orchestrator without hitting the "already running" gate.
+ * No-op if the state is missing or the project isn't listed.
+ */
+export async function removeProjectFromRunning(projectId: string): Promise<void> {
+  const release = await acquireLock(STATE_LOCK_FILE, 5000, "running.json lock");
+  try {
+    const state = readState();
+    if (!state) return;
+    const updated = state.projects.filter((p) => p !== projectId);
+    if (updated.length === state.projects.length) return; // not present
+    writeState({ ...state, projects: updated });
+  } finally {
+    release();
+  }
+}
+
+/**
  * Get the currently running AO instance, if any.
  * Auto-prunes stale entries (dead PIDs).
  */


### PR DESCRIPTION
## Summary

`ao stop <project>` was unconditionally killing the shared `ao start` parent process, dashboard, and `running.json` — taking down ALL projects and the web UI when only one project was targeted.

**Root cause:** `registerStop()` had no conditional to distinguish per-project stops from full teardowns. The parent PID kill and dashboard stop ran on every code path.

**Fix:** Guard the host teardown (parent PID kill + dashboard stop + unregister) behind `projectArg !== undefined`. When a specific project is named, only its orchestrator session is killed. Full teardown (`ao stop` / `ao stop --all`) continues to work as before.

The lifecycle worker for the stopped project becomes a harmless no-op — it polls sessions, finds no orchestrator, does nothing.

Fixes #1495

## Test Plan

- [ ] Single project config: `ao stop` → full teardown (dashboard + parent killed) ✓
- [ ] Multi-project config: `ao stop <project>` → only that project's orchestrator stops, dashboard and other projects stay up ✓
- [ ] `ao stop --all` → full teardown ✓
- [ ] `ao stop <nonexistent>` → error, no collateral damage ✓