### PR TITLE
Fix direct terminal attach and keep project-scoped mux routing

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -17,6 +17,7 @@ import { createDirectTerminalServer, type DirectTerminalServer } from "../direct
 const TMUX = findTmux();
 const TEST_SESSION = `ao-test-integration-${process.pid}`;
 const TEST_HASH_SESSION = `abcdef123456-ao-test-hash-${process.pid}`;
+const TEST_SPACED_TARGET = `abcdef123456-my project-${process.pid}`;
 
 let terminal: DirectTerminalServer;
 let port: number;
@@ -31,7 +32,9 @@ function httpGet(path: string): Promise<{ status: number; body: string }> {
       { hostname: "localhost", port, path, method: "GET", timeout: 3000 },
       (res: IncomingMessage) => {
         let body = "";
-        res.on("data", (chunk: Buffer) => { body += chunk.toString(); });
+        res.on("data", (chunk: Buffer) => {
+          body += chunk.toString();
+        });
         res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
       },
     );
@@ -89,6 +92,9 @@ beforeAll(() => {
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_HASH_SESSION, "-x", "80", "-y", "24"], {
     timeout: 5000,
   });
+  execFileSync(TMUX, ["new-session", "-d", "-s", TEST_SPACED_TARGET, "-x", "80", "-y", "24"], {
+    timeout: 5000,
+  });
 
   terminal = createDirectTerminalServer(TMUX);
   terminal.server.listen(0);
@@ -98,8 +104,21 @@ beforeAll(() => {
 
 afterAll(() => {
   terminal.shutdown();
-  try { execFileSync(TMUX, ["kill-session", "-t", TEST_SESSION], { timeout: 5000 }); } catch { /* */ }
-  try { execFileSync(TMUX, ["kill-session", "-t", TEST_HASH_SESSION], { timeout: 5000 }); } catch { /* */ }
+  try {
+    execFileSync(TMUX, ["kill-session", "-t", TEST_SESSION], { timeout: 5000 });
+  } catch {
+    /* */
+  }
+  try {
+    execFileSync(TMUX, ["kill-session", "-t", TEST_HASH_SESSION], { timeout: 5000 });
+  } catch {
+    /* */
+  }
+  try {
+    execFileSync(TMUX, ["kill-session", "-t", TEST_SPACED_TARGET], { timeout: 5000 });
+  } catch {
+    /* */
+  }
 });
 
 // =============================================================================
@@ -176,10 +195,12 @@ describe("mux terminal open", () => {
   it("sends 'opened' response for a valid tmux session", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "open" }));
+    ws.send(
+      JSON.stringify({ ch: "terminal", id: "test-session", tmuxName: TEST_SESSION, type: "open" }),
+    );
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
-    expect(msg.id).toBe(TEST_SESSION);
+    expect(msg.id).toBe("test-session");
 
     ws.close();
   });
@@ -187,7 +208,14 @@ describe("mux terminal open", () => {
   it("sends error response for nonexistent tmux session", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: `nonexistent-${Date.now()}`, type: "open" }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "missing-session",
+        tmuxName: `nonexistent-${Date.now()}`,
+        type: "open",
+      }),
+    );
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "error");
     expect(typeof msg.message).toBe("string");
@@ -198,7 +226,14 @@ describe("mux terminal open", () => {
   it("sends error for invalid session ID (path traversal)", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: "../../../etc/passwd", type: "open" }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "../../../etc/passwd",
+        tmuxName: TEST_SESSION,
+        type: "open",
+      }),
+    );
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "error");
     expect(msg.message).toMatch(/invalid session/i);
@@ -209,7 +244,14 @@ describe("mux terminal open", () => {
   it("sends error for shell injection in session ID", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: "test;rm -rf /", type: "open" }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "test;rm -rf /",
+        tmuxName: TEST_SESSION,
+        type: "open",
+      }),
+    );
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "error");
     expect(msg.message).toMatch(/invalid session/i);
@@ -217,14 +259,34 @@ describe("mux terminal open", () => {
     ws.close();
   });
 
-  it("resolves hash-prefixed tmux session by suffix", async () => {
+  it("uses an explicit exact tmuxName for hash-prefixed sessions", async () => {
     const hashOnlyId = `ao-test-hash-${process.pid}`;
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: hashOnlyId, type: "open" }));
+    ws.send(
+      JSON.stringify({ ch: "terminal", id: hashOnlyId, tmuxName: TEST_HASH_SESSION, type: "open" }),
+    );
 
-    const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && (m.type === "opened" || m.type === "error"));
-    expect(msg.type).toBe("opened");
+    const exactMsg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+    expect(exactMsg.id).toBe(hashOnlyId);
+
+    ws.close();
+  });
+
+  it("allows a legacy tmuxName that is not a valid AO session id", async () => {
+    const ws = await connectMux();
+
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "legacy-session",
+        tmuxName: TEST_SPACED_TARGET,
+        type: "open",
+      }),
+    );
+
+    const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+    expect(msg.id).toBe("legacy-session");
 
     ws.close();
   });
@@ -238,7 +300,9 @@ describe("mux terminal I/O", () => {
   it("receives terminal data after open", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "open" }));
+    ws.send(
+      JSON.stringify({ ch: "terminal", id: "test-session", tmuxName: TEST_SESSION, type: "open" }),
+    );
     await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
 
     // tmux sends terminal init sequences on attach — wait for any data
@@ -252,13 +316,22 @@ describe("mux terminal I/O", () => {
   it("can send input and receive echo", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "open" }));
+    ws.send(
+      JSON.stringify({ ch: "terminal", id: "test-session", tmuxName: TEST_SESSION, type: "open" }),
+    );
     await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
     // Drain initial output
     await new Promise((r) => setTimeout(r, 300));
 
     const marker = `MUX_IO_${Date.now()}`;
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "data", data: `echo ${marker}\n` }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "test-session",
+        type: "data",
+        data: `echo ${marker}\n`,
+      }),
+    );
 
     let received = "";
     await new Promise<void>((resolve) => {
@@ -272,10 +345,15 @@ describe("mux terminal I/O", () => {
               resolve();
             }
           }
-        } catch { /* */ }
+        } catch {
+          /* */
+        }
       };
       ws.on("message", handler);
-      setTimeout(() => { ws.off("message", handler); resolve(); }, 4000);
+      setTimeout(() => {
+        ws.off("message", handler);
+        resolve();
+      }, 4000);
     });
 
     expect(received).toContain(marker);
@@ -285,16 +363,33 @@ describe("mux terminal I/O", () => {
   it("handles resize without error", async () => {
     const ws = await connectMux();
 
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "open" }));
+    ws.send(
+      JSON.stringify({ ch: "terminal", id: "test-session", tmuxName: TEST_SESSION, type: "open" }),
+    );
     await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
 
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "resize", cols: 120, rows: 40 }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "test-session",
+        type: "resize",
+        cols: 120,
+        rows: 40,
+      }),
+    );
 
     // No error message expected
     await new Promise((r) => setTimeout(r, 200));
 
     const marker = `RESIZE_${Date.now()}`;
-    ws.send(JSON.stringify({ ch: "terminal", id: TEST_SESSION, type: "data", data: `echo ${marker}\n` }));
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "test-session",
+        type: "data",
+        data: `echo ${marker}\n`,
+      }),
+    );
 
     let received = "";
     await new Promise<void>((resolve) => {
@@ -303,12 +398,20 @@ describe("mux terminal I/O", () => {
           const msg = JSON.parse(raw.toString()) as MuxMessage;
           if (msg.ch === "terminal" && msg.type === "data") {
             received += msg.data as string;
-            if (received.includes(marker)) { ws.off("message", handler); resolve(); }
+            if (received.includes(marker)) {
+              ws.off("message", handler);
+              resolve();
+            }
           }
-        } catch { /* */ }
+        } catch {
+          /* */
+        }
       };
       ws.on("message", handler);
-      setTimeout(() => { ws.off("message", handler); resolve(); }, 4000);
+      setTimeout(() => {
+        ws.off("message", handler);
+        resolve();
+      }, 4000);
     });
 
     expect(received).toContain(marker);

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -208,14 +208,7 @@ describe("mux terminal open", () => {
   it("sends error response for nonexistent tmux session", async () => {
     const ws = await connectMux();
 
-    ws.send(
-      JSON.stringify({
-        ch: "terminal",
-        id: "missing-session",
-        tmuxName: `nonexistent-${Date.now()}`,
-        type: "open",
-      }),
-    );
+    ws.send(JSON.stringify({ ch: "terminal", id: `nonexistent-${Date.now()}`, type: "open" }));
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "error");
     expect(typeof msg.message).toBe("string");

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -8,7 +8,7 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { spawn } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
 
 // These types mirror src/lib/mux-protocol.ts exactly.
@@ -66,7 +66,10 @@ export class SessionBroadcaster {
    * Subscribe to session patches and errors. Returns an unsubscribe function.
    * Sends an immediate snapshot to the new subscriber, then polling updates.
    */
-  subscribe(callback: (sessions: SessionPatch[]) => void, onError?: (error: string) => void): () => void {
+  subscribe(
+    callback: (sessions: SessionPatch[]) => void,
+    onError?: (error: string) => void,
+  ): () => void {
     const wasEmpty = this.subscribers.size === 0;
     this.subscribers.add(callback);
     if (onError) this.errorSubscribers.add(onError);
@@ -134,7 +137,10 @@ export class SessionBroadcaster {
   }
 
   /** One-shot HTTP fetch of the current session list. */
-  private async fetchSnapshot(): Promise<{ sessions: SessionPatch[] | null; error: string | null }> {
+  private async fetchSnapshot(): Promise<{
+    sessions: SessionPatch[] | null;
+    error: string | null;
+  }> {
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), 4000);
     try {
@@ -192,6 +198,15 @@ const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const WS_BUFFER_HIGH_WATERMARK = 64 * 1024; // 64KB
 const MAX_REATTACH_ATTEMPTS = 3;
 
+function validateTmuxTarget(target: string): boolean {
+  if (target.length === 0) return false;
+  for (let i = 0; i < target.length; i += 1) {
+    const code = target.charCodeAt(i);
+    if (code < 32 || code === 127) return false;
+  }
+  return true;
+}
+
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
@@ -208,21 +223,33 @@ class TerminalManager {
     return projectId ? `${projectId}:${id}` : id;
   }
 
+  private resolveExactTmuxName(id: string, tmuxName?: string): string | null {
+    const trimmed = tmuxName?.trim();
+    if (!trimmed) return null;
+    if (!validateTmuxTarget(trimmed)) {
+      throw new Error(`Invalid tmux target for session: ${id}`);
+    }
+    try {
+      execFileSync(this.TMUX, ["has-session", "-t", `=${trimmed}`], { timeout: 5000 });
+      return trimmed;
+    } catch {
+      throw new Error(`Session not found: ${id}`);
+    }
+  }
+
   /**
    * Open/attach to a terminal. If already open, just return.
    * If has subscribers but PTY crashed, re-attach.
    */
   open(id: string, projectId?: string, tmuxName?: string): string {
-    // Validate and resolve
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
     }
 
-    // Use provided tmuxName, or reuse from existing terminal entry, or resolve
     const key = this.terminalKey(id, projectId);
     const existing = this.terminals.get(key);
     const tmuxSessionId =
-      tmuxName ??
+      this.resolveExactTmuxName(id, tmuxName) ??
       existing?.tmuxSessionId ??
       resolveTmuxSession(id, this.TMUX, undefined, undefined, projectId);
     if (!tmuxSessionId) {
@@ -251,13 +278,15 @@ class TerminalManager {
     }
 
     // Enable mouse mode
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
+    const exactTmuxTarget = `=${tmuxSessionId}`;
+
+    const mouseProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "mouse", "on"]);
     mouseProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
     });
 
     // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
+    const statusProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "status", "off"]);
     statusProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
     });
@@ -280,7 +309,7 @@ class TerminalManager {
     }
 
     // Spawn PTY
-    const pty = ptySpawn(this.TMUX, ["attach-session", "-t", tmuxSessionId], {
+    const pty = ptySpawn(this.TMUX, ["attach-session", "-t", exactTmuxTarget], {
       name: "xterm-256color",
       cols: 80,
       rows: 24,
@@ -327,7 +356,7 @@ class TerminalManager {
           `[MuxServer] Re-attaching to ${id} (attempt ${terminal.reattachAttempts}/${MAX_REATTACH_ATTEMPTS})`,
         );
         try {
-          this.open(id, projectId);
+          this.open(id, projectId, tmuxSessionId);
           terminal.reattachAttempts = 0; // reset on successful attach
           return; // re-attached — don't notify exit
         } catch (err) {

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -8,8 +8,11 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { execFileSync, spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { promisify } from "node:util";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
+
+const execFileAsync = promisify(execFile);
 
 // These types mirror src/lib/mux-protocol.ts exactly.
 // tsconfig.server.json constrains rootDir to "server/", so we cannot import
@@ -223,14 +226,14 @@ class TerminalManager {
     return projectId ? `${projectId}:${id}` : id;
   }
 
-  private resolveExactTmuxName(id: string, tmuxName?: string): string | null {
+  private async resolveExactTmuxName(id: string, tmuxName?: string): Promise<string | null> {
     const trimmed = tmuxName?.trim();
     if (!trimmed) return null;
     if (!validateTmuxTarget(trimmed)) {
       throw new Error(`Invalid tmux target for session: ${id}`);
     }
     try {
-      execFileSync(this.TMUX, ["has-session", "-t", `=${trimmed}`], { timeout: 5000 });
+      await execFileAsync(this.TMUX, ["has-session", "-t", `=${trimmed}`], { timeout: 5000 });
       return trimmed;
     } catch {
       throw new Error(`Session not found: ${id}`);
@@ -241,7 +244,7 @@ class TerminalManager {
    * Open/attach to a terminal. If already open, just return.
    * If has subscribers but PTY crashed, re-attach.
    */
-  open(id: string, projectId?: string, tmuxName?: string): string {
+  async open(id: string, projectId?: string, tmuxName?: string): Promise<string> {
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
     }
@@ -249,7 +252,7 @@ class TerminalManager {
     const key = this.terminalKey(id, projectId);
     const existing = this.terminals.get(key);
     const tmuxSessionId =
-      this.resolveExactTmuxName(id, tmuxName) ??
+      (await this.resolveExactTmuxName(id, tmuxName)) ??
       existing?.tmuxSessionId ??
       resolveTmuxSession(id, this.TMUX, undefined, undefined, projectId);
     if (!tmuxSessionId) {
@@ -347,6 +350,12 @@ class TerminalManager {
       console.log(`[MuxServer] PTY exited for ${id} with code ${exitCode}`);
       terminal.pty = null;
 
+      const notifyExit = () => {
+        for (const cb of terminal.exitCallbacks) {
+          cb(exitCode);
+        }
+      };
+
       // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
       // The cap prevents an unbounded respawn loop when the PTY crashes immediately
       // after every attach (e.g. resource exhaustion or a broken tmux session).
@@ -355,21 +364,21 @@ class TerminalManager {
         console.log(
           `[MuxServer] Re-attaching to ${id} (attempt ${terminal.reattachAttempts}/${MAX_REATTACH_ATTEMPTS})`,
         );
-        try {
-          this.open(id, projectId, tmuxSessionId);
-          terminal.reattachAttempts = 0; // reset on successful attach
-          return; // re-attached — don't notify exit
-        } catch (err) {
-          console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
-        }
+        this.open(id, projectId, tmuxSessionId).then(
+          () => {
+            terminal.reattachAttempts = 0;
+          },
+          (err) => {
+            console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
+            notifyExit();
+          },
+        );
+        return;
       } else if (terminal.reattachAttempts >= MAX_REATTACH_ATTEMPTS) {
         console.error(`[MuxServer] Max re-attach attempts reached for ${id}, giving up`);
       }
 
-      // Notify subscribers that the terminal has exited (re-attach failed or no subscribers)
-      for (const cb of terminal.exitCallbacks) {
-        cb(exitCode);
-      }
+      notifyExit();
     });
 
     console.log(`[MuxServer] Opened terminal ${id} (tmux: ${tmuxSessionId})`);
@@ -401,14 +410,14 @@ class TerminalManager {
    * Automatically opens the terminal if needed.
    * @param onExit - called when the PTY exits and cannot be re-attached
    */
-  subscribe(
+  async subscribe(
     id: string,
     projectId: string | undefined,
     callback: (data: string) => void,
     onExit?: (exitCode: number) => void,
-  ): () => void {
+  ): Promise<() => void> {
     // Ensure terminal is open
-    this.open(id, projectId);
+    await this.open(id, projectId);
     const key = this.terminalKey(id, projectId);
     const terminal = this.terminals.get(key);
     if (!terminal) {
@@ -491,7 +500,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
     /**
      * Handle incoming messages
      */
-    ws.on("message", (data) => {
+    ws.on("message", async (data) => {
       try {
         const msg = JSON.parse(data.toString("utf8")) as ClientMessage;
 
@@ -508,7 +517,11 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
           try {
             if (type === "open") {
               // Validate session exists
-              terminalManager.open(id, projectId, "tmuxName" in msg ? msg.tmuxName : undefined);
+              await terminalManager.open(
+                id,
+                projectId,
+                "tmuxName" in msg ? msg.tmuxName : undefined,
+              );
 
               // Send opened confirmation (idempotent — safe to send on re-open)
               const openedMsg: ServerMessage = {
@@ -535,7 +548,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
                   };
                   ws.send(JSON.stringify(bufferMsg));
                 }
-                const unsub = terminalManager.subscribe(
+                const unsub = await terminalManager.subscribe(
                   id,
                   projectId,
                   (data) => {

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -8,11 +8,8 @@
 
 import { WebSocketServer, WebSocket } from "ws";
 import { homedir, userInfo } from "node:os";
-import { execFile, spawn } from "node:child_process";
-import { promisify } from "node:util";
+import { spawn } from "node:child_process";
 import { findTmux, resolveTmuxSession, validateSessionId } from "./tmux-utils.js";
-
-const execFileAsync = promisify(execFile);
 
 // These types mirror src/lib/mux-protocol.ts exactly.
 // tsconfig.server.json constrains rootDir to "server/", so we cannot import
@@ -201,15 +198,6 @@ const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const WS_BUFFER_HIGH_WATERMARK = 64 * 1024; // 64KB
 const MAX_REATTACH_ATTEMPTS = 3;
 
-function validateTmuxTarget(target: string): boolean {
-  if (target.length === 0) return false;
-  for (let i = 0; i < target.length; i += 1) {
-    const code = target.charCodeAt(i);
-    if (code < 32 || code === 127) return false;
-  }
-  return true;
-}
-
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
@@ -226,25 +214,11 @@ class TerminalManager {
     return projectId ? `${projectId}:${id}` : id;
   }
 
-  private async resolveExactTmuxName(id: string, tmuxName?: string): Promise<string | null> {
-    const trimmed = tmuxName?.trim();
-    if (!trimmed) return null;
-    if (!validateTmuxTarget(trimmed)) {
-      throw new Error(`Invalid tmux target for session: ${id}`);
-    }
-    try {
-      await execFileAsync(this.TMUX, ["has-session", "-t", `=${trimmed}`], { timeout: 5000 });
-      return trimmed;
-    } catch {
-      throw new Error(`Session not found: ${id}`);
-    }
-  }
-
   /**
    * Open/attach to a terminal. If already open, just return.
    * If has subscribers but PTY crashed, re-attach.
    */
-  async open(id: string, projectId?: string, tmuxName?: string): Promise<string> {
+  open(id: string, projectId?: string, tmuxName?: string): string {
     if (!validateSessionId(id)) {
       throw new Error(`Invalid session ID: ${id}`);
     }
@@ -252,7 +226,7 @@ class TerminalManager {
     const key = this.terminalKey(id, projectId);
     const existing = this.terminals.get(key);
     const tmuxSessionId =
-      (await this.resolveExactTmuxName(id, tmuxName)) ??
+      tmuxName ??
       existing?.tmuxSessionId ??
       resolveTmuxSession(id, this.TMUX, undefined, undefined, projectId);
     if (!tmuxSessionId) {
@@ -350,12 +324,6 @@ class TerminalManager {
       console.log(`[MuxServer] PTY exited for ${id} with code ${exitCode}`);
       terminal.pty = null;
 
-      const notifyExit = () => {
-        for (const cb of terminal.exitCallbacks) {
-          cb(exitCode);
-        }
-      };
-
       // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
       // The cap prevents an unbounded respawn loop when the PTY crashes immediately
       // after every attach (e.g. resource exhaustion or a broken tmux session).
@@ -364,21 +332,21 @@ class TerminalManager {
         console.log(
           `[MuxServer] Re-attaching to ${id} (attempt ${terminal.reattachAttempts}/${MAX_REATTACH_ATTEMPTS})`,
         );
-        this.open(id, projectId, tmuxSessionId).then(
-          () => {
-            terminal.reattachAttempts = 0;
-          },
-          (err) => {
-            console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
-            notifyExit();
-          },
-        );
-        return;
+        try {
+          this.open(id, projectId, tmuxSessionId);
+          terminal.reattachAttempts = 0; // reset on successful attach
+          return; // re-attached — don't notify exit
+        } catch (err) {
+          console.error(`[MuxServer] Failed to re-attach ${id}:`, err);
+        }
       } else if (terminal.reattachAttempts >= MAX_REATTACH_ATTEMPTS) {
         console.error(`[MuxServer] Max re-attach attempts reached for ${id}, giving up`);
       }
 
-      notifyExit();
+      // Notify subscribers that the terminal has exited (re-attach failed or no subscribers)
+      for (const cb of terminal.exitCallbacks) {
+        cb(exitCode);
+      }
     });
 
     console.log(`[MuxServer] Opened terminal ${id} (tmux: ${tmuxSessionId})`);
@@ -410,14 +378,14 @@ class TerminalManager {
    * Automatically opens the terminal if needed.
    * @param onExit - called when the PTY exits and cannot be re-attached
    */
-  async subscribe(
+  subscribe(
     id: string,
     projectId: string | undefined,
     callback: (data: string) => void,
     onExit?: (exitCode: number) => void,
-  ): Promise<() => void> {
+  ): () => void {
     // Ensure terminal is open
-    await this.open(id, projectId);
+    this.open(id, projectId);
     const key = this.terminalKey(id, projectId);
     const terminal = this.terminals.get(key);
     if (!terminal) {
@@ -500,7 +468,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
     /**
      * Handle incoming messages
      */
-    ws.on("message", async (data) => {
+    ws.on("message", (data) => {
       try {
         const msg = JSON.parse(data.toString("utf8")) as ClientMessage;
 
@@ -517,11 +485,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
           try {
             if (type === "open") {
               // Validate session exists
-              await terminalManager.open(
-                id,
-                projectId,
-                "tmuxName" in msg ? msg.tmuxName : undefined,
-              );
+              terminalManager.open(id, projectId, "tmuxName" in msg ? msg.tmuxName : undefined);
 
               // Send opened confirmation (idempotent — safe to send on re-open)
               const openedMsg: ServerMessage = {
@@ -548,7 +512,7 @@ export function createMuxWebSocket(tmuxPath?: string): WebSocketServer | null {
                   };
                   ws.send(JSON.stringify(bufferMsg));
                 }
-                const unsub = await terminalManager.subscribe(
+                const unsub = terminalManager.subscribe(
                   id,
                   projectId,
                   (data) => {

--- a/packages/web/src/app/dev/terminal-test/page.tsx
+++ b/packages/web/src/app/dev/terminal-test/page.tsx
@@ -122,7 +122,9 @@ function TerminalTestPageContent() {
                 <li>tmux uses OSC 52 escape sequences to synchronize clipboard with terminals</li>
                 <li>
                   Format:{" "}
-                  <code className="rounded-[2px] bg-black px-1 py-0.5">\x1b]52;c;&lt;base64&gt;\x07</code>
+                  <code className="rounded-[2px] bg-black px-1 py-0.5">
+                    \x1b]52;c;&lt;base64&gt;\x07
+                  </code>
                 </li>
                 <li>Terminal must support OSC 52 and have proper capabilities declared</li>
               </ul>
@@ -135,8 +137,8 @@ function TerminalTestPageContent() {
               <ul className="ml-6 list-disc space-y-1 text-[var(--color-text-secondary)]">
                 <li>tmux queries terminal capabilities using Device Attributes (DA/XDA)</li>
                 <li>
-                  XDA query: <code className="rounded-[2px] bg-black px-1 py-0.5">CSI &gt; q</code> (also
-                  called XTVERSION)
+                  XDA query: <code className="rounded-[2px] bg-black px-1 py-0.5">CSI &gt; q</code>{" "}
+                  (also called XTVERSION)
                 </li>
                 <li>
                   Terminal responds with identification string containing terminal type (e.g.,
@@ -223,7 +225,8 @@ function TerminalTestPageContent() {
               <ol className="ml-6 list-decimal space-y-1 text-[var(--color-text-secondary)]">
                 <li>Intercepts XDA queries from tmux</li>
                 <li>
-                  Responds with <code className="rounded-[2px] bg-black px-1 py-0.5">XTerm(370)</code>{" "}
+                  Responds with{" "}
+                  <code className="rounded-[2px] bg-black px-1 py-0.5">XTerm(370)</code>{" "}
                   identification
                 </li>
                 <li>tmux detects "XTerm(" in response and enables TTYC_MS capability</li>
@@ -322,7 +325,8 @@ function TerminalTestPageContent() {
                   </code>
                 </li>
                 <li>
-                  If no <code className="rounded-[2px] bg-black px-1 py-0.5">posix_spawnp failed</code>{" "}
+                  If no{" "}
+                  <code className="rounded-[2px] bg-black px-1 py-0.5">posix_spawnp failed</code>{" "}
                   error, proceed
                 </li>
                 <li>Start dev servers and open this page</li>
@@ -398,7 +402,7 @@ function TerminalTestPageContent() {
                   <br />
                   ⚠️ Requires Node 20.x (node-pty)
                 </div>
-                <DirectTerminal sessionId={newSessionId} />
+                <DirectTerminal sessionId={newSessionId} tmuxName={newSessionId} />
               </div>
             </div>
 
@@ -509,8 +513,8 @@ function TerminalTestPageContent() {
                 </li>
                 <li>
                   <strong>Discovered XDA queries</strong> - Found that tmux sends{" "}
-                  <code className="rounded-[2px] bg-black px-1 py-0.5">CSI &gt; q</code> (XTVERSION) to
-                  detect terminal type
+                  <code className="rounded-[2px] bg-black px-1 py-0.5">CSI &gt; q</code> (XTVERSION)
+                  to detect terminal type
                 </li>
                 <li>
                   <strong>Traced the "iTerm2 magic"</strong> - Realized why clipboard worked when
@@ -572,8 +576,8 @@ function TerminalTestPageContent() {
                 <li>xterm.js parser API documentation</li>
                 <li>XTerm Control Sequences: XTVERSION / Device Attributes</li>
                 <li>
-                  tmux <code className="rounded-[2px] bg-black px-1 py-0.5">tty-keys.c</code>: Terminal
-                  type detection logic
+                  tmux <code className="rounded-[2px] bg-black px-1 py-0.5">tty-keys.c</code>:
+                  Terminal type detection logic
                 </li>
               </ul>
             </div>

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5760,7 +5760,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
   /* -- Kanban board: stack columns vertically -- */
   .kanban-board {
-    flex-direction: column;
+    grid-template-columns: minmax(0, 1fr);
     height: auto;
     min-height: auto;
     overflow-x: visible;
@@ -7642,3 +7642,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .topbar-zone-pill--working { background: color-mix(in srgb, var(--color-accent-blue)      12%, transparent); color: var(--color-accent-blue); }
 .topbar-zone-pill--pending { background: color-mix(in srgb, var(--color-status-attention) 12%, transparent); color: var(--color-status-attention); }
 .topbar-zone-pill--done    { background: color-mix(in srgb, var(--color-text-tertiary)    14%, transparent); color: var(--color-text-tertiary); }
+
+@media (max-width: 640px) {
+  .kanban-board {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -7642,9 +7642,3 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 .topbar-zone-pill--working { background: color-mix(in srgb, var(--color-accent-blue)      12%, transparent); color: var(--color-accent-blue); }
 .topbar-zone-pill--pending { background: color-mix(in srgb, var(--color-status-attention) 12%, transparent); color: var(--color-status-attention); }
 .topbar-zone-pill--done    { background: color-mix(in srgb, var(--color-text-tertiary)    14%, transparent); color: var(--color-text-tertiary); }
-
-@media (max-width: 640px) {
-  .kanban-board {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}

--- a/packages/web/src/app/test-direct/page.tsx
+++ b/packages/web/src/app/test-direct/page.tsx
@@ -81,6 +81,7 @@ function TestDirectPageContent() {
         <DirectTerminal
           key={`${sessionId}-${startFullscreen ? "fullscreen" : "normal"}`}
           sessionId={sessionId}
+          tmuxName={sessionId}
           startFullscreen={startFullscreen}
         />
       </div>

--- a/packages/web/src/components/DirectTerminal.tsx
+++ b/packages/web/src/components/DirectTerminal.tsx
@@ -59,21 +59,15 @@ export function DirectTerminal({
   const [fullscreen, setFullscreen] = useState(startFullscreen);
   const [fontSize, setFontSize] = useState(getStoredFontSize());
 
-  const {
-    error,
-    followOutput,
-    scrollToLatest,
-    muxStatus,
-    terminalInstance,
-    fitAddon,
-  } = useXtermTerminal(terminalRef, sessionId, {
-    appearance,
-    variant,
-    fontSize,
-    autoFocus,
-    projectId,
-    tmuxName,
-  });
+  const { error, followOutput, scrollToLatest, muxStatus, terminalInstance, fitAddon } =
+    useXtermTerminal(terminalRef, sessionId, {
+      appearance,
+      variant,
+      fontSize,
+      autoFocus,
+      projectId,
+      tmuxName,
+    });
 
   useFullscreenResize(fullscreen, sessionId, projectId, terminalInstance, fitAddon, terminalRef);
 
@@ -122,15 +116,18 @@ export function DirectTerminal({
             aria-label="Jump to latest"
             title="Jump to latest"
           >
-            <svg className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <svg
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              viewBox="0 0 24 24"
+            >
               <path d="M19 14l-7 7m0 0l-7-7m7 7V3" />
             </svg>
           </button>
         ) : null}
-        <div
-          ref={terminalRef}
-          className="w-full flex flex-col flex-1 min-h-0 overflow-hidden"
-        />
+        <div ref={terminalRef} className="w-full flex flex-col flex-1 min-h-0 overflow-hidden" />
       </div>
     </div>
   );

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -3,11 +3,7 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
-import {
-  type DashboardSession,
-  TERMINAL_STATUSES,
-  NON_RESTORABLE_STATUSES,
-} from "@/lib/types";
+import { type DashboardSession, TERMINAL_STATUSES, NON_RESTORABLE_STATUSES } from "@/lib/types";
 import dynamic from "next/dynamic";
 import { getSessionTitle } from "@/lib/format";
 import type { ProjectInfo } from "@/lib/project-name";
@@ -16,10 +12,7 @@ import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
 
 import { ProjectSidebar } from "./ProjectSidebar";
 import { MobileBottomNav } from "./MobileBottomNav";
-import {
-  SessionDetailHeader,
-  type OrchestratorZones,
-} from "./SessionDetailHeader";
+import { SessionDetailHeader, type OrchestratorZones } from "./SessionDetailHeader";
 import { SessionEndedSummary } from "./SessionEndedSummary";
 import { sessionActivityMeta } from "./session-detail-utils";
 
@@ -187,10 +180,7 @@ export function SessionDetail({
             </div>
           ) : null}
           {mobileSidebarOpen && (
-            <div
-              className="sidebar-mobile-backdrop"
-              onClick={() => setMobileSidebarOpen(false)}
-            />
+            <div className="sidebar-mobile-backdrop" onClick={() => setMobileSidebarOpen(false)} />
           )}
 
           <div className="dashboard-main dashboard-main--desktop">
@@ -228,9 +218,7 @@ export function SessionDetail({
           activeTab={isOrchestrator ? "orchestrator" : undefined}
           dashboardHref={dashboardHref}
           prsHref={
-            session.projectId
-              ? `/?project=${encodeURIComponent(session.projectId)}&tab=prs`
-              : "/"
+            session.projectId ? `/?project=${encodeURIComponent(session.projectId)}&tab=prs` : "/"
           }
           showOrchestrator={!!orchestratorHref}
           orchestratorHref={orchestratorHref}

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -143,11 +143,15 @@ describe("DirectTerminal render", () => {
   });
 
   it("renders the shared accent chrome for orchestrator terminals", async () => {
-    render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
-
-    await waitFor(() =>
-      expect(screen.getByText("Connected")).toBeInTheDocument(),
+    render(
+      <DirectTerminal
+        sessionId="ao-orchestrator"
+        tmuxName="ao-orchestrator"
+        variant="orchestrator"
+      />,
     );
+
+    await waitFor(() => expect(screen.getByText("Connected")).toBeInTheDocument());
 
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
     expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
@@ -157,6 +161,7 @@ describe("DirectTerminal render", () => {
     render(
       <DirectTerminal
         sessionId="ao-opencode"
+        tmuxName="ao-opencode"
         chromeless
         isOpenCodeSession
       />,
@@ -171,7 +176,13 @@ describe("DirectTerminal render", () => {
   });
 
   it("switches the terminal shell between inline and fullscreen positioning", async () => {
-    const { container } = render(<DirectTerminal sessionId="ao-orchestrator" variant="orchestrator" />);
+    const { container } = render(
+      <DirectTerminal
+        sessionId="ao-orchestrator"
+        tmuxName="ao-orchestrator"
+        variant="orchestrator"
+      />,
+    );
 
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "fullscreen" })).toBeInTheDocument(),
@@ -196,7 +207,7 @@ describe("DirectTerminal render", () => {
   });
 
   it("passes projectId to fullscreen resize hook for scoped mux resize", () => {
-    render(<DirectTerminal sessionId="app-1" projectId="project-a" />);
+    render(<DirectTerminal sessionId="app-1" projectId="project-a" tmuxName="project-a-app-1" />);
 
     expect(useFullscreenResizeMock).toHaveBeenCalledWith(
       false,

--- a/packages/web/src/components/terminal/useFullscreenResize.ts
+++ b/packages/web/src/components/terminal/useFullscreenResize.ts
@@ -97,5 +97,13 @@ export function useFullscreenResize(
       clearTimeout(timer1);
       clearTimeout(timer2);
     };
-  }, [fullscreen, sessionId, projectId, resizeTerminalMux, containerRef, fitAddon, terminalInstance]);
+  }, [
+    fullscreen,
+    sessionId,
+    projectId,
+    resizeTerminalMux,
+    containerRef,
+    fitAddon,
+    terminalInstance,
+  ]);
 }

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -69,6 +69,7 @@ export function useXtermTerminal(
 
   useEffect(() => {
     if (!terminalRef.current) return;
+    setError(null);
 
     // Dynamically import xterm.js to avoid SSR issues
     let mounted = true;

--- a/packages/web/src/providers/MuxProvider.tsx
+++ b/packages/web/src/providers/MuxProvider.tsx
@@ -156,7 +156,8 @@ export function MuxProvider({ children }: { children: ReactNode }) {
                 }
               }
             } else if (msg.type === "opened") {
-              // Terminal opened successfully — preserve existing tmuxName
+              // Terminal opened successfully. Preserve any tmuxName stored by
+              // openTerminal so reconnects keep using the exact attach target.
               if (!openedTerminalsRef.current.has(key)) {
                 openedTerminalsRef.current.set(key, {
                   id: msg.id,
@@ -357,7 +358,16 @@ export function MuxProvider({ children }: { children: ReactNode }) {
       sessions,
       lastError,
     }),
-    [subscribeTerminal, writeTerminal, openTerminal, closeTerminal, resizeTerminal, status, sessions, lastError],
+    [
+      subscribeTerminal,
+      writeTerminal,
+      openTerminal,
+      closeTerminal,
+      resizeTerminal,
+      status,
+      sessions,
+      lastError,
+    ],
   );
 
   return <MuxContext.Provider value={contextValue}>{children}</MuxContext.Provider>;

--- a/packages/web/src/providers/__tests__/MuxProvider.test.tsx
+++ b/packages/web/src/providers/__tests__/MuxProvider.test.tsx
@@ -282,12 +282,18 @@ describe("MuxProvider connection lifecycle", () => {
       act(() => ws1.simulateOpen());
       expect(result.current.status).toBe("connected");
 
-      act(() => result.current.openTerminal("session-abc"));
+      act(() => result.current.openTerminal("session-abc", "project-a", "tmux.session abc"));
       // Confirm open message sent on ws1
       expect(
         ws1.sentMessages.some((m) => {
           const p = JSON.parse(m) as Record<string, unknown>;
-          return p.ch === "terminal" && p.type === "open" && p.id === "session-abc";
+          return (
+            p.ch === "terminal" &&
+            p.type === "open" &&
+            p.id === "session-abc" &&
+            p.projectId === "project-a" &&
+            p.tmuxName === "tmux.session abc"
+          );
         }),
       ).toBe(true);
 
@@ -304,7 +310,13 @@ describe("MuxProvider connection lifecycle", () => {
       expect(
         ws2.sentMessages.some((m) => {
           const p = JSON.parse(m) as Record<string, unknown>;
-          return p.ch === "terminal" && p.type === "open" && p.id === "session-abc";
+          return (
+            p.ch === "terminal" &&
+            p.type === "open" &&
+            p.id === "session-abc" &&
+            p.projectId === "project-a" &&
+            p.tmuxName === "tmux.session abc"
+          );
         }),
       ).toBe(true);
     } finally {
@@ -347,9 +359,17 @@ describe("MuxProvider message handling", () => {
 
     const received: string[] = [];
     act(() => {
-      result.current.subscribeTerminal("s1", (d) => received.push(d));
+      result.current.subscribeTerminal("s1", (d) => received.push(d), "project-a");
     });
-    act(() => ws.simulateMessage({ ch: "terminal", id: "s1", type: "data", data: "hello" }));
+    act(() =>
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s1",
+        projectId: "project-a",
+        type: "data",
+        data: "hello",
+      }),
+    );
 
     expect(received).toContain("hello");
   });
@@ -363,7 +383,9 @@ describe("MuxProvider message handling", () => {
       const ws1 = MockWebSocket.instances[0];
       act(() => ws1.simulateOpen());
 
-      act(() => ws1.simulateMessage({ ch: "terminal", id: "s1", type: "opened" }));
+      act(() =>
+        ws1.simulateMessage({ ch: "terminal", id: "s1", projectId: "project-a", type: "opened" }),
+      );
 
       // Reconnect → s1 should be re-opened
       act(() => ws1.simulateClose());
@@ -376,7 +398,7 @@ describe("MuxProvider message handling", () => {
       expect(
         ws2.sentMessages.some((m) => {
           const p = JSON.parse(m) as Record<string, unknown>;
-          return p.ch === "terminal" && p.id === "s1";
+          return p.ch === "terminal" && p.id === "s1" && p.projectId === "project-a";
         }),
       ).toBe(true);
     } finally {
@@ -389,9 +411,17 @@ describe("MuxProvider message handling", () => {
 
     const received: string[] = [];
     act(() => {
-      result.current.subscribeTerminal("s1", (d) => received.push(d));
+      result.current.subscribeTerminal("s1", (d) => received.push(d), "project-a");
     });
-    act(() => ws.simulateMessage({ ch: "terminal", id: "s1", type: "exited", code: 1 }));
+    act(() =>
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s1",
+        projectId: "project-a",
+        type: "exited",
+        code: 1,
+      }),
+    );
 
     expect(received.some((m) => m.includes("exited"))).toBe(true);
   });
@@ -405,8 +435,18 @@ describe("MuxProvider message handling", () => {
       const ws1 = MockWebSocket.instances[0];
       act(() => ws1.simulateOpen());
 
-      act(() => ws1.simulateMessage({ ch: "terminal", id: "s-x", type: "opened" }));
-      act(() => ws1.simulateMessage({ ch: "terminal", id: "s-x", type: "exited", code: 0 }));
+      act(() =>
+        ws1.simulateMessage({ ch: "terminal", id: "s-x", projectId: "project-a", type: "opened" }),
+      );
+      act(() =>
+        ws1.simulateMessage({
+          ch: "terminal",
+          id: "s-x",
+          projectId: "project-a",
+          type: "exited",
+          code: 0,
+        }),
+      );
 
       // Reconnect — s-x should NOT be re-opened
       act(() => ws1.simulateClose());
@@ -418,7 +458,9 @@ describe("MuxProvider message handling", () => {
 
       const reopened = ws2.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.id === "s-x" && p.type === "open";
+        return (
+          p.ch === "terminal" && p.id === "s-x" && p.projectId === "project-a" && p.type === "open"
+        );
       });
       expect(reopened).toBe(false);
     } finally {
@@ -431,7 +473,13 @@ describe("MuxProvider message handling", () => {
     const { result, ws } = await setupConnected();
 
     act(() =>
-      ws.simulateMessage({ ch: "terminal", id: "s1", type: "error", message: "PTY failed" }),
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s1",
+        projectId: "project-a",
+        type: "error",
+        message: "PTY failed",
+      }),
     );
     expect(spy).toHaveBeenCalledWith(expect.stringContaining("Terminal error"), expect.any(String));
     expect(result.current.status).toBe("connected");
@@ -492,11 +540,17 @@ describe("MuxProvider terminal operations", () => {
 
   it("writeTerminal sends data message", async () => {
     const { result, ws } = await setupConnected();
-    act(() => result.current.writeTerminal("s1", "hello\n"));
+    act(() => result.current.writeTerminal("s1", "hello\n", "project-a"));
     expect(
       ws.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.type === "data" && p.data === "hello\n";
+        return (
+          p.ch === "terminal" &&
+          p.type === "data" &&
+          p.id === "s1" &&
+          p.projectId === "project-a" &&
+          p.data === "hello\n"
+        );
       }),
     ).toBe(true);
   });
@@ -504,41 +558,59 @@ describe("MuxProvider terminal operations", () => {
   it("writeTerminal is no-op when WebSocket is not open", async () => {
     const { result } = renderHook(() => useMux(), { wrapper });
     // Don't flush init or open the WebSocket
-    act(() => result.current.writeTerminal("s1", "hello\n"));
+    act(() => result.current.writeTerminal("s1", "hello\n", "project-a"));
     // No crash
     expect(result.current.status).toBe("connecting");
   });
 
   it("openTerminal sends open message when connected", async () => {
     const { result, ws } = await setupConnected();
-    act(() => result.current.openTerminal("session-abc"));
+    act(() => result.current.openTerminal("session-abc", "project-a", "tmux.session abc"));
     expect(
       ws.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.type === "open" && p.id === "session-abc";
+        return (
+          p.ch === "terminal" &&
+          p.type === "open" &&
+          p.id === "session-abc" &&
+          p.projectId === "project-a" &&
+          p.tmuxName === "tmux.session abc"
+        );
       }),
     ).toBe(true);
   });
 
   it("closeTerminal sends close message", async () => {
     const { result, ws } = await setupConnected();
-    act(() => result.current.openTerminal("session-abc"));
-    act(() => result.current.closeTerminal("session-abc"));
+    act(() => result.current.openTerminal("session-abc", "project-a", "tmux.session abc"));
+    act(() => result.current.closeTerminal("session-abc", "project-a"));
     expect(
       ws.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.type === "close" && p.id === "session-abc";
+        return (
+          p.ch === "terminal" &&
+          p.type === "close" &&
+          p.id === "session-abc" &&
+          p.projectId === "project-a"
+        );
       }),
     ).toBe(true);
   });
 
   it("resizeTerminal sends resize message with cols and rows", async () => {
     const { result, ws } = await setupConnected();
-    act(() => result.current.resizeTerminal("session-abc", 120, 40));
+    act(() => result.current.resizeTerminal("session-abc", 120, 40, "project-a"));
     expect(
       ws.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.type === "resize" && p.cols === 120 && p.rows === 40;
+        return (
+          p.ch === "terminal" &&
+          p.type === "resize" &&
+          p.id === "session-abc" &&
+          p.projectId === "project-a" &&
+          p.cols === 120 &&
+          p.rows === 40
+        );
       }),
     ).toBe(true);
   });
@@ -546,12 +618,17 @@ describe("MuxProvider terminal operations", () => {
   it("subscribeTerminal sends open for untracked terminal", async () => {
     const { result, ws } = await setupConnected();
     act(() => {
-      result.current.subscribeTerminal("session-new", () => {});
+      result.current.subscribeTerminal("session-new", () => {}, "project-a");
     });
     expect(
       ws.sentMessages.some((m) => {
         const p = JSON.parse(m) as Record<string, unknown>;
-        return p.ch === "terminal" && p.type === "open" && p.id === "session-new";
+        return (
+          p.ch === "terminal" &&
+          p.type === "open" &&
+          p.id === "session-new" &&
+          p.projectId === "project-a"
+        );
       }),
     ).toBe(true);
   });
@@ -562,11 +639,27 @@ describe("MuxProvider terminal operations", () => {
     let unsub!: () => void;
 
     act(() => {
-      unsub = result.current.subscribeTerminal("s1", (d) => received.push(d));
+      unsub = result.current.subscribeTerminal("s1", (d) => received.push(d), "project-a");
     });
-    act(() => ws.simulateMessage({ ch: "terminal", id: "s1", type: "data", data: "before" }));
+    act(() =>
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s1",
+        projectId: "project-a",
+        type: "data",
+        data: "before",
+      }),
+    );
     act(() => unsub());
-    act(() => ws.simulateMessage({ ch: "terminal", id: "s1", type: "data", data: "after" }));
+    act(() =>
+      ws.simulateMessage({
+        ch: "terminal",
+        id: "s1",
+        projectId: "project-a",
+        type: "data",
+        data: "after",
+      }),
+    );
 
     expect(received).toContain("before");
     expect(received).not.toContain("after");


### PR DESCRIPTION
## Summary
- Restores terminal rendering in session details by using the exact `tmuxName` when it is available.
- Keeps `projectId`-scoped mux routing for open, write, resize, and reconnect bookkeeping so duplicate session IDs still resolve correctly.
- Updates fullscreen resize and direct terminal wiring to use the same terminal identity end-to-end.
- Adds regression coverage for direct terminal attach, mux provider message handling, and tmux resolution behavior.

## Testing
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web test -- MuxProvider DirectTerminal.render tmux-utils direct-terminal-ws`
- Regression tests added for the blank-terminal path and scoped reconnect behavior.