### PR TITLE
fix(web): refresh session sidebar from local metadata writes

### DIFF
--- a/.changeset/session-sidebar-react-query.md
+++ b/.changeset/session-sidebar-react-query.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Keep session-detail sidebar sessions visible across refresh failures by moving that sidebar fetch to TanStack Query.

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -105,6 +105,43 @@ describe("list", () => {
     expect(readMetadataRaw(sessionsDir, "app-1")!["codexThreadId"]).toBe("thread-1");
   });
 
+  it("listLocal reads metadata without runtime or agent probes", async () => {
+    const runtimeWithSpy: Runtime = {
+      ...mockRuntime,
+      isAlive: vi.fn().mockResolvedValue(true),
+    };
+    const agentWithSpy: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue({ state: "active" }),
+      getSessionInfo: vi.fn().mockResolvedValue({ summary: "Live summary" }),
+    };
+    const registryWithSpies: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return runtimeWithSpy;
+        if (slot === "agent") return agentWithSpy;
+        return null;
+      }),
+    };
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/w1",
+      branch: "feat/a",
+      status: "working",
+      project: "my-app",
+      runtimeHandle: makeHandle("rt-1"),
+    });
+
+    const sm = createSessionManager({ config, registry: registryWithSpies });
+    const sessions = await sm.listLocal("my-app");
+
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].id).toBe("app-1");
+    expect(runtimeWithSpy.isAlive).not.toHaveBeenCalled();
+    expect(agentWithSpy.getActivityState).not.toHaveBeenCalled();
+    expect(agentWithSpy.getSessionInfo).not.toHaveBeenCalled();
+  });
+
   it("does not backfill role onto foreign bare-id orchestrator records (issue #1048)", async () => {
     // Regression guard for PR #1075 review comment: a legacy record whose id
     // is `{projectId}-orchestrator` (pre-numbered scheme, wrong prefix) must

--- a/packages/core/src/__tests__/test-utils.ts
+++ b/packages/core/src/__tests__/test-utils.ts
@@ -506,6 +506,7 @@ export function createMockSessionManager(): OpenCodeSessionManager {
       ),
     restore: vi.fn().mockResolvedValue(makeSession()),
     list: vi.fn().mockResolvedValue([]),
+    listLocal: vi.fn().mockResolvedValue([]),
     listCached: vi.fn().mockResolvedValue([]),
     invalidateCache: vi.fn(),
     remap: vi.fn().mockResolvedValue("app-1"),

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2199,8 +2199,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     return promise;
   }
 
-  async function list(projectId?: string): Promise<Session[]> {
-    const allSessions = Object.entries(config.projects).flatMap(([entryProjectId, project]) => {
+  function listSessionRecords(projectId?: string): Array<{
+    sessionName: string;
+    projectId: string;
+    raw: Record<string, string>;
+  }> {
+    return Object.entries(config.projects).flatMap(([entryProjectId, project]) => {
       if (projectId && entryProjectId !== projectId) return [];
       return loadActiveSessionRecords(entryProjectId, project).map((record) => ({
         sessionName: record.sessionName,
@@ -2208,6 +2212,46 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         raw: record.raw,
       }));
     });
+  }
+
+  function sessionFromRecord(record: {
+    sessionName: string;
+    projectId: string;
+    raw: Record<string, string>;
+  }): Session | null {
+    const project = config.projects[record.projectId];
+    if (!project) return null;
+
+    const sessionsDir = getProjectSessionsDir(record.projectId);
+
+    let createdAt: Date | undefined;
+    let modifiedAt: Date | undefined;
+    try {
+      const metaPath = join(sessionsDir, `${record.sessionName}.json`);
+      const stats = statSync(metaPath);
+      createdAt = stats.birthtime;
+      modifiedAt = stats.mtime;
+    } catch {
+      // If stat fails, timestamps will fall back to current time.
+    }
+
+    return metadataToSession(record.sessionName, record.raw, {
+      projectId: record.projectId,
+      sessionPrefix: project.sessionPrefix,
+      createdAt,
+      modifiedAt,
+      workspacePathFallback: project.path,
+    });
+  }
+
+  async function listLocal(projectId?: string): Promise<Session[]> {
+    return listSessionRecords(projectId)
+      .map((record) => sessionFromRecord(record))
+      .filter((session): session is Session => session !== null);
+  }
+
+  async function list(projectId?: string): Promise<Session[]> {
+    const allSessions = listSessionRecords(projectId);
     let openCodeSessionListPromise: Promise<OpenCodeSessionListEntry[]> | undefined;
 
     const tasks = allSessions.map(async ({ sessionName, projectId: sessionProjectId, raw }) => {
@@ -2215,29 +2259,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       if (!project) return null;
 
       const sessionsDir = getProjectSessionsDir(sessionProjectId);
-
-      let createdAt: Date | undefined;
-      let modifiedAt: Date | undefined;
-      try {
-        const metaPath = join(sessionsDir, `${sessionName}.json`);
-        const stats = statSync(metaPath);
-        createdAt = stats.birthtime;
-        modifiedAt = stats.mtime;
-      } catch {
-        // If stat fails, timestamps will fall back to current time
-      }
-
-      const session = metadataToSession(
-        sessionName,
-        raw,
-        {
-          projectId: sessionProjectId,
-          sessionPrefix: project.sessionPrefix,
-          createdAt,
-          modifiedAt,
-          workspacePathFallback: project.path,
-        },
-      );
+      const session = sessionFromRecord({ sessionName, projectId: sessionProjectId, raw });
+      if (!session) return null;
       const selection = resolveSelectionForSession(project, sessionName, raw);
       const effectiveAgentName = selection.agentName;
       const plugins = resolvePlugins(project, effectiveAgentName);
@@ -3586,6 +3609,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     relaunchOrchestrator,
     restore,
     list,
+    listLocal,
     listCached,
     invalidateCache,
     get,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1881,6 +1881,8 @@ export interface SessionManager {
 export interface OpenCodeSessionManager extends SessionManager {
   /** Remap session to OpenCode session ID, returns the mapped OpenCode session ID */
   remap(sessionId: SessionId, force?: boolean): Promise<string>;
+  /** List sessions from local metadata only, without live runtime or agent probes. */
+  listLocal(projectId?: string): Promise<Session[]>;
   listCached(projectId?: string): Promise<Session[]>;
   invalidateCache(): void;
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -55,6 +55,7 @@
     "@aoagents/ao-plugin-tracker-github": "workspace:*",
     "@aoagents/ao-plugin-tracker-linear": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
+    "@tanstack/react-query": "^5.100.6",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import type * as NodeFs from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Socket } from "node:net";
@@ -114,17 +115,25 @@ function resetPtyMock(): void {
 
 describe("SessionBroadcaster", () => {
   let broadcaster: SessionBroadcasterType;
+  let originalAoConfigPath: string | undefined;
 
   beforeEach(() => {
     vi.useFakeTimers();
     mockFetch.mockReset();
     recordActivityEvent.mockClear();
     resetPtyMock();
+    originalAoConfigPath = process.env["AO_CONFIG_PATH"];
+    delete process.env["AO_CONFIG_PATH"];
     broadcaster = new SessionBroadcaster("3000");
   });
 
   afterEach(() => {
     vi.clearAllTimers();
+    if (originalAoConfigPath === undefined) {
+      delete process.env["AO_CONFIG_PATH"];
+    } else {
+      process.env["AO_CONFIG_PATH"] = originalAoConfigPath;
+    }
     vi.useRealTimers();
   });
 
@@ -258,6 +267,60 @@ describe("SessionBroadcaster", () => {
       // Should be called again from polling
       expect(cb1).toHaveBeenCalledTimes(2);
       expect(cb2).toHaveBeenCalledTimes(2);
+    });
+
+    it("broadcasts a fresh snapshot when watched session metadata changes", async () => {
+      const patches = [makePatch("s1")];
+      let watchCallback:
+        | ((eventType: string, filename: string | Buffer | null) => void)
+        | undefined;
+      const watcher = { close: vi.fn() } as unknown as NodeFs.FSWatcher;
+      const watchSpy = vi.fn((_path: string, _options: unknown, listener: unknown) => {
+        if (typeof listener !== "function") {
+          throw new TypeError("watch listener must be a function");
+        }
+        watchCallback = listener as (
+          eventType: string,
+          filename: string | Buffer | null,
+        ) => void;
+        return watcher;
+      });
+      const watchImpl = watchSpy as unknown as typeof NodeFs.watch;
+      const mkdirImpl = vi.fn((() => undefined) as typeof NodeFs.mkdirSync);
+      broadcaster = new SessionBroadcaster("3000", {
+        metadataSessionDirs: ["/tmp/ao-sessions"],
+        mkdir: mkdirImpl,
+        watch: watchImpl,
+        watchDebounceMs: 5,
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessions: [] }),
+      });
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessions: patches }),
+      });
+
+      const callback = vi.fn();
+      const unsubscribe = broadcaster.subscribe(callback);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mkdirImpl).toHaveBeenCalledWith("/tmp/ao-sessions", { recursive: true });
+      expect(watchSpy).toHaveBeenCalledWith(
+        "/tmp/ao-sessions",
+        { persistent: false },
+        expect.any(Function),
+      );
+
+      watchCallback?.("rename", "s1.json");
+      await vi.advanceTimersByTimeAsync(5);
+
+      expect(callback).toHaveBeenLastCalledWith(patches);
+
+      unsubscribe();
+      expect(watcher.close).toHaveBeenCalled();
     });
 
     it("isolates subscriber errors — one throw does not skip others", async () => {

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -8,11 +8,13 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import { spawn } from "node:child_process";
+import { mkdirSync, watch, type FSWatcher } from "node:fs";
 import { type Socket, connect as netConnect } from "node:net";
 import {
   DEFAULT_DASHBOARD_NOTIFICATION_LIMIT,
   getEnvDefaults,
   getDashboardNotificationStorePath,
+  getProjectSessionsDir,
   isWindows,
   loadConfig,
   normalizeDashboardNotificationLimit,
@@ -70,6 +72,13 @@ interface SessionPatch {
   lastActivityAt: string;
 }
 
+interface SessionBroadcasterOptions {
+  metadataSessionDirs?: string[];
+  watch?: typeof watch;
+  mkdir?: typeof mkdirSync;
+  watchDebounceMs?: number;
+}
+
 /**
  * Manages polling of session patches from Next.js /api/sessions/patches.
  * Broadcasts to all subscribed callbacks.
@@ -83,15 +92,25 @@ export class SessionBroadcaster {
   // Tracks the last fetch outcome so we only emit ui.session_broadcast_failed on
   // the healthy → failing transition (not every 3s during an outage).
   private lastFetchOk = true;
+  private metadataWatchers: FSWatcher[] = [];
+  private metadataRefreshTimer: ReturnType<typeof setTimeout> | null = null;
   private readonly baseUrl: string;
+  private readonly metadataSessionDirs?: string[];
+  private readonly watchImpl: typeof watch;
+  private readonly mkdirImpl: typeof mkdirSync;
+  private readonly watchDebounceMs: number;
 
-  constructor(nextPort: string) {
+  constructor(nextPort: string, options: SessionBroadcasterOptions = {}) {
     this.baseUrl = `http://localhost:${nextPort}`;
+    this.metadataSessionDirs = options.metadataSessionDirs;
+    this.watchImpl = options.watch ?? watch;
+    this.mkdirImpl = options.mkdir ?? mkdirSync;
+    this.watchDebounceMs = options.watchDebounceMs ?? 100;
   }
 
   /**
    * Subscribe to session patches and errors. Returns an unsubscribe function.
-   * Sends an immediate snapshot to the new subscriber, then polling updates.
+   * Sends an immediate snapshot to the new subscriber, then polling/watcher updates.
    */
   subscribe(
     callback: (sessions: SessionPatch[]) => void,
@@ -118,8 +137,9 @@ export class SessionBroadcaster {
       }
     });
 
-    // Start polling if this is the first subscriber
+    // Start polling and metadata watchers if this is the first subscriber
     if (wasEmpty) {
+      this.startMetadataWatchers();
       this.intervalId = setInterval(() => {
         if (this.polling) return;
         this.polling = true;
@@ -139,6 +159,7 @@ export class SessionBroadcaster {
       if (onError) this.errorSubscribers.delete(onError);
       if (this.subscribers.size === 0) {
         this.disconnect();
+        this.stopMetadataWatchers();
       }
     };
   }
@@ -160,6 +181,72 @@ export class SessionBroadcaster {
       } catch (err) {
         console.error("[MuxServer] Session error subscriber threw:", err);
       }
+    }
+  }
+
+  private discoverMetadataSessionDirs(): string[] {
+    if (this.metadataSessionDirs) return this.metadataSessionDirs;
+
+    const configPath = process.env["AO_CONFIG_PATH"];
+    if (!configPath) return [];
+
+    try {
+      const config = loadConfig(configPath);
+      return Object.keys(config.projects).map((projectId) => getProjectSessionsDir(projectId));
+    } catch (err) {
+      console.warn(
+        "[MuxServer] Could not initialize session metadata watcher:",
+        err instanceof Error ? err.message : err,
+      );
+      return [];
+    }
+  }
+
+  private startMetadataWatchers(): void {
+    if (this.metadataWatchers.length > 0) return;
+
+    for (const sessionsDir of this.discoverMetadataSessionDirs()) {
+      try {
+        this.mkdirImpl(sessionsDir, { recursive: true });
+        const watcher = this.watchImpl(
+          sessionsDir,
+          { persistent: false },
+          (_eventType, filename) => {
+            if (filename && !String(filename).endsWith(".json")) return;
+            this.scheduleMetadataRefresh();
+          },
+        );
+        this.metadataWatchers.push(watcher);
+      } catch (err) {
+        console.warn(
+          "[MuxServer] Could not watch session metadata directory:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  private scheduleMetadataRefresh(): void {
+    if (this.subscribers.size === 0 || this.metadataRefreshTimer) return;
+
+    this.metadataRefreshTimer = setTimeout(() => {
+      this.metadataRefreshTimer = null;
+      void this.fetchSnapshot().then((result) => {
+        if (this.subscribers.size === 0) return;
+        if (result.sessions) this.broadcast(result.sessions);
+        else if (result.error) this.broadcastError(result.error);
+      });
+    }, this.watchDebounceMs);
+  }
+
+  private stopMetadataWatchers(): void {
+    for (const watcher of this.metadataWatchers) {
+      watcher.close();
+    }
+    this.metadataWatchers = [];
+    if (this.metadataRefreshTimer) {
+      clearTimeout(this.metadataRefreshTimer);
+      this.metadataRefreshTimer = null;
     }
   }
 

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -1554,9 +1554,12 @@ describe("API Routes", () => {
     it("returns patches array with lightweight fields", async () => {
       const res = await patchesGET(makeRequest("http://localhost:3000/api/sessions/patches"));
       expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
       const data = await res.json();
       expect(Array.isArray(data.sessions)).toBe(true);
       expect(data.sessions.length).toBe(testSessions.length);
+      expect(mockSessionManager.listLocal).toHaveBeenCalled();
+      expect(mockSessionManager.list).not.toHaveBeenCalled();
     });
 
     it("each patch contains id, status, activity, attentionLevel, lastActivityAt", async () => {

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -105,6 +105,7 @@ const multiProjectSessions: Session[] = [
 
 const mockSessionManager: SessionManager = {
   list: vi.fn(async () => testSessions),
+  listLocal: vi.fn(async () => testSessions),
   listCached: vi.fn(async () => testSessions),
   invalidateCache: vi.fn(),
   get: vi.fn(async (id: string) => testSessions.find((s) => s.id === id) ?? null),
@@ -257,6 +258,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Re-set default return values
   (mockSessionManager.list as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
+  (mockSessionManager.listLocal as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
   (mockSessionManager.listCached as ReturnType<typeof vi.fn>).mockResolvedValue(testSessions);
   (mockSessionManager.get as ReturnType<typeof vi.fn>).mockImplementation(
     async (id: string) => testSessions.find((s) => s.id === id) ?? null,
@@ -404,6 +406,50 @@ describe("API Routes", () => {
       expect(data.sessions.map((session: { id: string }) => session.id)).toEqual(["docs-2"]);
       expect(mockSessionManager.list).toHaveBeenCalledWith("docs-app");
       expect(mockSessionManager.listCached).not.toHaveBeenCalledWith("docs-app");
+    });
+
+    it("uses local metadata only for sidebar view requests", async () => {
+      (mockSessionManager.listLocal as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (projectId?: string) =>
+          multiProjectSessions.filter((session) => !projectId || session.projectId === projectId),
+      );
+      const metadataSpy = vi.spyOn(serialize, "enrichSessionsMetadata");
+
+      const res = await sessionsGET(
+        makeRequest("http://localhost:3000/api/sessions?project=docs-app&view=sidebar"),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.orchestratorId).toBe("docs-orchestrator");
+      expect(data.sessions.map((session: { id: string }) => session.id)).toEqual(["docs-2"]);
+      expect(mockSessionManager.listLocal).toHaveBeenCalledWith("docs-app");
+      expect(mockSessionManager.list).not.toHaveBeenCalled();
+      expect(mockSessionManager.listCached).not.toHaveBeenCalledWith("docs-app");
+      expect(metadataSpy).not.toHaveBeenCalled();
+
+      metadataSpy.mockRestore();
+    });
+
+    it("uses local metadata only for sidebar orchestrator lookups", async () => {
+      (mockSessionManager.listLocal as ReturnType<typeof vi.fn>).mockImplementationOnce(
+        async (projectId?: string) =>
+          multiProjectSessions.filter((session) => !projectId || session.projectId === projectId),
+      );
+
+      const res = await sessionsGET(
+        makeRequest(
+          "http://localhost:3000/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar",
+        ),
+      );
+      expect(res.status).toBe(200);
+      const data = await res.json();
+
+      expect(data.orchestratorId).toBe("app-orchestrator");
+      expect(data.sessions).toEqual([]);
+      expect(mockSessionManager.listLocal).toHaveBeenCalledWith("my-app");
+      expect(mockSessionManager.list).not.toHaveBeenCalled();
+      expect(mockSessionManager.listCached).not.toHaveBeenCalledWith("my-app");
     });
 
     it("prefers the most recently active live orchestrator for project-scoped worker navigation", async () => {

--- a/packages/web/src/app/api/sessions/patches/route.ts
+++ b/packages/web/src/app/api/sessions/patches/route.ts
@@ -4,6 +4,7 @@ import { getAttentionLevel } from "@/lib/types";
 import { filterWorkerSessions } from "@/lib/project-utils";
 
 export const dynamic = "force-dynamic";
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 export async function GET(request: Request) {
   try {
@@ -16,7 +17,7 @@ export async function GET(request: Request) {
         ? projectFilter
         : undefined;
 
-    const coreSessions = await sessionManager.listCached(requestedProjectId);
+    const coreSessions = await sessionManager.listLocal(requestedProjectId);
     const visibleSessions = filterWorkerSessions(coreSessions, projectFilter, config.projects);
 
     // Convert to dashboard format
@@ -33,12 +34,12 @@ export async function GET(request: Request) {
       lastActivityAt: session.lastActivityAt,
     }));
 
-    return Response.json({ sessions: patches });
+    return Response.json({ sessions: patches }, { headers: NO_STORE_HEADERS });
   } catch (err) {
     console.error("[GET /api/sessions/patches]", err);
     return Response.json(
       { error: err instanceof Error ? err.message : "Failed to fetch session patches" },
-      { status: 500 },
+      { status: 500, headers: NO_STORE_HEADERS },
     );
   }
 }

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -78,15 +78,20 @@ export async function GET(request: Request) {
     const activeOnly = searchParams.get("active") === "true";
     const orchestratorOnly = searchParams.get("orchestratorOnly") === "true";
     const fresh = searchParams.get("fresh") === "true";
+    const sidebarView = searchParams.get("view") === "sidebar";
 
     const { config, registry, sessionManager } = await getServices();
     const requestedProjectId =
       projectFilter && projectFilter !== "all" && config.projects[projectFilter]
         ? projectFilter
         : undefined;
-    const coreSessions = fresh
-      ? await sessionManager.list(requestedProjectId)
-      : await sessionManager.listCached(requestedProjectId);
+    // Sidebar navigation should be local and predictable: the live "fresh"
+    // path may probe runtimes, agents, OpenCode discovery, and tracker metadata.
+    const coreSessions = sidebarView
+      ? await sessionManager.listLocal(requestedProjectId)
+      : fresh
+        ? await sessionManager.list(requestedProjectId)
+        : await sessionManager.listCached(requestedProjectId);
     const visibleSessions = filterProjectSessions(coreSessions, projectFilter, config.projects);
     const orchestrators = requestedProjectId
       ? listPreferredProjectOrchestrators(visibleSessions, config.projects)
@@ -106,7 +111,12 @@ export async function GET(request: Request) {
         startedAt,
         outcome: "success",
         statusCode: 200,
-        data: { orchestratorOnly: true, orchestratorCount: orchestrators.length, fresh },
+        data: {
+          orchestratorOnly: true,
+          orchestratorCount: orchestrators.length,
+          fresh,
+          sidebarView,
+        },
       });
 
       return jsonWithCorrelation(
@@ -143,10 +153,12 @@ export async function GET(request: Request) {
       dashboardSessions = activeIndices.map((index) => dashboardSessions[index]);
     }
 
-    const metadataSettled = await settlesWithin(
-      enrichSessionsMetadata(workerSessions, dashboardSessions, config, registry),
-      METADATA_ENRICH_TIMEOUT_MS,
-    );
+    const metadataSettled = sidebarView
+      ? true
+      : await settlesWithin(
+          enrichSessionsMetadata(workerSessions, dashboardSessions, config, registry),
+          METADATA_ENRICH_TIMEOUT_MS,
+        );
 
     if (metadataSettled) {
       // PR enrichment: read from session metadata (written by CLI lifecycle).
@@ -165,7 +177,7 @@ export async function GET(request: Request) {
       startedAt,
       outcome: "success",
       statusCode: 200,
-      data: { sessionCount: dashboardSessions.length, activeOnly, fresh },
+      data: { sessionCount: dashboardSessions.length, activeOnly, fresh, sidebarView },
     });
 
     return jsonWithCorrelation(

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -12,7 +12,10 @@ import { filterProjectSessions } from "@/lib/project-utils";
 import { settlesWithin } from "@/lib/async-utils";
 import { type DashboardOrchestratorLink } from "@/lib/types";
 
+export const dynamic = "force-dynamic";
+
 const METADATA_ENRICH_TIMEOUT_MS = 3_000;
+const NO_STORE_HEADERS = { "Cache-Control": "no-store" };
 
 function compareOrchestratorRecency(
   a: { lastActivityAt?: Date | null; createdAt?: Date | null; id: string },
@@ -125,7 +128,7 @@ export async function GET(request: Request) {
           orchestrators,
           sessions: [],
         },
-        { status: 200 },
+        { status: 200, headers: NO_STORE_HEADERS },
         correlationId,
       );
     }
@@ -187,7 +190,7 @@ export async function GET(request: Request) {
         orchestratorId,
         orchestrators,
       },
-      { status: 200 },
+      { status: 200, headers: NO_STORE_HEADERS },
       correlationId,
     );
   } catch (err) {
@@ -206,7 +209,7 @@ export async function GET(request: Request) {
     }
     return jsonWithCorrelation(
       { error: err instanceof Error ? err.message : "Failed to list sessions" },
-      { status: 500 },
+      { status: 500, headers: NO_STORE_HEADERS },
       correlationId,
     );
   }

--- a/packages/web/src/app/providers.tsx
+++ b/packages/web/src/app/providers.tsx
@@ -1,12 +1,18 @@
 "use client";
 
+import { useState, type ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { MuxProvider } from "@/providers/MuxProvider";
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
   return (
     <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
-      <MuxProvider>{children}</MuxProvider>
+      <QueryClientProvider client={queryClient}>
+        <MuxProvider>{children}</MuxProvider>
+      </QueryClientProvider>
     </ThemeProvider>
   );
 }

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -1,9 +1,11 @@
 import { act, render, screen, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
 import type { SessionPatch } from "@/lib/mux-protocol";
 
 const sessionDetailSpy = vi.fn();
+const projectSidebarSpy = vi.fn();
 const replaceSpy = vi.fn();
 let mockPathname = "/projects/my-app/sessions/worker-1";
 let mockParams: Record<string, string> = { id: "worker-1" };
@@ -28,6 +30,13 @@ vi.mock("@/components/SessionDetail", () => ({
   SessionDetail: (props: unknown) => {
     sessionDetailSpy(props);
     return <div data-testid="session-detail" />;
+  },
+}));
+
+vi.mock("@/components/ProjectSidebar", () => ({
+  ProjectSidebar: (props: unknown) => {
+    projectSidebarSpy(props);
+    return <div data-testid="project-sidebar" />;
   },
 }));
 
@@ -58,7 +67,22 @@ function makeWorkerSession(): DashboardSession {
 async function flushAsyncWork(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
   });
+}
+
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0,
+        retry: false,
+      },
+    },
+  });
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
 }
 
 describe("SessionPage project polling", () => {
@@ -66,6 +90,7 @@ describe("SessionPage project polling", () => {
     vi.useFakeTimers();
     vi.resetModules();
     sessionDetailSpy.mockClear();
+    projectSidebarSpy.mockClear();
     replaceSpy.mockClear();
     mockPathname = "/projects/my-app/sessions/worker-1";
     mockParams = { id: "worker-1", projectId: "my-app" };
@@ -144,7 +169,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(fetch).toHaveBeenCalledWith(
@@ -248,7 +273,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     await act(async () => {
@@ -291,7 +316,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(screen.getByText("Session not found")).toBeInTheDocument();
@@ -323,7 +348,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(screen.getByText("Failed to load session")).toBeInTheDocument();
@@ -363,7 +388,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
 
     expect(screen.getByText("Loading session…")).toBeInTheDocument();
 
@@ -426,7 +451,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(sessionFetches).toBe(1);
@@ -494,11 +519,11 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    const firstRender = render(<SessionPage />);
+    const firstRender = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
     firstRender.unmount();
 
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(fetchMock.mock.calls.filter(([url]) => url === "/api/projects")).toHaveLength(2);
@@ -554,7 +579,7 @@ describe("SessionPage project polling", () => {
 
     const { default: SessionPage } = await import("./page");
 
-    const rendered = render(<SessionPage />);
+    const rendered = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     rendered.unmount();
@@ -566,6 +591,300 @@ describe("SessionPage project polling", () => {
     );
   });
 
+
+it("marks sidebar data as loading until the sessions list resolves", async () => {
+    const workerSession = makeWorkerSession();
+    let resolveSidebarSessions: ((value: Response) => void) | null = null;
+
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response);
+      }
+
+      if (url === "/api/sessions?fresh=true") {
+        return new Promise<Response>((resolve) => {
+          resolveSidebarSessions = resolve;
+        });
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    renderWithQueryClient(<SessionPage />);
+    await flushAsyncWork();
+
+    const latestBeforeSidebarResolve = projectSidebarSpy.mock.lastCall?.[0] as {
+      loading?: boolean;
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestBeforeSidebarResolve.loading).toBe(true);
+    expect(latestBeforeSidebarResolve.sessions).toBeNull();
+    expect(resolveSidebarSessions).not.toBeNull();
+
+    await act(async () => {
+      resolveSidebarSessions?.({
+        ok: true,
+        status: 200,
+        json: async () => ({ sessions: [workerSession] }),
+      } as Response);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await flushAsyncWork();
+
+    const latestAfterSidebarResolve = projectSidebarSpy.mock.lastCall?.[0] as {
+      loading?: boolean;
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestAfterSidebarResolve.loading).toBe(false);
+    expect(latestAfterSidebarResolve.sessions).toEqual([workerSession]);
+  });
+
+  it("surfaces sidebar fetch failures instead of leaving the loading skeleton active", async () => {
+    const workerSession = makeWorkerSession();
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions?fresh=true") {
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({}),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    renderWithQueryClient(<SessionPage />);
+    await flushAsyncWork();
+
+    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
+      error?: boolean;
+      errorMessage?: string;
+      loading?: boolean;
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.loading).toBe(false);
+    expect(latestProps.error).toBe(true);
+    expect(latestProps.errorMessage).toBe("HTTP 500");
+    expect(latestProps.sessions).toEqual([]);
+  });
+
+  it("keeps the last sidebar sessions visible when a background refresh fails", async () => {
+    const workerSession = makeWorkerSession();
+    let sidebarFetchCount = 0;
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions?fresh=true") {
+        sidebarFetchCount += 1;
+        if (sidebarFetchCount === 1) {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({ sessions: [workerSession] }),
+          } as Response;
+        }
+
+        return {
+          ok: false,
+          status: 500,
+          json: async () => ({ error: "GitHub API rate limited" }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    renderWithQueryClient(<SessionPage />);
+    await flushAsyncWork();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+    await flushAsyncWork();
+
+    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
+      error?: boolean;
+      errorMessage?: string;
+      loading?: boolean;
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.loading).toBe(false);
+    expect(latestProps.error).toBe(true);
+    expect(latestProps.errorMessage).toBe("GitHub API rate limited");
+    expect(latestProps.sessions).toEqual([workerSession]);
+  });
+
+  it("applies mux snapshots that arrive before the initial sidebar fetch resolves", async () => {
+    const workerSession = makeWorkerSession();
+    const muxPatchedLastActivityAt = "2026-04-14T12:00:00.000Z";
+    let resolveSidebarSessions: ((value: Response) => void) | null = null;
+
+    mockMuxState.current = {
+      status: "connected",
+      sessions: [
+        {
+          id: "worker-1",
+          status: "working",
+          activity: "ready",
+          attentionLevel: "pending",
+          lastActivityAt: muxPatchedLastActivityAt,
+        },
+      ],
+    };
+
+    global.fetch = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response);
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response);
+      }
+
+      if (url === "/api/sessions?fresh=true") {
+        return new Promise<Response>((resolve) => {
+          resolveSidebarSessions = resolve;
+        });
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response);
+      }
+
+      return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+
+    renderWithQueryClient(<SessionPage />);
+    await flushAsyncWork();
+
+    await act(async () => {
+      resolveSidebarSessions?.({
+        ok: true,
+        status: 200,
+        json: async () => ({ sessions: [workerSession] }),
+      } as Response);
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await flushAsyncWork();
+
+    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.sessions).toEqual([
+      {
+        ...workerSession,
+        activity: "ready",
+        lastActivityAt: muxPatchedLastActivityAt,
+      },
+    ]);
+  });
 
 
   it("redirects the legacy session URL to the project-scoped route for clean projects", async () => {
@@ -612,7 +931,7 @@ describe("SessionPage project polling", () => {
     }) as typeof fetch;
 
     const { default: SessionPage } = await import("./page");
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(replaceSpy).toHaveBeenCalledWith("/projects/my-app/sessions/worker-1");
@@ -664,7 +983,7 @@ describe("SessionPage project polling", () => {
     }) as typeof fetch;
 
     const { default: SessionPage } = await import("./page");
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(replaceSpy).toHaveBeenCalledWith("/projects/broken-app/sessions/worker-1");
@@ -719,7 +1038,7 @@ describe("SessionPage project polling", () => {
     }) as typeof fetch;
 
     const { default: SessionPage } = await import("./page");
-    render(<SessionPage />);
+    renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     expect(replaceSpy).toHaveBeenCalledWith("/projects/other-app/sessions/worker-1");

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -139,7 +139,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -147,7 +147,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -181,20 +181,20 @@ describe("SessionPage project polling", () => {
       expect.any(Object),
     );
     expect(fetch).toHaveBeenCalledWith(
-      "/api/sessions?fresh=true",
-      expect.any(Object),
+      "/api/sessions?view=sidebar",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true",
-      expect.any(Object),
+      "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
 
     expect(
       vi
         .mocked(fetch)
         .mock.calls.filter(
-          ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true",
+          ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar",
         ),
     ).toHaveLength(1);
 
@@ -207,12 +207,12 @@ describe("SessionPage project polling", () => {
       vi
         .mocked(fetch)
         .mock.calls.filter(
-          ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true",
+          ([url]) => url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar",
         ),
     ).toHaveLength(1);
 
     expect(
-      vi.mocked(fetch).mock.calls.filter(([url]) => url === "/api/sessions?fresh=true"),
+      vi.mocked(fetch).mock.calls.filter(([url]) => url === "/api/sessions?view=sidebar"),
     ).toHaveLength(3);
   });
 
@@ -244,7 +244,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -252,7 +252,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -260,7 +260,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&fresh=true") {
+      if (url === "/api/sessions?project=my-app&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -282,8 +282,8 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(fetch).toHaveBeenCalledWith(
-      "/api/sessions?project=my-app&fresh=true",
-      expect.any(Object),
+      "/api/sessions?project=my-app&view=sidebar",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
   });
 
@@ -375,7 +375,7 @@ describe("SessionPage project polling", () => {
         });
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -438,7 +438,7 @@ describe("SessionPage project polling", () => {
         return Promise.reject(new DOMException("Aborted", "AbortError"));
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -497,7 +497,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -505,7 +505,7 @@ describe("SessionPage project polling", () => {
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -527,7 +527,7 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(fetchMock.mock.calls.filter(([url]) => url === "/api/projects")).toHaveLength(2);
-    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/sessions?fresh=true")).toHaveLength(
+    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/sessions?view=sidebar")).toHaveLength(
       2,
     );
   });
@@ -556,7 +556,7 @@ describe("SessionPage project polling", () => {
         } as Response);
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -564,7 +564,7 @@ describe("SessionPage project polling", () => {
         } as Response);
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return new Promise<Response>((_, reject) => {
           init?.signal?.addEventListener(
             "abort",
@@ -616,13 +616,13 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response);
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return new Promise<Response>((resolve) => {
           resolveSidebarSessions = resolve;
         });
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -690,7 +690,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: false,
           status: 500,
@@ -698,7 +698,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -751,7 +751,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         sidebarFetchCount += 1;
         if (sidebarFetchCount === 1) {
           return {
@@ -768,7 +768,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -840,13 +840,13 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response);
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return new Promise<Response>((resolve) => {
           resolveSidebarSessions = resolve;
         });
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return Promise.resolve({
           ok: true,
           status: 200,
@@ -911,7 +911,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -919,7 +919,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -963,7 +963,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -971,7 +971,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?project=broken-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=broken-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -1018,7 +1018,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?fresh=true") {
+      if (url === "/api/sessions?view=sidebar") {
         return {
           ok: true,
           status: 200,
@@ -1026,7 +1026,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
         } as Response;
       }
 
-      if (url === "/api/sessions?project=other-app&orchestratorOnly=true&fresh=true") {
+      if (url === "/api/sessions?project=other-app&orchestratorOnly=true&view=sidebar") {
         return {
           ok: true,
           status: 200,

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -4,6 +4,12 @@ import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 import type { DashboardSession } from "@/lib/types";
 import type { SessionPatch } from "@/lib/mux-protocol";
 
+const SIDEBAR_SESSIONS_QUERY_KEY = ["session-detail", "sidebar-sessions"] as const;
+
+interface SidebarSessionsQueryData {
+  sessions: DashboardSession[];
+}
+
 const sessionDetailSpy = vi.fn();
 const projectSidebarSpy = vi.fn();
 const replaceSpy = vi.fn();
@@ -72,8 +78,8 @@ async function flushAsyncWork(): Promise<void> {
   });
 }
 
-function renderWithQueryClient(ui: React.ReactElement) {
-  const queryClient = new QueryClient({
+function createTestQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: {
         gcTime: 0,
@@ -81,8 +87,18 @@ function renderWithQueryClient(ui: React.ReactElement) {
       },
     },
   });
+}
 
-  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+function renderWithQueryClient(ui: React.ReactElement) {
+  const queryClient = createTestQueryClient();
+  return {
+    ...render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>),
+    queryClient,
+  };
+}
+
+function getSidebarQueryData(queryClient: QueryClient): SidebarSessionsQueryData | undefined {
+  return queryClient.getQueryData<SidebarSessionsQueryData>(SIDEBAR_SESSIONS_QUERY_KEY);
 }
 
 describe("SessionPage project polling", () => {
@@ -172,14 +188,8 @@ describe("SessionPage project polling", () => {
     renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/projects",
-      expect.any(Object),
-    );
-    expect(fetch).toHaveBeenCalledWith(
-      "/api/sessions/worker-1",
-      expect.any(Object),
-    );
+    expect(fetch).toHaveBeenCalledWith("/api/projects", expect.any(Object));
+    expect(fetch).toHaveBeenCalledWith("/api/sessions/worker-1", expect.any(Object));
     expect(fetch).toHaveBeenCalledWith(
       "/api/sessions?view=sidebar",
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -474,7 +484,6 @@ describe("SessionPage project polling", () => {
     expect(screen.getAllByText("Failed to load session").length).toBeGreaterThan(0);
   });
 
-
   it("revalidates projects and sidebar sessions on remount even when cache exists", async () => {
     const workerSession = makeWorkerSession();
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
@@ -527,9 +536,9 @@ describe("SessionPage project polling", () => {
     await flushAsyncWork();
 
     expect(fetchMock.mock.calls.filter(([url]) => url === "/api/projects")).toHaveLength(2);
-    expect(fetchMock.mock.calls.filter(([url]) => url === "/api/sessions?view=sidebar")).toHaveLength(
-      2,
-    );
+    expect(
+      fetchMock.mock.calls.filter(([url]) => url === "/api/sessions?view=sidebar"),
+    ).toHaveLength(2);
   });
 
   it("silences aborted sidebar refreshes during unmount", async () => {
@@ -591,8 +600,7 @@ describe("SessionPage project polling", () => {
     );
   });
 
-
-it("marks sidebar data as loading until the sessions list resolves", async () => {
+  it("marks sidebar data as loading until the sessions list resolves", async () => {
     const workerSession = makeWorkerSession();
     let resolveSidebarSessions: ((value: Response) => void) | null = null;
 
@@ -635,17 +643,11 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
 
     const { default: SessionPage } = await import("./page");
 
-    renderWithQueryClient(<SessionPage />);
+    const { queryClient } = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
-    const latestBeforeSidebarResolve = projectSidebarSpy.mock.lastCall?.[0] as {
-      loading?: boolean;
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestBeforeSidebarResolve.loading).toBe(true);
-    expect(latestBeforeSidebarResolve.sessions).toBeNull();
     expect(resolveSidebarSessions).not.toBeNull();
+    expect(queryClient.getQueryState(SIDEBAR_SESSIONS_QUERY_KEY)?.status).toBe("pending");
 
     await act(async () => {
       resolveSidebarSessions?.({
@@ -658,13 +660,8 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
     });
     await flushAsyncWork();
 
-    const latestAfterSidebarResolve = projectSidebarSpy.mock.lastCall?.[0] as {
-      loading?: boolean;
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestAfterSidebarResolve.loading).toBe(false);
-    expect(latestAfterSidebarResolve.sessions).toEqual([workerSession]);
+    expect(queryClient.getQueryState(SIDEBAR_SESSIONS_QUERY_KEY)?.status).toBe("success");
+    expect(getSidebarQueryData(queryClient)?.sessions).toEqual([workerSession]);
   });
 
   it("surfaces sidebar fetch failures instead of leaving the loading skeleton active", async () => {
@@ -711,20 +708,13 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
 
     const { default: SessionPage } = await import("./page");
 
-    renderWithQueryClient(<SessionPage />);
+    const { queryClient } = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
-    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
-      error?: boolean;
-      errorMessage?: string;
-      loading?: boolean;
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestProps.loading).toBe(false);
-    expect(latestProps.error).toBe(true);
-    expect(latestProps.errorMessage).toBe("HTTP 500");
-    expect(latestProps.sessions).toEqual([]);
+    const queryState = queryClient.getQueryState(SIDEBAR_SESSIONS_QUERY_KEY);
+    expect(queryState?.status).toBe("error");
+    expect(queryState?.error).toEqual(expect.objectContaining({ message: "HTTP 500" }));
+    expect(getSidebarQueryData(queryClient)).toBeUndefined();
   });
 
   it("keeps the last sidebar sessions visible when a background refresh fails", async () => {
@@ -781,25 +771,21 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
 
     const { default: SessionPage } = await import("./page");
 
-    renderWithQueryClient(<SessionPage />);
+    const { queryClient } = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
+
+    expect(getSidebarQueryData(queryClient)?.sessions).toEqual([workerSession]);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(2_000);
     });
     await flushAsyncWork();
 
-    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
-      error?: boolean;
-      errorMessage?: string;
-      loading?: boolean;
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestProps.loading).toBe(false);
-    expect(latestProps.error).toBe(true);
-    expect(latestProps.errorMessage).toBe("GitHub API rate limited");
-    expect(latestProps.sessions).toEqual([workerSession]);
+    expect(sidebarFetchCount).toBeGreaterThanOrEqual(2);
+    expect(getSidebarQueryData(queryClient)?.sessions).toEqual([workerSession]);
+    expect(queryClient.getQueryState(SIDEBAR_SESSIONS_QUERY_KEY)?.error).toEqual(
+      expect.objectContaining({ message: "GitHub API rate limited" }),
+    );
   });
 
   it("applies mux snapshots that arrive before the initial sidebar fetch resolves", async () => {
@@ -859,7 +845,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
 
     const { default: SessionPage } = await import("./page");
 
-    renderWithQueryClient(<SessionPage />);
+    const { queryClient } = renderWithQueryClient(<SessionPage />);
     await flushAsyncWork();
 
     await act(async () => {
@@ -873,11 +859,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
     });
     await flushAsyncWork();
 
-    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestProps.sessions).toEqual([
+    expect(getSidebarQueryData(queryClient)?.sessions).toEqual([
       {
         ...workerSession,
         activity: "ready",
@@ -942,14 +924,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
     }) as typeof fetch;
 
     const { default: SessionPage } = await import("./page");
-    const queryClient = new QueryClient({
-      defaultOptions: {
-        queries: {
-          gcTime: 0,
-          retry: false,
-        },
-      },
-    });
+    const queryClient = createTestQueryClient();
     const view = render(
       <QueryClientProvider client={queryClient}>
         <SessionPage />
@@ -992,11 +967,7 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
     });
     await flushAsyncWork();
 
-    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
-      sessions?: DashboardSession[] | null;
-    };
-
-    expect(latestProps.sessions?.map((session) => session.id)).toEqual([
+    expect(getSidebarQueryData(queryClient)?.sessions.map((session) => session.id)).toEqual([
       "worker-1",
       "worker-2",
     ]);

--- a/packages/web/src/app/sessions/[id]/page.test.tsx
+++ b/packages/web/src/app/sessions/[id]/page.test.tsx
@@ -213,7 +213,7 @@ describe("SessionPage project polling", () => {
 
     expect(
       vi.mocked(fetch).mock.calls.filter(([url]) => url === "/api/sessions?view=sidebar"),
-    ).toHaveLength(3);
+    ).toHaveLength(6);
   });
 
   it("does not deadlock project polling after a cached worker poll is skipped", async () => {
@@ -886,6 +886,121 @@ it("marks sidebar data as loading until the sessions list resolves", async () =>
     ]);
   });
 
+  it("refreshes the sidebar immediately when mux sees a new session id", async () => {
+    const workerSession = makeWorkerSession();
+    const newWorkerSession: DashboardSession = {
+      ...makeWorkerSession(),
+      id: "worker-2",
+      branch: "feat/new-worker",
+      issueId: "https://linear.app/test/issue/INT-101",
+      issueUrl: "https://linear.app/test/issue/INT-101",
+      issueLabel: "INT-101",
+      summary: "New worker session",
+    };
+    let sidebarFetchCount = 0;
+
+    global.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === "/api/projects") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            projects: [{ id: "my-app", name: "My App", sessionPrefix: "my-app" }],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions/worker-1") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => workerSession,
+        } as Response;
+      }
+
+      if (url === "/api/sessions?view=sidebar") {
+        sidebarFetchCount += 1;
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({
+            sessions: sidebarFetchCount === 1 ? [workerSession] : [workerSession, newWorkerSession],
+          }),
+        } as Response;
+      }
+
+      if (url === "/api/sessions?project=my-app&orchestratorOnly=true&view=sidebar") {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => ({ orchestratorId: "my-app-orchestrator" }),
+        } as Response;
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const { default: SessionPage } = await import("./page");
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          gcTime: 0,
+          retry: false,
+        },
+      },
+    });
+    const view = render(
+      <QueryClientProvider client={queryClient}>
+        <SessionPage />
+      </QueryClientProvider>,
+    );
+    await flushAsyncWork();
+
+    mockMuxState.current = {
+      status: "connected",
+      sessions: [
+        {
+          id: "worker-1",
+          status: "working",
+          activity: "active",
+          attentionLevel: "working",
+          lastActivityAt: workerSession.lastActivityAt,
+        },
+        {
+          id: "worker-2",
+          status: "working",
+          activity: "active",
+          attentionLevel: "working",
+          lastActivityAt: newWorkerSession.lastActivityAt,
+        },
+      ],
+    };
+
+    await act(async () => {
+      view.rerender(
+        <QueryClientProvider client={queryClient}>
+          <SessionPage />
+        </QueryClientProvider>,
+      );
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await flushAsyncWork();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    await flushAsyncWork();
+
+    const latestProps = projectSidebarSpy.mock.lastCall?.[0] as {
+      sessions?: DashboardSession[] | null;
+    };
+
+    expect(latestProps.sessions?.map((session) => session.id)).toEqual([
+      "worker-1",
+      "worker-2",
+    ]);
+  });
 
   it("redirects the legacy session URL to the project-scoped route for clean projects", async () => {
     mockPathname = "/sessions/worker-1";

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef, type ReactNode } from "react";
 import { useParams, usePathname, useRouter } from "next/navigation";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { ACTIVITY_STATE, SESSION_STATUS, isOrchestratorSession } from "@aoagents/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
@@ -77,8 +78,14 @@ interface ProjectSessionsBody {
   orchestrators?: Array<{ id: string; projectId: string; projectName: string }>;
 }
 
+interface SidebarSessionsQueryData {
+  sessions: DashboardSession[];
+  orchestrators?: DashboardOrchestratorLink[];
+}
+
 let cachedProjects: ProjectInfo[] | null = null;
 let cachedSidebarSessions: DashboardSession[] | null = null;
+const SIDEBAR_SESSIONS_QUERY_KEY = ["session-detail", "sidebar-sessions"] as const;
 const SESSION_PAGE_REFRESH_INTERVAL_MS = 2000;
 const SESSION_FETCH_TIMEOUT_MS = 8000;
 const SESSION_LOAD_MAX_CONSECUTIVE_FAILURES = 4;
@@ -106,20 +113,6 @@ function areProjectsEqual(previous: ProjectInfo[] | null, next: ProjectInfo[]): 
   return previous.every((project, index) => {
     const candidate = next[index];
     return JSON.stringify(project) === JSON.stringify(candidate);
-  });
-}
-
-function areSidebarSessionsEqual(
-  previous: DashboardSession[] | null,
-  next: DashboardSession[],
-): boolean {
-  if (!previous || previous.length !== next.length) {
-    return false;
-  }
-
-  return previous.every((session, index) => {
-    const candidate = next[index];
-    return JSON.stringify(session) === JSON.stringify(candidate);
   });
 }
 
@@ -194,6 +187,7 @@ function SessionPageShell({
   sidebarOrchestrators,
   sidebarLoading,
   sidebarError,
+  sidebarErrorMessage,
   onRetrySidebar,
   activeProjectId,
   activeSessionId,
@@ -205,6 +199,7 @@ function SessionPageShell({
   sidebarOrchestrators?: ProjectSidebarOrchestrator[];
   sidebarLoading: boolean;
   sidebarError: boolean;
+  sidebarErrorMessage?: string;
   onRetrySidebar: () => void;
   activeProjectId?: string;
   activeSessionId?: string;
@@ -277,6 +272,7 @@ function SessionPageShell({
               orchestrators={sidebarOrchestrators}
               loading={sidebarLoading}
               error={sidebarError}
+              errorMessage={sidebarErrorMessage}
               onRetry={onRetrySidebar}
               activeProjectId={activeProjectId}
               activeSessionId={activeSessionId}
@@ -401,16 +397,9 @@ export default function SessionPage() {
   );
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [projectsLoading, setProjectsLoading] = useState(cachedProjects === null);
-  const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(
-    () => cachedSidebarSessions,
-  );
-  const [sidebarOrchestrators, setSidebarOrchestrators] = useState<
-    ProjectSidebarOrchestrator[] | undefined
-  >(undefined);
   const [loading, setLoading] = useState(cachedSession === null);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
-  const [sidebarError, setSidebarError] = useState(false);
   const [prefixByProject, setPrefixByProject] = useState<Map<string, string>>(new Map());
   const sessionProjectId = session?.projectId ?? null;
   const allPrefixes = [...prefixByProject.values()];
@@ -423,17 +412,17 @@ export default function SessionPage() {
   const prefixByProjectRef = useRef<Map<string, string>>(new Map());
   const hasLoadedSessionRef = useRef(cachedSession !== null);
   const pendingMuxSessionsRef = useRef<SessionPatch[] | null>(null);
+  const sidebarSessionsRef = useRef<DashboardSession[] | null>(cachedSidebarSessions);
   // In-flight guards — prevent concurrent duplicate fetches
   const fetchingSessionRef = useRef(false);
   const fetchingProjectSessionsRef = useRef(false);
-  const fetchingSidebarRef = useRef(false);
   const sessionFetchControllerRef = useRef<AbortController | null>(null);
   const projectSessionsFetchControllerRef = useRef<AbortController | null>(null);
-  const sidebarFetchControllerRef = useRef<AbortController | null>(null);
   const pageUnloadingRef = useRef(false);
   const sessionLoadFailureCountRef = useRef(0);
   const sessionLoadFirstFailureAtRef = useRef<number | null>(null);
   const sessionLoadRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const queryClient = useQueryClient();
 
   const clearSessionLoadRetry = useCallback(() => {
     if (sessionLoadRetryTimerRef.current) {
@@ -448,10 +437,57 @@ export default function SessionPage() {
     clearSessionLoadRetry();
   }, [clearSessionLoadRetry]);
 
+  const {
+    data: queriedSidebarData,
+    error: sidebarQueryError,
+    isError: sidebarQueryIsError,
+    isPending: sidebarQueryIsPending,
+    isRefetchError: sidebarQueryIsRefetchError,
+    refetch: refetchSidebarSessionsQuery,
+  } = useQuery<SidebarSessionsQueryData, Error>({
+    queryKey: SIDEBAR_SESSIONS_QUERY_KEY,
+    queryFn: async ({ signal }) => {
+      const body = await fetchJsonWithTimeout<{
+        sessions?: DashboardSession[];
+        orchestrators?: DashboardOrchestratorLink[];
+      } | null>("/api/sessions?fresh=true", {
+        signal,
+        timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
+        timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
+      });
+      const restSessions = body?.sessions ?? [];
+      const sessions =
+        applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
+      return { sessions, orchestrators: body?.orchestrators };
+    },
+    initialData: () =>
+      cachedSidebarSessions === null ? undefined : { sessions: cachedSidebarSessions },
+    initialDataUpdatedAt: 0,
+    refetchInterval: SESSION_PAGE_REFRESH_INTERVAL_MS,
+    refetchOnWindowFocus: false,
+    retry: false,
+    staleTime: SESSION_PAGE_REFRESH_INTERVAL_MS,
+  });
+
+  const sidebarSessions = queriedSidebarData?.sessions ?? (sidebarQueryIsError ? [] : null);
+  const sidebarOrchestrators = queriedSidebarData?.orchestrators;
+  const sidebarError = sidebarQueryIsError || sidebarQueryIsRefetchError;
+  const sidebarErrorMessage = sidebarQueryError?.message;
+  const sidebarLoading = sidebarQueryIsPending;
+  const refetchSidebarSessions = useCallback(async (): Promise<void> => {
+    await refetchSidebarSessionsQuery();
+  }, [refetchSidebarSessionsQuery]);
+
   // Keep prefixByProjectRef in sync so fetchProjectSessions (stable [] dep) reads latest map
   useEffect(() => {
     prefixByProjectRef.current = prefixByProject;
   }, [prefixByProject]);
+
+  useEffect(() => {
+    if (queriedSidebarData === undefined) return;
+    cachedSidebarSessions = queriedSidebarData.sessions;
+    sidebarSessionsRef.current = queriedSidebarData.sessions;
+  }, [queriedSidebarData]);
 
   // Fetch project prefix map once on mount so isOrchestratorSession can use the correct prefix
   const fetchProjects = useCallback(async () => {
@@ -670,44 +706,6 @@ export default function SessionPage() {
     }
   }, []);
 
-  const fetchSidebarSessions = useCallback(async () => {
-    if (fetchingSidebarRef.current) return;
-    fetchingSidebarRef.current = true;
-    const controller = new AbortController();
-    sidebarFetchControllerRef.current = controller;
-    try {
-      const body = await fetchJsonWithTimeout<{
-        sessions?: DashboardSession[];
-        orchestrators?: DashboardOrchestratorLink[];
-      } | null>("/api/sessions?fresh=true", {
-        signal: controller.signal,
-        timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
-        timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
-      });
-      const restSessions = body?.sessions ?? [];
-      const nextSessions =
-        applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
-      cachedSidebarSessions = nextSessions;
-      setSidebarOrchestrators(body?.orchestrators);
-      setSidebarError(false);
-      setSidebarSessions((current) =>
-        areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions,
-      );
-    } catch (err) {
-      if (pageUnloadingRef.current || controller.signal.aborted || isAbortLikeError(err)) {
-        return;
-      }
-      console.error("Failed to fetch sidebar sessions:", err);
-      setSidebarError(true);
-      setSidebarSessions((current) => (current === null ? [] : current));
-    } finally {
-      fetchingSidebarRef.current = false;
-      if (sidebarFetchControllerRef.current === controller) {
-        sidebarFetchControllerRef.current = null;
-      }
-    }
-  }, []);
-
   useEffect(() => {
     if (!mux?.sessions) return;
 
@@ -724,30 +722,36 @@ export default function SessionPage() {
     // Read current sessions via the module-level cache so this effect reacts to
     // new mux data only — keeping `sidebarSessions` out of the dep array avoids
     // re-running on every state change that the effect itself produces.
-    const next = applyMuxSessionPatches(cachedSidebarSessions, mux.sessions);
-    if (next !== cachedSidebarSessions) {
+    const currentSidebarSessions = sidebarSessionsRef.current;
+    const next = applyMuxSessionPatches(currentSidebarSessions, mux.sessions);
+    if (next !== currentSidebarSessions) {
       cachedSidebarSessions = next;
-      setSidebarSessions(next);
+      sidebarSessionsRef.current = next;
+      queryClient.setQueryData<SidebarSessionsQueryData>(SIDEBAR_SESSIONS_QUERY_KEY, (current) => ({
+        sessions: next,
+        orchestrators: current?.orchestrators,
+      }));
     }
 
-    if (mux.sessions.length === 0 || !cachedSidebarSessions) {
+    const latestSidebarSessions = sidebarSessionsRef.current;
+    if (mux.sessions.length === 0 || !latestSidebarSessions) {
       return;
     }
 
-    const cachedIds = new Set(cachedSidebarSessions.map((sidebarSession) => sidebarSession.id));
+    const cachedIds = new Set(latestSidebarSessions.map((sidebarSession) => sidebarSession.id));
     const muxIds = new Set(mux.sessions.map((muxSession) => muxSession.id));
     if (cachedIds.size !== muxIds.size) {
-      void fetchSidebarSessions();
+      void refetchSidebarSessions();
       return;
     }
 
     for (const muxId of muxIds) {
       if (!cachedIds.has(muxId)) {
-        void fetchSidebarSessions();
+        void refetchSidebarSessions();
         return;
       }
     }
-  }, [fetchSidebarSessions, mux?.sessions, mux?.status]);
+  }, [queryClient, refetchSidebarSessions, mux?.sessions, mux?.status]);
 
   useEffect(() => {
     if (!sessionIsOrchestrator) {
@@ -757,8 +761,8 @@ export default function SessionPage() {
 
   // Initial fetch — load independent sidebar/session data in parallel.
   useEffect(() => {
-    void Promise.all([fetchProjects(), fetchSession(), fetchSidebarSessions()]);
-  }, [fetchProjects, fetchSession, fetchSidebarSessions]);
+    void Promise.all([fetchProjects(), fetchSession()]);
+  }, [fetchProjects, fetchSession]);
 
   useEffect(() => {
     if (!sessionProjectId) return;
@@ -771,10 +775,9 @@ export default function SessionPage() {
     const interval = setInterval(() => {
       fetchSession();
       fetchProjectSessions();
-      fetchSidebarSessions();
     }, SESSION_PAGE_REFRESH_INTERVAL_MS);
     return () => clearInterval(interval);
-  }, [fetchSession, fetchProjectSessions, fetchSidebarSessions]);
+  }, [fetchSession, fetchProjectSessions]);
 
   useEffect(() => {
     pageUnloadingRef.current = false;
@@ -796,7 +799,6 @@ export default function SessionPage() {
       clearSessionLoadRetry();
       sessionFetchControllerRef.current?.abort();
       projectSessionsFetchControllerRef.current?.abort();
-      sidebarFetchControllerRef.current?.abort();
     };
   }, [clearSessionLoadRetry]);
 
@@ -807,9 +809,10 @@ export default function SessionPage() {
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
         sidebarOrchestrators={sidebarOrchestrators}
-        sidebarLoading={sidebarSessions === null}
+        sidebarLoading={sidebarLoading}
         sidebarError={sidebarError}
-        onRetrySidebar={fetchSidebarSessions}
+        sidebarErrorMessage={sidebarErrorMessage}
+        onRetrySidebar={refetchSidebarSessions}
         activeProjectId={expectedProjectId ?? undefined}
         activeSessionId={id}
       >
@@ -838,9 +841,10 @@ export default function SessionPage() {
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
         sidebarOrchestrators={sidebarOrchestrators}
-        sidebarLoading={sidebarSessions === null}
+        sidebarLoading={sidebarLoading}
         sidebarError={sidebarError}
-        onRetrySidebar={fetchSidebarSessions}
+        sidebarErrorMessage={sidebarErrorMessage}
+        onRetrySidebar={refetchSidebarSessions}
         activeProjectId={expectedProjectId ?? undefined}
         activeSessionId={id}
       >
@@ -867,9 +871,10 @@ export default function SessionPage() {
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
         sidebarOrchestrators={sidebarOrchestrators}
-        sidebarLoading={sidebarSessions === null}
+        sidebarLoading={sidebarLoading}
         sidebarError={sidebarError}
-        onRetrySidebar={fetchSidebarSessions}
+        sidebarErrorMessage={sidebarErrorMessage}
+        onRetrySidebar={refetchSidebarSessions}
         activeProjectId={session?.projectId ?? expectedProjectId ?? undefined}
         activeSessionId={id}
       >
@@ -884,7 +889,7 @@ export default function SessionPage() {
               setSessionMissing(false);
               setLoading(true);
               resetSessionLoadFailures();
-              void Promise.all([fetchProjects(), fetchSession(), fetchSidebarSessions()]);
+              void Promise.all([fetchProjects(), fetchSession(), refetchSidebarSessions()]);
             },
           }}
           secondaryAction={{
@@ -906,9 +911,10 @@ export default function SessionPage() {
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
         sidebarOrchestrators={sidebarOrchestrators}
-        sidebarLoading={sidebarSessions === null}
+        sidebarLoading={sidebarLoading}
         sidebarError={sidebarError}
-        onRetrySidebar={fetchSidebarSessions}
+        sidebarErrorMessage={sidebarErrorMessage}
+        onRetrySidebar={refetchSidebarSessions}
         activeProjectId={expectedProjectId ?? undefined}
         activeSessionId={id}
       >

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -443,7 +443,6 @@ export default function SessionPage() {
     error: sidebarQueryError,
     isError: sidebarQueryIsError,
     isPending: sidebarQueryIsPending,
-    isRefetchError: sidebarQueryIsRefetchError,
     refetch: refetchSidebarSessionsQuery,
   } = useQuery<SidebarSessionsQueryData, Error>({
     queryKey: SIDEBAR_SESSIONS_QUERY_KEY,
@@ -474,7 +473,7 @@ export default function SessionPage() {
 
   const sidebarSessions = queriedSidebarData?.sessions ?? (sidebarQueryIsError ? [] : null);
   const sidebarOrchestrators = queriedSidebarData?.orchestrators;
-  const sidebarError = sidebarQueryIsError || sidebarQueryIsRefetchError;
+  const sidebarError = sidebarQueryIsError;
   const sidebarErrorMessage = sidebarQueryError?.message;
   const sidebarLoading = sidebarQueryIsPending;
   const refetchSidebarSessions = useCallback(async (): Promise<void> => {

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -87,6 +87,7 @@ let cachedProjects: ProjectInfo[] | null = null;
 let cachedSidebarSessions: DashboardSession[] | null = null;
 const SIDEBAR_SESSIONS_QUERY_KEY = ["session-detail", "sidebar-sessions"] as const;
 const SESSION_PAGE_REFRESH_INTERVAL_MS = 2000;
+const SIDEBAR_SESSIONS_REFRESH_INTERVAL_MS = 1000;
 const SESSION_FETCH_TIMEOUT_MS = 8000;
 const SESSION_LOAD_MAX_CONSECUTIVE_FAILURES = 4;
 const SESSION_LOAD_MAX_RETRY_ELAPSED_MS = 30_000;
@@ -452,6 +453,7 @@ export default function SessionPage() {
         orchestrators?: DashboardOrchestratorLink[];
       } | null>("/api/sessions?view=sidebar", {
         signal,
+        cache: "no-store",
         timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
         timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
       });
@@ -463,10 +465,11 @@ export default function SessionPage() {
     initialData: () =>
       cachedSidebarSessions === null ? undefined : { sessions: cachedSidebarSessions },
     initialDataUpdatedAt: 0,
-    refetchInterval: SESSION_PAGE_REFRESH_INTERVAL_MS,
+    refetchInterval: SIDEBAR_SESSIONS_REFRESH_INTERVAL_MS,
+    refetchIntervalInBackground: true,
     refetchOnWindowFocus: false,
     retry: false,
-    staleTime: SESSION_PAGE_REFRESH_INTERVAL_MS,
+    staleTime: SIDEBAR_SESSIONS_REFRESH_INTERVAL_MS,
   });
 
   const sidebarSessions = queriedSidebarData?.sessions ?? (sidebarQueryIsError ? [] : null);
@@ -657,6 +660,7 @@ export default function SessionPage() {
         : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true&view=sidebar`;
       const body = await fetchJsonWithTimeout<ProjectSessionsBody>(query, {
         signal: controller.signal,
+        cache: "no-store",
         timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
         timeoutMessage: `Project sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
       });

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -450,7 +450,7 @@ export default function SessionPage() {
       const body = await fetchJsonWithTimeout<{
         sessions?: DashboardSession[];
         orchestrators?: DashboardOrchestratorLink[];
-      } | null>("/api/sessions?fresh=true", {
+      } | null>("/api/sessions?view=sidebar", {
         signal,
         timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
         timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
@@ -653,8 +653,8 @@ export default function SessionPage() {
     projectSessionsFetchControllerRef.current = controller;
     try {
       const query = isOrchestrator
-        ? `/api/sessions?project=${encodeURIComponent(projectId)}&fresh=true`
-        : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true&fresh=true`;
+        ? `/api/sessions?project=${encodeURIComponent(projectId)}&view=sidebar`
+        : `/api/sessions?project=${encodeURIComponent(projectId)}&orchestratorOnly=true&view=sidebar`;
       const body = await fetchJsonWithTimeout<ProjectSessionsBody>(query, {
         signal: controller.signal,
         timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -727,7 +727,7 @@ export default function SessionPage() {
     // re-running on every state change that the effect itself produces.
     const currentSidebarSessions = sidebarSessionsRef.current;
     const next = applyMuxSessionPatches(currentSidebarSessions, mux.sessions);
-    if (next !== currentSidebarSessions) {
+    if (next !== null && next !== currentSidebarSessions) {
       cachedSidebarSessions = next;
       sidebarSessionsRef.current = next;
       queryClient.setQueryData<SidebarSessionsQueryData>(SIDEBAR_SESSIONS_QUERY_KEY, (current) => ({

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -34,6 +34,7 @@ interface ProjectSidebarProps {
   activeSessionId: string | undefined;
   loading?: boolean;
   error?: boolean;
+  errorMessage?: string;
   onRetry?: () => void;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
@@ -278,6 +279,7 @@ function ProjectSidebarInner({
   activeSessionId,
   loading = false,
   error = false,
+  errorMessage,
   onRetry,
   collapsed = false,
   onToggleCollapsed: _onToggleCollapsed,
@@ -1056,7 +1058,11 @@ function ProjectSidebarInner({
                     })
                   ) : error ? (
                     <div className="px-3 py-2">
-                      <div className="project-sidebar__empty">Failed to load sessions</div>
+                      <div className="project-sidebar__empty">
+                        {errorMessage
+                          ? `Failed to load sessions: ${errorMessage}`
+                          : "Failed to load sessions"}
+                      </div>
                       <button
                         type="button"
                         className="mt-2 text-xs font-medium text-[var(--color-link)] hover:underline"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1909,10 +1909,10 @@ packages:
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
   '@tanstack/query-core@5.100.6':
-    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+    resolution: {integrity: sha512-Os2CPUr98to98RYm+D4qGqGkiffn7MGSyl2547a4MljVkHE30AMJRqTiyCqBfMwzAx/I91vCkAxp5tHSla6Twg==}
 
   '@tanstack/react-query@5.100.6':
-    resolution: {integrity: sha512-vAqcy84Zn5lJJx1aAVOHWUwHaowp+ALcP5NpLY6bZ4oKt1pzbP2Kf7RzKzdfSp2ltZUIYHG0cIYqbWJZgqZgA==}
+    resolution: {integrity: sha512-uVSrps0PV16Cxmcn2rvL+dUhwTpTUtiRW347AEeYxMZXO2pZe9ja7E24PAMGoQ5u2g89DD8u4QhOviBk+RN8RA==}
     peerDependencies:
       react: ^18 || ^19
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -712,6 +712,9 @@ importers:
       '@aoagents/ao-plugin-workspace-worktree':
         specifier: workspace:*
         version: link:../plugins/workspace-worktree
+      '@tanstack/react-query':
+        specifier: ^5.100.6
+        version: 5.100.6(react@19.2.5)
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
@@ -1904,6 +1907,14 @@ packages:
 
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
+
+  '@tanstack/query-core@5.100.6':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@tanstack/react-query@5.100.6':
+    resolution: {integrity: sha512-vAqcy84Zn5lJJx1aAVOHWUwHaowp+ALcP5NpLY6bZ4oKt1pzbP2Kf7RzKzdfSp2ltZUIYHG0cIYqbWJZgqZgA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4992,6 +5003,13 @@ snapshots:
       '@tailwindcss/oxide': 4.2.2
       postcss: 8.5.9
       tailwindcss: 4.2.2
+
+  '@tanstack/query-core@5.100.6': {}
+
+  '@tanstack/react-query@5.100.6(react@19.2.5)':
+    dependencies:
+      '@tanstack/query-core': 5.100.6
+      react: 19.2.5
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add TanStack Query to the web app provider and use it only for the session-detail sidebar sessions query
- keep the last successful sidebar session list visible when a background refresh fails
- add a sidebar-only `/api/sessions?view=sidebar` path that reads local session metadata via `listLocal()` instead of the live/enriched path
- make `/api/events` and `/api/sessions/patches` local-only with no-store responses so sidebar membership snapshots avoid runtime and agent probes
- watch AO project session metadata directories from the mux WebSocket server and broadcast a fresh sessions snapshot when session JSON files change
- pass the actual sidebar fetch error through to ProjectSidebar for better diagnostics

Closes #1410

## Why
The stale sidebar was not because local JSON reads are inherently slow. The slow path was that the detail-page sidebar and membership signals still depended on APIs that could touch runtime liveness, agent probes, OpenCode discovery, and metadata enrichment. Polling faster helped a little, but it did not make burst-spawn changes arrive when AO writes the local session metadata.

This PR makes the sidebar data path local-only and adds a direct local signal: when AO writes a project session metadata JSON file, the mux server debounces briefly, fetches `/api/sessions/patches`, and pushes that snapshot to connected browsers. The React Query sidebar then overlays known lightweight patch changes and refetches the full local sidebar list when membership changes, which is the piece needed for newly spawned workers to appear quickly.

## Validation
- `pnpm build`
- `pnpm lint`
- `pnpm test`
- `pnpm -r --filter '!@aoagents/ao-tui' typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web test -- server/__tests__/mux-websocket.test.ts`
- `pnpm --filter @aoagents/ao-web test -- 'src/app/sessions/[id]/page.test.tsx'`
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/api-routes.test.ts -t 'sidebar|sessions/patches|streams initial snapshot'`

## Notes
- Full `pnpm typecheck` is still blocked locally by the pre-existing `@aoagents/ao-tui` package importing missing `attachTmuxSession` from `@aoagents/ao-core`; the tracked non-TUI workspace typecheck passes.
- Full `pnpm --filter @aoagents/ao-web test` still has existing failures outside this fix: stale PR-enrichment expectations in `src/__tests__/api-routes.test.ts` and a missing `enrichSessionIssue` test import in `src/lib/__tests__/serialize.test.ts`. The sidebar/mux tests above pass.
- `agent-ci` was run and paused on the existing `npm-audit` advisories for `postcss <8.5.10` via `next@15.5.15`; that dependency audit is outside this sidebar-only PR.