### PR TITLE
fix(core): preserve reaction tracker across status oscillation

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2759,11 +2759,12 @@ describe("reactions", () => {
       expect.objectContaining({ type: "reaction.escalated" }),
     );
 
-    // After escalation, tracker is cleared — new CI failure starts fresh
+    // After escalation, tracker is marked escalated — needs 2 stable passing polls to clear
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ ciStatus: "passing" }),
     );
-    await lm.check("app-1");
+    await lm.check("app-1"); // stableCount = 1
+    await lm.check("app-1"); // stableCount = 2 → clearReactionTracker
     vi.mocked(mockSessionManager.send).mockClear();
     vi.mocked(notifier.notify).mockClear();
 
@@ -2905,7 +2906,10 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
   });
 
-  it("CI escalation clears tracker — next CI failure gets fresh budget", async () => {
+  it("CI escalation silences further dispatches — clears only after stable CI pass", async () => {
+    // retries:1 → attempt 1 sends, attempt 2 escalates.
+    // After escalation: tracker.escalated=true silences subsequent oscillations.
+    // Tracker clears only after 2 consecutive passing polls; then next failure gets fresh budget.
     const notifier = createMockNotifier();
 
     config.reactions = {
@@ -2946,13 +2950,13 @@ describe("reactions", () => {
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     vi.mocked(mockSessionManager.send).mockClear();
 
-    // CI passes briefly
+    // CI passes briefly (ci_failed → pr_open, stableCount = 1)
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ ciStatus: "passing" }),
     );
     await lm.check("app-1");
 
-    // Oscillation 2: ci_failed (attempt 2 > retries:1 — escalate)
+    // Oscillation 2: pr_open → ci_failed (attempt 2 > retries:1 — escalate, tracker.escalated = true)
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ ciStatus: "failing" }),
     );
@@ -2961,25 +2965,98 @@ describe("reactions", () => {
     expect(notifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "reaction.escalated" }),
     );
+    vi.mocked(notifier.notify).mockClear();
 
-    // After escalation, tracker is cleared — next CI failure is a fresh incident
+    // CI passes once (stableCount = 1 — not enough to clear yet)
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ ciStatus: "passing" }),
     );
     await lm.check("app-1");
-    vi.mocked(mockSessionManager.send).mockClear();
-    vi.mocked(notifier.notify).mockClear();
 
+    // Oscillation 3: pr_open → ci_failed — escalated tracker short-circuits, NO dispatch
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ ciStatus: "failing" }),
     );
     await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+    vi.mocked(mockSessionManager.send).mockClear();
+    vi.mocked(notifier.notify).mockClear();
 
-    // Fresh budget — sends to agent (attempt 1 again), not escalate
+    // CI passes twice stably (stableCount → 1 → 2 → tracker cleared)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1"); // stableCount = 1
+    await lm.check("app-1"); // stableCount = 2 → clearReactionTracker
+
+    // Oscillation 4: pr_open → ci_failed — fresh budget: attempt 1, sends (not escalate)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    await lm.check("app-1");
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     expect(notifier.notify).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "reaction.escalated" }),
     );
+  });
+
+  it("single passing poll does not reset escalated ci-failed tracker", async () => {
+    // Regression: one passing poll must NOT clear the tracker. Requires 2 consecutive passing polls.
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing.",
+        retries: 1,
+        escalateAfter: 1,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ ciStatus: "failing" });
+    const mockSCM = createMockSCM({ enrichSessionsPRBatch: batchMock });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // Reach escalated state: attempt 1 → send, attempt 2 → escalate
+    await lm.check("app-1"); // pr_open → ci_failed: attempt 1, send
+    vi.mocked(mockSessionManager.send).mockClear();
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "passing" }));
+    await lm.check("app-1"); // ci_failed → pr_open
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1"); // pr_open → ci_failed: attempt 2 → escalate
+    expect(notifier.notify).toHaveBeenCalledWith(expect.objectContaining({ type: "reaction.escalated" }));
+    vi.mocked(notifier.notify).mockClear();
+
+    // ONE passing poll (stableCount = 1, not enough)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "passing" }));
+    await lm.check("app-1");
+
+    // Next CI failure: tracker still escalated → short-circuit
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(notifier.notify).not.toHaveBeenCalledWith(expect.objectContaining({ type: "reaction.escalated" }));
   });
 
   it("merge-conflict notify action preserves warning priority", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2758,11 +2758,28 @@ describe("reactions", () => {
     expect(notifier.notify).toHaveBeenCalledWith(
       expect.objectContaining({ type: "reaction.escalated" }),
     );
+
+    // After escalation, tracker is cleared — new CI failure starts fresh
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1");
+    vi.mocked(mockSessionManager.send).mockClear();
+    vi.mocked(notifier.notify).mockClear();
+
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    await lm.check("app-1");
+
+    // Fresh budget — sends to agent (attempt 1 again), not escalate
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
   });
 
-  it("merge conflict tracker accumulates across oscillations and escalates after time window", async () => {
-    vi.useFakeTimers();
-
+  it("merge conflict tracker resets on resolve — recurrence gets fresh budget", async () => {
     const notifier = createMockNotifier();
 
     config.reactions = {
@@ -2770,7 +2787,8 @@ describe("reactions", () => {
         auto: true,
         action: "send-to-agent",
         message: "Resolve merge conflicts.",
-        escalateAfter: "1s",
+        retries: 1,
+        escalateAfter: 1,
       },
     };
 
@@ -2797,41 +2815,31 @@ describe("reactions", () => {
       registry,
     });
 
-    try {
-      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+    // First conflict — dispatched to agent (attempt 1)
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
 
-      // First conflict — dispatched to agent (attempt 1)
-      await lm.check("app-1");
-      expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
-      vi.mocked(mockSessionManager.send).mockClear();
+    // Conflicts resolve — tracker clears (incident boundary)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ hasConflicts: false }),
+    );
+    await lm.check("app-1");
+    const metadata = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
 
-      // Conflicts resolve — dedup flag cleared, tracker preserved
-      vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
-        mockBatchEnrichment({ hasConflicts: false }),
-      );
-      await lm.check("app-1");
-      const metadata = readMetadataRaw(env.sessionsDir, "app-1");
-      expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
+    // Conflicts recur — fresh tracker (attempt 1 again, not 2)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ hasConflicts: true }),
+    );
+    vi.mocked(notifier.notify).mockClear();
+    await lm.check("app-1");
 
-      // Advance time past escalateAfter window
-      vi.setSystemTime(new Date("2025-01-01T12:00:02.000Z"));
-
-      // Conflicts recur — tracker exists with firstTriggered from 2s ago > 1s escalateAfter
-      vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
-        mockBatchEnrichment({ hasConflicts: true }),
-      );
-      vi.mocked(notifier.notify).mockClear();
-      await lm.check("app-1");
-
-      // Should escalate to human, not send to agent
-      expect(mockSessionManager.send).not.toHaveBeenCalled();
-      expect(notifier.notify).toHaveBeenCalledWith(
-        expect.objectContaining({ type: "reaction.escalated" }),
-      );
-    } finally {
-      lm.stop();
-      vi.useRealTimers();
-    }
+    // Fresh budget — sends to agent (attempt 1), not escalate
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
   });
 
   it("non-persistent reaction keys still clear on status exit", async () => {
@@ -2895,6 +2903,132 @@ describe("reactions", () => {
     // With retries:1, attempt 2 would escalate. But tracker was cleared,
     // so this is attempt 1 again — still sends to agent.
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("CI escalation clears tracker — next CI failure gets fresh budget", async () => {
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing. Fix it.",
+        retries: 1,
+        escalateAfter: 1,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ ciStatus: "failing" });
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: batchMock,
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // Oscillation 1: pr_open → ci_failed (attempt 1 — send to agent)
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // CI passes briefly
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1");
+
+    // Oscillation 2: ci_failed (attempt 2 > retries:1 — escalate)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+
+    // After escalation, tracker is cleared — next CI failure is a fresh incident
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1");
+    vi.mocked(mockSessionManager.send).mockClear();
+    vi.mocked(notifier.notify).mockClear();
+
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    await lm.check("app-1");
+
+    // Fresh budget — sends to agent (attempt 1 again), not escalate
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+  });
+
+  it("merge-conflict notify action preserves warning priority", async () => {
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "notify",
+      },
+    };
+    config.notificationRouting = {
+      urgent: ["desktop"],
+      action: ["desktop"],
+      warning: ["desktop"],
+      info: [],
+    };
+
+    const batchMock = mockBatchEnrichment({ hasConflicts: true });
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: batchMock,
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    // With info routing empty and warning routing to desktop,
+    // notify should fire at "warning" priority (not "info")
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "reaction.triggered",
+        priority: "warning",
+      }),
+    );
   });
 });
 

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2680,6 +2680,222 @@ describe("reactions", () => {
     );
     expect(alertsNotifier.notify).not.toHaveBeenCalled();
   });
+
+  it("CI failure tracker survives status oscillation and escalates after retries", async () => {
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing. Fix it.",
+        retries: 2,
+        escalateAfter: 2,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ ciStatus: "failing" });
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: batchMock,
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // Oscillation 1: pr_open → ci_failed (attempt 1 — send to agent)
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // CI starts passing → ci_failed → pr_open (tracker survives)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("pr_open");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+
+    // Oscillation 2: pr_open → ci_failed (attempt 2 — send to agent)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("ci_failed");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // CI passes again
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing" }),
+    );
+    await lm.check("app-1");
+
+    // Oscillation 3: pr_open → ci_failed (attempt 3 > retries:2 — escalate)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "failing" }),
+    );
+    vi.mocked(notifier.notify).mockClear();
+    await lm.check("app-1");
+
+    // Should NOT send to agent — should escalate to human
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(notifier.notify).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+  });
+
+  it("merge conflict tracker accumulates across oscillations and escalates after time window", async () => {
+    vi.useFakeTimers();
+
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Resolve merge conflicts.",
+        escalateAfter: "1s",
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ hasConflicts: true });
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: batchMock,
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    try {
+      vi.setSystemTime(new Date("2025-01-01T12:00:00.000Z"));
+
+      // First conflict — dispatched to agent (attempt 1)
+      await lm.check("app-1");
+      expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+      vi.mocked(mockSessionManager.send).mockClear();
+
+      // Conflicts resolve — dedup flag cleared, tracker preserved
+      vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+        mockBatchEnrichment({ hasConflicts: false }),
+      );
+      await lm.check("app-1");
+      const metadata = readMetadataRaw(env.sessionsDir, "app-1");
+      expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
+
+      // Advance time past escalateAfter window
+      vi.setSystemTime(new Date("2025-01-01T12:00:02.000Z"));
+
+      // Conflicts recur — tracker exists with firstTriggered from 2s ago > 1s escalateAfter
+      vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+        mockBatchEnrichment({ hasConflicts: true }),
+      );
+      vi.mocked(notifier.notify).mockClear();
+      await lm.check("app-1");
+
+      // Should escalate to human, not send to agent
+      expect(mockSessionManager.send).not.toHaveBeenCalled();
+      expect(notifier.notify).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "reaction.escalated" }),
+      );
+    } finally {
+      lm.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it("non-persistent reaction keys still clear on status exit", async () => {
+    config.reactions = {
+      "changes-requested": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Address review comments.",
+        retries: 1,
+        escalateAfter: 1,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ reviewDecision: "changes_requested" });
+    const mockSCM = createMockSCM({
+      enrichSessionsPRBatch: batchMock,
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // Transition to changes_requested (attempt 1 — send to agent)
+    await lm.check("app-1");
+    expect(lm.getStates().get("app-1")).toBe("changes_requested");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // Transition away — tracker clears (non-persistent key)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing", reviewDecision: "none" }),
+    );
+    await lm.check("app-1");
+
+    // Transition back — fresh tracker (attempt 1 again, NOT 2)
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ reviewDecision: "changes_requested" }),
+    );
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+
+    // Transition away and back again — still attempt 1, not escalating
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ ciStatus: "passing", reviewDecision: "none" }),
+    );
+    await lm.check("app-1");
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
+      mockBatchEnrichment({ reviewDecision: "changes_requested" }),
+    );
+    await lm.check("app-1");
+    // With retries:1, attempt 2 would escalate. But tracker was cleared,
+    // so this is attempt 1 again — still sends to agent.
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("pollAll terminal status accounting", () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -3059,6 +3059,131 @@ describe("reactions", () => {
     expect(notifier.notify).not.toHaveBeenCalledWith(expect.objectContaining({ type: "reaction.escalated" }));
   });
 
+  it("pending CI does not count toward ci-failed tracker resolution", async () => {
+    // Regression: real CI goes failing → pending (new run started) → failing.
+    // "pending" must NOT count as resolution — only "passing" does.
+    // Without this, 2 pending polls between failures wipe the tracker and we're back at #1409.
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing.",
+        retries: 2,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ ciStatus: "failing" });
+    const mockSCM = createMockSCM({ enrichSessionsPRBatch: batchMock });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // CI failing: pr_open → ci_failed, attempt 1 — send
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // CI goes pending (agent pushed a fix, new run started): ci_failed → pr_open
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "pending" }));
+    await lm.check("app-1"); // stableCount must NOT increment
+    await lm.check("app-1"); // two pending polls — must NOT clear tracker
+
+    // CI fails again (run completed failing): pr_open → ci_failed, attempt 2 — send
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1");
+    // If pending had wrongly cleared the tracker, this would be attempt 1 (fresh), not attempt 2.
+    // Attempt 2 ≤ retries:2 → sends to agent (not escalates)
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    vi.mocked(mockSessionManager.send).mockClear();
+
+    // CI goes pending again, then failing — attempt 3 > retries:2 → escalate
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "pending" }));
+    await lm.check("app-1"); // pending: no clear
+    await lm.check("app-1"); // pending: no clear
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled(); // escalated, not sent to agent
+  });
+
+  it("only passing CI resets ci-failed tracker — pending mid-run does not interfere", async () => {
+    // Complementary to previous: failing → pending(many) → passing(2) → failing SHOULD clear.
+    // Pending during CI run doesn't block resolution; only the final passing state matters.
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI is failing.",
+        retries: 1,
+        escalateAfter: 1,
+      },
+    };
+
+    const batchMock = mockBatchEnrichment({ ciStatus: "failing" });
+    const mockSCM = createMockSCM({ enrichSessionsPRBatch: batchMock });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    // Reach escalated state: attempt 1 → send, attempt 2 → escalate
+    await lm.check("app-1"); // attempt 1, send
+    vi.mocked(mockSessionManager.send).mockClear();
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "passing" }));
+    await lm.check("app-1"); // ci_failed → pr_open
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1"); // attempt 2 → escalate
+    vi.mocked(notifier.notify).mockClear();
+
+    // CI goes pending (new run) — stableCount stays 0, does NOT progress toward resolution
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "pending" }));
+    await lm.check("app-1");
+    await lm.check("app-1");
+    await lm.check("app-1"); // many pending polls — stableCount never reaches threshold
+
+    // CI finally passes (2 stable polls) → tracker cleared
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "passing" }));
+    await lm.check("app-1"); // stableCount = 1
+    await lm.check("app-1"); // stableCount = 2 → clearReactionTracker
+
+    // Next CI failure gets fresh budget: attempt 1, send
+    vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(mockBatchEnrichment({ ciStatus: "failing" }));
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+  });
+
   it("merge-conflict notify action preserves warning priority", async () => {
     const notifier = createMockNotifier();
 

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -92,6 +92,11 @@ function parseDuration(str: string): number {
   }
 }
 
+/** Reaction keys for conditions that can oscillate (e.g. CI failing→pending→failing).
+ *  Their trackers survive status exit so the escalation budget accumulates
+ *  across oscillations instead of resetting to zero each time. */
+const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
+
 type WorkspaceBranchProbe =
   | { kind: "branch"; branch: string }
   | { kind: "detached" }
@@ -394,11 +399,6 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
-
-  /** Reaction keys for conditions that can oscillate (e.g. CI failing→pending→failing).
-   *  Their trackers survive status exit so the escalation budget accumulates
-   *  across oscillations instead of resetting to zero each time. */
-  const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -1657,7 +1657,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         (reactionConfig.auto !== false || reactionConfig.action === "notify")
       ) {
         try {
-          // Build enriched config with dynamic base branch message
+          // Build enriched config with dynamic base branch message.
+          // Note: executeReaction's notify path defaults to "info" priority (was "warning"
+          // in the old direct-dispatch code). Users who set action:"notify" for merge-conflicts
+          // should set priority:"warning" explicitly in their config if needed.
           const enrichedConfig = { ...reactionConfig };
           if (reactionConfig.action === "send-to-agent" && !reactionConfig.message) {
             const baseBranch = session.pr.baseBranch ?? "the default branch";

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -94,8 +94,11 @@ function parseDuration(str: string): number {
 
 /** Reaction keys for conditions that can oscillate (e.g. CI failing→pending→failing).
  *  Their trackers survive status exit so the escalation budget accumulates
- *  across oscillations instead of resetting to zero each time. */
-const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
+ *  across oscillations instead of resetting to zero each time.
+ *  Note: "merge-conflicts" is NOT here — statusToEventType never emits
+ *  "merge.conflicts", so the transition handler at line ~1892 can't reach it.
+ *  Merge-conflict tracker lifecycle is managed in maybeDispatchMergeConflicts. */
+const PERSISTENT_REACTION_KEYS = new Set(["ci-failed"]);
 
 type WorkspaceBranchProbe =
   | { kind: "branch"; branch: string }
@@ -1201,6 +1204,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         data: { reactionKey, attempts: tracker.attempts },
       });
       await notifyHuman(event, reactionConfig.priority ?? "urgent");
+
+      // Clear the tracker so future incidents get a fresh budget.
+      // Without this, long-lived sessions that escalated once would
+      // immediately escalate on every future occurrence of the condition.
+      reactionTrackers.delete(trackerKey);
+
       return {
         reactionType: reactionKey,
         success: true,
@@ -1658,10 +1667,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       ) {
         try {
           // Build enriched config with dynamic base branch message.
-          // Note: executeReaction's notify path defaults to "info" priority (was "warning"
-          // in the old direct-dispatch code). Users who set action:"notify" for merge-conflicts
-          // should set priority:"warning" explicitly in their config if needed.
-          const enrichedConfig = { ...reactionConfig };
+          // Preserve "warning" priority from old direct-dispatch code unless
+          // the user explicitly set a different priority in their config.
+          const enrichedConfig = {
+            ...reactionConfig,
+            priority: reactionConfig.priority ?? ("warning" as const),
+          };
           if (reactionConfig.action === "send-to-agent" && !reactionConfig.message) {
             const baseBranch = session.pr.baseBranch ?? "the default branch";
             const behindNote = cachedData.isBehind ? ` is behind ${baseBranch} and` : "";
@@ -1674,7 +1685,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             conflictReactionKey,
             enrichedConfig,
           );
-          if (result.success) {
+          // Only set dedup flag for non-escalated success — escalation hands off
+          // to the human, so we must NOT suppress future agent dispatches if the
+          // condition recurs after the tracker resets.
+          if (result.success && result.action !== "escalated") {
             updateSessionMetadata(session, {
               lastMergeConflictDispatched: "true",
             });
@@ -1684,11 +1698,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         }
       }
     } else if (lastDispatched === "true") {
-      // Conflicts resolved — clear dedup flag so we can re-dispatch if they recur,
-      // but preserve reaction tracker so escalation budget accumulates.
+      // Conflicts resolved — clear dedup flag and reaction tracker so future
+      // conflicts start a fresh incident with a fresh escalation budget.
       updateSessionMetadata(session, {
         lastMergeConflictDispatched: "",
       });
+      clearReactionTracker(session.id, conflictReactionKey);
     }
   }
 
@@ -1884,8 +1899,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
 
       // Clear reaction trackers for the old status so retries reset on state changes.
-      // Persistent keys (ci-failed, merge-conflicts) are excluded — their trackers
-      // survive oscillation so the escalation budget accumulates across cycles.
+      // Persistent keys (ci-failed) are excluded — their trackers survive oscillation
+      // so the escalation budget accumulates across cycles. On escalation, the tracker
+      // is cleared in executeReaction so future incidents get a fresh budget.
       const oldEventType = statusToEventType(undefined, oldStatus);
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -394,6 +394,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   const states = new Map<SessionId, SessionStatus>();
   const reactionTrackers = new Map<string, ReactionTracker>(); // "sessionId:reactionKey"
+
+  /** Reaction keys for conditions that can oscillate (e.g. CI failing→pending→failing).
+   *  Their trackers survive status exit so the escalation budget accumulates
+   *  across oscillations instead of resetting to zero each time. */
+  const PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"]);
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let polling = false; // re-entrancy guard
   let allCompleteEmitted = false; // guard against repeated all_complete
@@ -1652,32 +1657,32 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         (reactionConfig.auto !== false || reactionConfig.action === "notify")
       ) {
         try {
-          if (reactionConfig.action === "send-to-agent") {
+          // Build enriched config with dynamic base branch message
+          const enrichedConfig = { ...reactionConfig };
+          if (reactionConfig.action === "send-to-agent" && !reactionConfig.message) {
             const baseBranch = session.pr.baseBranch ?? "the default branch";
             const behindNote = cachedData.isBehind ? ` is behind ${baseBranch} and` : "";
-            const message =
-              reactionConfig.message ??
-              `Your PR branch${behindNote} has merge conflicts with ${baseBranch}. Rebase your branch on ${baseBranch}, resolve the conflicts, and push. You should not need to call gh for merge status unless you need additional context — this information is current.`;
-            await sessionManager.send(session.id, message);
-          } else {
-            const event = createEvent("merge.conflicts", {
-              sessionId: session.id,
-              projectId: session.projectId,
-              message: `${session.id}: PR has merge conflicts`,
-            });
-            await notifyHuman(event, reactionConfig.priority ?? "warning");
+            enrichedConfig.message = `Your PR branch${behindNote} has merge conflicts with ${baseBranch}. Rebase your branch on ${baseBranch}, resolve the conflicts, and push. You should not need to call gh for merge status unless you need additional context — this information is current.`;
           }
 
-          updateSessionMetadata(session, {
-            lastMergeConflictDispatched: "true",
-          });
+          const result = await executeReaction(
+            session.id,
+            session.projectId,
+            conflictReactionKey,
+            enrichedConfig,
+          );
+          if (result.success) {
+            updateSessionMetadata(session, {
+              lastMergeConflictDispatched: "true",
+            });
+          }
         } catch {
-          // Send failed — will retry on next poll cycle
+          // Dispatch failed — will retry on next poll cycle
         }
       }
     } else if (lastDispatched === "true") {
-      // Conflicts resolved — clear so we can re-dispatch if they recur
-      clearReactionTracker(session.id, conflictReactionKey);
+      // Conflicts resolved — clear dedup flag so we can re-dispatch if they recur,
+      // but preserve reaction tracker so escalation budget accumulates.
       updateSessionMetadata(session, {
         lastMergeConflictDispatched: "",
       });
@@ -1875,11 +1880,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         allCompleteEmitted = false;
       }
 
-      // Clear reaction trackers for the old status so retries reset on state changes
+      // Clear reaction trackers for the old status so retries reset on state changes.
+      // Persistent keys (ci-failed, merge-conflicts) are excluded — their trackers
+      // survive oscillation so the escalation budget accumulates across cycles.
       const oldEventType = statusToEventType(undefined, oldStatus);
       if (oldEventType) {
         const oldReactionKey = eventToReactionKey(oldEventType);
-        if (oldReactionKey) {
+        if (oldReactionKey && !PERSISTENT_REACTION_KEYS.has(oldReactionKey)) {
           clearReactionTracker(session.id, oldReactionKey);
         }
       }

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -100,6 +100,11 @@ function parseDuration(str: string): number {
  *  Merge-conflict tracker lifecycle is managed in maybeDispatchMergeConflicts. */
 const PERSISTENT_REACTION_KEYS = new Set(["ci-failed"]);
 
+/** Number of consecutive CI-passing polls required before the ci-failed tracker
+ *  (including its escalated flag) is cleared, allowing a fresh budget for the
+ *  next real CI failure incident. */
+const CI_PASSING_STABLE_THRESHOLD = 2;
+
 type WorkspaceBranchProbe =
   | { kind: "branch"; branch: string }
   | { kind: "detached" }
@@ -393,6 +398,9 @@ export interface LifecycleManagerDeps {
 interface ReactionTracker {
   attempts: number;
   firstTriggered: Date;
+  /** True after this reaction has escalated. Short-circuits further dispatches
+   *  until the underlying condition resolves and the tracker is explicitly cleared. */
+  escalated?: boolean;
 }
 
 /** Create a LifecycleManager instance. */
@@ -1172,6 +1180,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       reactionTrackers.set(trackerKey, tracker);
     }
 
+    // Already escalated — wait for the condition to resolve before resuming.
+    if (tracker.escalated) {
+      return { reactionType: reactionKey, success: true, action: "escalated", escalated: true };
+    }
+
     // Increment attempts before checking escalation
     tracker.attempts++;
 
@@ -1205,10 +1218,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
       await notifyHuman(event, reactionConfig.priority ?? "urgent");
 
-      // Clear the tracker so future incidents get a fresh budget.
-      // Without this, long-lived sessions that escalated once would
-      // immediately escalate on every future occurrence of the condition.
-      reactionTrackers.delete(trackerKey);
+      // Mark as escalated — silences further dispatches until the underlying
+      // condition resolves and clearReactionTracker() is called explicitly.
+      tracker.escalated = true;
 
       return {
         reactionType: reactionKey,
@@ -1866,6 +1878,27 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
     if (Object.keys(metadataUpdates).length > 0) {
       updateSessionMetadata(session, metadataUpdates);
+    }
+
+    // CI resolution tracking — reset the ci-failed tracker (including its escalated
+    // flag) once CI has been passing for CI_PASSING_STABLE_THRESHOLD consecutive polls.
+    // This lets the next real CI failure start with a fresh budget.
+    if (session.pr) {
+      const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
+      const cachedData = prEnrichmentCache.get(prKey);
+      if (cachedData) {
+        if (cachedData.ciStatus !== "failing") {
+          const stableCount = Number(session.metadata["ciPassingStableCount"] ?? "0") + 1;
+          if (stableCount >= CI_PASSING_STABLE_THRESHOLD) {
+            clearReactionTracker(session.id, "ci-failed");
+            updateSessionMetadata(session, { ciPassingStableCount: "" });
+          } else {
+            updateSessionMetadata(session, { ciPassingStableCount: String(stableCount) });
+          }
+        } else if (session.metadata["ciPassingStableCount"]) {
+          updateSessionMetadata(session, { ciPassingStableCount: "" });
+        }
+      }
     }
 
     if (newStatus !== oldStatus) {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1887,7 +1887,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
       const cachedData = prEnrichmentCache.get(prKey);
       if (cachedData) {
-        if (cachedData.ciStatus !== "failing") {
+        if (cachedData.ciStatus === "passing") {
           const stableCount = Number(session.metadata["ciPassingStableCount"] ?? "0") + 1;
           if (stableCount >= CI_PASSING_STABLE_THRESHOLD) {
             clearReactionTracker(session.id, "ci-failed");
@@ -1896,6 +1896,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             updateSessionMetadata(session, { ciPassingStableCount: String(stableCount) });
           }
         } else if (session.metadata["ciPassingStableCount"]) {
+          // pending or failing resets the stability window — only "passing" counts as resolution
           updateSessionMetadata(session, { ciPassingStableCount: "" });
         }
       }


### PR DESCRIPTION
Closes #1409

## Summary

The lifecycle manager's reaction system has a retry + escalate mechanism: when CI fails, it sends a message to the agent, and after N retries (`retries: 2` = 3 attempts), escalates to a human. But the retry budget was resetting on every status oscillation, causing infinite message spam and preventing escalation.

**Three root causes fixed:**

1. **Reaction tracker cleared unconditionally on status exit** (`lifecycle-manager.ts:1878-1885`). Every transition away from `ci_failed` deleted the tracker. When CI failed again, a fresh tracker was created with `attempts: 0`. The retry budget never exhausted.

2. **Merge conflict dispatch bypassed `executeReaction` entirely** (`lifecycle-manager.ts:1654-1676`). `maybeDispatchMergeConflicts()` called `sessionManager.send()` directly, so the `escalateAfter: "15m"` config for merge-conflicts was dead code — escalation could never trigger.

3. **Merge conflict tracker cleared on resolve** (`lifecycle-manager.ts:1680`). When conflicts resolved, both the reaction tracker and dedup flag were cleared. When conflicts recurred, the escalation budget started from zero.

## Implementation Plan

### Change 1: Persistent reaction keys

Added `PERSISTENT_REACTION_KEYS = new Set(["ci-failed", "merge-conflicts"])`. These keys represent conditions that can oscillate (CI failing→pending→failing, conflicts resolving→recurring). Their trackers survive status exit so the escalation budget accumulates across oscillations.

At the status-exit clear (line 1883), persistent keys are now excluded:
```typescript
if (oldReactionKey && !PERSISTENT_REACTION_KEYS.has(oldReactionKey)) {
  clearReactionTracker(session.id, oldReactionKey);
}
```

### Change 2: Route merge conflicts through `executeReaction`

Replaced direct `sessionManager.send()` / `notifyHuman()` calls in `maybeDispatchMergeConflicts()` with a call to `executeReaction()`. This enables the existing `escalateAfter: "15m"` config that was previously ignored. Dynamic base branch messages are built before the call via an enriched config.

### Change 3: Preserve merge-conflicts tracker on resolve

When conflicts resolve, only the dedup flag (`lastMergeConflictDispatched`) is cleared — allowing re-notification if conflicts recur. The reaction tracker is preserved so the escalation budget continues counting. Terminal-state clearing (PR closed/merged) remains unchanged.

### Behavior after fix

**CI failure oscillation:**
```
Poll 1: CI failing  → send to agent       (attempts: 1)
Poll 2: CI pending  → tracker PRESERVED
Poll 3: CI failing  → send to agent       (attempts: 2)
Poll 4: CI pending  → tracker PRESERVED
Poll 5: CI failing  → attempts 3 > retries 2 → ESCALATE TO HUMAN
```

**Merge conflict oscillation:**
```
Conflict 1: send to agent (attempts: 1, firstTriggered = T)
Resolved:   dedup flag cleared, tracker preserved
Conflict 2: send to agent (attempts: 2)
Resolved:   dedup flag cleared, tracker preserved
Conflict 3: if T + 15min elapsed → ESCALATE TO HUMAN
```

## Test plan

- [x] **CI failure oscillation test**: Simulates 3 oscillations (ci_failed → pr_open → ci_failed). Verifies agent receives messages on attempts 1-2, then human is notified via escalation on attempt 3.
- [x] **Merge conflict time-based escalation test**: Simulates conflict → resolve → recur with `vi.useFakeTimers()`. Verifies escalation triggers after the `escalateAfter` window.
- [x] **Non-persistent keys test**: Verifies `changes-requested` tracker still clears on status exit (only persistent keys are protected).
- [x] All 917 existing tests pass
- [x] Full typecheck passes across all packages