### PR TITLE
fix: protect live dashboard artifacts

### DIFF
--- a/packages/cli/__tests__/commands/dashboard.test.ts
+++ b/packages/cli/__tests__/commands/dashboard.test.ts
@@ -99,7 +99,9 @@ describe("isInstalledUnderNodeModules", () => {
   it("returns true for a Windows node_modules path segment", async () => {
     const { isInstalledUnderNodeModules } = await import("../../src/lib/dashboard-rebuild.js");
 
-    expect(isInstalledUnderNodeModules("C:\\Users\\me\\node_modules\\@composio\\ao-web")).toBe(true);
+    expect(isInstalledUnderNodeModules("C:\\Users\\me\\node_modules\\@composio\\ao-web")).toBe(
+      true,
+    );
   });
 
   it("returns false for source paths containing node_modules as plain text", async () => {
@@ -137,7 +139,8 @@ describe("rebuildDashboardProductionArtifacts", () => {
 
     mockExec.mockResolvedValue({ stdout: "", stderr: "" });
 
-    const { rebuildDashboardProductionArtifacts } = await import("../../src/lib/dashboard-rebuild.js");
+    const { rebuildDashboardProductionArtifacts } =
+      await import("../../src/lib/dashboard-rebuild.js");
 
     await rebuildDashboardProductionArtifacts(webDir);
 
@@ -153,7 +156,8 @@ describe("rebuildDashboardProductionArtifacts", () => {
 
     mockExec.mockRejectedValue(new Error("build failed"));
 
-    const { rebuildDashboardProductionArtifacts } = await import("../../src/lib/dashboard-rebuild.js");
+    const { rebuildDashboardProductionArtifacts } =
+      await import("../../src/lib/dashboard-rebuild.js");
 
     await expect(rebuildDashboardProductionArtifacts(webDir)).rejects.toThrow(
       "Failed to rebuild dashboard production artifacts",
@@ -161,7 +165,8 @@ describe("rebuildDashboardProductionArtifacts", () => {
   });
 
   it("throws when called from an npm-installed path", async () => {
-    const { rebuildDashboardProductionArtifacts } = await import("../../src/lib/dashboard-rebuild.js");
+    const { rebuildDashboardProductionArtifacts } =
+      await import("../../src/lib/dashboard-rebuild.js");
 
     await expect(
       rebuildDashboardProductionArtifacts("/usr/local/lib/node_modules/@aoagents/ao-web"),
@@ -244,8 +249,7 @@ describe("looksLikeStaleBuild pattern matching", () => {
 
   it("detects vendor-chunks module not found (the actual bug)", () => {
     // This is the exact error from the bug report
-    const stderr =
-      "Error: Cannot find module '/path/to/.next/server/vendor-chunks/xterm@5.3.0.js'";
+    const stderr = "Error: Cannot find module '/path/to/.next/server/vendor-chunks/xterm@5.3.0.js'";
     expect(looksLikeStaleBuild(stderr)).toBe(true);
   });
 
@@ -277,5 +281,40 @@ describe("looksLikeStaleBuild pattern matching", () => {
   it("does not flag normal startup output", () => {
     const stderr = "ready - started server on 0.0.0.0:3000";
     expect(looksLikeStaleBuild(stderr)).toBe(false);
+  });
+});
+
+describe("findRunningDashboardPidsForWebDir", () => {
+  it("returns only listeners whose cwd matches the web directory", async () => {
+    const webDir = join(tmpDir, "packages", "web");
+    mkdirSync(webDir, { recursive: true });
+
+    mockExecSilent
+      .mockResolvedValueOnce("111\n222\n")
+      .mockResolvedValueOnce(`p111\nn${webDir}\n`)
+      .mockResolvedValueOnce("p222\nn/tmp/other\n");
+
+    const { findRunningDashboardPidsForWebDir } =
+      await import("../../src/lib/dashboard-rebuild.js");
+
+    await expect(findRunningDashboardPidsForWebDir(webDir, [3000])).resolves.toEqual(["111"]);
+    expect(mockExecSilent).toHaveBeenCalledWith("lsof", ["-ti", ":3000", "-sTCP:LISTEN"]);
+    expect(mockExecSilent).toHaveBeenCalledWith("lsof", ["-a", "-p", "111", "-d", "cwd", "-Fn"]);
+  });
+
+  it("deduplicates dashboard pids found on multiple ports", async () => {
+    const webDir = join(tmpDir, "packages", "web");
+    mkdirSync(webDir, { recursive: true });
+
+    mockExecSilent
+      .mockResolvedValueOnce("111\n")
+      .mockResolvedValueOnce(`p111\nn${webDir}\n`)
+      .mockResolvedValueOnce("111\n")
+      .mockResolvedValueOnce(`p111\nn${webDir}\n`);
+
+    const { findRunningDashboardPidsForWebDir } =
+      await import("../../src/lib/dashboard-rebuild.js");
+
+    await expect(findRunningDashboardPidsForWebDir(webDir, [3000, 3001])).resolves.toEqual(["111"]);
   });
 });

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -1219,6 +1219,26 @@ describe("start command — orchestrator session strategy display", () => {
     expect(output).not.toContain("tmux attach");
   });
 
+  it("passes the requested and reassigned dashboard ports to rebuild", async () => {
+    mockConfigRef.current = makeConfig({ "my-app": makeProject() });
+
+    const webDir = await import("../../src/lib/web-dir.js");
+    vi.mocked(webDir.findWebDir).mockReturnValue(tmpDir);
+    vi.mocked(webDir.isPortAvailable).mockResolvedValue(false);
+    vi.mocked(webDir.findFreePort).mockResolvedValue(3001);
+    mkdirSync(join(tmpDir, "server"), { recursive: true });
+    writeFileSync(join(tmpDir, "package.json"), "{}");
+
+    const dashboardRebuild = await import("../../src/lib/dashboard-rebuild.js");
+
+    await program.parseAsync(["node", "test", "start", "--rebuild", "--no-orchestrator"]);
+
+    expect(dashboardRebuild.rebuildDashboardProductionArtifacts).toHaveBeenCalledWith(tmpDir, [
+      3000,
+      3001,
+    ]);
+  });
+
   it("opens the most recent orchestrator session page when multiple existing orchestrators found with dashboard enabled and reuse is explicit", async () => {
     mockConfigRef.current = makeConfig({
       "my-app": makeProject({ orchestratorSessionStrategy: "reuse" }),

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -103,8 +103,8 @@ export function registerDashboard(program: Command): void {
 
         process.exit(code ?? 0);
       });
+      /* c8 ignore stop */
     });
-  /* c8 ignore stop */
 }
 
 /**

--- a/packages/cli/src/commands/dashboard.ts
+++ b/packages/cli/src/commands/dashboard.ts
@@ -6,10 +6,8 @@ import { loadConfig } from "@aoagents/ao-core";
 import { findWebDir, buildDashboardEnv, waitForPortAndOpen } from "../lib/web-dir.js";
 import {
   clearStaleCacheIfNeeded,
-  findRunningDashboardPid,
   isInstalledUnderNodeModules,
   rebuildDashboardProductionArtifacts,
-  waitForPortFree,
 } from "../lib/dashboard-rebuild.js";
 import { preflight } from "../lib/preflight.js";
 import { DEFAULT_PORT } from "../lib/constants.js";
@@ -34,24 +32,7 @@ export function registerDashboard(program: Command): void {
       const localWebDir = findWebDir(); // throws with install-specific guidance if not found
 
       if (opts.rebuild) {
-        // Check if a dashboard is already running on this port.
-        const runningPid = await findRunningDashboardPid(port);
-
-        if (runningPid) {
-          // Stop the running server before rebuilding or restarting below.
-          console.log(
-            chalk.dim(`Stopping dashboard (PID ${runningPid}) on port ${port}...`),
-          );
-          try {
-            process.kill(parseInt(runningPid, 10), "SIGTERM");
-          } catch {
-            // Process already exited (ESRCH) — that's fine
-          }
-          // Wait for port to be released
-          await waitForPortFree(port, 5000);
-        }
-
-        await rebuildDashboardProductionArtifacts(localWebDir);
+        await rebuildDashboardProductionArtifacts(localWebDir, [port]);
         // Fall through to start the dashboard on this port.
       } else {
         await preflight.checkBuilt(localWebDir);
@@ -123,7 +104,7 @@ export function registerDashboard(program: Command): void {
         process.exit(code ?? 0);
       });
     });
-    /* c8 ignore stop */
+  /* c8 ignore stop */
 }
 
 /**

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1241,6 +1241,7 @@ async function runStartup(
 
   // Start dashboard (unless --no-dashboard)
   if (opts?.dashboard !== false) {
+    const requestedDashboardPort = port;
     if (!(await isPortAvailable(port))) {
       const newPort = await findFreePort(port + 1);
       if (newPort === null) {
@@ -1258,7 +1259,9 @@ async function runStartup(
     const isMonorepo = existsSync(resolve(webDir, "server"));
     const willUseDevServer = isMonorepo && opts?.dev === true;
     if (opts?.rebuild) {
-      await rebuildDashboardProductionArtifacts(webDir, [port]);
+      await rebuildDashboardProductionArtifacts(webDir, [
+        ...new Set([requestedDashboardPort, port]),
+      ]);
     } else if (!willUseDevServer) {
       await preflight.checkBuilt(webDir);
       await clearStaleCacheIfNeeded(webDir);

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1258,7 +1258,7 @@ async function runStartup(
     const isMonorepo = existsSync(resolve(webDir, "server"));
     const willUseDevServer = isMonorepo && opts?.dev === true;
     if (opts?.rebuild) {
-      await rebuildDashboardProductionArtifacts(webDir);
+      await rebuildDashboardProductionArtifacts(webDir, [port]);
     } else if (!willUseDevServer) {
       await preflight.checkBuilt(webDir);
       await clearStaleCacheIfNeeded(webDir);

--- a/packages/cli/src/lib/dashboard-rebuild.ts
+++ b/packages/cli/src/lib/dashboard-rebuild.ts
@@ -3,8 +3,8 @@
  * running dashboard processes, and rebuilds production artifacts.
  */
 
-import { resolve } from "node:path";
 import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { normalize, resolve } from "node:path";
 import ora from "ora";
 import { exec, execSilent } from "./shell.js";
 
@@ -24,7 +24,7 @@ export function assertDashboardRebuildSupported(webDir: string): void {
   if (isInstalledUnderNodeModules(webDir)) {
     throw new Error(
       "Dashboard rebuild is only available from a source checkout. " +
-      "Run `ao update`, or reinstall with `npm install -g @aoagents/ao@latest`.",
+        "Run `ao update`, or reinstall with `npm install -g @aoagents/ao@latest`.",
     );
   }
 }
@@ -42,6 +42,65 @@ export async function findRunningDashboardPid(port: number): Promise<string | nu
   return pid;
 }
 
+async function getProcessCwd(pid: string): Promise<string | null> {
+  const output = await execSilent("lsof", ["-a", "-p", pid, "-d", "cwd", "-Fn"]);
+  if (!output) return null;
+
+  const cwdLine = output.split("\n").find((line) => line.startsWith("n"));
+  const cwd = cwdLine?.slice(1).trim();
+  return cwd ? normalize(cwd) : null;
+}
+
+/**
+ * Find live dashboard server PIDs whose current working directory is webDir.
+ */
+export async function findRunningDashboardPidsForWebDir(
+  webDir: string,
+  ports: readonly number[],
+): Promise<string[]> {
+  const expectedCwd = normalize(resolve(webDir));
+  const pids = new Set<string>();
+
+  for (const port of ports) {
+    const output = await execSilent("lsof", ["-ti", `:${port}`, "-sTCP:LISTEN"]);
+    if (!output) continue;
+    for (const rawPid of output.split("\n")) {
+      const pid = rawPid.trim();
+      if (!/^\d+$/.test(pid)) continue;
+      const cwd = await getProcessCwd(pid);
+      if (cwd === expectedCwd) pids.add(pid);
+    }
+  }
+
+  return [...pids];
+}
+
+/**
+ * Stop any live production dashboard serving from webDir before mutating .next.
+ */
+export async function stopRunningDashboardsForWebDir(
+  webDir: string,
+  ports: readonly number[],
+): Promise<void> {
+  const pids = await findRunningDashboardPidsForWebDir(webDir, ports);
+  if (pids.length === 0) return;
+
+  console.log(
+    `Stopping running dashboard${pids.length === 1 ? "" : "s"} before rebuilding .next (PID${pids.length === 1 ? "" : "s"} ${pids.join(", ")})...`,
+  );
+  for (const pid of pids) {
+    try {
+      process.kill(Number(pid), "SIGTERM");
+    } catch {
+      // Process already exited (ESRCH) — that's fine.
+    }
+  }
+
+  for (const port of ports) {
+    await waitForPortFree(port, 5000);
+  }
+}
+
 /**
  * Wait for a port to be free (no process listening).
  * Throws if the port is still busy after the timeout.
@@ -53,7 +112,9 @@ export async function waitForPortFree(port: number, timeoutMs: number): Promise<
     if (!pid) return;
     await new Promise((r) => setTimeout(r, 200));
   }
-  throw new Error(`Port ${port} still in use after ${timeoutMs}ms — old process did not exit in time`);
+  throw new Error(
+    `Port ${port} still in use after ${timeoutMs}ms — old process did not exit in time`,
+  );
 }
 
 /**
@@ -119,9 +180,13 @@ export async function clearStaleCacheIfNeeded(webDir: string): Promise<void> {
  * Rebuild dashboard production artifacts (Next.js build + server compilation)
  * from a source checkout. Throws if called from an npm global install.
  */
-export async function rebuildDashboardProductionArtifacts(webDir: string): Promise<void> {
+export async function rebuildDashboardProductionArtifacts(
+  webDir: string,
+  ports: readonly number[] = [],
+): Promise<void> {
   assertDashboardRebuildSupported(webDir);
 
+  await stopRunningDashboardsForWebDir(webDir, ports);
   await cleanNextCache(webDir);
 
   const workspaceRoot = resolve(webDir, "../..");
@@ -138,4 +203,3 @@ export async function rebuildDashboardProductionArtifacts(webDir: string): Promi
     );
   }
 }
-

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -15,7 +15,7 @@
     "dev": "concurrently \"npm:dev:next\" \"npm:dev:direct-terminal\"",
     "dev:next": "next dev -p ${PORT:-3000}",
     "dev:direct-terminal": "node scripts/dev-direct-terminal.mjs",
-    "prebuild": "rimraf .next dist-server",
+    "prebuild": "node scripts/guard-production-artifact-clean.mjs && rimraf .next dist-server",
     "build": "next build && tsc -p tsconfig.server.json && node scripts/stamp-version.js",
     "start": "next start",
     "start:all": "node dist-server/start-all.js",
@@ -23,7 +23,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "clean": "rimraf .next dist-server",
+    "clean": "node scripts/guard-production-artifact-clean.mjs && rimraf .next dist-server",
     "screenshot": "tsx e2e/screenshot.ts",
     "screenshot:install": "npx playwright install chromium"
   },

--- a/packages/web/scripts/guard-production-artifact-clean.mjs
+++ b/packages/web/scripts/guard-production-artifact-clean.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, normalize, join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const webDir = normalize(resolve(process.cwd()));
+const runningPath = join(homedir(), ".agent-orchestrator", "running.json");
+
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error && error.code === "EPERM";
+  }
+}
+
+function readRunningState() {
+  try {
+    const parsed = JSON.parse(readFileSync(runningPath, "utf8"));
+    if (!parsed || typeof parsed.pid !== "number" || typeof parsed.port !== "number") return null;
+    if (!isPidAlive(parsed.pid)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function lsof(args) {
+  try {
+    return execFileSync("lsof", args, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function processCwd(pid) {
+  const output = lsof(["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
+  const cwdLine = output.split("\n").find((line) => line.startsWith("n"));
+  return cwdLine ? normalize(cwdLine.slice(1)) : null;
+}
+
+const running = readRunningState();
+if (running) {
+  const pids = lsof(["-ti", `:${running.port}`, "-sTCP:LISTEN"])
+    .split("\n")
+    .map((pid) => pid.trim())
+    .filter((pid) => /^\d+$/.test(pid));
+
+  const matchingPid = pids.find((pid) => processCwd(pid) === webDir);
+  if (matchingPid) {
+    console.error(
+      `Refusing to delete production dashboard artifacts while AO dashboard is running from this checkout (PID ${matchingPid}, port ${running.port}).\n` +
+        "Stop it first with `ao stop`, or rebuild through `ao start --rebuild` / `ao dashboard --rebuild` so AO can stop the old dashboard safely.",
+    );
+    process.exit(1);
+  }
+}

--- a/packages/web/scripts/guard-production-artifact-clean.mjs
+++ b/packages/web/scripts/guard-production-artifact-clean.mjs
@@ -1,10 +1,18 @@
 #!/usr/bin/env node
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, normalize, resolve } from "node:path";
 
-const webDir = normalize(resolve(process.cwd()));
+function canonicalPath(path) {
+  try {
+    return normalize(realpathSync(path));
+  } catch {
+    return normalize(resolve(path));
+  }
+}
+
+const webDir = canonicalPath(process.cwd());
 const runningPath = join(homedir(), ".agent-orchestrator", "running.json");
 
 function isPidAlive(pid) {
@@ -32,6 +40,7 @@ function execText(command, args) {
     return execFileSync(command, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
     }).trim();
   } catch (error) {
     return error && error.code === "ENOENT" ? null : "";
@@ -46,7 +55,7 @@ function processCwd(pid) {
   const output = lsof(["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
   if (!output) return null;
   const cwdLine = output.split("\n").find((line) => line.startsWith("n"));
-  return cwdLine ? normalize(cwdLine.slice(1)) : null;
+  return cwdLine ? canonicalPath(cwdLine.slice(1)) : null;
 }
 
 function pidsListeningOnPort(port) {

--- a/packages/web/scripts/guard-production-artifact-clean.mjs
+++ b/packages/web/scripts/guard-production-artifact-clean.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { resolve, normalize, join } from "node:path";
-import { execFileSync } from "node:child_process";
+import { join, normalize, resolve } from "node:path";
 
 const webDir = normalize(resolve(process.cwd()));
 const runningPath = join(homedir(), ".agent-orchestrator", "running.json");
@@ -27,34 +27,64 @@ function readRunningState() {
   }
 }
 
-function lsof(args) {
+function execText(command, args) {
   try {
-    return execFileSync("lsof", args, {
+    return execFileSync(command, args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-  } catch {
-    return "";
+  } catch (error) {
+    return error && error.code === "ENOENT" ? null : "";
   }
+}
+
+function lsof(args) {
+  return execText("lsof", args);
 }
 
 function processCwd(pid) {
   const output = lsof(["-a", "-p", String(pid), "-d", "cwd", "-Fn"]);
+  if (!output) return null;
   const cwdLine = output.split("\n").find((line) => line.startsWith("n"));
   return cwdLine ? normalize(cwdLine.slice(1)) : null;
 }
 
+function pidsListeningOnPort(port) {
+  const lsofOutput = lsof(["-ti", `:${port}`, "-sTCP:LISTEN"]);
+  if (lsofOutput !== null) {
+    return lsofOutput
+      .split("\n")
+      .map((pid) => pid.trim())
+      .filter((pid) => /^\d+$/.test(pid));
+  }
+
+  if (process.platform !== "win32") return [];
+
+  const netstatOutput = execText("netstat", ["-ano", "-p", "tcp"]);
+  if (!netstatOutput) return [];
+
+  return netstatOutput
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/))
+    .filter((columns) => columns.length >= 5)
+    .filter((columns) => columns[1]?.endsWith(`:${port}`) && columns[3] === "LISTENING")
+    .map((columns) => columns[4])
+    .filter((pid) => typeof pid === "string" && /^\d+$/.test(pid));
+}
+
 const running = readRunningState();
 if (running) {
-  const pids = lsof(["-ti", `:${running.port}`, "-sTCP:LISTEN"])
-    .split("\n")
-    .map((pid) => pid.trim())
-    .filter((pid) => /^\d+$/.test(pid));
+  const pids = pidsListeningOnPort(running.port);
+  const matchingPid =
+    process.platform === "win32" ? pids[0] : pids.find((pid) => processCwd(pid) === webDir);
 
-  const matchingPid = pids.find((pid) => processCwd(pid) === webDir);
   if (matchingPid) {
+    const checkoutDetail =
+      process.platform === "win32"
+        ? "AO dashboard is running on the configured port"
+        : "AO dashboard is running from this checkout";
     console.error(
-      `Refusing to delete production dashboard artifacts while AO dashboard is running from this checkout (PID ${matchingPid}, port ${running.port}).\n` +
+      `Refusing to delete production dashboard artifacts while ${checkoutDetail} (PID ${matchingPid}, port ${running.port}).\n` +
         "Stop it first with `ao stop`, or rebuild through `ao start --rebuild` / `ao dashboard --rebuild` so AO can stop the old dashboard safely.",
     );
     process.exit(1);


### PR DESCRIPTION
## Summary

Fixes ComposioHQ/agent-orchestrator#1589 by preventing production dashboard rebuilds and clean scripts from deleting `.next` while a dashboard from the same checkout is still serving those artifacts.

## What changed

- `ao start --rebuild` and `ao dashboard --rebuild` now stop matching dashboard server processes for the same web checkout before mutating `.next`.
- Web `prebuild` and `clean` scripts now run a guard that refuses direct artifact deletion when the running AO dashboard is serving from the same `packages/web` directory.
- Added tests for matching dashboard listeners by cwd so unrelated processes on the port are not treated as AO dashboard servers.

## Validation

- `NODE_ENV=production pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm --filter @aoagents/ao-cli test -- __tests__/commands/dashboard.test.ts`
- `pnpm test` (fails in existing `packages/cli/__tests__/commands/start.test.ts` stop-command cases after setup tests leave a global config; dashboard tests and integration suites otherwise ran)

---

🤖 Generated with Codex