### PR TITLE
fix(core): deliver enriched review content on changes_requested transition

### DIFF
--- a/.changeset/fix-review-enrichment-double-billing.md
+++ b/.changeset/fix-review-enrichment-double-billing.md
@@ -1,0 +1,13 @@
+---
+"@aoagents/ao-core": patch
+---
+
+fix(core): prevent double-billing reaction attempts on changes_requested transition
+
+The enriched review dispatch in `maybeDispatchReviewBacklog` now sends directly via
+`sessionManager.send` when the transition handler already called `executeReaction` for
+the same reaction key. This prevents the attempt counter from incrementing twice in a
+single poll cycle, which would cause premature escalation for projects with `retries: 1`.
+
+Also moves the review backlog throttle timestamp after the SCM fetch so a failed
+`getReviewThreads` call doesn't block retries for 2 minutes.

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2061,11 +2061,89 @@ describe("reactions", () => {
     expect(enrichedMessage).toContain("@reviewer");
     expect(enrichedMessage).toContain("Please add validation");
 
-    // Second check is throttled (within REVIEW_BACKLOG_THROTTLE_MS window) and
-    // the fingerprint already matches — neither path re-sends.
+    // Second check: throttled (within REVIEW_BACKLOG_THROTTLE_MS window) and
+    // fingerprint already matches dispatch hash — neither path re-sends.
     vi.mocked(mockSessionManager.send).mockClear();
     await lm.check("app-1");
     expect(mockSessionManager.send).not.toHaveBeenCalled();
+  });
+
+  it("does not double-bill reaction attempts on changes_requested transition with retries:1", async () => {
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "changes-requested": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Handle requested changes.",
+        retries: 1,
+      },
+    };
+
+    const mockSCM = createMockSCM({
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      enrichSessionsPRBatch: vi.fn().mockImplementation(async (prs: PRInfo[]) => {
+        const result = new Map();
+        for (const pr of prs) {
+          result.set(`${pr.owner}/${pr.repo}#${pr.number}`, {
+            state: "open",
+            ciStatus: "passing",
+            reviewDecision: "changes_requested",
+            mergeable: false,
+          });
+        }
+        return result;
+      }),
+      getReviewThreads: vi.fn().mockResolvedValue({
+        threads: [
+          {
+            id: "c1",
+            author: "reviewer",
+            body: "Needs validation",
+            path: "src/handler.ts",
+            line: 10,
+            isResolved: false,
+            createdAt: new Date(),
+            url: "https://example.com/comment/retries",
+            isBot: false,
+          },
+        ],
+        reviews: [],
+      }),
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    // Transition handler sends the generic message (attempt 1), and the backlog
+    // dispatch sends the enriched message directly (no attempt increment).
+    // Total sends = 2 but reaction attempts = 1, so no escalation.
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    expect(notifier.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reaction.escalated" }),
+    );
+
+    // The enriched message should contain the actual review content
+    const enrichedMessage = vi.mocked(mockSessionManager.send).mock.calls[1]![1] as string;
+    expect(enrichedMessage).toContain("src/handler.ts:10");
+    expect(enrichedMessage).toContain("Needs validation");
   });
 
   it("dispatches detailed automated review comments when using the default sentinel message", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2146,6 +2146,79 @@ describe("reactions", () => {
     expect(enrichedMessage).toContain("Needs validation");
   });
 
+  it("routes enriched review dispatch through executeReaction when action is notify (not send-to-agent)", async () => {
+    const notifier = createMockNotifier();
+
+    config.reactions = {
+      "changes-requested": {
+        auto: true,
+        action: "notify",
+        message: "Review changes requested.",
+      },
+    };
+    config.notificationRouting = {
+      ...config.notificationRouting,
+      info: ["desktop"],
+    };
+
+    const mockSCM = createMockSCM({
+      getReviewDecision: vi.fn().mockResolvedValue("changes_requested"),
+      enrichSessionsPRBatch: vi.fn().mockImplementation(async (prs: PRInfo[]) => {
+        const result = new Map();
+        for (const pr of prs) {
+          result.set(`${pr.owner}/${pr.repo}#${pr.number}`, {
+            state: "open",
+            ciStatus: "passing",
+            reviewDecision: "changes_requested",
+            mergeable: false,
+          });
+        }
+        return result;
+      }),
+      getReviewThreads: vi.fn().mockResolvedValue({
+        threads: [
+          {
+            id: "c1",
+            author: "reviewer",
+            body: "Fix the type",
+            path: "src/api.ts",
+            line: 5,
+            isResolved: false,
+            createdAt: new Date(),
+            url: "https://example.com/comment/notify",
+            isBot: false,
+          },
+        ],
+        reviews: [],
+      }),
+    });
+
+    const registry: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string, name: string) => {
+        if (slot === "runtime") return plugins.runtime;
+        if (slot === "agent") return plugins.agent;
+        if (slot === "scm") return mockSCM;
+        if (slot === "notifier" && name === "desktop") return notifier;
+        return null;
+      }),
+    };
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    // action: "notify" should NOT send to the agent — it routes through
+    // executeReaction → notifyHuman. The bypass branch must not fire.
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+    expect(notifier.notify).toHaveBeenCalled();
+  });
+
   it("dispatches detailed automated review comments when using the default sentinel message", async () => {
     config.reactions = {
       "bugbot-comments": {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1998,7 +1998,7 @@ describe("reactions", () => {
     expect(metadata?.["lastPendingReviewDispatchHash"]).toBe("c1");
   });
 
-  it("does not double-send when changes_requested transition already triggered the reaction", async () => {
+  it("sends enriched review content on changes_requested transition alongside the generic message", async () => {
     config.reactions = {
       "changes-requested": {
         auto: true,
@@ -2052,12 +2052,19 @@ describe("reactions", () => {
     });
 
     await lm.check("app-1");
-    await lm.check("app-1");
 
-    // First call is the transition reaction (static message), second would be
-    // the review backlog dispatch. But the changes_requested transition guard
-    // prevents double-send, so only 1 call total.
-    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    // First call is the transition reaction (generic message), second is
+    // the backlog dispatch with actual review comment content.
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(2);
+    const enrichedMessage = vi.mocked(mockSessionManager.send).mock.calls[1]![1] as string;
+    expect(enrichedMessage).toContain("src/route.ts:44");
+    expect(enrichedMessage).toContain("@reviewer");
+    expect(enrichedMessage).toContain("Please add validation");
+
+    // Second check should not re-send — fingerprint matches.
+    vi.mocked(mockSessionManager.send).mockClear();
+    await lm.check("app-1");
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
   });
 
   it("dispatches detailed automated review comments when using the default sentinel message", async () => {

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2061,7 +2061,8 @@ describe("reactions", () => {
     expect(enrichedMessage).toContain("@reviewer");
     expect(enrichedMessage).toContain("Please add validation");
 
-    // Second check should not re-send — fingerprint matches.
+    // Second check is throttled (within REVIEW_BACKLOG_THROTTLE_MS window) and
+    // the fingerprint already matches — neither path re-sends.
     vi.mocked(mockSessionManager.send).mockClear();
     await lm.check("app-1");
     expect(mockSessionManager.send).not.toHaveBeenCalled();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -676,7 +676,7 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
       auto: true,
       action: "send-to-agent",
       message:
-        "There are review comments on your PR. Details will follow shortly.",
+        "There are new review comments on your PR requesting changes.",
       escalateAfter: "30m",
     },
     "bugbot-comments": {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1485,11 +1485,9 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         return;
       }
     }
-    lastReviewBacklogCheckAt.set(session.id, Date.now());
-
     // Single GraphQL call for all review threads (human + bot) + review summaries.
     // Split locally by isBot for separate reaction pipelines.
-    let allThreads: ReviewComment[] | null = null;
+    let allThreads: ReviewComment[];
     let reviewSummaries: ReviewSummary[] = [];
     try {
       if (scm.getReviewThreads) {
@@ -1501,11 +1499,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
         allThreads = await scm.getPendingComments(session.pr);
       }
     } catch {
-      // Failed to fetch — preserve existing metadata
+      // Failed to fetch — preserve existing metadata.
+      // Don't update the throttle timestamp so the next poll retries immediately
+      // instead of being blocked for 2 minutes with the agent left on a bare notification.
+      return;
     }
 
+    // Only stamp the throttle after a successful SCM fetch. If the fetch failed,
+    // we returned above so the next poll can retry without waiting 2 minutes.
+    lastReviewBacklogCheckAt.set(session.id, Date.now());
+
     // Persist review comments + summaries to metadata for dashboard consumption
-    if (allThreads !== null) {
+    {
       const unresolved = allThreads.filter((c) => !c.isBot);
       const reviewBlob = JSON.stringify({
         unresolvedThreads: unresolved.length,
@@ -1527,12 +1532,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
     }
 
-    const pendingComments = allThreads ? allThreads.filter((c) => !c.isBot) : null;
-    const automatedComments = allThreads ? allThreads.filter((c) => c.isBot) : null;
+    const pendingComments = allThreads.filter((c) => !c.isBot);
+    const automatedComments = allThreads.filter((c) => c.isBot);
 
     // --- Pending (human) review comments ---
-    // null = SCM fetch failed; skip processing to preserve existing metadata.
-    if (pendingComments !== null) {
+    {
       const pendingFingerprint = makeFingerprint(pendingComments.map((comment) => comment.id));
       const lastPendingFingerprint = session.metadata["lastPendingReviewFingerprint"] ?? "";
       const lastPendingDispatchHash = session.metadata["lastPendingReviewDispatchHash"] ?? "";
@@ -1563,12 +1567,30 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           reactionConfig.action &&
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
-          const enrichedConfig = {
-            ...reactionConfig,
-            message: formatReviewCommentsMessage(pendingComments, "reviewer", reviewSummaries),
-          };
-          const result = await executeReaction(session, humanReactionKey, enrichedConfig);
-          if (result.success) {
+          const enrichedMessage = formatReviewCommentsMessage(
+            pendingComments,
+            "reviewer",
+            reviewSummaries,
+          );
+
+          // When the transition handler already called executeReaction for this
+          // key, send the enriched payload directly to avoid double-billing the
+          // reaction attempt budget. A project with retries:1 would otherwise
+          // escalate on the very first transition poll.
+          let success = false;
+          if (transitionReaction?.key === humanReactionKey) {
+            try {
+              await sessionManager.send(session.id, enrichedMessage);
+              success = true;
+            } catch {
+              // Send failed — will retry on next unthrottled poll
+            }
+          } else {
+            const enrichedConfig = { ...reactionConfig, message: enrichedMessage };
+            const result = await executeReaction(session, humanReactionKey, enrichedConfig);
+            success = result.success;
+          }
+          if (success) {
             updateSessionMetadata(session, {
               lastPendingReviewDispatchHash: pendingFingerprint,
               lastPendingReviewDispatchAt: new Date().toISOString(),
@@ -1579,7 +1601,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
 
     // --- Automated (bot) review comments ---
-    if (automatedComments !== null) {
+    {
       const automatedFingerprint = makeFingerprint(automatedComments.map((comment) => comment.id));
       const lastAutomatedFingerprint = session.metadata["lastAutomatedReviewFingerprint"] ?? "";
       const lastAutomatedDispatchHash = session.metadata["lastAutomatedReviewDispatchHash"] ?? "";
@@ -1605,14 +1627,22 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           reactionConfig.action &&
           (reactionConfig.auto !== false || reactionConfig.action === "notify")
         ) {
-          // Always enrich with formatted comment listing so the agent has inline
-          // data and doesn't need to re-fetch via gh api.
-          const enrichedConfig = {
-            ...reactionConfig,
-            message: formatReviewCommentsMessage(automatedComments, "bot"),
-          };
-          const result = await executeReaction(session, automatedReactionKey, enrichedConfig);
-          if (result.success) {
+          const enrichedMessage = formatReviewCommentsMessage(automatedComments, "bot");
+
+          let success = false;
+          if (transitionReaction?.key === automatedReactionKey) {
+            try {
+              await sessionManager.send(session.id, enrichedMessage);
+              success = true;
+            } catch {
+              // Send failed — will retry on next unthrottled poll
+            }
+          } else {
+            const enrichedConfig = { ...reactionConfig, message: enrichedMessage };
+            const result = await executeReaction(session, automatedReactionKey, enrichedConfig);
+            success = result.success;
+          }
+          if (success) {
             updateSessionMetadata(session, {
               lastAutomatedReviewDispatchHash: automatedFingerprint,
               lastAutomatedReviewDispatchAt: new Date().toISOString(),

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1472,11 +1472,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // (getReviewThreads) consumes API quota on every poll.
     //
     // Exception: bypass throttle when a transition reaction just fired for a
-    // review reaction key. The transitionReaction branch records
-    // lastPendingReviewDispatchHash, which requires the current fingerprint from
-    // the API. If we throttle here, that metadata never gets written and the
-    // next unthrottled poll sees a "new" fingerprint, clears the reaction tracker,
-    // and fires a duplicate dispatch.
+    // review reaction key. The enriched dispatch needs the current fingerprint
+    // from the API so it can fire and record the hash in the same cycle. If we
+    // throttle here, the next unthrottled poll sees a "new" fingerprint, clears
+    // the reaction tracker, and fires a duplicate dispatch.
     const hasRelevantTransition =
       transitionReaction?.key === humanReactionKey ||
       transitionReaction?.key === automatedReactionKey;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1439,7 +1439,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
   async function maybeDispatchReviewBacklog(
     session: Session,
-    oldStatus: SessionStatus,
+    _oldStatus: SessionStatus,
     newStatus: SessionStatus,
     transitionReaction?: { key: string; result: ReactionResult | null },
   ): Promise<void> {
@@ -1557,20 +1557,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           lastPendingReviewDispatchHash: "",
           lastPendingReviewDispatchAt: "",
         });
-      } else if (
-        transitionReaction?.key === humanReactionKey &&
-        transitionReaction.result?.success
-      ) {
-        if (lastPendingDispatchHash !== pendingFingerprint) {
-          updateSessionMetadata(session, {
-            lastPendingReviewDispatchHash: pendingFingerprint,
-            lastPendingReviewDispatchAt: new Date().toISOString(),
-          });
-        }
-      } else if (
-        !(oldStatus !== newStatus && newStatus === "changes_requested") &&
-        pendingFingerprint !== lastPendingDispatchHash
-      ) {
+      } else if (pendingFingerprint !== lastPendingDispatchHash) {
         const reactionConfig = getReactionConfigForSession(session, humanReactionKey);
         if (
           reactionConfig &&

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1577,8 +1577,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           // key, send the enriched payload directly to avoid double-billing the
           // reaction attempt budget. A project with retries:1 would otherwise
           // escalate on the very first transition poll.
+          // Only bypass for "send-to-agent" — "notify" actions must go through
+          // executeReaction so they route to notifyHuman instead of the agent.
           let success = false;
-          if (transitionReaction?.key === humanReactionKey) {
+          if (
+            transitionReaction?.key === humanReactionKey &&
+            reactionConfig.action === "send-to-agent"
+          ) {
             try {
               await sessionManager.send(session.id, enrichedMessage);
               success = true;
@@ -1630,7 +1635,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           const enrichedMessage = formatReviewCommentsMessage(automatedComments, "bot");
 
           let success = false;
-          if (transitionReaction?.key === automatedReactionKey) {
+          if (
+            transitionReaction?.key === automatedReactionKey &&
+            reactionConfig.action === "send-to-agent"
+          ) {
             try {
               await sessionManager.send(session.id, enrichedMessage);
               success = true;


### PR DESCRIPTION
## Summary

Fixes a bug where the agent never received actual review comment content when a PR transitioned to `changes_requested`. The agent only got a generic message — *"There are review comments on your PR. Details will follow shortly."* — but the detailed review bodies (file paths, line numbers, authors, comment text) never followed.

Closes #1558

## Root Cause

The review dispatch in `maybeDispatchReviewBacklog` has two paths:

| Path | When | What it sends |
|------|------|---------------|
| **Transition reaction** | Status transitions to `changes_requested` | Generic message from config |
| **Backlog dispatch** | Comment fingerprint changes | Enriched content via `formatReviewCommentsMessage()` |

On the first transition, the transition reaction fired (generic message), then the backlog dispatch recorded the fingerprint hash as "already dispatched" — **without ever sending the actual comment content**. The deduplication logic then blocked the enriched dispatch from ever firing for those comments:

1. **Branch B** (lines 1477-1486): recorded `lastPendingReviewDispatchHash` when the transition reaction succeeded, burning the hash without delivering content
2. **Transition guard** (line 1488): `!(oldStatus !== newStatus && newStatus === "changes_requested")` explicitly skipped the enriched dispatch during the transition poll

This is unlike `ci-failed`, which enriches its transition reaction with actual CI check details from the batch cache. `changes-requested` never got the same treatment — review threads are fetched separately in `maybeDispatchReviewBacklog`, not in the batch PR enrichment.

## Fix

- **Remove Branch B** — the block that recorded the dispatch hash when the transition reaction succeeded without sending enriched content
- **Remove the transition guard** — so the backlog dispatch fires in the same poll cycle as the transition
- **Update default message** — remove the "Details will follow shortly" promise since details now arrive immediately

After the fix, the enriched review content (file paths, line numbers, authors, comment bodies, thread IDs) is dispatched in the same poll cycle as the transition. The agent receives two messages back-to-back: the generic transition notification followed immediately by the detailed review content. Subsequent polls skip dispatch because the fingerprint hash matches — no duplicates.

## Files Changed

- `packages/core/src/lifecycle-manager.ts` — removed premature hash recording and transition guard from `maybeDispatchReviewBacklog`
- `packages/core/src/config.ts` — updated default `changes-requested` message
- `packages/core/src/__tests__/lifecycle-manager.test.ts` — updated test to verify enriched content is delivered on transition

## Test plan

- [x] All 1006 core tests pass (`pnpm --filter @aoagents/ao-core test`)
- [ ] Verify agent receives detailed review comments on first `changes_requested` transition
- [ ] Verify no duplicate dispatch on subsequent polls with unchanged comments
- [ ] Verify new comments arriving while in `changes_requested` trigger a fresh enriched dispatch