### PR TITLE
fix(web): source sidebar orchestrator from API field, not session list

### DIFF
--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -5,7 +5,10 @@ import { useParams, usePathname, useRouter } from "next/navigation";
 import { ACTIVITY_STATE, SESSION_STATUS, isOrchestratorSession } from "@aoagents/ao-core/types";
 import { SessionDetail } from "@/components/SessionDetail";
 import { ErrorDisplay } from "@/components/ErrorDisplay";
-import { ProjectSidebar } from "@/components/ProjectSidebar";
+import {
+  ProjectSidebar,
+  type ProjectSidebarOrchestrator,
+} from "@/components/ProjectSidebar";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
 import { type DashboardSession, type ActivityState, getAttentionLevel } from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
@@ -170,6 +173,7 @@ function SessionPageShell({
   projects,
   projectsLoading,
   sidebarSessions,
+  sidebarOrchestrators,
   sidebarLoading,
   sidebarError,
   onRetrySidebar,
@@ -180,6 +184,7 @@ function SessionPageShell({
   projects: ProjectInfo[];
   projectsLoading: boolean;
   sidebarSessions: DashboardSession[] | null;
+  sidebarOrchestrators?: ProjectSidebarOrchestrator[];
   sidebarLoading: boolean;
   sidebarError: boolean;
   onRetrySidebar: () => void;
@@ -251,6 +256,7 @@ function SessionPageShell({
             <ProjectSidebar
               projects={projects}
               sessions={sidebarSessions}
+              orchestrators={sidebarOrchestrators}
               loading={sidebarLoading}
               error={sidebarError}
               onRetry={onRetrySidebar}
@@ -380,6 +386,9 @@ export default function SessionPage() {
   const [sidebarSessions, setSidebarSessions] = useState<DashboardSession[] | null>(
     () => cachedSidebarSessions,
   );
+  const [sidebarOrchestrators, setSidebarOrchestrators] = useState<
+    ProjectSidebarOrchestrator[] | undefined
+  >(undefined);
   const [loading, setLoading] = useState(cachedSession === null);
   const [routeError, setRouteError] = useState<Error | null>(null);
   const [sessionMissing, setSessionMissing] = useState(false);
@@ -596,18 +605,19 @@ export default function SessionPage() {
     const controller = new AbortController();
     sidebarFetchControllerRef.current = controller;
     try {
-      const body = await fetchJsonWithTimeout<{ sessions?: DashboardSession[] } | null>(
-        "/api/sessions?fresh=true",
-        {
-          signal: controller.signal,
-          timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
-          timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
-        },
-      );
+      const body = await fetchJsonWithTimeout<{
+        sessions?: DashboardSession[];
+        orchestrators?: ProjectSidebarOrchestrator[];
+      } | null>("/api/sessions?fresh=true", {
+        signal: controller.signal,
+        timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,
+        timeoutMessage: `Sidebar sessions request timed out after ${PROJECT_SIDEBAR_FETCH_TIMEOUT_MS}ms`,
+      });
       const restSessions = body?.sessions ?? [];
       const nextSessions =
         applyMuxSessionPatches(restSessions, pendingMuxSessionsRef.current ?? []) ?? restSessions;
       cachedSidebarSessions = nextSessions;
+      setSidebarOrchestrators(body?.orchestrators);
       setSidebarError(false);
       setSidebarSessions((current) =>
         areSidebarSessionsEqual(current, nextSessions) ? current : nextSessions,
@@ -724,6 +734,7 @@ export default function SessionPage() {
         projects={projects}
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
+        sidebarOrchestrators={sidebarOrchestrators}
         sidebarLoading={sidebarSessions === null}
         sidebarError={sidebarError}
         onRetrySidebar={fetchSidebarSessions}
@@ -754,6 +765,7 @@ export default function SessionPage() {
         projects={projects}
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
+        sidebarOrchestrators={sidebarOrchestrators}
         sidebarLoading={sidebarSessions === null}
         sidebarError={sidebarError}
         onRetrySidebar={fetchSidebarSessions}
@@ -782,6 +794,7 @@ export default function SessionPage() {
         projects={projects}
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
+        sidebarOrchestrators={sidebarOrchestrators}
         sidebarLoading={sidebarSessions === null}
         sidebarError={sidebarError}
         onRetrySidebar={fetchSidebarSessions}
@@ -819,6 +832,7 @@ export default function SessionPage() {
         projects={projects}
         projectsLoading={projectsLoading}
         sidebarSessions={sidebarSessions}
+        sidebarOrchestrators={sidebarOrchestrators}
         sidebarLoading={sidebarSessions === null}
         sidebarError={sidebarError}
         onRetrySidebar={fetchSidebarSessions}
@@ -849,6 +863,7 @@ export default function SessionPage() {
       projectOrchestratorId={projectOrchestratorId}
       projects={projects}
       sidebarSessions={sidebarSessions}
+        sidebarOrchestrators={sidebarOrchestrators}
       sidebarLoading={sidebarSessions === null}
       sidebarError={sidebarError}
       onRetrySidebar={fetchSidebarSessions}

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -10,7 +10,12 @@ import {
   type ProjectSidebarOrchestrator,
 } from "@/components/ProjectSidebar";
 import { useMediaQuery, MOBILE_BREAKPOINT } from "@/hooks/useMediaQuery";
-import { type DashboardSession, type ActivityState, getAttentionLevel } from "@/lib/types";
+import {
+  type DashboardSession,
+  type DashboardOrchestratorLink,
+  type ActivityState,
+  getAttentionLevel,
+} from "@/lib/types";
 import { activityIcon } from "@/lib/activity-icons";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getSessionTitle } from "@/lib/format";
@@ -607,7 +612,7 @@ export default function SessionPage() {
     try {
       const body = await fetchJsonWithTimeout<{
         sessions?: DashboardSession[];
-        orchestrators?: ProjectSidebarOrchestrator[];
+        orchestrators?: DashboardOrchestratorLink[];
       } | null>("/api/sessions?fresh=true", {
         signal: controller.signal,
         timeoutMs: PROJECT_SIDEBAR_FETCH_TIMEOUT_MS,

--- a/packages/web/src/app/sessions/[id]/page.tsx
+++ b/packages/web/src/app/sessions/[id]/page.tsx
@@ -863,7 +863,7 @@ export default function SessionPage() {
       projectOrchestratorId={projectOrchestratorId}
       projects={projects}
       sidebarSessions={sidebarSessions}
-        sidebarOrchestrators={sidebarOrchestrators}
+      sidebarOrchestrators={sidebarOrchestrators}
       sidebarLoading={sidebarSessions === null}
       sidebarError={sidebarError}
       onRetrySidebar={fetchSidebarSessions}

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -605,6 +605,7 @@ function DashboardInner({
                 <ProjectSidebar
                   projects={projects}
                   sessions={sessions}
+                  orchestrators={activeOrchestrators}
                   activeProjectId={projectId}
                   activeSessionId={activeSessionId}
                   collapsed={sidebarCollapsed}

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -6,18 +6,30 @@ import { useRouter } from "next/navigation";
 import { cn } from "@/lib/cn";
 import type { ProjectInfo } from "@/lib/project-name";
 import { getAttentionLevel, type DashboardSession, type AttentionLevel } from "@/lib/types";
-import { isOrchestratorSession, isTerminalSession } from "@aoagents/ao-core/types";
+import { isOrchestratorSession } from "@aoagents/ao-core/types";
 import { getSessionTitle, humanizeBranch } from "@/lib/format";
 import { usePopoverClamp } from "@/hooks/usePopoverClamp";
-import { getOrchestratorSessionId } from "@/lib/orchestrator-utils";
 import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
 import { ThemeToggle } from "./ThemeToggle";
 import { AddProjectModal } from "./AddProjectModal";
 import { ProjectSettingsModal } from "./ProjectSettingsModal";
 
+/** Minimal shape needed to render an orchestrator link in the sidebar. */
+export interface ProjectSidebarOrchestrator {
+  id: string;
+  projectId: string;
+}
+
 interface ProjectSidebarProps {
   projects: ProjectInfo[];
   sessions: DashboardSession[] | null;
+  /**
+   * Per-project orchestrator link. Sourced upstream from `/api/sessions`
+   * (the `orchestrators` field), which already applies the canonical
+   * "prefer live, fall back to terminal" selection. Not derivable from
+   * `sessions`: the sessions endpoint strips orchestrators out.
+   */
+  orchestrators?: ProjectSidebarOrchestrator[];
   activeProjectId: string | undefined;
   activeSessionId: string | undefined;
   loading?: boolean;
@@ -78,6 +90,7 @@ export function ProjectSidebar(props: ProjectSidebarProps) {
 function ProjectSidebarInner({
   projects,
   sessions,
+  orchestrators,
   activeProjectId,
   activeSessionId,
   loading = false,
@@ -184,6 +197,11 @@ function ProjectSidebarInner({
   const allPrefixes = useMemo(
     () => visibleProjects.map((p) => p.sessionPrefix ?? p.id),
     [visibleProjects],
+  );
+
+  const orchestratorByProject = useMemo(
+    () => new Map((orchestrators ?? []).map((o) => [o.projectId, o])),
+    [orchestrators],
   );
 
   const sessionsByProject = useMemo(() => {
@@ -390,21 +408,7 @@ function ProjectSidebarInner({
           const visibleSessions = workerSessions;
           const hasActiveSessions = visibleSessions.length > 0;
 
-          const projectPrefix = prefixByProject.get(project.id);
-          const canonicalOrchestratorId = projectPrefix
-            ? getOrchestratorSessionId({ sessionPrefix: projectPrefix })
-            : null;
-          const orchestratorSession = sessions?.find(
-            (s) => s.projectId === project.id && s.id === canonicalOrchestratorId,
-          );
-          const liveOrchestrator =
-            orchestratorSession &&
-            !isTerminalSession({
-              status: orchestratorSession.status,
-              activity: orchestratorSession.activity,
-            })
-              ? orchestratorSession
-              : null;
+          const orchestratorLink = orchestratorByProject.get(project.id) ?? null;
 
           return (
             <div key={project.id} className="project-sidebar__project">
@@ -506,9 +510,9 @@ function ProjectSidebarInner({
                 ) : null}
 
                 {/* Orchestrator button */}
-                {!isDegraded && orchestratorSession && (
+                {!isDegraded && orchestratorLink && (
                   <Link
-                    href={projectSessionPath(project.id, orchestratorSession.id)}
+                    href={projectSessionPath(project.id, orchestratorLink.id)}
                     onClick={(e) => {
                       e.stopPropagation();
                       onMobileClose?.();
@@ -571,17 +575,14 @@ function ProjectSidebarInner({
                       role="menu"
                       aria-label={`${project.name} actions`}
                     >
-                      {liveOrchestrator ? (
+                      {orchestratorLink ? (
                         <button
                           type="button"
                           className="project-sidebar__proj-menu-item"
                           role="menuitem"
                           onClick={() => {
                             setProjectMenuOpenId(null);
-                            navigate(
-                              projectSessionPath(project.id, liveOrchestrator.id),
-                              liveOrchestrator,
-                            );
+                            navigate(projectSessionPath(project.id, orchestratorLink.id));
                           }}
                         >
                           Open orchestrator

--- a/packages/web/src/components/ProjectSidebar.tsx
+++ b/packages/web/src/components/ProjectSidebar.tsx
@@ -199,6 +199,9 @@ function ProjectSidebarInner({
     [visibleProjects],
   );
 
+  // The API (selectPreferredOrchestratorId) sends at most one entry per
+  // project, so collapsing into a Map keyed by projectId is lossless. If a
+  // future API change starts emitting multiples, the last one wins here.
   const orchestratorByProject = useMemo(
     () => new Map((orchestrators ?? []).map((o) => [o.projectId, o])),
     [orchestrators],

--- a/packages/web/src/components/PullRequestsPage.tsx
+++ b/packages/web/src/components/PullRequestsPage.tsx
@@ -115,6 +115,7 @@ export function PullRequestsPage({
           <ProjectSidebar
             projects={projects}
             sessions={sessions}
+            orchestrators={orchestratorLinks}
             activeProjectId={projectId}
             activeSessionId={undefined}
             collapsed={sidebarCollapsed}

--- a/packages/web/src/components/SessionDetail.tsx
+++ b/packages/web/src/components/SessionDetail.tsx
@@ -14,7 +14,7 @@ import type { ProjectInfo } from "@/lib/project-name";
 import { SidebarContext } from "./workspace/SidebarContext";
 import { projectDashboardPath, projectSessionPath } from "@/lib/routes";
 
-import { ProjectSidebar } from "./ProjectSidebar";
+import { ProjectSidebar, type ProjectSidebarOrchestrator } from "./ProjectSidebar";
 import { MobileBottomNav } from "./MobileBottomNav";
 import {
   SessionDetailHeader,
@@ -44,6 +44,7 @@ interface SessionDetailProps {
   projectOrchestratorId?: string | null;
   projects?: ProjectInfo[];
   sidebarSessions?: DashboardSession[] | null;
+  sidebarOrchestrators?: ProjectSidebarOrchestrator[];
   sidebarLoading?: boolean;
   sidebarError?: boolean;
   onRetrySidebar?: () => void;
@@ -56,6 +57,7 @@ export function SessionDetail({
   projectOrchestratorId = null,
   projects = [],
   sidebarSessions = [],
+  sidebarOrchestrators,
   sidebarLoading = false,
   sidebarError = false,
   onRetrySidebar,
@@ -175,6 +177,7 @@ export function SessionDetail({
               <ProjectSidebar
                 projects={projects}
                 sessions={sidebarSessions}
+                orchestrators={sidebarOrchestrators}
                 loading={sidebarLoading}
                 error={sidebarError}
                 onRetry={onRetrySidebar}

--- a/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
+++ b/packages/web/src/components/__tests__/ProjectSidebar.test.tsx
@@ -404,19 +404,12 @@ describe("ProjectSidebar", () => {
     expect(screen.queryByText("Orchestrator")).not.toBeInTheDocument();
   });
 
-  it("shows 'Open orchestrator' in the project actions menu when a live orchestrator exists", async () => {
+  it("shows 'Open orchestrator' in the project actions menu when the orchestrators prop has an entry", async () => {
     render(
       <ProjectSidebar
         projects={projects}
-        sessions={[
-          makeSession({
-            id: "project-2-orchestrator",
-            projectId: "project-2",
-            summary: "Orchestrator",
-            metadata: { role: "orchestrator" },
-            status: "working",
-          }),
-        ]}
+        sessions={[]}
+        orchestrators={[{ id: "project-2-orchestrator-1", projectId: "project-2" }]}
         activeProjectId="project-1"
         activeSessionId={undefined}
       />,
@@ -429,11 +422,12 @@ describe("ProjectSidebar", () => {
     ).toBeInTheDocument();
   });
 
-  it("omits 'Open orchestrator' from the menu when no orchestrator session exists", async () => {
+  it("omits 'Open orchestrator' from the menu when no orchestrator entry exists for the project", async () => {
     render(
       <ProjectSidebar
         projects={projects}
         sessions={[]}
+        orchestrators={[{ id: "project-1-orchestrator", projectId: "project-1" }]}
         activeProjectId="project-1"
         activeSessionId={undefined}
       />,
@@ -445,44 +439,12 @@ describe("ProjectSidebar", () => {
     expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
   });
 
-  it("omits 'Open orchestrator' when the orchestrator session is terminal", async () => {
+  it("navigates to the orchestrator id from the prop when 'Open orchestrator' is clicked", async () => {
     render(
       <ProjectSidebar
         projects={projects}
-        sessions={[
-          makeSession({
-            id: "project-2-orchestrator",
-            projectId: "project-2",
-            summary: "Orchestrator",
-            metadata: { role: "orchestrator" },
-            status: "killed",
-            activity: "exited",
-          }),
-        ]}
-        activeProjectId="project-1"
-        activeSessionId={undefined}
-      />,
-    );
-
-    fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
-
-    expect(await screen.findByRole("menuitem", { name: "Project settings" })).toBeInTheDocument();
-    expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
-  });
-
-  it("navigates to the orchestrator session when 'Open orchestrator' is clicked", async () => {
-    render(
-      <ProjectSidebar
-        projects={projects}
-        sessions={[
-          makeSession({
-            id: "project-2-orchestrator",
-            projectId: "project-2",
-            summary: "Orchestrator",
-            metadata: { role: "orchestrator" },
-            status: "working",
-          }),
-        ]}
+        sessions={[]}
+        orchestrators={[{ id: "project-2-orchestrator-1", projectId: "project-2" }]}
         activeProjectId="project-1"
         activeSessionId={undefined}
       />,
@@ -491,7 +453,7 @@ describe("ProjectSidebar", () => {
     fireEvent.click(screen.getByRole("button", { name: /Project actions for Project Two/i }));
     fireEvent.click(await screen.findByRole("menuitem", { name: "Open orchestrator" }));
 
-    expect(mockPush).toHaveBeenCalledWith("/projects/project-2/sessions/project-2-orchestrator");
+    expect(mockPush).toHaveBeenCalledWith("/projects/project-2/sessions/project-2-orchestrator-1");
     await waitFor(() => {
       expect(screen.queryByRole("menuitem", { name: "Open orchestrator" })).not.toBeInTheDocument();
     });


### PR DESCRIPTION
## Summary

Follow-up to #1615. The merged version of "Open orchestrator" never renders for any project because it looks up the orchestrator inside the `sessions` prop — but `/api/sessions/route.ts:121-128` strips ALL orchestrators from that array before returning. They live on a separate `orchestrators` field of the same response, which the merged code doesn't read.

Same root cause silently breaks the pre-existing **orchestrator icon button** next to the dashboard icon in each project row (`ProjectSidebar.tsx:500-527`). Both render conditions are gated on the same dead lookup.

## Repro on `main`

1. Run `ao start` on any project.
2. Confirm an orchestrator session exists on disk (e.g. `~/.agent-orchestrator/projects/<project>/sessions/<prefix>-orchestrator.json`).
3. Open the dashboard. Hover the project in the sidebar → click the 3-dot menu.
4. **Expected:** "Open orchestrator" entry. **Actual:** menu shows only "Project settings" and "Remove project".
5. Same project row: the orchestrator icon button next to the dashboard icon is also missing.
6. DevTools → Network → `/api/sessions` response: `sessions[]` contains zero orchestrators; the `orchestrators[]` field has them.

## Fix

Add an `orchestrators` prop to `ProjectSidebar`. Each parent passes the data it already has:

| Parent | Source |
|---|---|
| `Dashboard.tsx` | `activeOrchestrators` (already in scope) |
| `PullRequestsPage.tsx` | `orchestratorLinks` (already in scope) |
| `sessions/[id]/page.tsx` | reads the `orchestrators` field already returned by `/api/sessions` and threads it through `SessionPageShell` → `SessionDetail` as `sidebarOrchestrators` |

Both the menu entry and the icon button render off `orchestratorByProject.get(project.id)`. The live-vs-terminal selection lives in the API (`selectPreferredOrchestratorId`) and is no longer the sidebar's concern.

Net **-17 lines** vs the current merged code.

## Test plan

- [x] `pnpm build` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --filter @aoagents/ao-web test` — 820/823 (same 3 pre-existing failures as `upstream/main`, all unrelated)
- [x] Sidebar tests refocused: 18/18 pass; the prop is the contract, the API tests cover selection
- [ ] Manual: hover sidebar project with running orchestrator → 3-dot menu shows "Open orchestrator" → click → lands on orchestrator session
- [ ] Manual: orchestrator icon button next to dashboard icon also appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)