### PR TITLE
feat(web): add 'Open orchestrator' to sidebar 3-dot menu

### DIFF
--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -6,7 +6,7 @@ import { useRouter } from "next/navigation";
 import { cn } from "@/lib/cn";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getAttentionLevel, type DashboardSession, type AttentionLevel } from "@/lib/types";
-import { isOrchestratorSession } from "@aoagents/ao-core/types";
+import { isOrchestratorSession, isTerminalSession } from "@aoagents/ao-core/types";
 import { getSessionTitle, humanizeBranch } from "@/lib/format";
 import { usePopoverClamp } from "@/hooks/usePopoverClamp";
 import { getOrchestratorSessionId } from "@/lib/orchestrator-utils";
@@ -397,6 +397,13 @@ function ProjectSidebarInner({
           const orchestratorSession = sessions?.find(
             (s) => s.projectId === project.id && s.id === canonicalOrchestratorId,
           );
+          const hasLiveOrchestrator = Boolean(
+            orchestratorSession &&
+              !isTerminalSession({
+                status: orchestratorSession.status,
+                activity: orchestratorSession.activity,
+              }),
+          );
 
           return (
             <div key={project.id} className="project-sidebar__project">
@@ -563,6 +570,22 @@ function ProjectSidebarInner({
                       role="menu"
                       aria-label={`${project.name} actions`}
                     >
+                      {hasLiveOrchestrator && orchestratorSession ? (
+                        <button
+                          type="button"
+                          className="project-sidebar__proj-menu-item"
+                          role="menuitem"
+                          onClick={() => {
+                            setProjectMenuOpenId(null);
+                            navigate(
+                              projectSessionPath(project.id, orchestratorSession.id),
+                              orchestratorSession,
+                            );
+                          }}
+                        >
+                          Open orchestrator
+                        </button>
+                      ) : null}
                       <button
                         type="button"
                         className="project-sidebar__proj-menu-item"

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -397,13 +397,14 @@ function ProjectSidebarInner({
           const orchestratorSession = sessions?.find(
             (s) => s.projectId === project.id && s.id === canonicalOrchestratorId,
           );
-          const hasLiveOrchestrator = Boolean(
+          const liveOrchestrator =
             orchestratorSession &&
-              !isTerminalSession({
-                status: orchestratorSession.status,
-                activity: orchestratorSession.activity,
-              }),
-          );
+            !isTerminalSession({
+              status: orchestratorSession.status,
+              activity: orchestratorSession.activity,
+            })
+              ? orchestratorSession
+              : null;
 
           return (
             <div key={project.id} className="project-sidebar__project">
@@ -570,7 +571,7 @@ function ProjectSidebarInner({
                       role="menu"
                       aria-label={`${project.name} actions`}
                     >
-                      {hasLiveOrchestrator && orchestratorSession ? (
+                      {liveOrchestrator ? (
                         <button
                           type="button"
                           className="project-sidebar__proj-menu-item"
@@ -578,8 +579,8 @@ function ProjectSidebarInner({
                           onClick={() => {
                             setProjectMenuOpenId(null);
                             navigate(
-                              projectSessionPath(project.id, orchestratorSession.id),
-                              orchestratorSession,
+                              projectSessionPath(project.id, liveOrchestrator.id),
+                              liveOrchestrator,
                             );
                           }}
                         >

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -404,6 +404,99 @@ describe("ProjectSidebar", () => {
     expect(screen.queryByText("Orchestrator")).not.toBeInTheDocument();
   });
 
+  it("shows 'Open orchestrator' in the project actions menu when a live orchestrator exists", async () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[
+          makeSession({
+            id: "project-2-orchestrator",
+            projectId: "project-2",
+            summary: "Orchestrator",
+            metadata: { role: "orchestrator" },
+            status: "working",
+          }),
+        ]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+
+    expect(
+      await screen.findByRole("menuitem", { name: "Open orchestrator" }),
+    ).toBeInTheDocument();
+  });
+
+  it("omits 'Open orchestrator' from the menu when no orchestrator session exists", async () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+
+    expect(await screen.findByRole("menuitem", { name: "Project settings" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
+  });
+
+  it("omits 'Open orchestrator' when the orchestrator session is terminal", async () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[
+          makeSession({
+            id: "project-2-orchestrator",
+            projectId: "project-2",
+            summary: "Orchestrator",
+            metadata: { role: "orchestrator" },
+            status: "killed",
+            activity: "exited",
+          }),
+        ]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+
+    expect(await screen.findByRole("menuitem", { name: "Project settings" })).toBeInTheDocument();
+    expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
+  });
+
+  it("navigates to the orchestrator session when 'Open orchestrator' is clicked", async () => {
+    render(
+      <ProjectSidebar
+        projects={projects}
+        sessions={[
+          makeSession({
+            id: "project-2-orchestrator",
+            projectId: "project-2",
+            summary: "Orchestrator",
+            metadata: { role: "orchestrator" },
+            status: "working",
+          }),
+        ]}
+        activeProjectId="project-1"
+        activeSessionId={undefined}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
+    fireEvent.click(await screen.findByRole("menuitem", { name: "Open orchestrator" }));
+
+    expect(mockPush).toHaveBeenCalledWith("/projects/project-2/sessions/project-2-orchestrator");
+    await waitFor(() => {
+      expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
+    });
+  });
+
   it("renders the collapsed rail when collapsed", () => {
     const { container } = render(
       <ProjectSidebar


### PR DESCRIPTION
## Summary

- Adds an **Open orchestrator** entry at the top of each project's 3-dot menu in the sidebar.
- Hidden when no live orchestrator exists (matches the existing orchestrator icon-button pattern at lines 500-527 — no precedent for disabled menu items).
- Single-file change to `ProjectSidebar.tsx` plus 4 new tests.

Closes #1613

## Why

The orchestrator is the most-used session per project but today's only entry point is an unlabeled icon next to the dashboard icon — easy to miss. The labeled menu entry adds discoverability without removing the power-user fast path.

## Behavior

| State | Menu shows |
|-------|------------|
| Live orchestrator (any non-terminal status) | ✅ "Open orchestrator" + "Project settings" + "Remove project" |
| No orchestrator session at all | ❌ menu unchanged from today (2 items) |
| Only a terminal orchestrator (killed/done/merged) | ❌ menu unchanged from today |

Click navigates via the existing `navigate()` helper, which seeds `sessionStorage` for instant hydration — same pattern other in-tree clicks use.

## Notes

- The existing orchestrator icon button (lines 500–527) still uses `<Link>` directly and skips the `sessionStorage` seeding. This new entry uses `navigate()` correctly. There's a minor inconsistency in hydration behavior between the two; out of scope for this PR but worth a follow-up.
- Visual spacing in a 3-item menu vs 2-item menu was eyeballed — same `project-sidebar__proj-menu-item` class, no CSS changes needed.

## Test plan

- [x] `pnpm --filter @aoagents/ao-web test` — all 821 tests pass (3 pre-existing unrelated failures verified against main)
- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (warnings pre-existing, unrelated)
- [ ] Manual: hover sidebar project, open 3-dot menu, click "Open orchestrator" → lands on orchestrator session detail
- [ ] Manual: project with no `ao start` history → menu only shows Settings + Remove
- [ ] Manual: project where orchestrator was killed → menu only shows Settings + Remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)