### PR TITLE
fix: always enable filesystem browsing

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -71,5 +71,3 @@ and add `ao` to the `plugins=(...)` list in `~/.zshrc`.
 ## Multi-Project Rollout
 
 Portfolio mode is enabled by default. Users do not need to set `AO_ENABLE_PORTFOLIO` unless they explicitly want to disable portfolio/project-management flows.
-
-The web add-project directory picker is separately gated by `AO_ALLOW_FILESYSTEM_BROWSE=1`. Treat this as a release requirement for the multi-project rollout: without it, users can still use config- and CLI-based project registration, but the web filesystem browser in the add-project flow is unavailable.

--- a/packages/web/src/__tests__/filesystem-browse-api.test.ts
+++ b/packages/web/src/__tests__/filesystem-browse-api.test.ts
@@ -12,18 +12,14 @@ function makeRequest(rawUrl: string): NextRequest {
 
 describe("/api/filesystem/browse", () => {
   let originalHome: string | undefined;
-  let originalBrowseEnv: string | undefined;
   let homeDir: string;
   let outsideDir: string;
 
   beforeEach(() => {
     originalHome = process.env["HOME"];
-    originalBrowseEnv = process.env["AO_ALLOW_FILESYSTEM_BROWSE"];
-
     homeDir = mkdtempSync(path.join(tmpdir(), "ao-home-"));
     outsideDir = mkdtempSync(path.join(tmpdir(), "ao-outside-"));
     process.env["HOME"] = homeDir;
-    delete process.env["AO_ALLOW_FILESYSTEM_BROWSE"];
   });
 
   afterEach(() => {
@@ -33,33 +29,18 @@ describe("/api/filesystem/browse", () => {
       process.env["HOME"] = originalHome;
     }
 
-    if (originalBrowseEnv === undefined) {
-      delete process.env["AO_ALLOW_FILESYSTEM_BROWSE"];
-    } else {
-      process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = originalBrowseEnv;
-    }
-
     rmSync(homeDir, { recursive: true, force: true });
     rmSync(outsideDir, { recursive: true, force: true });
   });
 
-  it("returns 404 when the env var is missing", async () => {
+  it("browses HOME without requiring an environment flag", async () => {
     const response = await browseGET(makeRequest("/api/filesystem/browse?path=~"));
 
-    expect(response.status).toBe(404);
-  });
-
-  it("returns 404 when the env var is not equal to 1", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "true";
-
-    const response = await browseGET(makeRequest("/api/filesystem/browse?path=~"));
-
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ entries: [] });
   });
 
   it("returns 400 when the requested path contains ..", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "1";
-
     const response = await browseGET(
       makeRequest("/api/filesystem/browse?path=projects/../secrets"),
     );
@@ -69,8 +50,6 @@ describe("/api/filesystem/browse", () => {
   });
 
   it("returns 400 for an absolute path outside HOME", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "1";
-
     const response = await browseGET(makeRequest("/api/filesystem/browse?path=/etc"));
 
     expect(response.status).toBe(400);
@@ -78,7 +57,6 @@ describe("/api/filesystem/browse", () => {
   });
 
   it("returns 400 for a symlink inside HOME that points outside", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "1";
     const outsideRepo = path.join(outsideDir, "external-repo");
     mkdirSync(outsideRepo);
     symlinkSync(outsideRepo, path.join(homeDir, "external-link"));
@@ -90,7 +68,6 @@ describe("/api/filesystem/browse", () => {
   });
 
   it("returns 400 for a restricted path inside HOME", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "1";
     mkdirSync(path.join(homeDir, ".ssh"));
 
     const response = await browseGET(makeRequest("/api/filesystem/browse?path=~/.ssh"));
@@ -100,7 +77,6 @@ describe("/api/filesystem/browse", () => {
   });
 
   it("returns minimal metadata only for a valid path inside HOME", async () => {
-    process.env["AO_ALLOW_FILESYSTEM_BROWSE"] = "1";
     const repoDir = path.join(homeDir, "repo");
     const plainDir = path.join(homeDir, "notes");
     const filePath = path.join(homeDir, "README.md");

--- a/packages/web/src/app/api/filesystem/browse/route.ts
+++ b/packages/web/src/app/api/filesystem/browse/route.ts
@@ -4,7 +4,6 @@ import { NextResponse, type NextRequest } from "next/server";
 import {
   PathSecurityError,
   assertDirectoryPath,
-  isFilesystemBrowseEnabled,
   shouldHideBrowseEntry,
 } from "@/lib/path-security";
 
@@ -50,10 +49,6 @@ function serializeEntry(rootPath: string, parentPath: string, entry: Dirent): Br
 }
 
 export async function GET(request: NextRequest) {
-  if (!isFilesystemBrowseEnabled()) {
-    return NextResponse.json({ error: "Not found" }, { status: 404 });
-  }
-
   const requestedPath = request.nextUrl.searchParams.get("path") ?? "~";
 
   let resolved;

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -72,14 +72,9 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
         const body = (await response.json().catch(() => null)) as
           | { error?: string; entries?: BrowseEntry[] }
           | null;
-        const isBrowseDisabled = response.status === 404 && body?.error === "Not found";
         setBrowseEntries([]);
-        setSelectedBrowsePath(isBrowseDisabled ? "" : options?.selectedPath ?? path);
-        setBrowseError(
-          isBrowseDisabled
-            ? "Directory browsing is unavailable in this environment. Set AO_ALLOW_FILESYSTEM_BROWSE=1 to enable it."
-            : body?.error ?? "Failed to browse directories.",
-        );
+        setSelectedBrowsePath(options?.selectedPath ?? path);
+        setBrowseError(body?.error ?? "Failed to browse directories.");
         return;
       }
 

--- a/packages/web/src/components/__tests__/AddProjectModal.test.tsx
+++ b/packages/web/src/components/__tests__/AddProjectModal.test.tsx
@@ -49,19 +49,17 @@ describe("AddProjectModal", () => {
     );
   });
 
-  it("shows a helpful message and disables submit when filesystem browsing is unavailable", async () => {
+  it("shows the server browse error and disables submit when browsing fails", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,
       status: 404,
-      json: async () => ({ error: "Not found" }),
+      json: async () => ({ error: "path not found" }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
     render(<AddProjectModal open onClose={vi.fn()} />);
 
-    expect(
-      await screen.findByText(/directory browsing is unavailable in this environment/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/path not found/i)).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /^add project$/i })).toBeDisabled();
   });
 

--- a/packages/web/src/lib/path-security.ts
+++ b/packages/web/src/lib/path-security.ts
@@ -76,10 +76,6 @@ export interface ResolvedHomePath {
   resolvedPath: string;
 }
 
-export function isFilesystemBrowseEnabled(): boolean {
-  return process.env["AO_ALLOW_FILESYSTEM_BROWSE"] === "1";
-}
-
 export function resolveHomeContainedPath(rawPath: string): ResolvedHomePath {
   const rootPath = homeRealPath();
   const requestedPath = rawPath.trim();


### PR DESCRIPTION
Closes #1596\n\n## Summary\n- remove the AO_ALLOW_FILESYSTEM_BROWSE gate from the filesystem browse API\n- remove the disabled-browse UI error path from the add-project modal\n- update browse API/modal tests and docs to reflect always-on directory browsing\n\n## Testing\n- pnpm typecheck\n- pnpm lint (passes with existing warnings)\n- pnpm --filter @aoagents/ao-web test src/__tests__/filesystem-browse-api.test.ts src/components/__tests__/AddProjectModal.test.tsx\n\n## Notes\n- pnpm build currently fails in the web Next.js prerender step with an existing /500 <Html> import error unrelated to this change.\n- pnpm test currently fails in existing CLI stop-command tests and unrelated web tests; targeted filesystem browse tests pass.