### PR TITLE
fix: make update checks install-method aware

### DIFF
--- a/packages/cli/__tests__/commands/doctor.test.ts
+++ b/packages/cli/__tests__/commands/doctor.test.ts
@@ -11,6 +11,8 @@ const {
   mockRegistry,
   mockGetCurrentVersion,
   mockReadCachedUpdateInfo,
+  mockDetectInstallMethod,
+  mockGetUpdateCommand,
 } = vi.hoisted(() => ({
   mockRunRepoScript: vi.fn(),
   mockFindConfigFile: vi.fn(),
@@ -25,6 +27,8 @@ const {
   },
   mockGetCurrentVersion: vi.fn(() => "0.2.2"),
   mockReadCachedUpdateInfo: vi.fn(() => null),
+  mockDetectInstallMethod: vi.fn(() => "unknown"),
+  mockGetUpdateCommand: vi.fn(() => "npm install -g @aoagents/ao@latest"),
 }));
 
 vi.mock("../../src/lib/script-runner.js", () => ({
@@ -36,7 +40,10 @@ vi.mock("@aoagents/ao-core", () => ({
   findConfigFile: (...args: unknown[]) => mockFindConfigFile(...args),
   getObservabilityBaseDir: () => "/tmp/.agent-orchestrator/observability",
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-  resolveNotifierTarget: (config: { notifiers?: Record<string, { plugin?: string }> }, reference: string) => {
+  resolveNotifierTarget: (
+    config: { notifiers?: Record<string, { plugin?: string }> },
+    reference: string,
+  ) => {
     const configured = config.notifiers?.[reference];
     return {
       reference,
@@ -51,8 +58,10 @@ vi.mock("../../src/lib/openclaw-probe.js", () => ({
 }));
 
 vi.mock("../../src/lib/update-check.js", () => ({
+  detectInstallMethod: () => mockDetectInstallMethod(),
   getCurrentVersion: () => mockGetCurrentVersion(),
-  readCachedUpdateInfo: () => mockReadCachedUpdateInfo(),
+  getUpdateCommand: (...args: unknown[]) => mockGetUpdateCommand(...args),
+  readCachedUpdateInfo: (...args: unknown[]) => mockReadCachedUpdateInfo(...args),
   isVersionOutdated: (current: string, latest: string) => {
     const parseVersion = (version: string) => {
       const [base, prerelease] = version.split("-", 2);
@@ -219,7 +228,9 @@ describe("doctor command", () => {
     const output = consoleLogSpy.mock.calls.map((call) => call[0]).join("\n");
     expect(output).toContain('defaults.runtime -> runtime plugin "tmux"');
     expect(output).toContain('projects.my-app.scm.plugin -> scm plugin "github"');
-    expect(output).toContain('defaults.notifiers: alerts (plugin: slack) -> notifier plugin "slack"');
+    expect(output).toContain(
+      'defaults.notifiers: alerts (plugin: slack) -> notifier plugin "slack"',
+    );
   });
 
   it("fails when a referenced plugin cannot be loaded", async () => {

--- a/packages/cli/__tests__/lib/update-check.test.ts
+++ b/packages/cli/__tests__/lib/update-check.test.ts
@@ -13,11 +13,19 @@ const { mockExistsSync, mockReadFileSync, mockWriteFileSync, mockUnlinkSync, moc
     mockMkdirSync: vi.fn(),
   }));
 
-const { mockExecFileSync } = vi.hoisted(() => ({
+const { mockExecFileSync, mockExecFile } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
+  mockExecFile: vi.fn((...args: unknown[]) => {
+    const callback = args.at(-1);
+    if (typeof callback === "function") {
+      callback(null, "", "");
+    }
+    return null;
+  }),
 }));
 
 vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
   execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
 }));
 
@@ -71,6 +79,13 @@ describe("update-check", () => {
     vi.resetAllMocks();
     mockExistsSync.mockReturnValue(false);
     mockExecFileSync.mockReturnValue("");
+    mockExecFile.mockImplementation((...args: unknown[]) => {
+      const callback = args.at(-1);
+      if (typeof callback === "function") {
+        callback(null, "", "");
+      }
+      return null;
+    });
   });
 
   afterEach(() => {
@@ -313,6 +328,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 
@@ -329,6 +345,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: old,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).toBeNull();
@@ -342,6 +359,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: recent,
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).not.toBeNull();
@@ -354,6 +372,7 @@ describe("update-check", () => {
           latestVersion: "0.5.0",
           checkedAt: now,
           currentVersionAtCheck: "9.9.9",
+          installMethod: "unknown",
         }),
       );
       expect(readCachedUpdateInfo()).toBeNull();
@@ -392,7 +411,7 @@ describe("update-check", () => {
       expect(readCachedUpdateInfo("pnpm-global")).toBeNull();
     });
 
-    it("treats legacy cache entries without installMethod as unsafe for git installs", () => {
+    it("treats legacy cache entries without installMethod as unsafe for all installs", () => {
       const currentVersion = getCurrentVersion();
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
@@ -402,6 +421,9 @@ describe("update-check", () => {
         }),
       );
       expect(readCachedUpdateInfo("git")).toBeNull();
+      expect(readCachedUpdateInfo("npm-global")).toBeNull();
+      expect(readCachedUpdateInfo("pnpm-global")).toBeNull();
+      expect(readCachedUpdateInfo("unknown")).toBeNull();
     });
 
     it("returns null when git cache was checked at a different HEAD", () => {
@@ -497,10 +519,11 @@ describe("update-check", () => {
         latestRevision: "abc123",
         isBehind: false,
       });
-      expect(mockExecFileSync).toHaveBeenCalledWith(
+      expect(mockExecFile).toHaveBeenCalledWith(
         "git",
         ["fetch", "origin", "main"],
         expect.objectContaining({ cwd: "/repo" }),
+        expect.any(Function),
       );
     });
 
@@ -633,6 +656,7 @@ describe("update-check", () => {
           latestVersion: "0.3.0",
           checkedAt: now,
           currentVersionAtCheck: currentVersion,
+          installMethod: "npm-global",
         }),
       );
       mockExistsSync.mockReturnValue(false);
@@ -905,6 +929,7 @@ describe("update-check", () => {
           latestVersion: "99.0.0",
           checkedAt: new Date().toISOString(),
           currentVersionAtCheck: currentVersion,
+          installMethod: "unknown",
         }),
       );
 

--- a/packages/cli/__tests__/lib/update-check.test.ts
+++ b/packages/cli/__tests__/lib/update-check.test.ts
@@ -13,6 +13,14 @@ const { mockExistsSync, mockReadFileSync, mockWriteFileSync, mockUnlinkSync, moc
     mockMkdirSync: vi.fn(),
   }));
 
+const { mockExecFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  execFileSync: (...args: unknown[]) => mockExecFileSync(...args),
+}));
+
 vi.mock("node:fs", async () => {
   const actual = await vi.importActual("node:fs");
   return {
@@ -44,6 +52,7 @@ import {
   getUpdateCommand,
   getCacheDir,
   readCachedUpdateInfo,
+  fetchGitLatestState,
   fetchLatestVersion,
   invalidateCache,
   writeCache,
@@ -61,6 +70,7 @@ describe("update-check", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     mockExistsSync.mockReturnValue(false);
+    mockExecFileSync.mockReturnValue("");
   });
 
   afterEach(() => {
@@ -127,39 +137,51 @@ describe("update-check", () => {
   describe("classifyInstallPath", () => {
     it("returns 'npm-global' for /usr/local/lib/node_modules path", () => {
       expect(
-        classifyInstallPath("/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/usr/local/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for nvm global path", () => {
       expect(
-        classifyInstallPath("/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.nvm/versions/node/v20.0.0/lib/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'npm-global' for Windows global path", () => {
       expect(
-        classifyInstallPath("C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js"),
+        classifyInstallPath(
+          "C:\\Users\\test\\AppData\\Roaming\\npm\\lib\\node_modules\\@aoagents\\ao-cli\\dist\\lib\\update-check.js",
+        ),
       ).toBe("npm-global");
     });
 
     it("returns 'pnpm-global' for pnpm global store path", () => {
       expect(
-        classifyInstallPath("/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/.local/share/pnpm/global/5/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("pnpm-global");
     });
 
     it("returns 'unknown' for local pnpm node_modules/.pnpm (not global)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/.pnpm/@aoagents+ao-cli@0.2.2/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
     it("returns 'unknown' for local project node_modules (npx)", () => {
       mockExistsSync.mockReturnValue(false);
       expect(
-        classifyInstallPath("/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js"),
+        classifyInstallPath(
+          "/home/user/my-project/node_modules/@aoagents/ao-cli/dist/lib/update-check.js",
+        ),
       ).toBe("unknown");
     });
 
@@ -189,9 +211,7 @@ describe("update-check", () => {
 
     it("returns 'unknown' when .git does not exist at the resolved repo root", () => {
       mockExistsSync.mockReturnValue(false);
-      expect(
-        classifyInstallPath("/tmp/random/path/update-check.ts"),
-      ).toBe("unknown");
+      expect(classifyInstallPath("/tmp/random/path/update-check.ts")).toBe("unknown");
     });
   });
 
@@ -358,6 +378,51 @@ describe("update-check", () => {
       mockReadFileSync.mockReturnValue("");
       expect(readCachedUpdateInfo()).toBeNull();
     });
+
+    it("returns null when cache install method differs", () => {
+      const currentVersion = getCurrentVersion();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: new Date().toISOString(),
+          currentVersionAtCheck: currentVersion,
+          installMethod: "npm-global",
+        }),
+      );
+      expect(readCachedUpdateInfo("pnpm-global")).toBeNull();
+    });
+
+    it("treats legacy cache entries without installMethod as unsafe for git installs", () => {
+      const currentVersion = getCurrentVersion();
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "0.3.0",
+          checkedAt: new Date().toISOString(),
+          currentVersionAtCheck: currentVersion,
+        }),
+      );
+      expect(readCachedUpdateInfo("git")).toBeNull();
+    });
+
+    it("returns null when git cache was checked at a different HEAD", () => {
+      const currentVersion = getCurrentVersion();
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "new-head\n";
+        return "";
+      });
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          latestVersion: "origin/main",
+          checkedAt: new Date().toISOString(),
+          currentVersionAtCheck: currentVersion,
+          installMethod: "git",
+          isOutdated: true,
+          currentRevisionAtCheck: "old-head",
+        }),
+      );
+
+      expect(readCachedUpdateInfo("git")).toBeNull();
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -375,7 +440,9 @@ describe("update-check", () => {
         currentVersionAtCheck: "0.2.2",
       });
 
-      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), { recursive: true });
+      expect(mockMkdirSync).toHaveBeenCalledWith(expect.stringContaining("ao"), {
+        recursive: true,
+      });
       expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
@@ -408,6 +475,54 @@ describe("update-check", () => {
           currentVersionAtCheck: "0.2.2",
         }),
       ).not.toThrow();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // fetchGitLatestState
+  // -----------------------------------------------------------------------
+
+  describe("fetchGitLatestState", () => {
+    it("returns not behind when HEAD matches origin/main", async () => {
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse") return "abc123\n";
+        return "";
+      });
+
+      const state = await fetchGitLatestState("/repo");
+
+      expect(state).toEqual({
+        ref: "origin/main",
+        headRevision: "abc123",
+        latestRevision: "abc123",
+        isBehind: false,
+      });
+      expect(mockExecFileSync).toHaveBeenCalledWith(
+        "git",
+        ["fetch", "origin", "main"],
+        expect.objectContaining({ cwd: "/repo" }),
+      );
+    });
+
+    it("returns behind when HEAD is an ancestor of origin/main", async () => {
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "local\n";
+        if (args[0] === "rev-parse" && args[1] === "origin/main") return "remote\n";
+        return "";
+      });
+
+      const state = await fetchGitLatestState("/repo");
+
+      expect(state?.isBehind).toBe(true);
+      expect(state?.latestRevision).toBe("remote");
+    });
+
+    it("returns null when git commands fail", async () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error("git failed");
+      });
+
+      await expect(fetchGitLatestState("/repo")).resolves.toBeNull();
     });
   });
 
@@ -522,7 +637,7 @@ describe("update-check", () => {
       );
       mockExistsSync.mockReturnValue(false);
 
-      const info = await checkForUpdate();
+      const info = await checkForUpdate({ installMethod: "npm-global" });
       expect(info.isOutdated).toBe(true);
       expect(info.latestVersion).toBe("0.3.0");
       expect(mockFetch).not.toHaveBeenCalled();
@@ -580,6 +695,7 @@ describe("update-check", () => {
       const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
       expect(written.latestVersion).toBe("0.3.0");
       expect(written.currentVersionAtCheck).toBe(getCurrentVersion());
+      expect(written.installMethod).toBe("unknown");
     });
 
     it("does NOT write cache when fetch fails", async () => {
@@ -636,6 +752,113 @@ describe("update-check", () => {
       expect(typeof info.recommendedCommand).toBe("string");
       expect(info.recommendedCommand.length).toBeGreaterThan(0);
     });
+
+    it("uses cached npm-global data for npm-global installs", async () => {
+      const currentVersion = getCurrentVersion();
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) {
+          return JSON.stringify({
+            latestVersion: "0.3.0",
+            checkedAt: new Date().toISOString(),
+            currentVersionAtCheck: currentVersion,
+            installMethod: "npm-global",
+          });
+        }
+        return JSON.stringify({ name: "not-ao" });
+      });
+
+      const info = await checkForUpdate({ installMethod: "npm-global" });
+
+      expect(info.latestVersion).toBe("0.3.0");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("uses npm registry and npm-global command for npm-global installs", async () => {
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) throw new Error("ENOENT");
+        return JSON.stringify({ name: "not-ao" });
+      });
+      mockExistsSync.mockReturnValue(false);
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: "0.3.0" }),
+      });
+
+      const info = await checkForUpdate({ force: true, installMethod: "npm-global" });
+      expect(info.installMethod).toBe("npm-global");
+      expect(info.latestVersion).toBe("0.3.0");
+      expect(info.recommendedCommand).toBe("npm install -g @aoagents/ao@latest");
+    });
+
+    it("uses npm registry and pnpm-global command for pnpm-global installs", async () => {
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) throw new Error("ENOENT");
+        return JSON.stringify({ name: "not-ao" });
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({ version: "0.3.0" }),
+      });
+
+      const info = await checkForUpdate({ force: true, installMethod: "pnpm-global" });
+      expect(info.installMethod).toBe("pnpm-global");
+      expect(info.latestVersion).toBe("0.3.0");
+      expect(info.recommendedCommand).toBe("pnpm add -g @aoagents/ao@latest");
+    });
+
+    it("uses cached git state without consulting npm registry", async () => {
+      const currentVersion = getCurrentVersion();
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "abc\n";
+        return "";
+      });
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) {
+          return JSON.stringify({
+            latestVersion: "origin/main",
+            checkedAt: new Date().toISOString(),
+            currentVersionAtCheck: currentVersion,
+            installMethod: "git",
+            isOutdated: false,
+            currentRevisionAtCheck: "abc",
+            latestRevisionAtCheck: "abc",
+          });
+        }
+        return JSON.stringify({ name: "@aoagents/ao" });
+      });
+
+      const info = await checkForUpdate();
+
+      expect(info.installMethod).toBe("git");
+      expect(info.isOutdated).toBe(false);
+      expect(info.latestVersion).toBe("origin/main");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("checks git source installs against origin/main when cache is stale", async () => {
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) throw new Error("ENOENT");
+        return JSON.stringify({ name: "@aoagents/ao" });
+      });
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "local\n";
+        if (args[0] === "rev-parse" && args[1] === "origin/main") return "remote\n";
+        return "";
+      });
+
+      const info = await checkForUpdate({ force: true, installMethod: "git", repoRoot: "/repo" });
+
+      expect(info.installMethod).toBe("git");
+      expect(info.isOutdated).toBe(true);
+      expect(info.latestVersion).toBe("origin/main");
+      expect(info.recommendedCommand).toBe("ao update");
+      expect(mockFetch).not.toHaveBeenCalled();
+      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
+      expect(written.installMethod).toBe("git");
+      expect(written.isOutdated).toBe(true);
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -691,7 +914,36 @@ describe("update-check", () => {
       const output = stderrSpy.mock.calls[0]![0] as string;
       expect(output).toContain("Update available");
       expect(output).toContain("99.0.0");
-      expect(output).toContain("ao update");
+      expect(output).toContain("npm install -g @aoagents/ao@latest");
+    });
+
+    it("prints git update notice from cached git state", () => {
+      const currentVersion = getCurrentVersion();
+      mockExistsSync.mockImplementation((path: string) => path.endsWith(".git"));
+      mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+        if (args[0] === "rev-parse" && args[1] === "HEAD") return "local\n";
+        return "";
+      });
+      mockReadFileSync.mockImplementation((path: string) => {
+        if (path.endsWith("update-check.json")) {
+          return JSON.stringify({
+            latestVersion: "origin/main",
+            checkedAt: new Date().toISOString(),
+            currentVersionAtCheck: currentVersion,
+            installMethod: "git",
+            isOutdated: true,
+            currentRevisionAtCheck: "local",
+          });
+        }
+        return JSON.stringify({ name: "@aoagents/ao" });
+      });
+
+      maybeShowUpdateNotice();
+
+      const output = stderrSpy.mock.calls[0]![0] as string;
+      expect(output).toContain("Update available from origin/main");
+      expect(output).toContain("Run: ao update");
+      expect(output).not.toContain("99.0.0");
     });
 
     it("does not print when versions match (not outdated)", () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -16,7 +16,13 @@ import {
 import { runRepoScript } from "../lib/script-runner.js";
 import { detectOpenClawInstallation, validateToken } from "../lib/openclaw-probe.js";
 import { importPluginModuleFromSource } from "../lib/plugin-store.js";
-import { getCurrentVersion, isVersionOutdated, readCachedUpdateInfo } from "../lib/update-check.js";
+import {
+  detectInstallMethod,
+  getCurrentVersion,
+  getUpdateCommand,
+  isVersionOutdated,
+  readCachedUpdateInfo,
+} from "../lib/update-check.js";
 
 // ---------------------------------------------------------------------------
 // Helpers — match the PASS / WARN / FAIL style of ao-doctor.sh
@@ -77,7 +83,12 @@ function collectPluginReferences(config: OrchestratorConfig): PluginReference[] 
   addPluginReference(refs, "runtime", config.defaults.runtime, "defaults.runtime");
   addPluginReference(refs, "agent", config.defaults.agent, "defaults.agent");
   addPluginReference(refs, "workspace", config.defaults.workspace, "defaults.workspace");
-  addPluginReference(refs, "agent", config.defaults.orchestrator?.agent, "defaults.orchestrator.agent");
+  addPluginReference(
+    refs,
+    "agent",
+    config.defaults.orchestrator?.agent,
+    "defaults.orchestrator.agent",
+  );
   addPluginReference(refs, "agent", config.defaults.worker?.agent, "defaults.worker.agent");
 
   for (const notifierName of config.defaults.notifiers ?? []) {
@@ -153,10 +164,7 @@ async function checkPluginResolution(
   ];
 
   for (const slot of slots) {
-    loadedBySlot.set(
-      slot,
-      new Set(registry.list(slot).map((manifest) => manifest.name)),
-    );
+    loadedBySlot.set(slot, new Set(registry.list(slot).map((manifest) => manifest.name)));
   }
 
   const references = collectPluginReferences(config);
@@ -210,7 +218,8 @@ function readOpenClawHealth(config: OrchestratorConfig): OpenClawHealthSummary |
     return {
       lastSuccessAt: typeof parsed.lastSuccessAt === "string" ? parsed.lastSuccessAt : null,
       lastFailureAt: typeof parsed.lastFailureAt === "string" ? parsed.lastFailureAt : null,
-      lastFailureError: typeof parsed.lastFailureError === "string" ? parsed.lastFailureError : null,
+      lastFailureError:
+        typeof parsed.lastFailureError === "string" ? parsed.lastFailureError : null,
       totalSent: typeof parsed.totalSent === "number" ? parsed.totalSent : 0,
       totalFailed: typeof parsed.totalFailed === "number" ? parsed.totalFailed : 0,
     };
@@ -234,9 +243,11 @@ async function checkOpenClawNotifier(
     "http://127.0.0.1:18789";
   // Resolve ${ENV_VAR} placeholders written by `ao setup openclaw` — the config
   // stores the literal string "${OPENCLAW_HOOKS_TOKEN}" which is truthy but wrong.
-  const rawToken = typeof openclawConfig["token"] === "string" ? openclawConfig["token"] : undefined;
+  const rawToken =
+    typeof openclawConfig["token"] === "string" ? openclawConfig["token"] : undefined;
   const envVarMatch = rawToken?.match(/^\$\{([^}]+)\}$/);
-  const token = (envVarMatch ? process.env[envVarMatch[1]] : rawToken) ?? process.env["OPENCLAW_HOOKS_TOKEN"];
+  const token =
+    (envVarMatch ? process.env[envVarMatch[1]] : rawToken) ?? process.env["OPENCLAW_HOOKS_TOKEN"];
 
   const installation = await detectOpenClawInstallation(url);
   if (installation.state === "running") {
@@ -387,15 +398,22 @@ function checkVersionFreshness(): void {
   console.log("Version:");
 
   const current = getCurrentVersion();
-  const cached = readCachedUpdateInfo();
+  const installMethod = detectInstallMethod();
+  const cached = readCachedUpdateInfo(installMethod);
 
   if (!cached) {
     pass(`ao v${current} installed (run any ao command to check for updates)`);
     return;
   }
 
-  if (isVersionOutdated(current, cached.latestVersion)) {
-    warn(`ao v${current} is outdated (latest: v${cached.latestVersion}). Run: ao update`);
+  const isOutdated =
+    installMethod === "git"
+      ? cached.isOutdated === true
+      : isVersionOutdated(current, cached.latestVersion);
+
+  if (isOutdated) {
+    const latest = installMethod === "git" ? cached.latestVersion : `v${cached.latestVersion}`;
+    warn(`ao v${current} is outdated (latest: ${latest}). Run: ${getUpdateCommand(installMethod)}`);
   } else {
     pass(`ao v${current} is the latest version`);
   }

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -7,6 +7,7 @@
  *   - `ao doctor` (version freshness check)
  */
 
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
@@ -29,10 +30,14 @@ export interface UpdateInfo {
   checkedAt: string | null;
 }
 
-interface CacheData {
+export interface CacheData {
   latestVersion: string;
   checkedAt: string;
   currentVersionAtCheck: string;
+  installMethod?: InstallMethod;
+  isOutdated?: boolean;
+  currentRevisionAtCheck?: string;
+  latestRevisionAtCheck?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -42,6 +47,8 @@ interface CacheData {
 const REGISTRY_URL = "https://registry.npmjs.org/@aoagents%2Fao/latest";
 const FETCH_TIMEOUT_MS = 3000;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const DEFAULT_GIT_REMOTE = "origin";
+const DEFAULT_GIT_BRANCH = "main";
 
 // ---------------------------------------------------------------------------
 // Install detection
@@ -71,6 +78,14 @@ function readPackageName(packageJsonPath: string): string | null {
   }
 }
 
+function getSourceRepoRoot(resolvedPath: string): string {
+  return resolve(dirname(resolvedPath), "../../../../");
+}
+
+export function getCurrentRepoRoot(): string {
+  return getSourceRepoRoot(fileURLToPath(import.meta.url));
+}
+
 export function isAgentOrchestratorRepoRoot(root: string): boolean {
   if (!existsSync(resolve(root, ".git"))) {
     return false;
@@ -95,16 +110,14 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
     // Note: /.pnpm/ alone is NOT a global signal — pnpm creates node_modules/.pnpm/
     // for local installs too. Only pnpm/global paths indicate a global install.
     const isPnpmGlobal =
-      resolvedPath.includes("/pnpm/global/") ||
-      resolvedPath.includes("\\pnpm\\global\\");
+      resolvedPath.includes("/pnpm/global/") || resolvedPath.includes("\\pnpm\\global\\");
 
     if (isPnpmGlobal) {
       return "pnpm-global";
     }
 
     const isNpmGlobal =
-      resolvedPath.includes("/lib/node_modules/") ||
-      resolvedPath.includes("\\lib\\node_modules\\");
+      resolvedPath.includes("/lib/node_modules/") || resolvedPath.includes("\\lib\\node_modules\\");
 
     if (isNpmGlobal) {
       return "npm-global";
@@ -116,7 +129,7 @@ export function classifyInstallPath(resolvedPath: string): InstallMethod {
 
   // Running from a source checkout → git install
   // Walk up from packages/cli/dist/lib/ (or src/lib/) to repo root
-  const repoRoot = resolve(dirname(resolvedPath), "../../../../");
+  const repoRoot = getSourceRepoRoot(resolvedPath);
   if (isAgentOrchestratorRepoRoot(repoRoot)) {
     return "git";
   }
@@ -152,6 +165,12 @@ export function getCurrentVersion(): string {
 // Update command mapping
 // ---------------------------------------------------------------------------
 
+export function getGitUpdateRef(): string {
+  const remote = process.env["AO_UPDATE_GIT_REMOTE"] || DEFAULT_GIT_REMOTE;
+  const branch = process.env["AO_UPDATE_GIT_BRANCH"] || DEFAULT_GIT_BRANCH;
+  return `${remote}/${branch}`;
+}
+
 export function getUpdateCommand(method: InstallMethod): string {
   switch (method) {
     case "git":
@@ -179,18 +198,35 @@ function getCachePath(): string {
   return join(getCacheDir(), "update-check.json");
 }
 
-/** Read cached update info. Returns null if missing, expired, corrupt, or version-mismatched. */
-export function readCachedUpdateInfo(): CacheData | null {
+/** Read cached update info. Returns null if missing, expired, corrupt, version-mismatched, or install-method-mismatched. */
+export function readCachedUpdateInfo(installMethod = detectInstallMethod()): CacheData | null {
   try {
     const raw = readFileSync(getCachePath(), "utf-8");
     const data = JSON.parse(raw) as CacheData;
 
     if (!data.latestVersion || !data.checkedAt) return null;
 
+    // Legacy cache entries were npm-registry based. They are unsafe for git/source installs.
+    if (!data.installMethod) {
+      if (installMethod === "git") return null;
+    } else if (data.installMethod !== installMethod) {
+      return null;
+    }
+
     // Cache is stale if user upgraded since the check
     const currentVersion = getCurrentVersion();
     if (data.currentVersionAtCheck && data.currentVersionAtCheck !== currentVersion) {
       return null;
+    }
+
+    if (installMethod === "git" && data.currentRevisionAtCheck) {
+      try {
+        if (runGit(["rev-parse", "HEAD"], getCurrentRepoRoot()) !== data.currentRevisionAtCheck) {
+          return null;
+        }
+      } catch {
+        return null;
+      }
     }
 
     // Cache expired
@@ -222,6 +258,51 @@ export function invalidateCache(): void {
 }
 
 // ---------------------------------------------------------------------------
+// Git fetch
+// ---------------------------------------------------------------------------
+
+export interface GitLatestState {
+  ref: string;
+  headRevision: string;
+  latestRevision: string;
+  isBehind: boolean;
+}
+
+function runGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf-8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+export async function fetchGitLatestState(
+  repoRoot = getCurrentRepoRoot(),
+): Promise<GitLatestState | null> {
+  try {
+    const remote = process.env["AO_UPDATE_GIT_REMOTE"] || DEFAULT_GIT_REMOTE;
+    const branch = process.env["AO_UPDATE_GIT_BRANCH"] || DEFAULT_GIT_BRANCH;
+    const ref = `${remote}/${branch}`;
+
+    runGit(["fetch", remote, branch], repoRoot);
+    const headRevision = runGit(["rev-parse", "HEAD"], repoRoot);
+    const latestRevision = runGit(["rev-parse", ref], repoRoot);
+
+    let isBehind = false;
+    try {
+      runGit(["merge-base", "--is-ancestor", "HEAD", ref], repoRoot);
+      isBehind = headRevision !== latestRevision;
+    } catch {
+      isBehind = false;
+    }
+
+    return { ref, headRevision, latestRevision, isBehind };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Registry fetch
 // ---------------------------------------------------------------------------
 
@@ -245,19 +326,26 @@ export async function fetchLatestVersion(): Promise<string | null> {
 // ---------------------------------------------------------------------------
 
 /** Check for updates, using cache when fresh and fetching when stale. */
-export async function checkForUpdate(opts?: { force?: boolean }): Promise<UpdateInfo> {
+export async function checkForUpdate(opts?: {
+  force?: boolean;
+  installMethod?: InstallMethod;
+  repoRoot?: string;
+}): Promise<UpdateInfo> {
   const currentVersion = getCurrentVersion();
-  const installMethod = detectInstallMethod();
+  const installMethod = opts?.installMethod ?? detectInstallMethod();
   const recommendedCommand = getUpdateCommand(installMethod);
 
   // Try cache first (unless forced)
   if (!opts?.force) {
-    const cached = readCachedUpdateInfo();
+    const cached = readCachedUpdateInfo(installMethod);
     if (cached) {
       return {
         currentVersion,
         latestVersion: cached.latestVersion,
-        isOutdated: isVersionOutdated(currentVersion, cached.latestVersion),
+        isOutdated:
+          cached.installMethod === "git"
+            ? cached.isOutdated === true
+            : isVersionOutdated(currentVersion, cached.latestVersion),
         installMethod,
         recommendedCommand,
         checkedAt: cached.checkedAt,
@@ -265,15 +353,42 @@ export async function checkForUpdate(opts?: { force?: boolean }): Promise<Update
     }
   }
 
-  // Fetch from registry
-  const latestVersion = await fetchLatestVersion();
   const now = new Date().toISOString();
+
+  if (installMethod === "git") {
+    const gitState = await fetchGitLatestState(opts?.repoRoot);
+    if (gitState) {
+      writeCache({
+        latestVersion: gitState.ref,
+        checkedAt: now,
+        currentVersionAtCheck: currentVersion,
+        installMethod,
+        isOutdated: gitState.isBehind,
+        currentRevisionAtCheck: gitState.headRevision,
+        latestRevisionAtCheck: gitState.latestRevision,
+      });
+    }
+
+    return {
+      currentVersion,
+      latestVersion: gitState?.ref ?? null,
+      isOutdated: gitState?.isBehind ?? false,
+      installMethod,
+      recommendedCommand,
+      checkedAt: gitState ? now : null,
+    };
+  }
+
+  // npm/pnpm/unknown installs use the npm registry as their update channel.
+  const latestVersion = await fetchLatestVersion();
 
   if (latestVersion) {
     writeCache({
       latestVersion,
       checkedAt: now,
       currentVersionAtCheck: currentVersion,
+      installMethod,
+      isOutdated: isVersionOutdated(currentVersion, latestVersion),
     });
   }
 
@@ -301,15 +416,22 @@ export function maybeShowUpdateNotice(): void {
   const skipArgs = ["update", "doctor", "--version", "-V", "--help", "-h"];
   if (process.argv.some((arg) => skipArgs.includes(arg))) return;
 
-  const cached = readCachedUpdateInfo();
+  const installMethod = detectInstallMethod();
+  const cached = readCachedUpdateInfo(installMethod);
   if (!cached) return;
 
   const currentVersion = getCurrentVersion();
-  if (!isVersionOutdated(currentVersion, cached.latestVersion)) return;
+  const isOutdated =
+    installMethod === "git"
+      ? cached.isOutdated === true
+      : isVersionOutdated(currentVersion, cached.latestVersion);
+  if (!isOutdated) return;
 
-  process.stderr.write(
-    `\nUpdate available: ${currentVersion} → ${cached.latestVersion} — Run: ao update\n\n`,
-  );
+  const message =
+    installMethod === "git"
+      ? `\nUpdate available from ${cached.latestVersion} — Run: ${getUpdateCommand(installMethod)}\n\n`
+      : `\nUpdate available: ${currentVersion} → ${cached.latestVersion} — Run: ${getUpdateCommand(installMethod)}\n\n`;
+  process.stderr.write(message);
 }
 
 /**

--- a/packages/cli/src/lib/update-check.ts
+++ b/packages/cli/src/lib/update-check.ts
@@ -7,12 +7,13 @@
  *   - `ao doctor` (version freshness check)
  */
 
-import { execFileSync } from "node:child_process";
+import { execFile, execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 import { getCliVersion } from "../options/version.js";
 
 // ---------------------------------------------------------------------------
@@ -49,6 +50,7 @@ const FETCH_TIMEOUT_MS = 3000;
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const DEFAULT_GIT_REMOTE = "origin";
 const DEFAULT_GIT_BRANCH = "main";
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Install detection
@@ -165,10 +167,20 @@ export function getCurrentVersion(): string {
 // Update command mapping
 // ---------------------------------------------------------------------------
 
-export function getGitUpdateRef(): string {
+export interface GitUpdateTarget {
+  remote: string;
+  branch: string;
+  ref: string;
+}
+
+export function getGitUpdateTarget(): GitUpdateTarget {
   const remote = process.env["AO_UPDATE_GIT_REMOTE"] || DEFAULT_GIT_REMOTE;
   const branch = process.env["AO_UPDATE_GIT_BRANCH"] || DEFAULT_GIT_BRANCH;
-  return `${remote}/${branch}`;
+  return { remote, branch, ref: `${remote}/${branch}` };
+}
+
+export function getGitUpdateRef(): string {
+  return getGitUpdateTarget().ref;
 }
 
 export function getUpdateCommand(method: InstallMethod): string {
@@ -206,12 +218,10 @@ export function readCachedUpdateInfo(installMethod = detectInstallMethod()): Cac
 
     if (!data.latestVersion || !data.checkedAt) return null;
 
-    // Legacy cache entries were npm-registry based. They are unsafe for git/source installs.
-    if (!data.installMethod) {
-      if (installMethod === "git") return null;
-    } else if (data.installMethod !== installMethod) {
-      return null;
-    }
+    // Legacy cache entries predate install-method scoping, so treat them as unsafe
+    // for every install method rather than guessing which update channel produced them.
+    if (!data.installMethod) return null;
+    if (data.installMethod !== installMethod) return null;
 
     // Cache is stale if user upgraded since the check
     const currentVersion = getCurrentVersion();
@@ -280,11 +290,9 @@ export async function fetchGitLatestState(
   repoRoot = getCurrentRepoRoot(),
 ): Promise<GitLatestState | null> {
   try {
-    const remote = process.env["AO_UPDATE_GIT_REMOTE"] || DEFAULT_GIT_REMOTE;
-    const branch = process.env["AO_UPDATE_GIT_BRANCH"] || DEFAULT_GIT_BRANCH;
-    const ref = `${remote}/${branch}`;
+    const { remote, branch, ref } = getGitUpdateTarget();
 
-    runGit(["fetch", remote, branch], repoRoot);
+    await execFileAsync("git", ["fetch", remote, branch], { cwd: repoRoot });
     const headRevision = runGit(["rev-parse", "HEAD"], repoRoot);
     const latestRevision = runGit(["rev-parse", ref], repoRoot);
 


### PR DESCRIPTION
## Summary
- scope update-check cache entries by install method and reject mismatched/unsafe legacy cache for git/source installs
- compare git/source installs against origin/main via git fetch/rev-parse instead of npm latest
- align startup and doctor update messaging with npm, pnpm, and git update commands

Closes #1592

## Tests
- pnpm --filter @aoagents/ao-cli test -- update-check.test.ts doctor.test.ts update.test.ts
- pnpm --filter @aoagents/ao-cli typecheck
- pnpm --filter @aoagents/ao-cli build
- pnpm typecheck
- pnpm lint (passes with existing warnings)

## Notes
- pnpm build currently fails in @aoagents/ao-web while prerendering /404 with an existing Next.js <Html> import error.
- pnpm test was rerun twice and failed in unrelated/flaky @aoagents/ao-core tests (migration timeout, then lifecycle-manager branch adoption assertion).
