### PR TITLE
fix(opencode): close stdin to prevent process leak on poll

### DIFF
--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -20,19 +20,32 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
   };
 });
 
-vi.mock("node:child_process", () => ({
-  execFile: (...args: unknown[]) => {
+vi.mock("node:child_process", () => {
+  const customSym = Symbol.for("nodejs.util.promisify.custom");
+  // Standard execFile callback signature: (err, stdout, stderr) as separate args.
+  const execFileMock = (...args: unknown[]) => {
     const callback = args[args.length - 1];
     if (typeof callback === "function") {
       const result = mockExecFileAsync(...args.slice(0, -1));
       if (result && typeof result.then === "function") {
         result
-          .then((r: { stdout: string; stderr: string }) => callback(null, r))
-          .catch((e: Error) => callback(e));
+          .then((r: { stdout: string; stderr: string }) =>
+            (callback as (e: Error | null, o: string, s: string) => void)(
+              null,
+              r.stdout ?? "",
+              r.stderr ?? "",
+            ),
+          )
+          .catch((e: Error) => (callback as (e: Error) => void)(e));
       }
     }
-  },
-}));
+    return undefined;
+  };
+  // promisify(execFile) custom resolution: returns {stdout, stderr} object.
+  (execFileMock as unknown as Record<symbol, unknown>)[customSym] = (...args: unknown[]) =>
+    mockExecFileAsync(...args);
+  return { execFile: execFileMock };
+});
 
 import { create, manifest, default as defaultExport } from "./index.js";
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -19,10 +19,30 @@ import {
   type WorkspaceHooksConfig,
   type OpenCodeAgentConfig,
 } from "@aoagents/ao-core";
-import { execFile, execFileSync } from "node:child_process";
+import { execFile, execFileSync, type ExecFileOptions } from "node:child_process";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+// Variant of execFileAsync that closes the child's stdin immediately after
+// spawn. opencode's CLI reads from stdin when it sees a pipe and hangs
+// waiting for input that never arrives — polling `opencode session list
+// --format json` would otherwise orphan one process per call, leaking
+// ~150MB each. Used only for opencode invocations.
+const runOpencode = (
+  args: readonly string[],
+  options?: ExecFileOptions,
+): Promise<{ stdout: string; stderr: string }> =>
+  new Promise((resolve, reject) => {
+    const child = execFile("opencode", args as string[], options ?? {}, (err, stdout, stderr) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve({ stdout: String(stdout ?? ""), stderr: String(stderr ?? "") });
+    });
+    child?.stdin?.end();
+  });
 
 interface OpenCodeSessionListEntry {
   id: string;
@@ -158,8 +178,7 @@ async function findOpenCodeSession(
   session: Session,
 ): Promise<OpenCodeSessionListEntry | null> {
   try {
-    const { stdout } = await execFileAsync(
-      "opencode",
+    const { stdout } = await runOpencode(
       ["session", "list", "--format", "json"],
       { timeout: 30_000 },
     );


### PR DESCRIPTION
The lifecycle manager polls `opencode session list --format json` every few seconds via execFileAsync. opencode reads from stdin when piped and hangs forever when it's left open, so each poll orphaned a ~150MB process. Within minutes the box would OOM.

Use a dedicated runOpencode wrapper that closes the child's stdin immediately after spawn. Other execFileAsync callers (tmux, ps) keep the existing promisified path.

Test mock updated to use standard execFile callback semantics (err, stdout, stderr as separate args) and provide a util.promisify.custom implementation for promisified callers.