### PR TITLE
fix: restore scrolling on session detail page

### DIFF
--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -194,7 +194,10 @@ export function SessionDetail({
           )}
 
           <div className="dashboard-main dashboard-main--desktop">
-            <main className="session-detail-page flex-1 min-h-0 flex flex-col bg-[var(--color-bg-base)]">
+            <main
+              className="session-detail-page flex-1 min-h-0 overflow-y-auto flex flex-col bg-[var(--color-bg-base)]"
+              data-testid="session-detail-scroll-region"
+            >
               <div className="flex-1 min-h-0 flex flex-col">
                 {!showTerminal ? (
                   <div className="session-detail-terminal-placeholder h-full" />

--- a/packages/web/src/components/__tests__/SessionDetail.layout.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.layout.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SessionDetail } from "../SessionDetail";
+import { makeSession } from "../../__tests__/helpers";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/dynamic", () => ({
+  default: (_loader: unknown, options?: { loading?: () => JSX.Element }) => {
+    const Loading = options?.loading;
+    return Loading ?? (() => <div data-testid="direct-terminal">terminal</div>);
+  },
+}));
+
+vi.mock("../ProjectSidebar", () => ({
+  ProjectSidebar: () => <div data-testid="project-sidebar" />,
+}));
+
+vi.mock("../MobileBottomNav", () => ({
+  MobileBottomNav: () => <nav aria-label="Session navigation" />,
+}));
+
+vi.mock("../SessionDetailHeader", () => ({
+  SessionDetailHeader: ({ headline }: { headline: string }) => <div>{headline}</div>,
+}));
+
+vi.mock("../SessionEndedSummary", () => ({
+  SessionEndedSummary: () => <div>Ended summary</div>,
+}));
+
+function mockDesktopViewport() {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+describe("SessionDetail layout", () => {
+  beforeEach(() => {
+    mockDesktopViewport();
+  });
+
+  it("renders the session body inside a dedicated vertical scroll region", () => {
+    render(<SessionDetail session={makeSession()} />);
+
+    const scrollRegion = screen.getByTestId("session-detail-scroll-region");
+    expect(scrollRegion).toHaveClass("flex-1", "min-h-0", "overflow-y-auto");
+    expect(scrollRegion.querySelector(".session-detail-terminal-placeholder")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- make the session detail page own a vertical scroll region so content below the terminal can be reached
- keep the terminal container flex sizing intact within the scrollable main area
- add a focused layout regression test for the session detail scroll container

## Validation
- pnpm build
- pnpm typecheck
- pnpm lint
- pnpm --filter @aoagents/ao-web test -- SessionDetail.layout.test.tsx SessionDetail.mobile.test.tsx

Upstream issue: https://github.com/ComposioHQ/agent-orchestrator/issues/1235