### PR TITLE
fix(web): pin Next.js workspace root to silence startup warning

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -1,5 +1,11 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: [
     "@aoagents/ao-core",
     "@aoagents/ao-plugin-agent-claude-code",


### PR DESCRIPTION
## Problem

Starting the AO dashboard in foreground mode prints a Next.js workspace-root inference warning when another lockfile exists above the repository checkout:

```
⚠ Warning: Next.js inferred your workspace root, but it may not be correct.
We detected multiple lockfiles and selected the directory of ~/package-lock.json as the root directory.
```

## Fix

Add `outputFileTracingRoot` to `packages/web/next.config.js`, pointing it at the monorepo root via `path.join(__dirname, "../..")`. This is the canonical Next.js solution — it tells Next.js exactly which directory is the workspace root, bypassing the heuristic that triggers when it finds lockfiles in parent directories.

## Changes

- `packages/web/next.config.js`: Added `import path` + `import { fileURLToPath }` + `outputFileTracingRoot: path.join(__dirname, "../..")` to the config object.

## Testing

- Config resolves correctly: `outputFileTracingRoot` → `/path/to/agent-orchestrator` (repo root containing `pnpm-lock.yaml`)
- Could not run `agent-ci` locally — `aoagent` user lacks Docker group membership (`EACCES /var/run/docker.sock`). CI will validate.
- Change is a pure config addition with no code logic changes.

Closes #1492