### PR TITLE
experiment: SCM interface redesign proposal

### DIFF
--- a/experiments/scm-implementation-plan.md
+++ b/experiments/scm-implementation-plan.md
@@ -1,0 +1,330 @@
+# SCM Interface Redesign: Implementation Plan
+
+## Context
+
+AO's lifecycle manager currently orchestrates 5+ scattered SCM method calls per poll cycle, managing provider-specific optimization details (ETag guards, GraphQL batching, review throttling) that belong inside the plugins. Additionally, hardcoded GitHub references exist in CLI and web. The goal is to make AO fully provider-agnostic by adding a single `poll()` method to the SCM interface, moving all optimization logic into the plugins, and removing hardcoded provider references.
+
+Design doc: `experiments/scm-interface-redesign.md` on branch `experiment/scm-gateway-design`.
+
+---
+
+## Phase 1: Type definitions
+
+**File: `packages/core/src/types.ts`**
+
+Add after the existing `PREnrichmentData` interface:
+
+```typescript
+export interface SessionPollInput {
+  sessionId: string;
+  session: Session;
+  project: ProjectConfig;
+}
+
+export interface SessionPollResult {
+  /** PR enrichment data. null if session has no PR. */
+  enrichment: PREnrichmentData | null;
+  /** Detected PR for sessions that didn't have one. null if no new PR found. */
+  detectedPR: PRInfo | null;
+  /** Review threads. null = plugin throttled this cycle (preserve existing metadata). */
+  reviewThreads: ReviewThreadsResult | null;
+}
+
+export type SessionPollResults = Map<string, SessionPollResult>;
+```
+
+Add to SCM interface (optional methods at the end):
+
+```typescript
+poll?(inputs: SessionPollInput[], observer?: BatchObserver): Promise<SessionPollResults>;
+checkAuth?(): Promise<void>;
+```
+
+Export `SessionPollInput`, `SessionPollResult`, `SessionPollResults` from `packages/core/src/index.ts`.
+
+---
+
+## Phase 2: GitHub plugin `poll()` + `checkAuth()`
+
+**File: `packages/plugins/scm-github/src/index.ts`**
+
+Add inside `createGitHubSCM()` scope:
+
+1. Add `lastReviewPollAt: Map<string, number>` and `REVIEW_POLL_THROTTLE_MS = 2 * 60 * 1000` (same as current lifecycle manager throttle).
+
+2. Add private `pollReviewThreads(session)` helper — checks throttle, calls existing `getReviewThreads(session.pr)`, returns `null` when throttled.
+
+3. Add `poll()` method to the returned SCM object:
+   - Collect PRs and repos from `inputs`
+   - Call existing `enrichSessionsPRBatchImpl(prs, observer, repos)` — reuse the current batch implementation
+   - For sessions without PR: call existing `detectPR()` gated by `batchResult.prListUnchangedRepos` (Guard 1 moves fully inside the plugin)
+   - Skip orchestrator sessions and `prAutoDetect === "off"` sessions (same conditions as current lifecycle manager lines 571-578)
+   - For sessions with PR: call `pollReviewThreads(session)` with internal throttle
+   - Return `Map<sessionId, SessionPollResult>`
+
+4. Add `checkAuth()`:
+   - Run `gh --version` → throw with install instructions if missing
+   - Run `gh auth status` → throw with auth instructions if not authenticated
+   - Reuse existing `execCli` helper from the plugin
+
+**Tests: `packages/plugins/scm-github/test/index.test.ts`**
+
+Add `describe("poll()")` block:
+- Returns enrichment for sessions with PRs (mock batch response)
+- Detects PRs for sessions without PR when Guard 1 permits
+- Skips PR detection when Guard 1 says unchanged
+- Throttles review threads to 2-minute intervals
+- Returns `null` reviewThreads when throttled
+- Handles batch failure gracefully (returns null enrichment)
+- Skips orchestrator sessions and `prAutoDetect === "off"`
+
+Add `describe("checkAuth()")`:
+- Throws with install message when `gh` missing
+- Throws with auth message when not authenticated
+- Succeeds when authenticated
+
+---
+
+## Phase 3: GitLab plugin `poll()` + `checkAuth()`
+
+**File: `packages/plugins/scm-gitlab/src/index.ts`**
+
+Same structure as GitHub but without batch optimization:
+
+1. Add `lastReviewPollAt` and throttle constant.
+
+2. Add `poll()`:
+   - For sessions with PR: parallel-call `getPRState()`, `getCISummary()`, `getReviewDecision()`, `getMergeability()` → assemble `PREnrichmentData`. Call `getReviewThreads()` with internal throttle.
+   - For sessions without PR: call `detectPR()` (no Guard 1 — GitLab has no ETag support)
+   - Skip orchestrator sessions and `prAutoDetect === "off"`
+   - Return `Map<sessionId, SessionPollResult>`
+
+3. Add `checkAuth()`:
+   - Run `glab --version` → throw with install instructions
+   - Run `glab auth status` → throw with auth instructions
+
+**Tests: `packages/plugins/scm-gitlab/test/index.test.ts`**
+
+Mirror GitHub test structure using `mockGlab()`.
+
+---
+
+## Phase 4: Lifecycle manager refactor
+
+**File: `packages/core/src/lifecycle-manager.ts`**
+
+This is the core change. Executed in sub-steps:
+
+### 4a: Add `pollReviewResults` cache
+
+At line ~433 (near existing `lastReviewBacklogCheckAt`):
+
+```typescript
+const pollReviewResults = new Map<string, ReviewThreadsResult>();
+```
+
+### 4b: Rename `populatePREnrichmentCache` → `populatePREnrichmentCacheLegacy`
+
+Keep the existing function body intact as the fallback path for plugins without `poll()`.
+
+### 4c: Add `pollSCMSessions()` function
+
+Replace the old `populatePREnrichmentCache` call with a new function (~50 lines) that:
+
+1. Clears `prEnrichmentCache`, `prListUnchangedRepos`, `pollReviewResults`
+2. Groups sessions by `project.scm.plugin`
+3. For each plugin:
+   - If `scm.poll` exists → call it, iterate results:
+     - Apply `detectedPR` to `session.pr` + write metadata
+     - Populate `prEnrichmentCache` (keyed by `"${owner}/${repo}#${number}"` — same key format as today)
+     - Populate `pollReviewResults` (keyed by `sessionId`)
+   - If no `poll()` → call `populatePREnrichmentCacheLegacy(sessions)`
+4. Extract the observer construction into `buildBatchObserver(pluginKey)` helper
+
+### 4d: Modify `maybeDispatchReviewBacklog()`
+
+Currently fetches review threads itself (lines 1409-1416). Change to:
+
+1. Check `pollReviewResults.get(session.id)` first
+2. If found → use those threads (plugin handled throttling)
+3. If not found AND `scm.poll` exists → `null` means throttled, skip, preserve metadata
+4. If not found AND no `poll()` → use existing fetch path with lifecycle manager's own throttle (legacy fallback)
+
+The fingerprinting, `isBot` splitting, reaction dispatch, and metadata persistence logic stays exactly as-is. Only the data source changes.
+
+### 4e: Persist review comments from poll results
+
+In `persistPREnrichmentToMetadata()` (line 615), after the existing enrichment blob write, add: if `pollReviewResults.has(session.id)`, persist `prReviewComments` metadata blob (same format as current `maybeDispatchReviewBacklog` lines 1424-1438). This ensures the dashboard gets fresh review data from `poll()`.
+
+### 4f: Update call sites
+
+In `pollAll()` (line 2211):
+```
+- await populatePREnrichmentCache(sessionsToCheck);
++ await pollSCMSessions(sessionsToCheck);
+```
+
+In `check()` (line 2329):
+```
+- await populatePREnrichmentCache([session]);
++ await pollSCMSessions([session]);
+```
+
+Add `pollReviewResults` to the stale-entry pruning loop (line 2234).
+
+### 4g: No changes needed to
+
+- `determineStatus()` — still reads from `prEnrichmentCache` (same Map, same keys)
+- `maybeDispatchMergeConflicts()` — still reads from `prEnrichmentCache`
+- `resolvePREnrichmentDecision()` / `resolvePRLiveDecision()` — unchanged
+- CI check detail for reaction messages — still reads `cachedData.ciChecks` from `prEnrichmentCache`
+
+**Invariants preserved:**
+- `prEnrichmentCache` populated before `checkSession()` runs (same ordering in `pollAll`)
+- `persistPREnrichmentToMetadata()` runs after `checkSession()` (same ordering)
+- Review fingerprinting and dispatch logic identical — only data source changes
+- Terminal state fallback (`getPRState` for merged/closed) still works via `determineStatus()`
+
+### Tests: `packages/core/src/__tests__/lifecycle-manager.test.ts`
+
+Update `createMockSCM()` in `test-utils.ts`:
+- Add `poll` mock that delegates to individual method mocks (so existing test overrides of `detectPR`, `enrichSessionsPRBatch`, etc. are reflected in `poll()` results)
+- Add `checkAuth` mock
+
+Add new test cases:
+- `poll()` provides enrichment data that drives status decisions
+- `poll()` detects PR and applies to session
+- `poll()` provides review threads that drive review backlog dispatch
+- `poll()` returns null reviewThreads (throttled) → lifecycle manager preserves existing metadata
+- `poll()` failure → lifecycle manager falls back to legacy path
+- Legacy path still works when `poll()` is undefined
+
+---
+
+## Phase 5: Remove hardcoded provider references
+
+### CLI spawn auth check
+
+**File: `packages/cli/src/commands/spawn.ts` (lines 100-105)**
+
+```
+- const needsGitHubAuth =
+-   project?.tracker?.plugin === "github" ||
+-   (options?.claimPr && project?.scm?.plugin === "github");
+- if (needsGitHubAuth) {
+-   await preflight.checkGhAuth();
+- }
++ // SCM auth check (provider-agnostic)
++ if (options?.claimPr && project?.scm?.plugin) {
++   const scm = registry.get<SCM>("scm", project.scm.plugin);
++   if (scm?.checkAuth) await scm.checkAuth();
++ }
++ // Tracker auth (still GitHub-specific until tracker interface gets checkAuth)
++ if (project?.tracker?.plugin === "github") {
++   await preflight.checkGhAuth();
++ }
+```
+
+### Web URL builders
+
+**File: `packages/web/src/lib/github-links.ts`**
+
+Rename to `packages/web/src/lib/scm-links.ts`. Make `buildCompareUrl()` derive origin from `pr.url` (same pattern `buildGitHubBranchUrl` already uses at line 58). Keep backward-compatible aliases:
+
+```typescript
+export { buildCompareUrl as buildGitHubCompareUrl };
+```
+
+**File: `packages/web/src/components/session-detail-utils.ts` (line 54)**
+
+Rename `buildGitHubBranchUrl` → `buildBranchUrl`. Already derives origin from `pr.url`. Add alias:
+
+```typescript
+export { buildBranchUrl as buildGitHubBranchUrl };
+```
+
+**Update imports in:**
+- `SessionDetailPRCard.tsx` — `buildGitHubCompareUrl` → `buildCompareUrl` from `@/lib/scm-links`
+- `SessionDetailHeader.tsx` — `buildGitHubBranchUrl` → `buildBranchUrl`
+- Any other component importing from `github-links.ts`
+
+**Rename test file:** `packages/web/src/lib/__tests__/github-links.test.ts` → `scm-links.test.ts`. Add test with GitLab-origin PR URL to verify origin derivation works for non-GitHub hosts.
+
+### CLI start clone (low priority)
+
+**File: `packages/cli/src/commands/start.ts` (line 459)**
+
+The `if (parsed.host === "github.com")` clone optimization is a convenience, not a correctness issue — the SSH/HTTPS fallback handles all providers. Add a comment clarifying this and leave as-is for now. A full fix would detect available CLIs (`gh`, `glab`) dynamically.
+
+---
+
+## Phase 6: Update test utilities
+
+**File: `packages/core/src/__tests__/test-utils.ts`**
+
+Update `createMockSCM()`:
+- Add `poll` field: `vi.fn()` that delegates to the mock's individual methods (`enrichSessionsPRBatch`, `detectPR`, `getReviewThreads`) so existing test overrides are automatically reflected
+- Add `checkAuth` field: `vi.fn().mockResolvedValue(undefined)`
+
+This ensures all existing lifecycle manager tests continue passing — they override individual SCM methods, and `poll()` delegates to those same mocks.
+
+---
+
+## Phase 7: Cleanup
+
+After all tests pass:
+
+1. Add `@deprecated Use poll()` JSDoc to `enrichSessionsPRBatch` in the SCM interface
+2. Remove `prListUnchangedRepos` from lifecycle manager (only used in legacy path, can be scoped inside `populatePREnrichmentCacheLegacy`)
+3. Scope `lastReviewBacklogCheckAt` inside the legacy branch of `maybeDispatchReviewBacklog`
+4. Remove `graphql_batch` metric logging from lifecycle manager (plugin logs its own metrics)
+5. Clean up duplicate `BatchObserver` type declaration in `types.ts` if it exists
+
+---
+
+## Dependency graph
+
+```
+Phase 1 (types) ──┬──→ Phase 2 (GitHub poll)  ──┐
+                  └──→ Phase 3 (GitLab poll)  ──┤
+                                                 ├──→ Phase 4 (lifecycle refactor) ──→ Phase 7 (cleanup)
+                  Phase 5 (hardcoded refs)  ─────┘
+                  Phase 6 (test utils) ──────────┘
+```
+
+Phases 2+3 run in parallel. Phase 5 is independent (touches different files). Phase 6 is woven into Phase 4.
+
+---
+
+## Verification
+
+1. `pnpm typecheck` — all packages pass
+2. `pnpm test` — all existing tests pass
+3. `pnpm --filter @aoagents/ao-web test` — web tests pass
+4. Manual test: `ao start` + `ao spawn --issue <issue>` → full lifecycle (PR detection → CI → review → merge → cleanup)
+5. Manual test: `ao status` shows correct PR/CI/review data
+6. Manual test: dashboard merge button works
+7. Grep for `"github"` in `packages/core/src/lifecycle-manager.ts` — zero matches
+8. Grep for `=== "github"` in `packages/cli/src/commands/` — only the tracker auth check remains
+
+---
+
+## Files modified
+
+| File | Change |
+|------|--------|
+| `packages/core/src/types.ts` | Add `SessionPollInput`, `SessionPollResult`, `poll()`, `checkAuth()` |
+| `packages/core/src/index.ts` | Export new types |
+| `packages/core/src/lifecycle-manager.ts` | Add `pollSCMSessions()`, modify `maybeDispatchReviewBacklog()`, modify `persistPREnrichmentToMetadata()`, update `pollAll()` and `check()` call sites |
+| `packages/plugins/scm-github/src/index.ts` | Add `poll()`, `checkAuth()`, internal review throttle |
+| `packages/plugins/scm-gitlab/src/index.ts` | Add `poll()`, `checkAuth()`, internal review throttle |
+| `packages/cli/src/commands/spawn.ts` | Replace `=== "github"` auth check with `scm.checkAuth()` |
+| `packages/web/src/lib/github-links.ts` | Rename to `scm-links.ts`, derive origin from `pr.url` |
+| `packages/web/src/components/session-detail-utils.ts` | Rename `buildGitHubBranchUrl` → `buildBranchUrl` |
+| `packages/web/src/components/SessionDetailPRCard.tsx` | Update import |
+| `packages/web/src/components/SessionDetailHeader.tsx` | Update import |
+| `packages/core/src/__tests__/test-utils.ts` | Add `poll` and `checkAuth` to mock SCM |
+| `packages/core/src/__tests__/lifecycle-manager.test.ts` | Add poll-path tests |
+| `packages/plugins/scm-github/test/index.test.ts` | Add poll + checkAuth tests |
+| `packages/plugins/scm-gitlab/test/index.test.ts` | Add poll + checkAuth tests |
+| `packages/web/src/lib/__tests__/github-links.test.ts` | Rename, add GitLab origin test |

--- a/experiments/scm-interface-redesign.md
+++ b/experiments/scm-interface-redesign.md
@@ -1,0 +1,285 @@
+# SCM Interface Redesign: Making AO Provider-Agnostic
+
+## Problem
+
+The SCM interface in `types.ts` is already the single contract between AO and any SCM provider. But AO reaches around the interface in places — the lifecycle manager orchestrates provider-specific optimization details, the CLI hard-checks plugin names, and the web hardcodes GitHub URLs.
+
+### Where provider knowledge leaks outside the plugins
+
+| Area | What leaks |
+|------|------------|
+| **Lifecycle manager** | `enrichSessionsPRBatch`, `prListUnchangedRepos`, Guard 1 ETag gating, `graphql_batch` metrics — all shaped around GitHub's batch strategy |
+| **CLI spawn** | `project.scm.plugin === "github"` for auth preflight |
+| **CLI start** | `host === "github.com"` for clone strategy |
+| **Web** | `buildGitHubCompareUrl()` / `buildGitHubBranchUrl()` hardcode `github.com` |
+
+### What the lifecycle manager does today
+
+The lifecycle manager owns ~200 lines of SCM orchestration:
+
+1. **`populatePREnrichmentCache()`** (~120 lines) — groups sessions by plugin, calls `enrichSessionsPRBatch()` (optional, only GitHub has it), manages `prEnrichmentCache` Map, manages `prListUnchangedRepos` (Guard 1 concept leaked into core), logs `graphql_batch` metrics, gates `detectPR()` based on Guard 1.
+
+2. **`determineStatus()`** — reads from `prEnrichmentCache`, falls back to individual `getPRState()` for cache misses (merged/closed only).
+
+3. **`maybeDispatchReviewBacklog()`** (~100 lines) — owns 2-minute throttle, checks if `scm.getReviewThreads` exists and falls back to `getPendingComments`, splits threads by `isBot`, manages fingerprint tracking, persists to metadata for dashboard.
+
+4. **`maybeDispatchMergeConflicts()`** — reads `hasConflicts` from `prEnrichmentCache`.
+
+The lifecycle manager knows that some plugins can batch and some can't, knows about ETag guards, manages caches shaped around GitHub's strategy, handles `getReviewThreads` vs `getPendingComments` fallback, and throttles review calls.
+
+---
+
+## Core insight
+
+The main thing AO does with SCM is: **poll the remote, detect changes in session PRs, update session states accordingly.**
+
+Every SCM method exists to answer one of these questions per session per poll cycle:
+
+```
+1. Does this session have a PR yet?          -> detectPR()
+2. What state is the PR in?                  -> getPRState() / getPRSummary()
+3. Is CI passing?                            -> getCIChecks() / getCISummary()
+4. What do reviewers say?                    -> getReviewDecision() / getReviewThreads()
+5. Can we merge?                             -> getMergeability()
+6. Are there new comments to act on?         -> getPendingComments() / getReviewThreads()
+7. Are there merge conflicts?                -> getMergeability().hasConflicts
+```
+
+All of these are "tell me the current remote state." The lifecycle manager shouldn't orchestrate how that data is fetched — it should just receive the answers.
+
+---
+
+## Solution
+
+The SCM interface in `types.ts` is already the gateway. We don't need a new layer. We need to:
+
+1. **Consolidate the polling into one `poll()` method** — so the lifecycle manager stops orchestrating internals.
+2. **Remove every SCM-provider-specific reference outside the plugins.**
+
+### Proposed interface
+
+```typescript
+interface SCM {
+  // Replaces: enrichSessionsPRBatch + detectPR + getPRState + getCISummary +
+  //           getReviewDecision + getMergeability + getReviewThreads + getPendingComments
+  poll(sessions: Session[], project: ProjectConfig): Promise<Map<string, SessionPRState>>
+
+  // Mutations — stay as-is
+  mergePR(pr: PRInfo, method?: MergeMethod): Promise<void>
+  closePR(pr: PRInfo): Promise<void>
+
+  // Operations — stay as-is
+  resolvePR(reference: string, project: ProjectConfig): Promise<PRInfo | null>
+  checkoutPR(pr: PRInfo, workspacePath: string): Promise<boolean>
+  assignPRToCurrentUser?(pr: PRInfo): Promise<void>
+
+  // Auth — new, replaces hardcoded plugin name checks
+  checkAuth?(): Promise<void>
+}
+```
+
+### Return shape from `poll()`
+
+One unified shape per session:
+
+```typescript
+interface SessionPRState {
+  prDetected: PRInfo | null
+  prState: "open" | "merged" | "closed" | null
+  ciStatus: "passing" | "failing" | "pending" | "none"
+  ciChecks: CICheck[]
+  reviewDecision: "approved" | "changes_requested" | "pending" | "none"
+  mergeability: {
+    mergeable: boolean
+    ciPassing: boolean
+    approved: boolean
+    noConflicts: boolean
+    blockers: string[]
+  }
+  reviewThreads: { threads: ReviewComment[], reviews: ReviewSummary[] } | null
+  hasConflicts: boolean
+  isDraft: boolean
+  title: string
+  additions: number
+  deletions: number
+}
+```
+
+### What moves where
+
+**Moves INTO the plugin's `poll()` implementation:**
+
+| Concern | Currently in lifecycle manager | After: inside plugin |
+|---------|-------------------------------|---------------------|
+| Batch enrichment orchestration | `populatePREnrichmentCache()` ~120 lines | GitHub plugin uses GraphQL batching internally |
+| PR enrichment cache | `prEnrichmentCache` Map in lifecycle manager | Plugin manages its own cache |
+| ETag guard gating | `prListUnchangedRepos` / Guard 1 skip logic | GitHub plugin's internal optimization |
+| Review throttling | 2-min throttle in `maybeDispatchReviewBacklog()` | Plugin decides when to refresh reviews |
+| `getReviewThreads` vs `getPendingComments` fallback | Lifecycle manager checks if method exists | Plugin returns review threads however it can |
+| `graphql_batch` metrics | Logged from lifecycle manager | Plugin logs its own metrics |
+
+**Stays in AO (provider-agnostic):**
+
+| Concern | Where |
+|---------|-------|
+| Call `scm.poll()` and read results | Lifecycle manager |
+| State transitions based on poll results | `lifecycle-status-decisions.ts` |
+| Review fingerprint tracking + dispatch | Lifecycle manager (reads from poll result) |
+| Merge conflict dispatch | Lifecycle manager (reads from poll result) |
+| `scm.mergePR()` / `scm.closePR()` | Session manager, web merge API |
+| `scm.resolvePR()` / `scm.checkoutPR()` | Session manager `claimPR()` |
+| `scm.checkAuth()` | CLI spawn preflight |
+
+---
+
+## Before and after
+
+### How the system behaves now
+
+```
+Lifecycle Manager (owns the choreography)
+|
+|  "I know that some plugins can batch, some can report
+|   unchanged repos, some have getReviewThreads and some
+|   don't. I orchestrate all of it."
+|
++-- populatePREnrichmentCache()           <- 120 lines
+|   +-- group sessions by plugin
+|   +-- call enrichSessionsPRBatch()      <- optional, only GitHub has it
+|   +-- manage prEnrichmentCache          <- lifecycle manager owns this Map
+|   +-- manage prListUnchangedRepos       <- Guard 1 concept leaked into core
+|   +-- log graphql_batch metrics         <- GitHub implementation detail in core
+|   +-- for sessions without PR:
+|       +-- check prListUnchangedRepos    <- skip if Guard 1 said no change
+|       +-- call detectPR()
+|
++-- determineStatus()
+|   +-- check prEnrichmentCache           <- read from the Map above
+|   +-- if cache miss:
+|   |   +-- call getPRState()             <- fallback, only for merged/closed
+|   +-- pass to resolvePREnrichmentDecision()
+|
++-- maybeDispatchReviewBacklog()          <- 100+ lines
+|   +-- 2-min throttle (lifecycle owns this)
+|   +-- if scm.getReviewThreads exists:
+|   |   +-- call getReviewThreads()
+|   +-- else:
+|   |   +-- call getPendingComments()     <- fallback
+|   +-- split by isBot
+|   +-- fingerprint tracking
+|   +-- persist to metadata for dashboard
+|
++-- maybeDispatchMergeConflicts()
+|   +-- read hasConflicts from prEnrichmentCache
+|
+CLI status
+|  +-- calls detectPR(), getCISummary(), getReviewDecision(),
+|     getPendingComments() fresh every time (4 API calls per session)
+|
+CLI spawn
+|  +-- if (project.scm.plugin === "github") checkGhAuth()
+|
+Web
+|  +-- buildGitHubCompareUrl() -> hardcoded "https://github.com"
+|  +-- merge API -> getPRState() + getMergeability() + mergePR()
+```
+
+### How the system should behave
+
+```
+Lifecycle Manager (knows nothing about SCM internals)
+|
+|  "I call poll(). I get states. I react."
+|
++-- const states = await scm.poll(sessions, project)
+|   |
+|   |  returns Map<sessionId, {
+|   |    prDetected, prState, ciStatus, ciChecks,
+|   |    reviewDecision, mergeability, reviewThreads,
+|   |    hasConflicts, isDraft, title, additions, deletions
+|   |  }>
+|   |
+|   +-- lifecycle manager just reads the map and transitions states.
+|      no cache management. no throttling. no fallbacks. no guards.
+|
++-- determineStatus()
+|   +-- read from poll() result -> resolvePREnrichmentDecision()
+|
++-- maybeDispatchReviewBacklog()
+|   +-- read reviewThreads from poll() result (already fetched, already split)
+|
++-- maybeDispatchMergeConflicts()
+|   +-- read hasConflicts from poll() result
+|
+CLI status
+|  +-- read last poll() result from metadata. zero API calls. instant.
+|
+CLI spawn
+|  +-- await scm.checkAuth()   <- plugin validates its own CLI auth
+|
+Web
+|  +-- buildBranchUrl(pr)      <- derives from pr.url origin, no hardcoded host
+|  +-- merge API -> scm.mergePR()
+
+
+Inside GitHub plugin (all GitHub knowledge lives here):
+|
++-- poll(sessions, project)
+    +-- Guard 1: ETag check on PR list
+    +-- Guard 2: ETag check on commit status
+    +-- GraphQL batch for changed PRs
+    +-- detectPR for sessions without PR (skipped if Guard 1 says no change)
+    +-- getReviewThreads (with internal throttle)
+    +-- cache management (TTL, LRU, positive-only detectPR)
+    +-- return unified Map
+
+
+Inside GitLab plugin (all GitLab knowledge lives here):
+|
++-- poll(sessions, project)
+    +-- glab api for each session's MR state
+    +-- glab api for pipelines
+    +-- glab api for approvals + discussions
+    +-- internal caching (whatever makes sense for GitLab)
+    +-- return unified Map
+```
+
+---
+
+## Comparison
+
+| | Now | After |
+|---|---|---|
+| **Lifecycle manager SCM code** | ~200 lines orchestrating 5+ methods, managing caches, throttling, fallbacks | ~5 lines: call `poll()`, read results |
+| **Lifecycle manager knows about** | batch vs non-batch plugins, ETag guards, review thread fallback, cache maps, throttle intervals | nothing — it gets a Map |
+| **Adding a new SCM plugin requires** | implementing 15+ methods, hoping the lifecycle manager's orchestration works for your plugin | implementing `poll()` + mutations |
+| **GitHub optimizations live in** | split between GitHub plugin (ETags, GraphQL) and lifecycle manager (cache, guard gating, throttle) | entirely inside GitHub plugin |
+| **CLI auth check** | `if (plugin === "github")` | `scm.checkAuth()` |
+| **Web URLs** | hardcoded `github.com` | derived from `pr.url` |
+| **Provider names in core/cli/web** | yes, scattered | zero |
+
+---
+
+## Hardcoded spots to fix
+
+| What | Where | Fix |
+|------|-------|-----|
+| `plugin === "github"` auth check | `cli/src/commands/spawn.ts:101` | Add `checkAuth()` to SCM interface. Each plugin validates its own CLI auth. |
+| `host === "github.com"` clone | `cli/src/commands/start.ts:459` | Detect CLI availability generically or add `cloneRepo()` to the interface. |
+| `buildGitHubCompareUrl()` | `web/src/lib/github-links.ts` | Derive URL from `pr.url` origin instead of hardcoding `github.com`. |
+| `buildGitHubBranchUrl()` | `web/src/components/session-detail-utils.ts:54` | Same — derive from `pr.url` origin. Already partially does this. |
+
+---
+
+## Webhook note
+
+The SCM interface also has `verifyWebhook()` and `parseWebhook()`. These are plumbed in the web webhook API route (`web/src/app/api/webhooks/[...slug]/route.ts`) but never actually used — AO runs locally and GitHub/GitLab can't POST to localhost. These can remain on the interface for future use but are not part of the core redesign.
+
+---
+
+## Non-goals
+
+- No new "gateway" layer or middleware. The SCM interface itself is the abstraction boundary.
+- No changes to the session lifecycle state machine or status decisions.
+- No changes to how mutations (`mergePR`, `closePR`) work.
+- No changes to the `claimPR` flow (just remove the hardcoded auth check).

--- a/experiments/scm-manual-testing.md
+++ b/experiments/scm-manual-testing.md
@@ -1,0 +1,105 @@
+# SCM Redesign: Manual Testing Plan
+
+After the refactor is complete, verify that AO behaves identically. The behavior should not change — only the internal structure.
+
+## 1. The basic loop — does polling work?
+
+```bash
+ao start
+ao spawn --issue <some-issue>
+```
+
+Watch the session go through its lifecycle:
+
+| What to check | How | What confirms it works |
+|---|---|---|
+| PR detection | Agent creates a PR | Dashboard shows PR link, status moves to `pr_open` |
+| CI tracking | PR triggers CI | Dashboard shows CI status (passing/failing/pending) |
+| CI failure reaction | Make CI fail (bad test) | Status moves to `ci_failed`, agent gets notified |
+| Review tracking | Leave a review comment on the PR | Status moves to `review_pending` or `changes_requested`, agent gets the comment |
+| Merge readiness | Approve PR + CI passes | Status moves to `mergeable` |
+| PR merged | Merge the PR | Status moves to `merged` → `cleanup` → `done` |
+
+If all those transitions happen correctly, `poll()` is working.
+
+## 2. CLI status — does it read cached data?
+
+```bash
+# While a session is active with a PR:
+ao status
+```
+
+**Before the change:** takes a few seconds (4 API calls per session).
+**After the change:** should be instant (reads last poll result from metadata).
+
+If `ao status` is instant and shows correct PR/CI/review data, the metadata path works.
+
+## 3. Merge from dashboard — do mutations work?
+
+Open the dashboard, find a mergeable PR, click merge.
+
+- PR should merge on GitHub/GitLab
+- Session should transition to `merged` → `cleanup` → `done`
+- Next poll should pick up the merged state
+
+## 4. Review comments — do they reach the agent?
+
+Leave an inline review comment on the PR. Wait for the next poll cycle (~30s).
+
+- Agent should receive the comment and start working on it
+- Dashboard should show the unresolved comment count
+- After agent pushes a fix, comment tracking should update
+
+## 5. Merge conflicts — does conflict detection work?
+
+Push a conflicting change to the base branch while a session's PR is open.
+
+- Dashboard should show conflict indicator
+- Agent should get notified about the conflict
+
+## 6. Auth preflight — does `checkAuth()` work?
+
+```bash
+# Log out of gh CLI:
+gh auth logout
+
+# Try to spawn:
+ao spawn --issue <some-issue>
+```
+
+Should fail with a clear auth error from the plugin, not a cryptic failure later.
+
+## 7. Web URLs — no hardcoded github.com?
+
+If you have a GitLab project, check:
+
+- Branch URL in session detail → should point to GitLab, not GitHub
+- Compare URL for conflicts → should point to GitLab
+
+## 8. The real proof — does GitLab actually work?
+
+Point AO at a GitLab repo:
+
+```yaml
+projects:
+  my-project:
+    repo: my-org/my-repo
+    scm:
+      plugin: gitlab
+```
+
+Run the same flow (spawn → PR → CI → review → merge). If it all works through the same AO code paths that work for GitHub, the provider-agnostic refactor is real.
+
+## 9. Regressions to watch for
+
+| Regression | How you'd notice |
+|---|---|
+| Poll returns stale data | Dashboard shows wrong CI status or review state |
+| Poll misses PR detection | Session stays in `working` even after agent created a PR |
+| Review throttle broken | Agent gets spammed with duplicate review comments, or never gets them |
+| Cache invalidation broken | After merging, dashboard still shows PR as open |
+| Metrics missing | Observability/logging for SCM calls disappears (check logs) |
+
+## Summary
+
+No special test harness needed. Spawn a session, let it create a PR, interact with the PR on GitHub/GitLab (review it, fail CI, merge it), and watch if AO reacts correctly at each step. If the lifecycle transitions match reality, the refactor works.


### PR DESCRIPTION
## Summary

- Design doc proposing a redesign of the SCM plugin interface to make AO fully provider-agnostic
- Consolidates 5+ scattered SCM calls in the lifecycle manager into a single `poll()` method
- Moves all optimization logic (ETag guards, GraphQL batching, caching) into the plugins where it belongs
- Identifies and proposes fixes for hardcoded GitHub references in core/cli/web

## Details

See `experiments/scm-interface-redesign.md` for the full proposal.

**This is a design doc only — no code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)