### PR TITLE
fix: register ao start projects globally

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -2103,8 +2103,6 @@ describe("stop command", () => {
 describe("start command — autoCreateConfig", () => {
   it("generates config with empty notifiers array (no desktop notifier added by default)", async () => {
     const globalConfigPath = join(tmpDir, "global-config.yaml");
-    const origGlobalEnv = process.env["AO_GLOBAL_CONFIG"];
-    process.env["AO_GLOBAL_CONFIG"] = globalConfigPath;
 
     const { detectEnvironment } = await import("../../src/lib/detect-env.js");
     vi.mocked(detectEnvironment).mockResolvedValue({
@@ -2139,38 +2137,33 @@ describe("start command — autoCreateConfig", () => {
     const callerContext = await import("../../src/lib/caller-context.js");
     vi.spyOn(callerContext, "isHumanCaller").mockReturnValue(false);
 
-    try {
-      await createConfigOnly();
+    await createConfigOnly();
 
-      const configPath = join(tmpDir, "agent-orchestrator.yaml");
-      expect(existsSync(configPath)).toBe(true);
-      expect(existsSync(globalConfigPath)).toBe(true);
+    const configPath = join(tmpDir, "agent-orchestrator.yaml");
+    expect(existsSync(configPath)).toBe(true);
+    expect(existsSync(globalConfigPath)).toBe(true);
 
-      const content = readFileSync(configPath, "utf-8");
-      const parsed = parseYaml(content) as {
-        $schema?: string;
-        defaults?: { notifiers?: unknown[] };
-      };
-      expect(parsed["$schema"]).toBe(
-        "https://raw.githubusercontent.com/ComposioHQ/agent-orchestrator/main/schema/config.schema.json",
-      );
-      expect(parsed.defaults?.notifiers).toEqual([]);
+    const content = readFileSync(configPath, "utf-8");
+    const parsed = parseYaml(content) as {
+      $schema?: string;
+      defaults?: { notifiers?: unknown[] };
+    };
+    expect(parsed["$schema"]).toBe(
+      "https://raw.githubusercontent.com/ComposioHQ/agent-orchestrator/main/schema/config.schema.json",
+    );
+    expect(parsed.defaults?.notifiers).toEqual([]);
 
-      const globalConfig = parseYaml(readFileSync(globalConfigPath, "utf-8")) as {
-        projects: Record<string, Record<string, unknown>>;
-      };
-      const registeredEntry = Object.values(globalConfig.projects).find(
-        (entry) => entry.path === realpathSync(tmpDir),
-      );
-      expect(registeredEntry).toMatchObject({
-        path: realpathSync(tmpDir),
-        defaultBranch: "main",
-      });
-      expect(registeredEntry?.sessionPrefix).toEqual(expect.any(String));
-    } finally {
-      if (origGlobalEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
-      else process.env["AO_GLOBAL_CONFIG"] = origGlobalEnv;
-    }
+    const globalConfig = parseYaml(readFileSync(globalConfigPath, "utf-8")) as {
+      projects: Record<string, Record<string, unknown>>;
+    };
+    const registeredEntry = Object.values(globalConfig.projects).find(
+      (entry) => entry.path === realpathSync(tmpDir),
+    );
+    expect(registeredEntry).toMatchObject({
+      path: realpathSync(tmpDir),
+      defaultBranch: "main",
+    });
+    expect(registeredEntry?.sessionPrefix).toEqual(expect.any(String));
   });
 });
 

--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -266,6 +266,7 @@ import { registerStart, registerStop, createConfigOnly } from "../../src/command
 let tmpDir: string;
 let program: Command;
 let cwdSpy: ReturnType<typeof vi.spyOn>;
+let originalGlobalConfigEnv: string | undefined;
 
 function createSpawnChild(options?: {
   /** Emit `error` instead of `close`. */
@@ -303,6 +304,8 @@ function createSpawnChild(options?: {
 
 beforeEach(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "ao-start-test-"));
+  originalGlobalConfigEnv = process.env["AO_GLOBAL_CONFIG"];
+  process.env["AO_GLOBAL_CONFIG"] = join(tmpDir, "global-config.yaml");
 
   program = new Command();
   program.exitOverride();
@@ -328,7 +331,11 @@ beforeEach(async () => {
   vi.mocked(webDir.findFreePort).mockResolvedValue(3000);
   vi.mocked(webDir.buildDashboardEnv).mockResolvedValue({});
   const projectDetection = await import("../../src/lib/project-detection.js");
-  vi.mocked(projectDetection.detectProjectType).mockReturnValue({ languages: [], frameworks: [], tools: [] });
+  vi.mocked(projectDetection.detectProjectType).mockReturnValue({
+    languages: [],
+    frameworks: [],
+    tools: [],
+  });
   vi.mocked(projectDetection.generateRulesFromTemplates).mockReturnValue(null);
   vi.mocked(projectDetection.formatProjectTypeForDisplay).mockReturnValue("");
 
@@ -412,6 +419,8 @@ beforeEach(async () => {
 
 afterEach(() => {
   if (cwdSpy) cwdSpy.mockRestore();
+  if (originalGlobalConfigEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
+  else process.env["AO_GLOBAL_CONFIG"] = originalGlobalConfigEnv;
   rmSync(tmpDir, { recursive: true, force: true });
   vi.restoreAllMocks();
 });
@@ -647,17 +656,13 @@ describe("start command — URL argument", () => {
     mockExecSilent.mockResolvedValue("Logged in");
 
     mockSpawn.mockImplementation(
-      (
-        cmd: string,
-        args: string[],
-        _opts?: { cwd?: string; env?: NodeJS.ProcessEnv },
-      ) => {
-      if (cmd === "gh" && args[0] === "repo" && args[1] === "clone") {
-        createFakeRepo(repoDir, "https://github.com/owner/my-app.git", {
-          "Cargo.toml": "",
-        });
-      }
-      return createSpawnChild({ closeCode: 0 });
+      (cmd: string, args: string[], _opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+        if (cmd === "gh" && args[0] === "repo" && args[1] === "clone") {
+          createFakeRepo(repoDir, "https://github.com/owner/my-app.git", {
+            "Cargo.toml": "",
+          });
+        }
+        return createSpawnChild({ closeCode: 0 });
       },
     );
 
@@ -696,25 +701,21 @@ describe("start command — URL argument", () => {
     });
 
     mockSpawn.mockImplementation(
-      (
-        cmd: string,
-        args: string[],
-        _opts?: { cwd?: string; env?: NodeJS.ProcessEnv },
-      ) => {
-      if (cmd === "git" && args[0] === "clone") {
-        const url = String(args[3] ?? "");
-        // SSH attempt fails (simulate non-zero exit)
-        if (url.startsWith("git@")) {
-          return createSpawnChild({ closeCode: 1 });
+      (cmd: string, args: string[], _opts?: { cwd?: string; env?: NodeJS.ProcessEnv }) => {
+        if (cmd === "git" && args[0] === "clone") {
+          const url = String(args[3] ?? "");
+          // SSH attempt fails (simulate non-zero exit)
+          if (url.startsWith("git@")) {
+            return createSpawnChild({ closeCode: 1 });
+          }
+
+          // HTTPS fallback succeeds
+          createFakeRepo(repoDir, "https://github.com/owner/my-app.git", {
+            "Cargo.toml": "",
+          });
         }
 
-        // HTTPS fallback succeeds
-        createFakeRepo(repoDir, "https://github.com/owner/my-app.git", {
-          "Cargo.toml": "",
-        });
-      }
-
-      return createSpawnChild({ closeCode: 0 });
+        return createSpawnChild({ closeCode: 0 });
       },
     );
 
@@ -1229,10 +1230,10 @@ describe("start command — orchestrator session strategy display", () => {
 
     await program.parseAsync(["node", "test", "start", "--rebuild", "--no-orchestrator"]);
 
-    expect(dashboardRebuild.rebuildDashboardProductionArtifacts).toHaveBeenCalledWith(tmpDir, [
-      3000,
-      3001,
-    ]);
+    expect(dashboardRebuild.rebuildDashboardProductionArtifacts).toHaveBeenCalledWith(
+      tmpDir,
+      [3000, 3001],
+    );
   });
 
   it("opens the most recent orchestrator session page when multiple existing orchestrators found with dashboard enabled and reuse is explicit", async () => {
@@ -2101,6 +2102,10 @@ describe("stop command", () => {
 
 describe("start command — autoCreateConfig", () => {
   it("generates config with empty notifiers array (no desktop notifier added by default)", async () => {
+    const globalConfigPath = join(tmpDir, "global-config.yaml");
+    const origGlobalEnv = process.env["AO_GLOBAL_CONFIG"];
+    process.env["AO_GLOBAL_CONFIG"] = globalConfigPath;
+
     const { detectEnvironment } = await import("../../src/lib/detect-env.js");
     vi.mocked(detectEnvironment).mockResolvedValue({
       isGitRepo: true,
@@ -2134,20 +2139,38 @@ describe("start command — autoCreateConfig", () => {
     const callerContext = await import("../../src/lib/caller-context.js");
     vi.spyOn(callerContext, "isHumanCaller").mockReturnValue(false);
 
-    await createConfigOnly();
+    try {
+      await createConfigOnly();
 
-    const configPath = join(tmpDir, "agent-orchestrator.yaml");
-    expect(existsSync(configPath)).toBe(true);
+      const configPath = join(tmpDir, "agent-orchestrator.yaml");
+      expect(existsSync(configPath)).toBe(true);
+      expect(existsSync(globalConfigPath)).toBe(true);
 
-    const content = readFileSync(configPath, "utf-8");
-    const parsed = parseYaml(content) as {
-      $schema?: string;
-      defaults?: { notifiers?: unknown[] };
-    };
-    expect(parsed["$schema"]).toBe(
-      "https://raw.githubusercontent.com/ComposioHQ/agent-orchestrator/main/schema/config.schema.json",
-    );
-    expect(parsed.defaults?.notifiers).toEqual([]);
+      const content = readFileSync(configPath, "utf-8");
+      const parsed = parseYaml(content) as {
+        $schema?: string;
+        defaults?: { notifiers?: unknown[] };
+      };
+      expect(parsed["$schema"]).toBe(
+        "https://raw.githubusercontent.com/ComposioHQ/agent-orchestrator/main/schema/config.schema.json",
+      );
+      expect(parsed.defaults?.notifiers).toEqual([]);
+
+      const globalConfig = parseYaml(readFileSync(globalConfigPath, "utf-8")) as {
+        projects: Record<string, Record<string, unknown>>;
+      };
+      const registeredEntry = Object.values(globalConfig.projects).find(
+        (entry) => entry.path === realpathSync(tmpDir),
+      );
+      expect(registeredEntry).toMatchObject({
+        path: realpathSync(tmpDir),
+        defaultBranch: "main",
+      });
+      expect(registeredEntry?.sessionPrefix).toEqual(expect.any(String));
+    } finally {
+      if (origGlobalEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
+      else process.env["AO_GLOBAL_CONFIG"] = origGlobalEnv;
+    }
   });
 });
 
@@ -2313,8 +2336,7 @@ describe("start command — already-running detection", () => {
         ) {
           return "https://github.com/org/new-repo.git";
         }
-        if (args[0] === "symbolic-ref" && workingDir === repoDir)
-          return "refs/remotes/origin/main";
+        if (args[0] === "symbolic-ref" && workingDir === repoDir) return "refs/remotes/origin/main";
         if (args[0] === "rev-parse" && args[1] === "--verify" && workingDir === repoDir)
           return "abc";
         return null;
@@ -2660,6 +2682,177 @@ describe("start command — path-based deduplication in addProjectToConfig", () 
     } finally {
       if (origEnv === undefined) delete process.env["AO_CONFIG_PATH"];
       else process.env["AO_CONFIG_PATH"] = origEnv;
+    }
+  });
+
+  it("registers projects in the global registry when adding to a non-global local config", async () => {
+    const currentRepoDir = join(tmpDir, "current-project");
+    const addedRepoDir = join(tmpDir, "added-project");
+    createFakeRepo(currentRepoDir, "https://github.com/org/current-project.git");
+    createFakeRepo(addedRepoDir, "https://github.com/org/added-project.git");
+
+    const localConfigPath = join(currentRepoDir, "agent-orchestrator.yaml");
+    const globalConfigPath = join(tmpDir, "global-config.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+    writeFileSync(
+      localConfigPath,
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            current: {
+              name: "Current",
+              repo: "org/current-project",
+              path: currentRepoDir,
+              defaultBranch: "main",
+              sessionPrefix: "cur",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
+
+    const origConfigEnv = process.env["AO_CONFIG_PATH"];
+    const origGlobalEnv = process.env["AO_GLOBAL_CONFIG"];
+    process.env["AO_CONFIG_PATH"] = localConfigPath;
+    process.env["AO_GLOBAL_CONFIG"] = globalConfigPath;
+
+    const shell = await import("../../src/lib/shell.js");
+    vi.mocked(shell.git).mockImplementation(async (args: string[], workingDir?: string) => {
+      if (args[0] === "rev-parse" && args[1] === "--git-dir" && workingDir === addedRepoDir)
+        return ".git";
+      if (
+        args[0] === "remote" &&
+        args[1] === "get-url" &&
+        args[2] === "origin" &&
+        workingDir === addedRepoDir
+      ) {
+        return "https://github.com/org/added-project.git";
+      }
+      if (args[0] === "symbolic-ref" && workingDir === addedRepoDir)
+        return "refs/remotes/origin/main";
+      if (args[0] === "rev-parse" && args[1] === "--verify" && workingDir === addedRepoDir)
+        return "abc";
+      return null;
+    });
+
+    try {
+      await program.parseAsync([
+        "node",
+        "test",
+        "start",
+        addedRepoDir,
+        "--no-dashboard",
+        "--no-orchestrator",
+      ]);
+
+      const localConfig = parseYaml(readFileSync(localConfigPath, "utf-8")) as {
+        projects: Record<string, Record<string, unknown>>;
+      };
+      expect(localConfig.projects["added-project"]).toMatchObject({
+        path: addedRepoDir,
+        defaultBranch: "main",
+      });
+
+      const globalConfig = parseYaml(readFileSync(globalConfigPath, "utf-8")) as {
+        projects: Record<string, Record<string, unknown>>;
+      };
+      const registeredEntry = Object.values(globalConfig.projects).find(
+        (entry) => entry.path === realpathSync(addedRepoDir),
+      );
+      expect(registeredEntry).toMatchObject({
+        path: realpathSync(addedRepoDir),
+        defaultBranch: "main",
+        sessionPrefix: "ap",
+      });
+    } finally {
+      if (origConfigEnv === undefined) delete process.env["AO_CONFIG_PATH"];
+      else process.env["AO_CONFIG_PATH"] = origConfigEnv;
+      if (origGlobalEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
+      else process.env["AO_GLOBAL_CONFIG"] = origGlobalEnv;
+    }
+  });
+
+  it("registers a local-yaml-only cwd project when a global registry already exists", async () => {
+    const projectADir = join(tmpDir, "project-a");
+    const projectBDir = join(tmpDir, "project-b");
+    createFakeRepo(projectADir, "https://github.com/org/project-a.git");
+    createFakeRepo(projectBDir, "https://github.com/org/project-b.git");
+
+    const localConfigPath = join(projectBDir, "agent-orchestrator.yaml");
+    const globalConfigPath = join(tmpDir, "global-config.yaml");
+    const { stringify: yamlStringify } = await import("yaml");
+
+    writeFileSync(
+      localConfigPath,
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            "project-b": {
+              name: "Project B",
+              repo: "org/project-b",
+              path: projectBDir,
+              defaultBranch: "main",
+              sessionPrefix: "pb",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
+    writeFileSync(
+      globalConfigPath,
+      yamlStringify(
+        {
+          defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+          projects: {
+            "project-a": {
+              projectId: "project-a",
+              path: realpathSync(projectADir),
+              defaultBranch: "main",
+              displayName: "Project A",
+              sessionPrefix: "pa",
+            },
+          },
+        },
+        { indent: 2 },
+      ),
+    );
+
+    const origConfigEnv = process.env["AO_CONFIG_PATH"];
+    const origGlobalEnv = process.env["AO_GLOBAL_CONFIG"];
+    process.env["AO_CONFIG_PATH"] = localConfigPath;
+    process.env["AO_GLOBAL_CONFIG"] = globalConfigPath;
+    const core = await import("@aoagents/ao-core");
+    mockConfigRef.current = core.loadConfig(localConfigPath) as unknown as Record<string, unknown>;
+
+    try {
+      await program.parseAsync(["node", "test", "start", "--no-dashboard", "--no-orchestrator"]);
+
+      const globalConfig = parseYaml(readFileSync(globalConfigPath, "utf-8")) as {
+        projects: Record<string, Record<string, unknown>>;
+      };
+      expect(
+        Object.values(globalConfig.projects).some(
+          (entry) =>
+            typeof entry.path === "string" &&
+            realpathSync(entry.path) === realpathSync(projectADir),
+        ),
+      ).toBe(true);
+      expect(
+        Object.values(globalConfig.projects).some(
+          (entry) =>
+            typeof entry.path === "string" &&
+            realpathSync(entry.path) === realpathSync(projectBDir),
+        ),
+      ).toBe(true);
+    } finally {
+      if (origConfigEnv === undefined) delete process.env["AO_CONFIG_PATH"];
+      else process.env["AO_CONFIG_PATH"] = origConfigEnv;
+      if (origGlobalEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
+      else process.env["AO_GLOBAL_CONFIG"] = origGlobalEnv;
     }
   });
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -115,8 +115,38 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
   writeLocalProjectConfig(projectPath, config);
 }
 
+function isProjectRegisteredInGlobalConfig(projectPath: string): boolean {
+  const globalConfigPath = getGlobalConfigPath();
+  if (!existsSync(globalConfigPath)) {
+    return false;
+  }
+
+  let canonicalProjectPath: string;
+  try {
+    canonicalProjectPath = realpathSync(resolve(projectPath));
+  } catch {
+    canonicalProjectPath = resolve(projectPath);
+  }
+
+  try {
+    const globalConfig = loadConfig(globalConfigPath);
+    return Object.values(globalConfig.projects).some((project) => {
+      try {
+        return realpathSync(resolve(project.path)) === canonicalProjectPath;
+      } catch {
+        return resolve(project.path) === canonicalProjectPath;
+      }
+    });
+  } catch {
+    return false;
+  }
+}
+
 function registerProjectForDashboard(projectId: string, project: ProjectConfig): string {
   if (!existsSync(project.path)) {
+    return projectId;
+  }
+  if (isProjectRegisteredInGlobalConfig(project.path)) {
     return projectId;
   }
 
@@ -1683,6 +1713,7 @@ export function registerStart(program: Command): void {
           let config: OrchestratorConfig;
           let projectId: string;
           let project: ProjectConfig;
+          let registeredProjectForDashboardThisStart = false;
 
           // ── Already-running detection (before any config mutation) ──
           const running = await isAlreadyRunning();
@@ -2133,6 +2164,7 @@ export function registerStart(program: Command): void {
                 // cwd is the target — auto-create config here
                 config = await autoCreateConfig(cwd());
               }
+              registeredProjectForDashboardThisStart = true;
               ({ projectId, project, config } = await resolveProject(config));
             } else {
               config = loadConfig(configPath);
@@ -2150,6 +2182,7 @@ export function registerStart(program: Command): void {
               } else {
                 // New project — add it to config
                 const addedId = await addProjectToConfig(config, resolvedPath);
+                registeredProjectForDashboardThisStart = true;
                 config = loadConfig(config.configPath);
                 projectId = addedId;
                 project = config.projects[projectId];
@@ -2164,6 +2197,7 @@ export function registerStart(program: Command): void {
               if (err instanceof ConfigNotFoundError) {
                 // First run — auto-create config
                 loadedConfig = await autoCreateConfig(cwd());
+                registeredProjectForDashboardThisStart = true;
               } else {
                 // A config file exists but failed to load — likely a flat local
                 // config whose project isn't registered in the global config yet.
@@ -2193,7 +2227,10 @@ export function registerStart(program: Command): void {
             ({ projectId, project, config } = await resolveProject(config, projectArg));
           }
 
-          if (!isCanonicalGlobalConfigPath(config.configPath)) {
+          if (
+            !registeredProjectForDashboardThisStart &&
+            !isCanonicalGlobalConfigPath(config.configPath)
+          ) {
             registerProjectForDashboard(projectId, project);
           }
 

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -115,6 +115,48 @@ function writeProjectBehaviorConfig(projectPath: string, config: LocalProjectCon
   writeLocalProjectConfig(projectPath, config);
 }
 
+function registerProjectForDashboard(projectId: string, project: ProjectConfig): string {
+  if (!existsSync(project.path)) {
+    return projectId;
+  }
+
+  const localConfig = {
+    ...(project.repo ? { repo: project.repo } : {}),
+    defaultBranch: project.defaultBranch,
+    sessionPrefix: project.sessionPrefix,
+  };
+
+  try {
+    return registerProjectInGlobalConfig(
+      projectId,
+      project.name ?? projectId,
+      project.path,
+      localConfig,
+      getGlobalConfigPath(),
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("is already registered at")) {
+      console.log(
+        chalk.dim(`  Project path already registered globally — skipping registry update.`),
+      );
+      return projectId;
+    }
+    if (error instanceof Error && error.message.includes("Duplicate session prefix")) {
+      return registerProjectInGlobalConfig(
+        projectId,
+        project.name ?? projectId,
+        project.path,
+        {
+          ...(project.repo ? { repo: project.repo } : {}),
+          defaultBranch: project.defaultBranch,
+        },
+        getGlobalConfigPath(),
+      );
+    }
+    throw error;
+  }
+}
+
 /**
  * Register a flat local config (agent-orchestrator.yaml without `projects:`)
  * into the global config so loadConfig can resolve it.
@@ -750,6 +792,7 @@ async function autoCreateConfig(workingDir: string): Promise<OrchestratorConfig>
   let repo: string | undefined = env.ownerRepo ?? undefined;
   const path = workingDir;
   const defaultBranch = env.defaultBranch || "main";
+  const sessionPrefix = generateSessionPrefix(projectId);
 
   // If no repo detected, inform the user and ask
   /* c8 ignore start -- interactive prompt, tested via onboarding integration */
@@ -780,6 +823,15 @@ async function autoCreateConfig(workingDir: string): Promise<OrchestratorConfig>
     console.log(chalk.yellow(`  ⚠ Port ${DEFAULT_PORT} is busy — using ${port} instead.`));
   }
 
+  const projectConfig: ProjectConfig = {
+    name: projectId,
+    sessionPrefix,
+    ...(repo ? { repo } : {}),
+    path,
+    defaultBranch,
+    ...(agentRules ? { agentRules } : {}),
+  };
+
   const config: Record<string, unknown> = {
     port: port ?? DEFAULT_PORT,
     defaults: {
@@ -789,14 +841,7 @@ async function autoCreateConfig(workingDir: string): Promise<OrchestratorConfig>
       notifiers: [],
     },
     projects: {
-      [projectId]: {
-        name: projectId,
-        sessionPrefix: generateSessionPrefix(projectId),
-        ...(repo ? { repo } : {}),
-        path,
-        defaultBranch,
-        ...(agentRules ? { agentRules } : {}),
-      },
+      [projectId]: projectConfig,
     },
   };
 
@@ -808,6 +853,8 @@ async function autoCreateConfig(workingDir: string): Promise<OrchestratorConfig>
   }
   const yamlContent = configToYaml(config);
   writeFileSync(outputPath, yamlContent);
+
+  registerProjectForDashboard(projectId, projectConfig);
 
   console.log(chalk.green(`✓ Config created: ${outputPath}\n`));
 
@@ -989,6 +1036,7 @@ async function addProjectToConfig(
     };
 
     writeFileSync(config.configPath, configToYaml(rawConfig as Record<string, unknown>));
+    registerProjectForDashboard(projectId, rawConfig.projects[projectId] as ProjectConfig);
     console.log(chalk.green(`\n✓ Added "${projectId}" to ${config.configPath}\n`));
   }
 
@@ -1352,7 +1400,9 @@ async function runStartup(
         const currentProjectSessions = lastStop.projectId === projectId ? lastStop.sessionIds : [];
         if (currentProjectSessions.length > 0) {
           console.log(
-            chalk.yellow(`\n  ${currentProjectSessions.length} session(s) were active before last ao stop (${stoppedAgo}):`),
+            chalk.yellow(
+              `\n  ${currentProjectSessions.length} session(s) were active before last ao stop (${stoppedAgo}):`,
+            ),
           );
           console.log(chalk.dim(`  ${currentProjectSessions.join(", ")}\n`));
         }
@@ -1400,9 +1450,13 @@ async function runStartup(
               }
             }
             if (restoredCount === allRestoreSessions.length) {
-              restoreSpinner.succeed(`Restored ${restoredCount}/${allRestoreSessions.length} session(s)`);
+              restoreSpinner.succeed(
+                `Restored ${restoredCount}/${allRestoreSessions.length} session(s)`,
+              );
             } else {
-              restoreSpinner.warn(`Restored ${restoredCount}/${allRestoreSessions.length} session(s)`);
+              restoreSpinner.warn(
+                `Restored ${restoredCount}/${allRestoreSessions.length} session(s)`,
+              );
             }
             for (const w of warnings) {
               console.log(chalk.yellow(w));
@@ -1414,9 +1468,7 @@ async function runStartup(
             // and the remaining sessions would never be retryable. When
             // every session restored (or was skipped), clear the file.
             if (failedSessionIds.size > 0) {
-              const remainingTarget = lastStop.sessionIds.filter((id) =>
-                failedSessionIds.has(id),
-              );
+              const remainingTarget = lastStop.sessionIds.filter((id) => failedSessionIds.has(id));
               const remainingOther = otherProjects
                 .map((p) => ({
                   projectId: p.projectId,
@@ -1639,8 +1691,7 @@ export function registerStart(program: Command): void {
           // running.json projects list, it was stopped via `ao stop <project>`.
           // Skip the "already running" menu and go straight to orchestrator
           // creation — the dashboard and lifecycle worker are still up.
-          const isProjectId =
-            projectArg && !isRepoUrl(projectArg) && !isLocalPath(projectArg);
+          const isProjectId = projectArg && !isRepoUrl(projectArg) && !isLocalPath(projectArg);
           const projectArgIsUrlOrPath =
             !!projectArg && (isRepoUrl(projectArg) || isLocalPath(projectArg));
 
@@ -1726,9 +1777,7 @@ export function registerStart(program: Command): void {
               // here so the global registry + repo can be loaded cleanly
               // on the very first read.
               const parsed = parseRepoUrl(requestedProjectArg);
-              console.log(
-                chalk.bold.cyan(`\n  Cloning ${parsed.ownerRepo} (${parsed.host})\n`),
-              );
+              console.log(chalk.bold.cyan(`\n  Cloning ${parsed.ownerRepo} (${parsed.host})\n`));
               await ensureGit("repository cloning");
 
               const cwdDir = cwd();
@@ -1878,9 +1927,7 @@ export function registerStart(program: Command): void {
           // leaving the original parent process orphaned.
           if (running && isProjectId) {
             const globalConfigPath = getGlobalConfigPath();
-            const cfg = existsSync(globalConfigPath)
-              ? loadConfig(globalConfigPath)
-              : loadConfig();
+            const cfg = existsSync(globalConfigPath) ? loadConfig(globalConfigPath) : loadConfig();
             const project = cfg.projects[projectArg];
             if (!project) {
               throw new Error(
@@ -1901,11 +1948,11 @@ export function registerStart(program: Command): void {
               systemPrompt,
             });
 
+            console.log(chalk.green(`✓ Orchestrator session ready: ${session.id}`));
             console.log(
-              chalk.green(`✓ Orchestrator session ready: ${session.id}`),
-            );
-            console.log(
-              chalk.green(`✓ Project "${projectArg}" reattached to running daemon (PID ${running.pid}).`),
+              chalk.green(
+                `✓ Project "${projectArg}" reattached to running daemon (PID ${running.pid}).`,
+              ),
             );
 
             // Invalidate the dashboard's cached services so the project page
@@ -2144,6 +2191,10 @@ export function registerStart(program: Command): void {
               }
             }
             ({ projectId, project, config } = await resolveProject(config, projectArg));
+          }
+
+          if (!isCanonicalGlobalConfigPath(config.configPath)) {
+            registerProjectForDashboard(projectId, project);
           }
 
           // ── Handle "new orchestrator" choice (deferred from already-running check) ──
@@ -2438,7 +2489,9 @@ export function registerStop(program: Command): void {
             if (killedSessionIds.length === 0) {
               spinner.fail("Failed to stop any sessions");
             } else if (killedSessionIds.length < activeSessions.length) {
-              spinner.warn(`Stopped ${killedSessionIds.length}/${activeSessions.length} session(s)`);
+              spinner.warn(
+                `Stopped ${killedSessionIds.length}/${activeSessions.length} session(s)`,
+              );
             } else {
               spinner.succeed(`Stopped ${killedSessionIds.length} session(s)`);
             }
@@ -2475,9 +2528,7 @@ export function registerStop(program: Command): void {
             await writeLastStop({
               stoppedAt: new Date().toISOString(),
               projectId: _projectId,
-              sessionIds: killedSessionIds.filter((id) =>
-                targetActive.some((s) => s.id === id),
-              ),
+              sessionIds: killedSessionIds.filter((id) => targetActive.some((s) => s.id === id)),
               otherProjects: otherProjects.length > 0 ? otherProjects : undefined,
             });
           }


### PR DESCRIPTION
Closes #1561

## Summary
- register first-run auto-created projects in the global config so the dashboard can discover them
- backfill the global registry when starting from a local non-global config or adding a project to a local wrapped config
- add regression coverage for first-run registration, non-global path adds, and local-yaml-only projects with an existing global registry

## Testing
- pnpm --filter @aoagents/ao-cli test -- start.test.ts
- pnpm typecheck
- pnpm lint (passes with existing warnings)
- pnpm test

Note: pnpm build currently fails in the web package during Next.js prerendering with an existing /404 error: <Html> should not be imported outside of pages/_document.
