### PR TITLE
fix(cli): supervise lifecycle workers for active projects

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -32,7 +32,7 @@ const {
   mockSessionManager,
   mockWaitForPortAndOpen,
   mockSpawn,
-  mockEnsureLifecycleWorker,
+  mockStartProjectSupervisor,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockExecSilent: vi.fn(),
@@ -52,7 +52,7 @@ const {
   },
   mockWaitForPortAndOpen: vi.fn().mockResolvedValue(undefined),
   mockSpawn: vi.fn(),
-  mockEnsureLifecycleWorker: vi.fn(),
+  mockStartProjectSupervisor: vi.fn(),
 }));
 
 const { mockDetectOpenClawInstallation } = vi.hoisted(() => ({
@@ -146,8 +146,13 @@ vi.mock("../../src/lib/create-session-manager.js", () => ({
 }));
 
 vi.mock("../../src/lib/lifecycle-service.js", () => ({
-  ensureLifecycleWorker: (...args: unknown[]) => mockEnsureLifecycleWorker(...args),
   stopAllLifecycleWorkers: vi.fn(),
+  listLifecycleWorkers: () => ["my-app"],
+}));
+
+vi.mock("../../src/lib/project-supervisor.js", () => ({
+  startProjectSupervisor: (...args: unknown[]) => mockStartProjectSupervisor(...args),
+  stopProjectSupervisor: vi.fn(),
 }));
 
 vi.mock("../../src/lib/web-dir.js", () => ({
@@ -368,11 +373,8 @@ beforeEach(async () => {
   });
   mockWaitForPortAndOpen.mockReset();
   mockWaitForPortAndOpen.mockResolvedValue(undefined);
-  mockEnsureLifecycleWorker.mockReset();
-  mockEnsureLifecycleWorker.mockResolvedValue({
-    running: true,
-    started: true,
-  });
+  mockStartProjectSupervisor.mockReset();
+  mockStartProjectSupervisor.mockResolvedValue({ stop: vi.fn(), reconcileNow: vi.fn() });
   mockDetectOpenClawInstallation.mockReset();
   mockDetectOpenClawInstallation.mockResolvedValue({
     state: "missing",
@@ -952,10 +954,7 @@ describe("start command — browser open waits for port", () => {
     const args = mockWaitForPortAndOpen.mock.calls[0];
     expect(args[1]).toContain("/projects/my-app/sessions/app-orchestrator");
     expect(args[2]).toBeInstanceOf(AbortSignal);
-    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
-      expect.objectContaining({ configPath: expect.any(String) }),
-      "my-app",
-    );
+    expect(mockStartProjectSupervisor).toHaveBeenCalledTimes(1);
   });
 
   it("skips browser open and lifecycle with --no-dashboard --no-orchestrator", async () => {
@@ -964,7 +963,7 @@ describe("start command — browser open waits for port", () => {
     await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
 
     expect(mockWaitForPortAndOpen).not.toHaveBeenCalled();
-    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockStartProjectSupervisor).not.toHaveBeenCalled();
   });
 
   it("skips browser open but still starts lifecycle with --no-dashboard alone", async () => {
@@ -976,10 +975,7 @@ describe("start command — browser open waits for port", () => {
     await program.parseAsync(["node", "test", "start", "--no-dashboard"]);
 
     expect(mockWaitForPortAndOpen).not.toHaveBeenCalled();
-    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
-      expect.objectContaining({ configPath: expect.any(String) }),
-      "my-app",
-    );
+    expect(mockStartProjectSupervisor).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -2059,9 +2055,8 @@ describe("stop command", () => {
       expect(mockSessionManager.ensureOrchestrator).toHaveBeenCalledWith(
         expect.objectContaining({ projectId: "project-2" }),
       );
-      // running.projects must NOT be expanded — lifecycle polling cannot be
-      // attached to the live daemon mid-flight, and `ao spawn` reads this
-      // field to decide whether to warn that polling is missing.
+      // The one-shot attach path does not mutate running.json directly;
+      // the long-lived supervisor reconciles it after attaching polling.
       expect(mockAddProjectToRunning).not.toHaveBeenCalled();
       // No menu — this is a deterministic attach, not an interactive choice.
       expect(mockPromptSelect).not.toHaveBeenCalled();

--- a/packages/cli/__tests__/lib/lifecycle-service.test.ts
+++ b/packages/cli/__tests__/lib/lifecycle-service.test.ts
@@ -10,6 +10,7 @@ vi.mock("../../src/lib/create-session-manager.js", () => ({
 // Import after mocks
 import {
   ensureLifecycleWorker,
+  stopLifecycleWorker,
   stopAllLifecycleWorkers,
   isLifecycleWorkerRunning,
   listLifecycleWorkers,
@@ -99,6 +100,42 @@ describe("lifecycle-service", () => {
     expect(result.started).toBe(true);
     expect(healthy.start).toHaveBeenCalledTimes(1);
     expect(isLifecycleWorkerRunning("healthy")).toBe(true);
+  });
+
+  it("stopLifecycleWorker is a no-op for unknown projects", () => {
+    expect(() => stopLifecycleWorker("missing")).not.toThrow();
+    expect(listLifecycleWorkers()).toEqual([]);
+  });
+
+  it("stopLifecycleWorker stops only the requested project", async () => {
+    const a = makeFakeLifecycle();
+    const b = makeFakeLifecycle();
+    mockGetLifecycleManager.mockImplementation(async (_cfg, projectId: string) =>
+      projectId === "a" ? a : b,
+    );
+
+    const config = makeConfig(["a", "b"]);
+    await ensureLifecycleWorker(config, "a");
+    await ensureLifecycleWorker(config, "b");
+
+    stopLifecycleWorker("a");
+
+    expect(a.stop).toHaveBeenCalledTimes(1);
+    expect(b.stop).not.toHaveBeenCalled();
+    expect(listLifecycleWorkers()).toEqual(["b"]);
+  });
+
+  it("stopLifecycleWorker removes a project even when lifecycle stop throws", async () => {
+    const broken = makeFakeLifecycle();
+    (broken.stop as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("stop failed");
+    });
+    mockGetLifecycleManager.mockResolvedValue(broken);
+
+    await ensureLifecycleWorker(makeConfig(["broken"]), "broken");
+
+    expect(() => stopLifecycleWorker("broken")).not.toThrow();
+    expect(listLifecycleWorkers()).toEqual([]);
   });
 
   it("stopAllLifecycleWorkers is a no-op when nothing is active", () => {

--- a/packages/cli/__tests__/lib/project-supervisor.test.ts
+++ b/packages/cli/__tests__/lib/project-supervisor.test.ts
@@ -237,18 +237,12 @@ describe("project-supervisor", () => {
     });
   });
 
-  it("does not reject when the initial supervisor reconcile fails", async () => {
+  it("rejects when the initial supervisor reconcile fails", async () => {
     mockLoadConfig.mockImplementation(() => {
       throw new Error("bad config");
     });
 
-    const handle = await startProjectSupervisor(1_000);
-
-    expect(handle).toEqual({
-      stop: expect.any(Function),
-      reconcileNow: expect.any(Function),
-    });
-    handle.stop();
+    await expect(startProjectSupervisor(1_000)).rejects.toThrow("bad config");
   });
 
   it("forwards the supervisor interval to lifecycle workers it starts", async () => {

--- a/packages/cli/__tests__/lib/project-supervisor.test.ts
+++ b/packages/cli/__tests__/lib/project-supervisor.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockLoadConfig = vi.fn();
+const mockGetSessionManager = vi.fn();
+const mockEnsureLifecycleWorker = vi.fn();
+const mockAddProjectToRunning = vi.fn();
+const mockRemoveProjectFromRunning = vi.fn();
+const activeWorkers = new Set<string>();
+
+vi.mock("@aoagents/ao-core", () => ({
+  getGlobalConfigPath: () => "/tmp/global-config.yaml",
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+  isTerminalSession: (session: { status: string; activity: string | null }) =>
+    ["done", "killed", "terminated", "errored", "merged", "cleanup"].includes(session.status) ||
+    session.activity === "exited",
+}));
+
+vi.mock("../../src/lib/create-session-manager.js", () => ({
+  getSessionManager: (...args: unknown[]) => mockGetSessionManager(...args),
+}));
+
+vi.mock("../../src/lib/lifecycle-service.js", () => ({
+  ensureLifecycleWorker: async (...args: unknown[]) => {
+    const projectId = args[1] as string;
+    const result = await mockEnsureLifecycleWorker(...args);
+    activeWorkers.add(projectId);
+    return result;
+  },
+  stopLifecycleWorker: (projectId: string) => {
+    activeWorkers.delete(projectId);
+  },
+  listLifecycleWorkers: () => Array.from(activeWorkers),
+}));
+
+vi.mock("../../src/lib/running-state.js", () => ({
+  addProjectToRunning: (...args: unknown[]) => mockAddProjectToRunning(...args),
+  removeProjectFromRunning: (...args: unknown[]) => mockRemoveProjectFromRunning(...args),
+}));
+
+import { reconcileProjectSupervisor } from "../../src/lib/project-supervisor.js";
+
+function makeConfig(projectIds: string[]) {
+  return {
+    configPath: "/tmp/global-config.yaml",
+    projects: Object.fromEntries(projectIds.map((id) => [id, { name: id, path: `/tmp/${id}` }])),
+  };
+}
+
+function makeSession(projectId: string, status = "working") {
+  return { id: `${projectId}-1`, projectId, status, activity: null };
+}
+
+describe("project-supervisor", () => {
+  let sessionsByProject: Map<string, unknown[]>;
+
+  beforeEach(() => {
+    activeWorkers.clear();
+    sessionsByProject = new Map();
+    mockLoadConfig.mockReset();
+    mockGetSessionManager.mockReset();
+    mockEnsureLifecycleWorker.mockReset();
+    mockAddProjectToRunning.mockReset();
+    mockRemoveProjectFromRunning.mockReset();
+    mockLoadConfig.mockReturnValue(makeConfig(["app"]));
+    mockGetSessionManager.mockResolvedValue({
+      list: async (projectId: string) => sessionsByProject.get(projectId) ?? [],
+    });
+    mockEnsureLifecycleWorker.mockResolvedValue({ running: true, started: true });
+  });
+
+  it("attaches a worker for a globally registered project with a non-terminal session", async () => {
+    sessionsByProject.set("app", [makeSession("app")]);
+
+    await reconcileProjectSupervisor();
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: "/tmp/global-config.yaml" }),
+      "app",
+      undefined,
+    );
+    expect(mockAddProjectToRunning).toHaveBeenCalledWith("app");
+    expect(activeWorkers.has("app")).toBe(true);
+  });
+
+  it("does not attach for a registered project with no non-terminal sessions", async () => {
+    sessionsByProject.set("app", [makeSession("app", "done")]);
+
+    await reconcileProjectSupervisor();
+
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockAddProjectToRunning).not.toHaveBeenCalled();
+  });
+
+  it("detaches a worker when the project is removed from global config", async () => {
+    activeWorkers.add("removed");
+    mockLoadConfig.mockReturnValue(makeConfig(["app"]));
+
+    await reconcileProjectSupervisor();
+
+    expect(activeWorkers.has("removed")).toBe(false);
+    expect(mockRemoveProjectFromRunning).toHaveBeenCalledWith("removed");
+  });
+
+  it("detaches a worker when the last session becomes terminal", async () => {
+    activeWorkers.add("app");
+    sessionsByProject.set("app", [makeSession("app", "done")]);
+
+    await reconcileProjectSupervisor();
+
+    expect(activeWorkers.has("app")).toBe(false);
+    expect(mockRemoveProjectFromRunning).toHaveBeenCalledWith("app");
+  });
+
+  it("updates running.projects for attached and detached workers", async () => {
+    activeWorkers.add("idle");
+    mockLoadConfig.mockReturnValue(makeConfig(["active", "idle"]));
+    sessionsByProject.set("active", [makeSession("active")]);
+    sessionsByProject.set("idle", [makeSession("idle", "done")]);
+
+    await reconcileProjectSupervisor();
+
+    expect(mockAddProjectToRunning).toHaveBeenCalledWith("active");
+    expect(mockRemoveProjectFromRunning).toHaveBeenCalledWith("idle");
+    expect(activeWorkers.has("active")).toBe(true);
+    expect(activeWorkers.has("idle")).toBe(false);
+  });
+
+  it("continues reconciling other projects when one project fails", async () => {
+    mockLoadConfig.mockReturnValue(makeConfig(["broken", "healthy"]));
+    sessionsByProject.set("healthy", [makeSession("healthy")]);
+    mockGetSessionManager.mockResolvedValue({
+      list: async (projectId: string) => {
+        if (projectId === "broken") throw new Error("boom");
+        return sessionsByProject.get(projectId) ?? [];
+      },
+    });
+
+    await reconcileProjectSupervisor();
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.anything(),
+      "healthy",
+      undefined,
+    );
+    expect(activeWorkers.has("healthy")).toBe(true);
+  });
+});

--- a/packages/cli/__tests__/lib/project-supervisor.test.ts
+++ b/packages/cli/__tests__/lib/project-supervisor.test.ts
@@ -245,6 +245,27 @@ describe("project-supervisor", () => {
     await expect(startProjectSupervisor(1_000)).rejects.toThrow("bad config");
   });
 
+  it("allows startup when the global config does not exist yet", async () => {
+    const error = Object.assign(
+      new Error("ENOENT: no such file or directory, open '/tmp/global-config.yaml'"),
+      {
+        code: "ENOENT",
+        path: "/tmp/global-config.yaml",
+      },
+    );
+    mockLoadConfig.mockImplementation(() => {
+      throw error;
+    });
+
+    const handle = await startProjectSupervisor(1_000);
+
+    expect(handle).toEqual({
+      stop: expect.any(Function),
+      reconcileNow: expect.any(Function),
+    });
+    handle.stop();
+  });
+
   it("forwards the supervisor interval to lifecycle workers it starts", async () => {
     sessionsByProject.set("app", [makeSession("app")]);
 

--- a/packages/cli/__tests__/lib/project-supervisor.test.ts
+++ b/packages/cli/__tests__/lib/project-supervisor.test.ts
@@ -5,14 +5,38 @@ const mockGetSessionManager = vi.fn();
 const mockEnsureLifecycleWorker = vi.fn();
 const mockAddProjectToRunning = vi.fn();
 const mockRemoveProjectFromRunning = vi.fn();
+const mockSetHealth = vi.fn();
 const activeWorkers = new Set<string>();
 
 vi.mock("@aoagents/ao-core", () => ({
+  createCorrelationId: () => "correlation-id",
+  createProjectObserver: () => ({ setHealth: (...args: unknown[]) => mockSetHealth(...args) }),
   getGlobalConfigPath: () => "/tmp/global-config.yaml",
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-  isTerminalSession: (session: { status: string; activity: string | null }) =>
-    ["done", "killed", "terminated", "errored", "merged", "cleanup"].includes(session.status) ||
-    session.activity === "exited",
+  isTerminalSession: (session: {
+    status: string;
+    activity: string | null;
+    lifecycle?: {
+      session: { state: string };
+      pr: { state: string };
+      runtime: { state: string };
+    };
+  }) => {
+    if (session.lifecycle) {
+      return (
+        session.lifecycle.session.state === "done" ||
+        session.lifecycle.session.state === "terminated" ||
+        session.lifecycle.pr.state === "merged" ||
+        session.lifecycle.runtime.state === "missing" ||
+        session.lifecycle.runtime.state === "exited"
+      );
+    }
+    return (
+      ["done", "killed", "terminated", "errored", "merged", "cleanup"].includes(
+        session.status,
+      ) || session.activity === "exited"
+    );
+  },
 }));
 
 vi.mock("../../src/lib/create-session-manager.js", () => ({
@@ -37,7 +61,11 @@ vi.mock("../../src/lib/running-state.js", () => ({
   removeProjectFromRunning: (...args: unknown[]) => mockRemoveProjectFromRunning(...args),
 }));
 
-import { reconcileProjectSupervisor } from "../../src/lib/project-supervisor.js";
+import {
+  reconcileProjectSupervisor,
+  startProjectSupervisor,
+  stopProjectSupervisor,
+} from "../../src/lib/project-supervisor.js";
 
 function makeConfig(projectIds: string[]) {
   return {
@@ -54,6 +82,7 @@ describe("project-supervisor", () => {
   let sessionsByProject: Map<string, unknown[]>;
 
   beforeEach(() => {
+    stopProjectSupervisor();
     activeWorkers.clear();
     sessionsByProject = new Map();
     mockLoadConfig.mockReset();
@@ -61,6 +90,7 @@ describe("project-supervisor", () => {
     mockEnsureLifecycleWorker.mockReset();
     mockAddProjectToRunning.mockReset();
     mockRemoveProjectFromRunning.mockReset();
+    mockSetHealth.mockReset();
     mockLoadConfig.mockReturnValue(makeConfig(["app"]));
     mockGetSessionManager.mockResolvedValue({
       list: async (projectId: string) => sessionsByProject.get(projectId) ?? [],
@@ -84,6 +114,24 @@ describe("project-supervisor", () => {
 
   it("does not attach for a registered project with no non-terminal sessions", async () => {
     sessionsByProject.set("app", [makeSession("app", "done")]);
+
+    await reconcileProjectSupervisor();
+
+    expect(mockEnsureLifecycleWorker).not.toHaveBeenCalled();
+    expect(mockAddProjectToRunning).not.toHaveBeenCalled();
+  });
+
+  it("treats lifecycle-terminal sessions as terminal even when legacy status is working", async () => {
+    sessionsByProject.set("app", [
+      {
+        ...makeSession("app", "working"),
+        lifecycle: {
+          session: { state: "done" },
+          pr: { state: "none" },
+          runtime: { state: "running" },
+        },
+      },
+    ]);
 
     await reconcileProjectSupervisor();
 
@@ -142,6 +190,118 @@ describe("project-supervisor", () => {
       "healthy",
       undefined,
     );
+    expect(mockSetHealth).toHaveBeenCalledWith(
+      expect.objectContaining({
+        surface: "project-supervisor.reconcile",
+        status: "warn",
+        projectId: "broken",
+      }),
+    );
     expect(activeWorkers.has("healthy")).toBe(true);
+  });
+
+  it("retries running-state registration for already-attached active projects", async () => {
+    sessionsByProject.set("app", [makeSession("app")]);
+    mockAddProjectToRunning.mockRejectedValueOnce(new Error("lock timeout"));
+
+    await reconcileProjectSupervisor();
+    await reconcileProjectSupervisor();
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledTimes(1);
+    expect(mockAddProjectToRunning).toHaveBeenCalledTimes(2);
+    expect(activeWorkers.has("app")).toBe(true);
+  });
+
+  it("returns its handle even if stopped during the initial reconcile", async () => {
+    let releaseList: (() => void) | undefined;
+    mockGetSessionManager.mockResolvedValue({
+      list: async () => {
+        await new Promise<void>((resolve) => {
+          releaseList = resolve;
+        });
+        return [];
+      },
+    });
+
+    const startPromise = startProjectSupervisor(1_000);
+    await vi.waitFor(() => expect(releaseList).toBeDefined());
+
+    stopProjectSupervisor();
+    releaseList?.();
+
+    const handle = await startPromise;
+
+    expect(handle).toEqual({
+      stop: expect.any(Function),
+      reconcileNow: expect.any(Function),
+    });
+  });
+
+  it("does not reject when the initial supervisor reconcile fails", async () => {
+    mockLoadConfig.mockImplementation(() => {
+      throw new Error("bad config");
+    });
+
+    const handle = await startProjectSupervisor(1_000);
+
+    expect(handle).toEqual({
+      stop: expect.any(Function),
+      reconcileNow: expect.any(Function),
+    });
+    handle.stop();
+  });
+
+  it("forwards the supervisor interval to lifecycle workers it starts", async () => {
+    sessionsByProject.set("app", [makeSession("app")]);
+
+    const handle = await startProjectSupervisor(1_234);
+
+    expect(mockEnsureLifecycleWorker).toHaveBeenCalledWith(
+      expect.objectContaining({ configPath: "/tmp/global-config.yaml" }),
+      "app",
+      1_234,
+    );
+    handle.stop();
+  });
+
+  it("reconcileNow waits for a queued reconcile when one is already running", async () => {
+    const handle = await startProjectSupervisor(1_000);
+    let firstRelease: (() => void) | undefined;
+    let secondRelease: (() => void) | undefined;
+    let listCalls = 0;
+    mockGetSessionManager.mockResolvedValue({
+      list: async () => {
+        listCalls++;
+        if (listCalls === 1) {
+          await new Promise<void>((resolve) => {
+            firstRelease = resolve;
+          });
+        } else if (listCalls === 2) {
+          await new Promise<void>((resolve) => {
+            secondRelease = resolve;
+          });
+        }
+        return [];
+      },
+    });
+
+    const firstReconcile = handle.reconcileNow();
+    await vi.waitFor(() => expect(firstRelease).toBeDefined());
+
+    let secondResolved = false;
+    const secondReconcile = handle.reconcileNow().then(() => {
+      secondResolved = true;
+    });
+
+    firstRelease?.();
+    await vi.waitFor(() => expect(secondRelease).toBeDefined());
+    expect(secondResolved).toBe(false);
+
+    secondRelease?.();
+    await firstReconcile;
+    await secondReconcile;
+
+    expect(secondResolved).toBe(true);
+    handle.stop();
   });
 });

--- a/packages/cli/src/commands/spawn.ts
+++ b/packages/cli/src/commands/spawn.ts
@@ -76,7 +76,7 @@ async function warnIfAONotRunning(projectId: string): Promise<void> {
   if (!running.projects.includes(projectId)) {
     console.log(
       chalk.yellow(
-        `⚠ The running AO instance (pid ${running.pid}) is not polling project "${projectId}". Run \`ao start ${projectId}\` so the new session is tracked.`,
+        `⚠ The running AO instance (pid ${running.pid}) is not polling project "${projectId}" yet. Lifecycle polling will attach within ~60s.`,
       ),
     );
   }

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -47,7 +47,7 @@ import {
 import { parse as yamlParse, stringify as yamlStringify } from "yaml";
 import { exec, execSilent, git } from "../lib/shell.js";
 import { getSessionManager } from "../lib/create-session-manager.js";
-import { ensureLifecycleWorker, stopAllLifecycleWorkers } from "../lib/lifecycle-service.js";
+import { stopAllLifecycleWorkers, listLifecycleWorkers } from "../lib/lifecycle-service.js";
 import { startBunTmpJanitor, stopBunTmpJanitor } from "../lib/bun-tmp-janitor.js";
 import {
   findWebDir,
@@ -72,6 +72,7 @@ import {
   clearLastStop,
 } from "../lib/running-state.js";
 import { preventIdleSleep } from "../lib/prevent-sleep.js";
+import { startProjectSupervisor, stopProjectSupervisor } from "../lib/project-supervisor.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
 import {
@@ -1228,7 +1229,6 @@ async function runStartup(
   }
 
   const shouldStartLifecycle = opts?.dashboard !== false || opts?.orchestrator !== false;
-  let lifecycleStatus: Awaited<ReturnType<typeof ensureLifecycleWorker>> | null = null;
   let port = config.port ?? DEFAULT_PORT;
   console.log(chalk.bold(`\nStarting orchestrator for ${chalk.cyan(project.name)}\n`));
 
@@ -1273,25 +1273,6 @@ async function runStartup(
     console.log(chalk.dim("  (Dashboard will be ready in a few seconds)\n"));
   }
 
-  if (shouldStartLifecycle) {
-    try {
-      spinner.start("Starting lifecycle worker");
-      lifecycleStatus = await ensureLifecycleWorker(config, projectId);
-      spinner.succeed(
-        lifecycleStatus.started ? "Lifecycle polling started" : "Lifecycle polling already running",
-      );
-    } catch (err) {
-      spinner.fail("Lifecycle worker failed to start");
-      if (dashboardProcess) {
-        dashboardProcess.kill();
-      }
-      throw new Error(
-        `Failed to start lifecycle worker: ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
-      );
-    }
-  }
-
   let selectedOrchestratorId: string | null = null;
 
   if (opts?.orchestrator !== false) {
@@ -1318,6 +1299,23 @@ async function runStartup(
       }
       throw new Error(
         `Failed to setup orchestrator: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+
+  if (shouldStartLifecycle) {
+    try {
+      spinner.start("Starting project supervisor");
+      await startProjectSupervisor();
+      spinner.succeed("Lifecycle project supervisor started");
+    } catch (err) {
+      spinner.fail("Project supervisor failed to start");
+      if (dashboardProcess) {
+        dashboardProcess.kill();
+      }
+      throw new Error(
+        `Failed to start project supervisor: ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
     }
@@ -1450,9 +1448,8 @@ async function runStartup(
     console.log(chalk.cyan("Dashboard:"), `http://localhost:${port}`);
   }
 
-  if (shouldStartLifecycle && lifecycleStatus) {
-    const lifecycleLabel = lifecycleStatus.started ? "started" : "already running";
-    console.log(chalk.cyan("Lifecycle:"), lifecycleLabel);
+  if (shouldStartLifecycle) {
+    console.log(chalk.cyan("Lifecycle:"), "supervised");
   }
 
   if (opts?.orchestrator !== false && selectedOrchestratorId) {
@@ -1839,9 +1836,8 @@ export function registerStart(program: Command): void {
 
             console.log(
               chalk.yellow(
-                `\n⚠ Lifecycle polling for "${resolvedId}" runs inside the long-lived ao start\n` +
-                  `  process, which is currently scoped to: ${running.projects.join(", ")}.\n` +
-                  `  Run \`ao stop && ao start ${resolvedId}\` to enable polling.\n`,
+                `\nℹ Lifecycle polling for "${resolvedId}" will attach within ~60s\n` +
+                  `  because the running ao start process now supervises active global projects.\n`,
               ),
             );
             console.log(chalk.dim(`  Opening dashboard: http://localhost:${running.port}\n`));
@@ -1886,15 +1882,6 @@ export function registerStart(program: Command): void {
               systemPrompt,
             });
 
-            // Deliberately do NOT add the project to `running.projects`.
-            // That field is the single source of truth for "lifecycle polling
-            // is attached", and polling cannot be added to the live daemon
-            // mid-flight — it requires a full daemon restart. Persisting the
-            // project here would make `ao spawn` suppress its
-            // "instance is not polling project X" warning while polling is in
-            // fact missing. The user is told below to restart the daemon for
-            // full polling; until they do, `ao spawn` should keep warning.
-
             console.log(
               chalk.green(`✓ Orchestrator session ready: ${session.id}`),
             );
@@ -1926,18 +1913,11 @@ export function registerStart(program: Command): void {
               );
             }
 
-            // Only warn about missing polling when the parent process is
-            // genuinely not polling this project. After `ao stop <project>`
-            // we deliberately leave the project in `running.projects`
-            // because the parent's in-memory lifecycle worker is still
-            // active — no warning needed in that case.
             if (!running.projects.includes(projectArg)) {
               console.log(
                 chalk.yellow(
-                  `\n⚠ Lifecycle polling for "${projectArg}" is not attached to this ao start\n` +
-                    `  process (it was started before the project was registered).\n` +
-                    `  Activity/PR state won't auto-update until the daemon is fully restarted\n` +
-                    `  (\`ao stop && ao start ${projectArg}\`).\n`,
+                  `\nℹ Lifecycle polling for "${projectArg}" will attach within ~60s\n` +
+                    `  because the running ao start process now supervises active global projects.\n`,
                 ),
               );
             }
@@ -2222,7 +2202,7 @@ export function registerStart(program: Command): void {
             configPath: config.configPath,
             port: actualPort,
             startedAt: new Date().toISOString(),
-            projects: [projectId],
+            projects: listLifecycleWorkers(),
           });
           unlockStartup();
 
@@ -2258,6 +2238,7 @@ export function registerStart(program: Command): void {
             const exitCode = signal === "SIGINT" ? 130 : 0;
 
             try {
+              stopProjectSupervisor();
               stopAllLifecycleWorkers();
             } catch {
               // Best-effort — never block shutdown on observability.
@@ -2509,15 +2490,10 @@ export function registerStop(program: Command): void {
           }
           await stopDashboard(running?.port ?? port);
         }
-        // Targeted stop deliberately does NOT remove the project from
-        // `running.json`. The parent `ao start` process keeps an in-memory
-        // lifecycle worker for this project (a child CLI process cannot
-        // reach into the parent's memory to stop it), so `running.projects`
-        // — which is the source of truth for "polling is attached" —
-        // continues to truthfully list this project. Subsequent
-        // `ao start <project>` falls into the attach branch and re-spawns
-        // the orchestrator session; `ao spawn` keeps suppressing its
-        // "not polling project X" warning because polling really is alive.
+        // Targeted stop deliberately does NOT edit `running.json` from this
+        // child CLI process. The long-lived parent supervises lifecycle
+        // workers and will remove the project from `running.projects` after
+        // it observes that the last session became terminal.
 
         if (projectArg) {
           console.log(chalk.bold.green(`\n✓ Stopped sessions for ${project.name}\n`));

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1449,7 +1449,13 @@ async function runStartup(
   }
 
   if (shouldStartLifecycle) {
-    console.log(chalk.cyan("Lifecycle:"), "supervised");
+    const supervisedProjects = listLifecycleWorkers().sort();
+    const projectSummary =
+      supervisedProjects.length > 0 ? `: ${supervisedProjects.join(", ")}` : "";
+    console.log(
+      chalk.cyan("Lifecycle:"),
+      `supervised (polling ${supervisedProjects.length} project(s)${projectSummary})`,
+    );
   }
 
   if (opts?.orchestrator !== false && selectedOrchestratorId) {

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -2200,9 +2200,8 @@ export function registerStart(program: Command): void {
           const actualPort = await runStartup(config, projectId, project, opts);
 
           // ── Register in running.json (Step 11) ──
-          // Only record the project this invocation actually polls. Other
-          // configured projects are not covered by this lifecycle loop, and
-          // `ao spawn` relies on this list to decide whether to warn users.
+          // During daemon startup, the project supervisor is the authoritative
+          // writer for lifecycle polling coverage across all active projects.
           await register({
             pid: process.pid,
             configPath: config.configPath,

--- a/packages/cli/src/lib/lifecycle-service.ts
+++ b/packages/cli/src/lib/lifecycle-service.ts
@@ -74,17 +74,21 @@ export async function ensureLifecycleWorker(
   return { running: true, started: true };
 }
 
+export function stopLifecycleWorker(projectId: string): void {
+  const entry = active.get(projectId);
+  if (!entry) return;
+
+  try {
+    entry.stop();
+  } catch {
+    // Best-effort
+  }
+  active.delete(projectId);
+}
+
 export function stopAllLifecycleWorkers(): void {
   for (const projectId of Array.from(active.keys())) {
-    const entry = active.get(projectId);
-    if (entry) {
-      try {
-        entry.stop();
-      } catch {
-        // Best-effort
-      }
-    }
-    active.delete(projectId);
+    stopLifecycleWorker(projectId);
   }
 }
 

--- a/packages/cli/src/lib/project-supervisor.ts
+++ b/packages/cli/src/lib/project-supervisor.ts
@@ -2,7 +2,10 @@ import {
   loadConfig,
   getGlobalConfigPath,
   isTerminalSession,
+  createCorrelationId,
+  createProjectObserver,
   type OrchestratorConfig,
+  type ProjectObserver,
 } from "@aoagents/ao-core";
 import { getSessionManager } from "./create-session-manager.js";
 import {
@@ -25,6 +28,25 @@ export interface ReconcileProjectSupervisorOptions {
   intervalMs?: number;
 }
 
+function reportProjectSupervisorError(
+  observer: ProjectObserver,
+  projectId: string,
+  reason: string,
+  error: unknown,
+): void {
+  observer.setHealth({
+    surface: "project-supervisor.reconcile",
+    status: "warn",
+    projectId,
+    correlationId: createCorrelationId("project-supervisor"),
+    reason,
+    details: {
+      projectId,
+      error: error instanceof Error ? error.message : String(error),
+    },
+  });
+}
+
 async function projectHasNonTerminalSession(
   config: OrchestratorConfig,
   projectId: string,
@@ -38,13 +60,23 @@ export async function reconcileProjectSupervisor(
   options: ReconcileProjectSupervisorOptions = {},
 ): Promise<void> {
   const config = loadConfig(getGlobalConfigPath());
+  const observer = createProjectObserver(config, "project-supervisor");
   const configuredProjectIds = new Set(Object.keys(config.projects));
   const activeProjectIds = new Set(listLifecycleWorkers());
 
   for (const projectId of activeProjectIds) {
     if (!configuredProjectIds.has(projectId)) {
-      stopLifecycleWorker(projectId);
-      await removeProjectFromRunning(projectId);
+      try {
+        stopLifecycleWorker(projectId);
+        await removeProjectFromRunning(projectId);
+      } catch (error) {
+        reportProjectSupervisorError(
+          observer,
+          projectId,
+          "Failed to detach lifecycle worker for removed project",
+          error,
+        );
+      }
     }
   }
 
@@ -53,14 +85,22 @@ export async function reconcileProjectSupervisor(
       const hasNonTerminalSession = await projectHasNonTerminalSession(config, projectId);
       const isAttached = listLifecycleWorkers().includes(projectId);
 
-      if (hasNonTerminalSession && !isAttached) {
-        await ensureLifecycleWorker(config, projectId, options.intervalMs);
+      if (hasNonTerminalSession) {
+        if (!isAttached) {
+          await ensureLifecycleWorker(config, projectId, options.intervalMs);
+        }
         await addProjectToRunning(projectId);
-      } else if (!hasNonTerminalSession && isAttached) {
+      } else if (isAttached) {
         stopLifecycleWorker(projectId);
         await removeProjectFromRunning(projectId);
       }
-    } catch {
+    } catch (error) {
+      reportProjectSupervisorError(
+        observer,
+        projectId,
+        "Failed to reconcile lifecycle worker for project",
+        error,
+      );
       // Best-effort per project: a broken project must not block others from reconciling.
     }
   }
@@ -74,22 +114,32 @@ export async function startProjectSupervisor(
   let reconciling = false;
   let pending = false;
   let stopped = false;
+  let waiters: Array<() => void> = [];
 
   const run = async (): Promise<void> => {
     if (stopped) return;
     if (reconciling) {
       pending = true;
-      return;
+      return new Promise<void>((resolve) => {
+        waiters.push(resolve);
+      });
     }
 
     reconciling = true;
     try {
       do {
         pending = false;
-        await reconcileProjectSupervisor();
+        try {
+          await reconcileProjectSupervisor({ intervalMs });
+        } catch {
+          // Best-effort background loop: transient config/state errors should not crash ao start.
+        }
       } while (pending && !stopped);
     } finally {
       reconciling = false;
+      const pendingWaiters = waiters;
+      waiters = [];
+      for (const resolve of pendingWaiters) resolve();
     }
   };
 
@@ -98,7 +148,7 @@ export async function startProjectSupervisor(
   }, intervalMs);
   timer.unref?.();
 
-  activeSupervisor = {
+  const handle: SupervisorHandle = {
     stop: () => {
       stopped = true;
       clearInterval(timer);
@@ -106,9 +156,10 @@ export async function startProjectSupervisor(
     },
     reconcileNow: run,
   };
+  activeSupervisor = handle;
 
   await run();
-  return activeSupervisor;
+  return handle;
 }
 
 export function stopProjectSupervisor(): void {

--- a/packages/cli/src/lib/project-supervisor.ts
+++ b/packages/cli/src/lib/project-supervisor.ts
@@ -28,6 +28,16 @@ export interface ReconcileProjectSupervisorOptions {
   intervalMs?: number;
 }
 
+function isMissingGlobalConfigError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    error.code === "ENOENT" &&
+    "path" in error &&
+    error.path === getGlobalConfigPath()
+  );
+}
+
 function reportProjectSupervisorError(
   observer: ProjectObserver,
   projectId: string,
@@ -132,6 +142,7 @@ export async function startProjectSupervisor(
         try {
           await reconcileProjectSupervisor({ intervalMs });
         } catch (error) {
+          if (isMissingGlobalConfigError(error)) return;
           if (!options.swallowErrors) throw error;
           // Best-effort background loop: transient config/state errors should not crash ao start.
         }

--- a/packages/cli/src/lib/project-supervisor.ts
+++ b/packages/cli/src/lib/project-supervisor.ts
@@ -1,0 +1,116 @@
+import {
+  loadConfig,
+  getGlobalConfigPath,
+  isTerminalSession,
+  type OrchestratorConfig,
+} from "@aoagents/ao-core";
+import { getSessionManager } from "./create-session-manager.js";
+import {
+  ensureLifecycleWorker,
+  listLifecycleWorkers,
+  stopLifecycleWorker,
+} from "./lifecycle-service.js";
+import { addProjectToRunning, removeProjectFromRunning } from "./running-state.js";
+
+const DEFAULT_SUPERVISOR_INTERVAL_MS = 60_000;
+
+interface SupervisorHandle {
+  stop: () => void;
+  reconcileNow: () => Promise<void>;
+}
+
+let activeSupervisor: SupervisorHandle | null = null;
+
+export interface ReconcileProjectSupervisorOptions {
+  intervalMs?: number;
+}
+
+async function projectHasNonTerminalSession(
+  config: OrchestratorConfig,
+  projectId: string,
+): Promise<boolean> {
+  const sm = await getSessionManager(config);
+  const sessions = await sm.list(projectId);
+  return sessions.some((session) => !isTerminalSession(session));
+}
+
+export async function reconcileProjectSupervisor(
+  options: ReconcileProjectSupervisorOptions = {},
+): Promise<void> {
+  const config = loadConfig(getGlobalConfigPath());
+  const configuredProjectIds = new Set(Object.keys(config.projects));
+  const activeProjectIds = new Set(listLifecycleWorkers());
+
+  for (const projectId of activeProjectIds) {
+    if (!configuredProjectIds.has(projectId)) {
+      stopLifecycleWorker(projectId);
+      await removeProjectFromRunning(projectId);
+    }
+  }
+
+  for (const projectId of configuredProjectIds) {
+    try {
+      const hasNonTerminalSession = await projectHasNonTerminalSession(config, projectId);
+      const isAttached = listLifecycleWorkers().includes(projectId);
+
+      if (hasNonTerminalSession && !isAttached) {
+        await ensureLifecycleWorker(config, projectId, options.intervalMs);
+        await addProjectToRunning(projectId);
+      } else if (!hasNonTerminalSession && isAttached) {
+        stopLifecycleWorker(projectId);
+        await removeProjectFromRunning(projectId);
+      }
+    } catch {
+      // Best-effort per project: a broken project must not block others from reconciling.
+    }
+  }
+}
+
+export async function startProjectSupervisor(
+  intervalMs: number = DEFAULT_SUPERVISOR_INTERVAL_MS,
+): Promise<SupervisorHandle> {
+  if (activeSupervisor) return activeSupervisor;
+
+  let reconciling = false;
+  let pending = false;
+  let stopped = false;
+
+  const run = async (): Promise<void> => {
+    if (stopped) return;
+    if (reconciling) {
+      pending = true;
+      return;
+    }
+
+    reconciling = true;
+    try {
+      do {
+        pending = false;
+        await reconcileProjectSupervisor();
+      } while (pending && !stopped);
+    } finally {
+      reconciling = false;
+    }
+  };
+
+  const timer = setInterval(() => {
+    void run();
+  }, intervalMs);
+  timer.unref?.();
+
+  activeSupervisor = {
+    stop: () => {
+      stopped = true;
+      clearInterval(timer);
+      activeSupervisor = null;
+    },
+    reconcileNow: run,
+  };
+
+  await run();
+  return activeSupervisor;
+}
+
+export function stopProjectSupervisor(): void {
+  activeSupervisor?.stop();
+}

--- a/packages/cli/src/lib/project-supervisor.ts
+++ b/packages/cli/src/lib/project-supervisor.ts
@@ -116,7 +116,7 @@ export async function startProjectSupervisor(
   let stopped = false;
   let waiters: Array<() => void> = [];
 
-  const run = async (): Promise<void> => {
+  const run = async (options: { swallowErrors?: boolean } = {}): Promise<void> => {
     if (stopped) return;
     if (reconciling) {
       pending = true;
@@ -131,7 +131,8 @@ export async function startProjectSupervisor(
         pending = false;
         try {
           await reconcileProjectSupervisor({ intervalMs });
-        } catch {
+        } catch (error) {
+          if (!options.swallowErrors) throw error;
           // Best-effort background loop: transient config/state errors should not crash ao start.
         }
       } while (pending && !stopped);
@@ -144,7 +145,7 @@ export async function startProjectSupervisor(
   };
 
   const timer = setInterval(() => {
-    void run();
+    void run({ swallowErrors: true });
   }, intervalMs);
   timer.unref?.();
 
@@ -158,7 +159,12 @@ export async function startProjectSupervisor(
   };
   activeSupervisor = handle;
 
-  await run();
+  try {
+    await run();
+  } catch (error) {
+    handle.stop();
+    throw error;
+  }
   return handle;
 }
 


### PR DESCRIPTION
## Description

Fixes the long-lived `ao start` process so lifecycle polling dynamically follows active globally registered projects without requiring a daemon restart.

- Adds a small project supervisor that reconciles the canonical global config to in-memory lifecycle workers.
- Attaches workers only for projects with at least one non-terminal session.
- Detaches workers when projects are removed or their last session becomes terminal.
- Keeps `running.projects` aligned with attached workers so `ao spawn` warning behavior remains accurate.
- Replaces restart-required messaging with “lifecycle polling will attach within ~60s”.

## Related Issue

Closes #1522

## Potential Risk & Impact

- Low/medium: changes lifecycle startup ownership from a direct initial worker to supervisor-managed attachment.
- Mitigated by targeted unit coverage for attach/detach, idle suppression, failure isolation, and start-command behavior.

## How Has This Been Tested?

- `pnpm --filter @aoagents/ao-cli test`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm lint` (passes with existing warnings only)
