### PR TITLE
fix(cli): skip rebuild when git install is already on latest version

### DIFF
--- a/packages/cli/__tests__/scripts/update-script.test.ts
+++ b/packages/cli/__tests__/scripts/update-script.test.ts
@@ -236,11 +236,12 @@ exit 0`,
     expect(result.stderr).toContain("commit or stash");
   });
 
-  it("exits early with 'Already on latest version' when local HEAD matches remote HEAD", () => {
+  it("skips rebuild but still runs smoke tests when local HEAD matches remote HEAD", () => {
     const tempRoot = mkdtempSync(join(tmpdir(), "ao-update-already-latest-"));
     const fakeRepo = join(tempRoot, "repo");
     mkdirSync(join(fakeRepo, "packages", "cli"), { recursive: true });
-    mkdirSync(join(fakeRepo, "packages", "ao"), { recursive: true });
+    mkdirSync(join(fakeRepo, "packages", "ao", "bin"), { recursive: true });
+    writeFileSync(join(fakeRepo, "packages", "ao", "bin", "ao.js"), "#!/usr/bin/env node\n");
 
     const binDir = join(tempRoot, "bin");
     mkdirSync(binDir, { recursive: true });
@@ -276,7 +277,7 @@ exit 0`,
       `printf 'node %s\\n' "$*" >> ${JSON.stringify(commandLog)}\nif [ "$1" = "--version" ]; then\n  printf 'v20.11.1\\n'\nfi\nexit 0`,
     );
 
-    const result = spawnSync("bash", [scriptPath, "--skip-smoke"], {
+    const result = spawnSync("bash", [scriptPath], {
       env: {
         ...process.env,
         PATH: `${binDir}:${process.env.PATH || ""}`,
@@ -290,9 +291,18 @@ exit 0`,
 
     expect(result.status).toBe(0);
     expect(result.stdout).toContain("Already on latest version");
+    // Rebuild commands should NOT have run
     expect(commands).not.toContain("pnpm install");
     expect(commands).not.toContain("pnpm --filter @aoagents/ao-core build");
     expect(commands).not.toContain("npm link");
+    expect(commands).not.toContain("git pull --ff-only origin main");
+    // Smoke tests SHOULD still have run
+    expect(commands).toContain(
+      `node ${join(fakeRepo, "packages", "ao", "bin", "ao.js")} --version`,
+    );
+    expect(commands).toContain(
+      `node ${join(fakeRepo, "packages", "ao", "bin", "ao.js")} doctor --help`,
+    );
   });
 
   it("rejects conflicting smoke flags in the script", () => {

--- a/packages/cli/__tests__/scripts/update-script.test.ts
+++ b/packages/cli/__tests__/scripts/update-script.test.ts
@@ -36,6 +36,8 @@ describe("ao-update.sh", () => {
   "status --porcelain") ;;
   "branch --show-current") printf 'main\\n' ;;
   "fetch origin main") ;;
+  "rev-parse HEAD") printf 'oldsha000\\n' ;;
+  "rev-parse origin/main") printf 'newsha111\\n' ;;
   "pull --ff-only origin main") ;;
   *) ;;
 esac\nexit 0`,
@@ -96,6 +98,8 @@ esac\nexit 0`,
   "status --porcelain") ;;
   "branch --show-current") printf 'main\\n' ;;
   "fetch upstream main") ;;
+  "rev-parse HEAD") printf 'oldsha000\\n' ;;
+  "rev-parse upstream/main") printf 'newsha111\\n' ;;
   "pull --ff-only upstream main") ;;
   *) ;;
 esac\nexit 0`,
@@ -232,6 +236,65 @@ exit 0`,
     expect(result.stderr).toContain("commit or stash");
   });
 
+  it("exits early with 'Already on latest version' when local HEAD matches remote HEAD", () => {
+    const tempRoot = mkdtempSync(join(tmpdir(), "ao-update-already-latest-"));
+    const fakeRepo = join(tempRoot, "repo");
+    mkdirSync(join(fakeRepo, "packages", "cli"), { recursive: true });
+    mkdirSync(join(fakeRepo, "packages", "ao"), { recursive: true });
+
+    const binDir = join(tempRoot, "bin");
+    mkdirSync(binDir, { recursive: true });
+    const commandLog = join(tempRoot, "commands.log");
+
+    const sha = "abc123def456abc123def456abc123def456abc123";
+
+    createFakeBinary(
+      binDir,
+      "git",
+      `printf 'git %s\\n' "$*" >> ${JSON.stringify(commandLog)}
+case "$*" in
+  "remote get-url upstream") exit 1 ;;
+  "rev-parse --is-inside-work-tree") printf 'true\\n' ;;
+  "status --porcelain") ;;
+  "branch --show-current") printf 'main\\n' ;;
+  "fetch origin main") ;;
+  "rev-parse HEAD") printf '${sha}\\n' ;;
+  "rev-parse origin/main") printf '${sha}\\n' ;;
+  *) ;;
+esac
+exit 0`,
+    );
+    createFakeBinary(
+      binDir,
+      "pnpm",
+      `printf 'pnpm %s\\n' "$*" >> ${JSON.stringify(commandLog)}\nif [ "$1" = "--version" ]; then\n  printf '9.15.4\\n'\nfi\nexit 0`,
+    );
+    createFakeBinary(binDir, "npm", `printf 'npm %s\\n' "$*" >> ${JSON.stringify(commandLog)}\nexit 0`);
+    createFakeBinary(
+      binDir,
+      "node",
+      `printf 'node %s\\n' "$*" >> ${JSON.stringify(commandLog)}\nif [ "$1" = "--version" ]; then\n  printf 'v20.11.1\\n'\nfi\nexit 0`,
+    );
+
+    const result = spawnSync("bash", [scriptPath, "--skip-smoke"], {
+      env: {
+        ...process.env,
+        PATH: `${binDir}:${process.env.PATH || ""}`,
+        AO_REPO_ROOT: fakeRepo,
+      },
+      encoding: "utf8",
+    });
+
+    const commands = readFileSync(commandLog, "utf8");
+    rmSync(tempRoot, { recursive: true, force: true });
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("Already on latest version");
+    expect(commands).not.toContain("pnpm install");
+    expect(commands).not.toContain("pnpm --filter @aoagents/ao-core build");
+    expect(commands).not.toContain("npm link");
+  });
+
   it("rejects conflicting smoke flags in the script", () => {
     const result = spawnSync("bash", [scriptPath, "--skip-smoke", "--smoke-only"], {
       encoding: "utf8",
@@ -262,6 +325,8 @@ exit 0`,
     fi
     ;;
   "branch --show-current") printf "main\\n" ;;
+  "rev-parse HEAD") printf "oldsha000\\n" ;;
+  "rev-parse origin/main") printf "newsha111\\n" ;;
   "pull --ff-only origin main") touch ${JSON.stringify(join(tempRoot, "post-dirty"))} ;;
 esac
 exit 0`,

--- a/packages/cli/src/assets/scripts/ao-update.sh
+++ b/packages/cli/src/assets/scripts/ao-update.sh
@@ -182,35 +182,34 @@ if [ "$SMOKE_ONLY" = false ]; then
   remote_sha="$(git rev-parse "$UPDATE_REMOTE/$TARGET_BRANCH")"
   if [ "$local_sha" = "$remote_sha" ]; then
     printf '\nAlready on latest version.\n'
-    exit 0
+  else
+    run_cmd git pull --ff-only "$UPDATE_REMOTE" "$TARGET_BRANCH"
+    run_cmd pnpm install
+
+    run_cmd pnpm --filter @aoagents/ao-core clean
+    run_cmd pnpm --filter @aoagents/ao-cli clean
+    run_cmd pnpm --filter @aoagents/ao-web clean
+
+    run_cmd pnpm --filter @aoagents/ao-core build
+    run_cmd pnpm --filter @aoagents/ao-cli build
+    run_cmd pnpm --filter @aoagents/ao-web build
+
+    printf '\nRefreshing ao launcher...\n'
+    (
+      cd "$REPO_ROOT/packages/ao"
+      if npm link 2>/dev/null; then
+        :
+      elif [ -t 0 ]; then
+        printf '  Permission denied. Retrying with sudo...\n'
+        sudo npm link
+      else
+        printf 'ERROR: Permission denied. Run manually: cd %s/packages/ao && sudo npm link\n' "$REPO_ROOT"
+        exit 1
+      fi
+    )
+
+    ensure_repo_clean "Update modified tracked files. Inspect git status, review the changes, and rerun after restoring a clean checkout if needed."
   fi
-
-  run_cmd git pull --ff-only "$UPDATE_REMOTE" "$TARGET_BRANCH"
-  run_cmd pnpm install
-
-  run_cmd pnpm --filter @aoagents/ao-core clean
-  run_cmd pnpm --filter @aoagents/ao-cli clean
-  run_cmd pnpm --filter @aoagents/ao-web clean
-
-  run_cmd pnpm --filter @aoagents/ao-core build
-  run_cmd pnpm --filter @aoagents/ao-cli build
-  run_cmd pnpm --filter @aoagents/ao-web build
-
-  printf '\nRefreshing ao launcher...\n'
-  (
-    cd "$REPO_ROOT/packages/ao"
-    if npm link 2>/dev/null; then
-      :
-    elif [ -t 0 ]; then
-      printf '  Permission denied. Retrying with sudo...\n'
-      sudo npm link
-    else
-      printf 'ERROR: Permission denied. Run manually: cd %s/packages/ao && sudo npm link\n' "$REPO_ROOT"
-      exit 1
-    fi
-  )
-
-  ensure_repo_clean "Update modified tracked files. Inspect git status, review the changes, and rerun after restoring a clean checkout if needed."
 fi
 
 if [ "$SKIP_SMOKE" = false ]; then

--- a/packages/cli/src/assets/scripts/ao-update.sh
+++ b/packages/cli/src/assets/scripts/ao-update.sh
@@ -177,6 +177,14 @@ if [ "$SMOKE_ONLY" = false ]; then
   maybe_sync_origin_with_upstream
 
   run_cmd git fetch "$UPDATE_REMOTE" "$TARGET_BRANCH"
+
+  local_sha="$(git rev-parse HEAD)"
+  remote_sha="$(git rev-parse "$UPDATE_REMOTE/$TARGET_BRANCH")"
+  if [ "$local_sha" = "$remote_sha" ]; then
+    printf '\nAlready on latest version.\n'
+    exit 0
+  fi
+
   run_cmd git pull --ff-only "$UPDATE_REMOTE" "$TARGET_BRANCH"
   run_cmd pnpm install
 


### PR DESCRIPTION
## Summary

- `ao update` on a git install was running the full rebuild pipeline (fetch, pull, pnpm install, clean, build, npm link) every invocation, even when nothing had changed
- After `git fetch`, we now compare local `HEAD` to the remote branch tip; if they match, we print `Already on latest version.` and exit 0
- The npm/pnpm install path already had this guard (`handleNpmUpdate` calls `checkForUpdate()` first) — this brings the git path to parity

## Root Cause

`handleGitUpdate()` in `update.ts` delegates unconditionally to `ao-update.sh` with no version check beforehand. The shell script had no mechanism to detect "nothing to do" — it fetched and rebuilt regardless of whether local HEAD matched the remote.

## Test Plan

- [x] New test: `ao-update.sh > exits early with 'Already on latest version' when local HEAD matches remote HEAD` — verifies exit 0, correct message, and that `pnpm install`/`pnpm build`/`npm link` are NOT called
- [x] All existing `update-script.test.ts` tests updated with `rev-parse HEAD`/`rev-parse origin/main` stubs returning different SHAs (so the update path still exercises correctly)
- [x] All 7 update-script tests pass
- [x] `pnpm build` passes

Closes #1584

🤖 Generated with [Claude Code](https://claude.com/claude-code)