### PR TITLE
fix(cli): register project command

### DIFF
--- a/packages/cli/__tests__/commands/project.test.ts
+++ b/packages/cli/__tests__/commands/project.test.ts
@@ -41,7 +41,7 @@ vi.mock("../../src/lib/prompts.js", () => ({
   promptConfirm: vi.fn(async () => true),
 }));
 
-import { registerProject_cmd } from "../../src/commands/project.js";
+import { registerProjectCommand } from "../../src/commands/project.js";
 
 let program: Command;
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -52,7 +52,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   program = new Command();
   program.exitOverride();
-  registerProject_cmd(program);
+  registerProjectCommand(program);
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
   _exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {

--- a/packages/cli/__tests__/program.test.ts
+++ b/packages/cli/__tests__/program.test.ts
@@ -6,4 +6,8 @@ describe("createProgram", () => {
   it("uses the CLI package version", () => {
     expect(createProgram().version()).toBe(packageJson.version);
   });
+
+  it("registers the project command", () => {
+    expect(createProgram().commands.some((command) => command.name() === "project")).toBe(true);
+  });
 });

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -29,7 +29,7 @@ function assertPortfolioEnabled(): void {
   process.exit(1);
 }
 
-export function registerProject_cmd(program: Command): void {
+export function registerProjectCommand(program: Command): void {
   const project = program.command("project").description("Manage portfolio projects");
 
   // ao project ls

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,6 +14,7 @@ import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
+import { registerProject_cmd } from "./commands/project.js";
 import { registerMigrateStorage } from "./commands/migrate-storage.js";
 import { registerCompletion } from "./commands/completion.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
@@ -45,6 +46,7 @@ export function createProgram(): Command {
   registerUpdate(program);
   registerSetup(program);
   registerPlugin(program);
+  registerProject_cmd(program);
   registerMigrateStorage(program);
   registerCompletion(program);
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -14,7 +14,7 @@ import { registerDoctor } from "./commands/doctor.js";
 import { registerUpdate } from "./commands/update.js";
 import { registerSetup } from "./commands/setup.js";
 import { registerPlugin } from "./commands/plugin.js";
-import { registerProject_cmd } from "./commands/project.js";
+import { registerProjectCommand } from "./commands/project.js";
 import { registerMigrateStorage } from "./commands/migrate-storage.js";
 import { registerCompletion } from "./commands/completion.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
@@ -46,7 +46,7 @@ export function createProgram(): Command {
   registerUpdate(program);
   registerSetup(program);
   registerPlugin(program);
-  registerProject_cmd(program);
+  registerProjectCommand(program);
   registerMigrateStorage(program);
   registerCompletion(program);
 


### PR DESCRIPTION
## Summary
- wire the existing project command into createProgram()
- add a program-level regression test so command files cannot exist without being exposed by the real CLI

Fixes #1574.

## Verification
- pnpm --filter @aoagents/ao-cli test -- __tests__/commands/project.test.ts __tests__/program.test.ts
- pre-commit gitleaks scan passed

## Notes
- pnpm --filter @aoagents/ao-cli typecheck currently fails on existing branch-wide core/CLI export drift, including pre-existing project.ts imports from @aoagents/ao-core. This PR only wires the existing command registration.