### PR TITLE
fix(agent-claude-code): fold underscores in Claude project slug (#1611)

### DIFF
--- a/.changeset/fix-claude-project-slug-underscore.md
+++ b/.changeset/fix-claude-project-slug-underscore.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-plugin-agent-claude-code": patch
+---
+
+Fix `toClaudeProjectPath` to fold underscores (and any other non-alphanumeric character) to dashes, matching Claude Code's actual on-disk slug encoding. Previously only `/`, `.`, and `:` were normalized, so AO project data dirs of the form `<sanitized>_<hash>` produced slugs that pointed to non-existent directories — `getSessionInfo` and `getRestoreCommand` could never locate the session JSONL, `claudeSessionUuid` never got persisted, and restoring orchestrator/worker sessions in any multi-project setup failed with a 409 "getRestoreCommand returned null". Fixes #1611.

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -61,6 +61,7 @@ import {
   manifest,
   default as defaultExport,
   resetPsCache,
+  toClaudeProjectPath,
   METADATA_UPDATER_SCRIPT,
 } from "./index.js";
 
@@ -147,6 +148,40 @@ beforeEach(() => {
   vi.clearAllMocks();
   resetPsCache();
   mockHomedir.mockReturnValue("/mock/home");
+});
+
+describe("toClaudeProjectPath", () => {
+  it("encodes a plain unix path", () => {
+    expect(toClaudeProjectPath("/Users/dev/projects/foo")).toBe("-Users-dev-projects-foo");
+  });
+
+  it("collapses dot directories like .worktrees into a leading double dash", () => {
+    expect(toClaudeProjectPath("/Users/dev/.worktrees/ao/ao-3")).toBe(
+      "-Users-dev--worktrees-ao-ao-3",
+    );
+  });
+
+  it("normalizes underscores to dashes (issue #1611)", () => {
+    // AO project data dirs are named `<sanitized>_<hash>`. Claude Code converts
+    // underscores to dashes when computing its on-disk project slug; without
+    // matching that here the slug points to a non-existent directory and
+    // restore loses the conversation.
+    expect(
+      toClaudeProjectPath(
+        "/Users/dev/.agent-orchestrator/projects/graph-isomorphism_d185b44d56/worktrees/gi-orchestrator",
+      ),
+    ).toBe(
+      "-Users-dev--agent-orchestrator-projects-graph-isomorphism-d185b44d56-worktrees-gi-orchestrator",
+    );
+  });
+
+  it("strips Windows drive colons and folds backslashes", () => {
+    expect(toClaudeProjectPath("C:\\Users\\dev\\foo")).toBe("C-Users-dev-foo");
+  });
+
+  it("collapses any other non-alphanumeric character into a dash", () => {
+    expect(toClaudeProjectPath("/Users/dev/proj@v2/foo bar")).toBe("-Users-dev-proj-v2-foo-bar");
+  });
 });
 
 describe("plugin manifest & exports", () => {
@@ -503,6 +538,19 @@ describe("getSessionInfo", () => {
       await agent.getSessionInfo(makeSession({ workspacePath: "/Users/dev/.worktrees/ao/ao-3" }));
       expect(mockReaddir).toHaveBeenCalledWith(
         "/mock/home/.claude/projects/-Users-dev--worktrees-ao-ao-3",
+      );
+    });
+
+    it("normalizes underscores to dashes (matches Claude Code on-disk slug, issue #1611)", async () => {
+      mockJsonlFiles('{"type":"user","message":{"content":"hello"}}');
+      await agent.getSessionInfo(
+        makeSession({
+          workspacePath:
+            "/Users/dev/.agent-orchestrator/projects/graph-isomorphism_d185b44d56/worktrees/gi-orchestrator",
+        }),
+      );
+      expect(mockReaddir).toHaveBeenCalledWith(
+        "/mock/home/.claude/projects/-Users-dev--agent-orchestrator-projects-graph-isomorphism-d185b44d56-worktrees-gi-orchestrator",
       );
     });
   });

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -231,21 +231,21 @@ export const manifest = {
  * Convert a workspace path to Claude's project directory path.
  * Claude stores sessions at ~/.claude/projects/{encoded-path}/
  *
- * Verified against Claude Code's actual encoding (as of v1.x):
- * the path has its leading / stripped, then all / and . are replaced with -.
- * e.g. /Users/dev/.worktrees/ao → Users-dev--worktrees-ao
+ * Verified against Claude Code's actual on-disk slugs: every non-alphanumeric
+ * character (other than `-`) is replaced with `-`. That includes `/`, `.`,
+ * and crucially `_` — AO's per-project data dirs are named like
+ * `<sanitized>_<hash>`, and without underscore folding the slug AO computes
+ * misses the directory Claude actually wrote (issue #1611).
  *
- * If Claude Code changes its encoding scheme this will silently break
- * introspection. The path can be validated at runtime by checking whether
- * the resulting directory exists.
+ * Windows drive letters keep their special handling: `C:\Users\...` → strip
+ * the colon, then encode → `C-Users-...`.
  *
  * Exported for testing purposes.
  */
 export function toClaudeProjectPath(workspacePath: string): string {
   // Handle Windows drive letters (C:\Users\... → C-Users-...)
-  const normalized = workspacePath.replace(/\\/g, "/");
-  // Claude Code replaces / and . with - (keeping the leading slash as a leading -)
-  return normalized.replace(/:/g, "").replace(/[/.]/g, "-");
+  const normalized = workspacePath.replace(/\\/g, "/").replace(/:/g, "");
+  return normalized.replace(/[^a-zA-Z0-9-]/g, "-");
 }
 
 /** Find the most recently modified .jsonl session file in a directory */


### PR DESCRIPTION
## Summary

Fixes #1611. The orchestrator-restore 409 was the loudest symptom of a slug-encoding bug that silently broke restore for **any** multi-project AO setup (orchestrator or worker, claude-code agent).

## Root cause

`toClaudeProjectPath` in `packages/plugins/agent-claude-code/src/index.ts` only replaced `/`, `.`, and `:` — but Claude Code's actual on-disk slug also folds underscores (and any other non-alphanumeric character) to `-`. AO names per-project data dirs `<sanitized>_<hash>` (e.g. `graph-isomorphism_d185b44d56`, `screen-ocr_cea728ec80`, `dep-graph_c82cc24448`), so AO's computed slug pointed at a directory that never existed.

Cascading effects:
1. `getSessionInfo` couldn't read the JSONL → `claudeSessionUuid` was never persisted to session metadata.
2. On restore, `getRestoreCommand`'s metadata lookup found nothing AND its workspace-scan fallback also missed (same bad slug) → returns `null`.
3. `session-manager.ts`'s native-restore guard then threw `SessionNotRestorableError` → API returned **409**.

## Disk-level evidence

| Project | Has underscore in dir name? | `claudeSessionUuid` persisted across all sessions? |
|---|---|---|
| `agent-orchestrator` | no | yes (10/10) |
| `graph-isomorphism_d185b44d56` | yes | **no (0/2)** |

Slug AO computed: `…graph-isomorphism_d185b44d56…`
Slug Claude wrote: `…graph-isomorphism-d185b44d56…`

The orchestrator failure in #1611 stood out because orchestrators are killed early, so they don't have other paths to compensate. Workers in underscored projects were silently affected too (same code path, same broken slug).

## Fix

One regex change — replace `[/.]` with `[^a-zA-Z0-9-]` so the slug matches Claude Code's actual encoding:

```diff
 export function toClaudeProjectPath(workspacePath: string): string {
-  const normalized = workspacePath.replace(/\\/g, "/");
-  return normalized.replace(/:/g, "").replace(/[/.]/g, "-");
+  const normalized = workspacePath.replace(/\\/g, "/").replace(/:/g, "");
+  return normalized.replace(/[^a-zA-Z0-9-]/g, "-");
 }
```

This is the core fix. No carve-outs in `session-manager.ts`, no orchestrator-vs-worker special casing — those would have just been compensating for `toClaudeProjectPath` being wrong.

## Tests

- New `toClaudeProjectPath` direct unit tests (5): plain unix path, dot-dirs, **underscore folding (#1611)**, Windows drive, other non-alphanumerics.
- New regression test in `getSessionInfo` path-conversion suite that exercises an AO-style underscored project path.
- All 158 claude-code plugin tests pass; all 1043 core tests pass.
- `pnpm build`, `pnpm typecheck`, `pnpm lint` clean (only pre-existing warnings).

## Test Plan

- [x] `pnpm --filter @aoagents/ao-plugin-agent-claude-code test`
- [x] `pnpm --filter @aoagents/ao-core test`
- [x] `pnpm build && pnpm typecheck && pnpm lint`
- [ ] Manual: spawn an orchestrator in an underscored-project, kill it, restore from dashboard — should resume the previous Claude conversation instead of 409'ing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)