### PR TITLE
refactor(cli): collapse running/not-running fork via ensureDaemon (PR B.2)

### DIFF
--- a/packages/cli/__tests__/lib/daemon.test.ts
+++ b/packages/cli/__tests__/lib/daemon.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const { mockUnregister, mockWaitForExit, mockProcessKill } = vi.hoisted(() => ({
   mockUnregister: vi.fn(),
@@ -10,11 +10,6 @@ vi.mock("../../src/lib/running-state.js", () => ({
   unregister: mockUnregister,
   waitForExit: mockWaitForExit,
 }));
-
-vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
-  mockProcessKill(pid, signal);
-  return true;
-}) as typeof process.kill);
 
 import { attachToDaemon, killExistingDaemon } from "../../src/lib/daemon.js";
 import type { RunningState } from "../../src/lib/running-state.js";
@@ -32,6 +27,20 @@ beforeEach(() => {
   mockUnregister.mockResolvedValue(undefined);
   mockWaitForExit.mockReset();
   mockProcessKill.mockReset();
+  // Spy is installed per-test and restored in afterEach so the mocked
+  // process.kill cannot leak into sibling test files when Vitest reuses
+  // worker threads.
+  vi.spyOn(process, "kill").mockImplementation(((
+    pid: number,
+    signal?: string | number,
+  ) => {
+    mockProcessKill(pid, signal);
+    return true;
+  }) as typeof process.kill);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("attachToDaemon", () => {

--- a/packages/cli/__tests__/lib/daemon.test.ts
+++ b/packages/cli/__tests__/lib/daemon.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockUnregister, mockWaitForExit, mockProcessKill } = vi.hoisted(() => ({
+  mockUnregister: vi.fn(),
+  mockWaitForExit: vi.fn(),
+  mockProcessKill: vi.fn(),
+}));
+
+vi.mock("../../src/lib/running-state.js", () => ({
+  unregister: mockUnregister,
+  waitForExit: mockWaitForExit,
+}));
+
+vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+  mockProcessKill(pid, signal);
+  return true;
+}) as typeof process.kill);
+
+import { attachToDaemon, killExistingDaemon } from "../../src/lib/daemon.js";
+import type { RunningState } from "../../src/lib/running-state.js";
+
+const fakeRunning: RunningState = {
+  pid: 12345,
+  configPath: "/fake/config.yaml",
+  port: 3000,
+  startedAt: "2026-05-04T00:00:00Z",
+  projects: ["my-app"],
+};
+
+beforeEach(() => {
+  mockUnregister.mockReset();
+  mockUnregister.mockResolvedValue(undefined);
+  mockWaitForExit.mockReset();
+  mockProcessKill.mockReset();
+});
+
+describe("attachToDaemon", () => {
+  it("returns an AttachedDaemon with the running state's port and pid", () => {
+    const daemon = attachToDaemon(fakeRunning);
+    expect(daemon.outcome).toBe("attached");
+    expect(daemon.port).toBe(3000);
+    expect(daemon.pid).toBe(12345);
+  });
+
+  it("notifyProjectChange POSTs /api/projects/reload and returns ok on 2xx", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 200 }));
+    const daemon = attachToDaemon(fakeRunning);
+    const result = await daemon.notifyProjectChange();
+    expect(result).toEqual({ ok: true });
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://localhost:3000/api/projects/reload",
+      { method: "POST" },
+    );
+    fetchSpy.mockRestore();
+  });
+
+  it("notifyProjectChange returns a reasoned failure on non-2xx", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 503 }));
+    const daemon = attachToDaemon(fakeRunning);
+    const result = await daemon.notifyProjectChange();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("503");
+    }
+    fetchSpy.mockRestore();
+  });
+
+  it("notifyProjectChange returns a reasoned failure when fetch throws", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("ECONNREFUSED"));
+    const daemon = attachToDaemon(fakeRunning);
+    const result = await daemon.notifyProjectChange();
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("ECONNREFUSED");
+    }
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("killExistingDaemon", () => {
+  it("SIGTERMs the daemon, awaits exit, and unregisters on the happy path", async () => {
+    mockWaitForExit.mockResolvedValueOnce(true);
+    await killExistingDaemon(fakeRunning);
+    expect(mockProcessKill).toHaveBeenCalledWith(12345, "SIGTERM");
+    expect(mockProcessKill).toHaveBeenCalledTimes(1);
+    expect(mockWaitForExit).toHaveBeenCalledWith(12345, 5000);
+    expect(mockUnregister).toHaveBeenCalled();
+  });
+
+  it("escalates to SIGKILL when SIGTERM does not exit within the timeout", async () => {
+    mockWaitForExit.mockResolvedValueOnce(false);
+    mockWaitForExit.mockResolvedValueOnce(true);
+    await killExistingDaemon(fakeRunning);
+    expect(mockProcessKill).toHaveBeenNthCalledWith(1, 12345, "SIGTERM");
+    expect(mockProcessKill).toHaveBeenNthCalledWith(2, 12345, "SIGKILL");
+    expect(mockUnregister).toHaveBeenCalled();
+  });
+
+  it("throws when SIGKILL also fails to exit, and does not unregister", async () => {
+    mockWaitForExit.mockResolvedValueOnce(false);
+    mockWaitForExit.mockResolvedValueOnce(false);
+    await expect(killExistingDaemon(fakeRunning)).rejects.toThrow(
+      /Failed to stop AO process \(PID 12345\)/,
+    );
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+
+  it("treats already-dead processes as success (process.kill throws ESRCH)", async () => {
+    mockProcessKill.mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    mockWaitForExit.mockResolvedValueOnce(true);
+    await expect(killExistingDaemon(fakeRunning)).resolves.toBeUndefined();
+    expect(mockUnregister).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1402,12 +1402,16 @@ export function registerStart(program: Command): void {
                 unlockStartup();
                 process.exit(0);
               } else if (choice === "add") {
-                // Add cwd against whatever config the cwd walks up to find.
-                // This intentionally does not register globally or spawn an
-                // orchestrator session — the user explicitly chose "add"
-                // (not "new"), so we just persist the project and open the
-                // dashboard. The next `ao start <id>` (or "new" choice)
-                // will spawn an orchestrator.
+                // Persist cwd against whatever config loadConfig() walks up
+                // to from the current directory. addProjectToConfig is
+                // canonical-aware: when that config happens to be the global
+                // one (the canonical fallback), the project lands in the
+                // global registry; when it is a cwd-local agent-orchestrator
+                // .yaml, the project is appended there. This matches the
+                // pre-B.2 behavior — the menu's "add" path deliberately does
+                // not spawn an orchestrator session, so the user can review
+                // the registration and start one explicitly via `ao start
+                // <id>` or the "new" menu choice.
                 const loadedCfg = loadConfig();
                 const addedId = await addProjectToConfig(loadedCfg, cwdResolved);
                 console.log(

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -22,16 +22,11 @@ import {
   generateSessionPrefix,
   getOrchestratorSessionId,
   isRepoUrl,
-  parseRepoUrl,
-  resolveCloneTarget,
-  isRepoAlreadyCloned,
   configToYaml,
   isCanonicalGlobalConfigPath,
   isTerminalSession,
   loadLocalProjectConfigDetailed,
   registerProjectInGlobalConfig,
-  detectScmPlatform,
-  sanitizeProjectId,
   getGlobalConfigPath,
   type OrchestratorConfig,
   type LocalProjectConfig,
@@ -60,15 +55,16 @@ import {
 import { preflight } from "../lib/preflight.js";
 import {
   register,
-  unregister,
   isAlreadyRunning,
   getRunning,
-  waitForExit,
+  unregister,
   acquireStartupLock,
   writeLastStop,
   readLastStop,
   clearLastStop,
+  type RunningState,
 } from "../lib/running-state.js";
+import { attachToDaemon, killExistingDaemon } from "../lib/daemon.js";
 import { startProjectSupervisor } from "../lib/project-supervisor.js";
 import { isHumanCaller } from "../lib/caller-context.js";
 import { detectEnvironment } from "../lib/detect-env.js";
@@ -426,31 +422,6 @@ async function promptInstallAgentRuntime(available: DetectedAgent[]): Promise<De
  *   3. Final fallback to `git clone --depth 1` with HTTPS URL — works for
  *      public repos without any auth setup.
  */
-/**
- * Detect the actual default branch of a freshly cloned repo.
- * Prefers `origin/HEAD` (the remote's default), falling back to the
- * current local branch. Returns null for empty repos (no commits).
- */
-async function detectClonedRepoDefaultBranch(repoPath: string): Promise<string | null> {
-  // origin/HEAD points at "refs/remotes/origin/<defaultBranch>" — the most
-  // accurate source for what the remote considers default.
-  const symref = await git(["symbolic-ref", "refs/remotes/origin/HEAD"], repoPath);
-  if (symref) {
-    const match = symref.trim().match(/^refs\/remotes\/origin\/(.+)$/);
-    if (match) return match[1];
-  }
-
-  // Some clones don't set origin/HEAD (e.g. older git or `--depth 1` edge
-  // cases). Fall back to the current local branch.
-  const head = await git(["symbolic-ref", "--short", "HEAD"], repoPath);
-  if (head) {
-    const trimmed = head.trim();
-    if (trimmed.length > 0) return trimmed;
-  }
-
-  return null;
-}
-
 async function cloneRepo(parsed: ParsedRepoUrl, targetDir: string, cwd: string): Promise<void> {
   // 1. Try gh repo clone (handles GitHub auth automatically)
   if (parsed.host === "github.com") {
@@ -1230,6 +1201,79 @@ async function stopDashboard(port: number): Promise<void> {
   console.log(chalk.yellow("Could not stop dashboard (may not be running)"));
 }
 
+/**
+ * Spawn an orchestrator session against an already-running daemon, invalidate
+ * the dashboard's project cache, and surface enough context for the user to
+ * find the new session.
+ *
+ * Replaces the per-arg-shape inline blocks (§3.2 URL/path-while-running and
+ * §3.3 project-id-while-running) that previously each carried their own
+ * messaging + reload + browser-open code. The two flows differ only in which
+ * line of "registered" vs "reattached" they print, driven by `justCreated`.
+ */
+async function attachAndSpawnOrchestrator(opts: {
+  running: RunningState;
+  config: OrchestratorConfig;
+  projectId: string;
+  project: ProjectConfig;
+  /** True when this CLI invocation registered the project for the first
+   *  time (URL clone or path register). Drives the "registered" vs
+   *  "reattached" message line. */
+  justCreated: boolean;
+}): Promise<void> {
+  const { running, config, projectId, project, justCreated } = opts;
+  const daemon = attachToDaemon(running);
+
+  console.log(
+    chalk.dim(
+      justCreated
+        ? "\n  Spawning orchestrator session...\n"
+        : "\n  Attaching to running AO instance...\n",
+    ),
+  );
+
+  const sm = await getSessionManager(config);
+  const systemPrompt = generateOrchestratorPrompt({ config, projectId, project });
+  const session = await sm.ensureOrchestrator({ projectId, systemPrompt });
+
+  if (justCreated) {
+    console.log(chalk.green(`\n✓ Project "${projectId}" registered in the global config.`));
+    console.log(chalk.green(`✓ Orchestrator session ready: ${session.id}`));
+  } else {
+    console.log(chalk.green(`✓ Orchestrator session ready: ${session.id}`));
+    console.log(
+      chalk.green(`✓ Project "${projectId}" reattached to running daemon (PID ${daemon.pid}).`),
+    );
+  }
+
+  const notifyResult = await daemon.notifyProjectChange();
+  if (notifyResult.ok) {
+    console.log(chalk.dim(`  Dashboard config reloaded.`));
+  } else {
+    console.log(
+      chalk.yellow(
+        `  ⚠ ${notifyResult.reason}. Refresh the page if the project doesn't show up.`,
+      ),
+    );
+  }
+
+  if (!running.projects.includes(projectId)) {
+    console.log(
+      chalk.yellow(
+        `\nℹ Lifecycle polling for "${projectId}" will attach within ~60s\n` +
+          `  because the running ao start process now supervises active global projects.\n`,
+      ),
+    );
+  }
+
+  if (isHumanCaller()) {
+    console.log(chalk.dim(`  Opening dashboard: http://localhost:${daemon.port}\n`));
+    openUrl(`http://localhost:${daemon.port}`);
+  } else {
+    console.log(`Dashboard: http://localhost:${daemon.port}`);
+  }
+}
+
 // =============================================================================
 // COMMAND REGISTRATION
 // =============================================================================
@@ -1271,331 +1315,40 @@ export function registerStart(program: Command): void {
           let project: ProjectConfig;
 
           // ── Already-running detection (before any config mutation) ──
-          const running = await isAlreadyRunning();
+          let running = await isAlreadyRunning();
           let startNewOrchestrator = false;
-          // If the parent is alive but the requested project is not in its
-          // running.json projects list, it was stopped via `ao stop <project>`.
-          // Skip the "already running" menu and go straight to orchestrator
-          // creation — the dashboard and lifecycle worker are still up.
           const isProjectId =
             projectArg && !isRepoUrl(projectArg) && !isLocalPath(projectArg);
           const projectArgIsUrlOrPath =
             !!projectArg && (isRepoUrl(projectArg) || isLocalPath(projectArg));
 
-          // URL/path arg while AO is already running: handle it here instead
-          // of letting the "already running" gate ignore the arg. Falling
-          // through to runStartup would spawn a duplicate dashboard, so we
-          // register against the GLOBAL config (so the dashboard sees it),
-          // spawn the orchestrator session, and open the existing dashboard.
-          //
-          // Non-TTY callers (scripts/agents) keep the old "AO is already
-          // running" message and do NOT mutate config behind the user's back.
-          if (running && projectArgIsUrlOrPath && isHumanCaller()) {
-            const requestedProjectArg = projectArg;
-            if (!requestedProjectArg) {
-              throw new Error("Expected project path or URL argument");
-            }
-            // Always register against the GLOBAL config — never the cwd's
-            // local config. Cross-project visibility lives in the global
-            // registry, and addProjectToConfig only routes to global when
-            // its config arg has the canonical global path.
-            const globalConfigPath = getGlobalConfigPath();
-            const globalCfg = existsSync(globalConfigPath)
-              ? loadConfig(globalConfigPath)
-              : loadConfig();
-
-            let existingId: string | null = null;
-            if (isRepoUrl(requestedProjectArg)) {
-              try {
-                const parsed = parseRepoUrl(requestedProjectArg);
-                for (const [id, p] of Object.entries(globalCfg.projects)) {
-                  if (p.repo === parsed.ownerRepo) {
-                    existingId = id;
-                    break;
-                  }
-                }
-              } catch {
-                /* unparseable URL — fall through to clone */
-              }
-            } else {
-              const resolvedPath = resolve(
-                requestedProjectArg.replace(/^~/, process.env["HOME"] || ""),
-              );
-              let canonicalTarget: string;
-              try {
-                canonicalTarget = realpathSync(resolvedPath);
-              } catch {
-                canonicalTarget = resolvedPath;
-              }
-              for (const [id, p] of Object.entries(globalCfg.projects)) {
-                try {
-                  const expanded = resolve(p.path.replace(/^~/, process.env["HOME"] || ""));
-                  if (realpathSync(expanded) === canonicalTarget) {
-                    existingId = id;
-                    break;
-                  }
-                } catch {
-                  /* skip unreadable */
-                }
-              }
-            }
-
-            // Already registered AND covered by the running daemon — open
-            // the dashboard, no menu, no re-clone.
-            if (existingId && running.projects.includes(existingId)) {
-              console.log(chalk.cyan(`\nℹ AO is already running.`));
-              console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
-              console.log(`  Project "${existingId}" is already registered and running.\n`);
-              openUrl(`http://localhost:${running.port}`);
+          // ── Already-running dispatch ──
+          // Whether we attach to a live daemon or spawn a new one, the
+          // project-resolution + orchestrator-spawn steps are the same.
+          // The fork lives in two places: this menu (human caller, no
+          // arg) where the user can quit/open/add-cwd/restart/spawn-new,
+          // and the post-resolve branch below that calls either
+          // attachAndSpawnOrchestrator (running) or runStartup (not).
+          if (running) {
+            if (!isHumanCaller() && !isProjectId) {
+              // Non-human caller, no arg or URL/path arg: print info and
+              // exit. Project-id args fall through to attach+spawn so
+              // automation can `ao start <id>` against a live daemon.
+              console.log(`AO is already running.`);
+              console.log(`Dashboard: http://localhost:${running.port}`);
+              console.log(`PID: ${running.pid}`);
+              console.log(`Projects: ${running.projects.join(", ")}`);
+              console.log(`To restart: ao stop && ao start`);
               unlockStartup();
               process.exit(0);
             }
 
-            // Register (or resolve existing) against the global config and
-            // spawn the orchestrator session.
-            let resolvedId: string;
-            if (existingId) {
-              resolvedId = existingId;
-            } else if (isRepoUrl(requestedProjectArg)) {
-              // Clone + register inline. We DO NOT call handleUrlStart —
-              // that helper writes a legacy wrapped (`projects:`) local
-              // config that the new resolver rejects, requiring a repair
-              // pass after the fact. Instead, we write a flat local config
-              // here so the global registry + repo can be loaded cleanly
-              // on the very first read.
-              const parsed = parseRepoUrl(requestedProjectArg);
-              console.log(
-                chalk.bold.cyan(`\n  Cloning ${parsed.ownerRepo} (${parsed.host})\n`),
-              );
-              await ensureGit("repository cloning");
-
-              const cwdDir = cwd();
-              const targetDir = resolveCloneTarget(parsed, cwdDir);
-              if (isRepoAlreadyCloned(targetDir, parsed.cloneUrl)) {
-                console.log(chalk.green(`  Reusing existing clone at ${targetDir}`));
-              } else {
-                try {
-                  await cloneRepo(parsed, targetDir, cwdDir);
-                  console.log(chalk.green(`  Cloned to ${targetDir}`));
-                } catch (err) {
-                  throw new Error(
-                    `Failed to clone ${parsed.ownerRepo}: ${err instanceof Error ? err.message : String(err)}`,
-                    { cause: err },
-                  );
-                }
-              }
-
-              // Detect the default branch from the cloned repo. If the
-              // repo is empty (no commits / no refs), this returns null —
-              // we cannot create a worktree, so fail early with a clear
-              // message rather than letting ensureOrchestrator throw a
-              // confusing "Unable to resolve base ref" error.
-              const detectedBranch = await detectClonedRepoDefaultBranch(targetDir);
-              if (!detectedBranch) {
-                throw new Error(
-                  `Repository "${parsed.ownerRepo}" appears to be empty (no commits or refs).\n` +
-                    `  AO needs at least one commit on the default branch to spawn an orchestrator.\n` +
-                    `  Push an initial commit, then re-run \`ao start ${requestedProjectArg}\`.`,
-                );
-              }
-
-              const platform = detectScmPlatform(parsed.host);
-              const requestedProjectId = sanitizeProjectId(parsed.repo);
-              // The global registry only persists identity (path, repo,
-              // defaultBranch, sessionPrefix). Plugin choices like scm /
-              // tracker live in the local flat config below.
-              resolvedId = registerProjectInGlobalConfig(
-                requestedProjectId,
-                parsed.repo,
-                targetDir,
-                {
-                  repo: parsed.ownerRepo,
-                  defaultBranch: detectedBranch,
-                },
-                globalConfigPath,
-              );
-
-              // Write a flat local config (behavior only, no `projects:`
-              // wrapper, no identity fields). Identity lives in the global
-              // registry; this file holds plugin choices for the project.
-              // Don't clobber a config that ships in the repo — if the
-              // upstream already commits agent-orchestrator.yaml, leave it
-              // for the user to reconcile.
-              const hasCommittedConfig =
-                existsSync(resolve(targetDir, "agent-orchestrator.yaml")) ||
-                existsSync(resolve(targetDir, "agent-orchestrator.yml"));
-              if (!hasCommittedConfig) {
-                writeLocalProjectConfig(targetDir, {
-                  scm: { plugin: platform !== "unknown" ? platform : "github" },
-                  tracker: {
-                    plugin: platform === "gitlab" ? "gitlab" : "github",
-                  },
-                });
-              }
-            } else {
-              const resolvedPath = resolve(
-                requestedProjectArg.replace(/^~/, process.env["HOME"] || ""),
-              );
-              resolvedId = await addProjectToConfig(globalCfg, resolvedPath);
-            }
-
-            // Reload the global config so the new project is visible to
-            // the session manager.
-            const refreshedConfig = loadConfig(globalConfigPath);
-            const newProject = refreshedConfig.projects[resolvedId];
-            if (!newProject) {
-              throw new Error(
-                `Failed to register "${resolvedId}" in the global config — aborting.`,
-              );
-            }
-
-            console.log(chalk.dim("\n  Spawning orchestrator session...\n"));
-            const sm = await getSessionManager(refreshedConfig);
-            const systemPrompt = generateOrchestratorPrompt({
-              config: refreshedConfig,
-              projectId: resolvedId,
-              project: newProject,
-            });
-            const session = await sm.ensureOrchestrator({
-              projectId: resolvedId,
-              systemPrompt,
-            });
-
-            console.log(
-              chalk.green(`\n✓ Project "${resolvedId}" registered in the global config.`),
-            );
-            console.log(chalk.green(`✓ Orchestrator session ready: ${session.id}`));
-
-            // Invalidate the dashboard's cached services so the new project
-            // appears immediately in the routes (otherwise /projects/<id> 404s
-            // until the daemon is restarted).
-            try {
-              const reloadRes = await fetch(
-                `http://localhost:${running.port}/api/projects/reload`,
-                { method: "POST" },
-              );
-              if (reloadRes.ok) {
-                console.log(chalk.dim(`  Dashboard config reloaded.`));
-              } else {
-                console.log(
-                  chalk.yellow(
-                    `  ⚠ Dashboard reload returned ${reloadRes.status}. Refresh the page if the new project doesn't show up.`,
-                  ),
-                );
-              }
-            } catch {
-              console.log(
-                chalk.yellow(
-                  `  ⚠ Could not reach dashboard to reload config. Refresh the page if the new project doesn't show up.`,
-                ),
-              );
-            }
-
-            console.log(
-              chalk.yellow(
-                `\nℹ Lifecycle polling for "${resolvedId}" will attach within ~60s\n` +
-                  `  because the running ao start process now supervises active global projects.\n`,
-              ),
-            );
-            console.log(chalk.dim(`  Opening dashboard: http://localhost:${running.port}\n`));
-            openUrl(`http://localhost:${running.port}`);
-            unlockStartup();
-            process.exit(0);
-          }
-
-          // Project-ID arg + daemon running. Always attach to the existing
-          // daemon: spawn the orchestrator session via the live session
-          // manager and reload the dashboard. We do NOT condition on
-          // `running.projects.includes(projectArg)` — that field is the
-          // truth about whether lifecycle polling is attached, but the
-          // user still expects `ao start <project>` to (re)create the
-          // orchestrator session whether polling is attached or not.
-          //
-          // Critically: do NOT fall through to runStartup() — that would
-          // start a second dashboard on a new port and clobber running.json,
-          // leaving the original parent process orphaned.
-          if (running && isProjectId) {
-            const globalConfigPath = getGlobalConfigPath();
-            const cfg = existsSync(globalConfigPath)
-              ? loadConfig(globalConfigPath)
-              : loadConfig();
-            const project = cfg.projects[projectArg];
-            if (!project) {
-              throw new Error(
-                `Project "${projectArg}" is not registered in the global config (${globalConfigPath}).\n` +
-                  `  Run \`ao project add\` or \`ao start <path|url>\` first.`,
-              );
-            }
-
-            console.log(chalk.dim("\n  Attaching to running AO instance...\n"));
-            const sm = await getSessionManager(cfg);
-            const systemPrompt = generateOrchestratorPrompt({
-              config: cfg,
-              projectId: projectArg,
-              project,
-            });
-            const session = await sm.ensureOrchestrator({
-              projectId: projectArg,
-              systemPrompt,
-            });
-
-            console.log(
-              chalk.green(`✓ Orchestrator session ready: ${session.id}`),
-            );
-            console.log(
-              chalk.green(`✓ Project "${projectArg}" reattached to running daemon (PID ${running.pid}).`),
-            );
-
-            // Invalidate the dashboard's cached services so the project page
-            // works immediately on the existing dashboard.
-            try {
-              const reloadRes = await fetch(
-                `http://localhost:${running.port}/api/projects/reload`,
-                { method: "POST" },
-              );
-              if (reloadRes.ok) {
-                console.log(chalk.dim(`  Dashboard config reloaded.`));
-              } else {
-                console.log(
-                  chalk.yellow(
-                    `  ⚠ Dashboard reload returned ${reloadRes.status}. Refresh the page if the project doesn't show up.`,
-                  ),
-                );
-              }
-            } catch {
-              console.log(
-                chalk.yellow(
-                  `  ⚠ Could not reach dashboard to reload config. Refresh the page if the project doesn't show up.`,
-                ),
-              );
-            }
-
-            if (!running.projects.includes(projectArg)) {
-              console.log(
-                chalk.yellow(
-                  `\nℹ Lifecycle polling for "${projectArg}" will attach within ~60s\n` +
-                    `  because the running ao start process now supervises active global projects.\n`,
-                ),
-              );
-            }
-            if (isHumanCaller()) {
-              console.log(chalk.dim(`  Opening dashboard: http://localhost:${running.port}\n`));
-              openUrl(`http://localhost:${running.port}`);
-            } else {
-              console.log(`Dashboard: http://localhost:${running.port}`);
-            }
-            unlockStartup();
-            process.exit(0);
-          }
-
-          if (running) {
-            if (isHumanCaller()) {
+            if (isHumanCaller() && !projectArg) {
               console.log(chalk.cyan(`\nℹ AO is already running.`));
               console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
               console.log(`  PID: ${running.pid} | Up since: ${running.startedAt}`);
               console.log(`  Projects: ${running.projects.join(", ")}\n`);
 
-              // Check if cwd is an unregistered git repo — offer to add it
               const cwdResolved = resolve(cwd());
               const cwdIsRegistered = running.projects.some((p) => {
                 try {
@@ -1610,7 +1363,7 @@ export function registerStart(program: Command): void {
                 }
               });
               const cwdHasGit = existsSync(resolve(cwdResolved, ".git"));
-              const _addCwdOption =
+              const addCwdOption =
                 !cwdIsRegistered && cwdHasGit
                   ? [
                       {
@@ -1630,7 +1383,7 @@ export function registerStart(program: Command): void {
                     label: "Start new orchestrator",
                     hint: "Add a new session for this project",
                   },
-                  ..._addCwdOption,
+                  ...addCwdOption,
                   {
                     value: "restart",
                     label: "Restart everything",
@@ -1642,11 +1395,19 @@ export function registerStart(program: Command): void {
               );
 
               if (choice === "open") {
-                const url = `http://localhost:${running.port}`;
-                openUrl(url);
+                openUrl(`http://localhost:${running.port}`);
+                unlockStartup();
+                process.exit(0);
+              } else if (choice === "quit") {
                 unlockStartup();
                 process.exit(0);
               } else if (choice === "add") {
+                // Add cwd against whatever config the cwd walks up to find.
+                // This intentionally does not register globally or spawn an
+                // orchestrator session — the user explicitly chose "add"
+                // (not "new"), so we just persist the project and open the
+                // dashboard. The next `ao start <id>` (or "new" choice)
+                // will spawn an orchestrator.
                 const loadedCfg = loadConfig();
                 const addedId = await addProjectToConfig(loadedCfg, cwdResolved);
                 console.log(
@@ -1658,56 +1419,34 @@ export function registerStart(program: Command): void {
                 unlockStartup();
                 process.exit(0);
               } else if (choice === "new") {
-                // Defer config mutation until after config is loaded below
+                // Spawn a new orchestrator entry against this daemon.
+                // Resolve happens below; the suffix mutation runs after.
                 startNewOrchestrator = true;
               } else if (choice === "restart") {
-                try {
-                  process.kill(running.pid, "SIGTERM");
-                } catch {
-                  /* already dead */
-                }
-                if (!(await waitForExit(running.pid, 5000))) {
-                  console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
-                  try {
-                    process.kill(running.pid, "SIGKILL");
-                  } catch {
-                    /* already dead */
-                  }
-                  if (!(await waitForExit(running.pid, 3000))) {
-                    throw new Error(
-                      `Failed to stop AO process (PID ${running.pid}). Check permissions or stop it manually.`,
-                    );
-                  }
-                }
-                await unregister();
+                await killExistingDaemon(running);
                 console.log(chalk.yellow("\n  Stopped existing instance. Restarting...\n"));
-                // Continue to startup below
-              } else {
-                unlockStartup();
-                process.exit(0);
+                running = null;
               }
-            } else {
-              // Agent/non-TTY caller — print info and exit
-              console.log(`AO is already running.`);
-              console.log(`Dashboard: http://localhost:${running.port}`);
-              console.log(`PID: ${running.pid}`);
-              console.log(`Projects: ${running.projects.join(", ")}`);
-              console.log(`To restart: ao stop && ao start`);
-              unlockStartup();
-              process.exit(0);
             }
           }
 
           // Unified project resolution. See lib/resolve-project.ts for the
-          // per-arg-shape dispatch (URL / path / project id / cwd).
-          const resolvedProject = await resolveOrCreateProject(projectArg, {
-            addProjectToConfig,
-            autoCreateConfig,
-            resolveProject,
-            resolveProjectByRepo,
-            registerFlatConfig,
-            cloneRepo,
-          });
+          // per-arg-shape dispatch (URL / path / project id / cwd). When
+          // a daemon is up, the resolver registers URL clones / new paths
+          // in the global config — the daemon's source of truth — so they
+          // are visible to the project supervisor without a daemon restart.
+          const resolvedProject = await resolveOrCreateProject(
+            projectArg,
+            {
+              addProjectToConfig,
+              autoCreateConfig,
+              resolveProject,
+              resolveProjectByRepo,
+              registerFlatConfig,
+              cloneRepo,
+            },
+            { targetGlobalRegistry: !!running },
+          );
           ({ config, projectId, project } = resolvedProject);
 
           // ── Handle "new orchestrator" choice (deferred from already-running check) ──
@@ -1744,7 +1483,39 @@ export function registerStart(program: Command): void {
             project = config.projects[newId];
           }
 
-          // ── Agent selection prompt (Step 10)──
+          // ── Daemon-running short-circuit and attach pipeline ──
+          if (running) {
+            // URL/path arg whose project is already registered and supervised
+            // by the running daemon: don't even spawn an orchestrator session,
+            // just open the dashboard. Mirrors the original §3.2 fast path.
+            if (
+              projectArgIsUrlOrPath &&
+              !resolvedProject.justCreated &&
+              running.projects.includes(projectId)
+            ) {
+              console.log(chalk.cyan(`\nℹ AO is already running.`));
+              console.log(`  Dashboard: ${chalk.cyan(`http://localhost:${running.port}`)}`);
+              console.log(`  Project "${projectId}" is already registered and running.\n`);
+              openUrl(`http://localhost:${running.port}`);
+              unlockStartup();
+              process.exit(0);
+            }
+
+            await attachAndSpawnOrchestrator({
+              running,
+              config,
+              projectId,
+              project,
+              justCreated: resolvedProject.justCreated,
+            });
+            unlockStartup();
+            process.exit(0);
+          }
+
+          // ── Agent selection prompt (not-running spawn path only) ──
+          // Skipped when attaching to an existing daemon: changing agents
+          // mid-flight against a live orchestrator session would not take
+          // effect until the next restart anyway.
           const agentOverride = opts?.interactive ? await promptAgentSelection() : null;
           if (agentOverride) {
             const { orchestratorAgent, workerAgent } = agentOverride;

--- a/packages/cli/src/lib/daemon.ts
+++ b/packages/cli/src/lib/daemon.ts
@@ -1,0 +1,105 @@
+/**
+ * Daemon attachment and lifecycle helpers.
+ *
+ * Pulls the "AO is already running" branches out of `start.ts` so the running
+ * vs. not-running fork in the entry command is a single decision point and
+ * the per-branch operations (attach, kill, dashboard cache invalidation) can
+ * be reused.
+ *
+ * Today this covers:
+ * - {@link attachToDaemon}: build a handle to an already-running daemon and
+ *   surface dashboard cache invalidation through {@link AttachedDaemon.notifyProjectChange}.
+ * - {@link killExistingDaemon}: SIGTERM -> wait -> SIGKILL the daemon and
+ *   unregister `running.json`. Used by the "Restart everything" menu option.
+ *
+ * Spawning a fresh daemon (dashboard + supervisor + register) still lives in
+ * `start.ts`'s `runStartup`. PR B's plan eventually folds that into a
+ * symmetrical `spawnDaemon` here, but doing so requires extracting last-stop
+ * restore + browser-open + shutdown-handler installation, which is out of
+ * scope for this PR.
+ */
+
+import chalk from "chalk";
+import { unregister, waitForExit, type RunningState } from "./running-state.js";
+
+/**
+ * Return value of `notifyProjectChange`. The daemon may be unreachable (user
+ * stopped the dashboard manually) — callers can choose to warn or throw based
+ * on whether they expect the daemon to be live.
+ */
+export type NotifyResult = { ok: true } | { ok: false; reason: string };
+
+/**
+ * Handle for a daemon that was already running when this CLI invocation
+ * started. Distinguishes from a freshly-spawned daemon (which would be
+ * managed in-process by `runStartup` + `installShutdownHandlers`).
+ */
+export interface AttachedDaemon {
+  readonly outcome: "attached";
+  readonly port: number;
+  readonly pid: number;
+  /**
+   * Tell the dashboard a project was added or changed so it reloads its
+   * cached config. Returns `{ ok: false }` on any error; the dashboard might
+   * be down (user killed it manually), so callers typically warn rather than
+   * throw.
+   */
+  notifyProjectChange(): Promise<NotifyResult>;
+}
+
+async function postProjectsReload(port: number): Promise<NotifyResult> {
+  try {
+    const res = await fetch(`http://localhost:${port}/api/projects/reload`, {
+      method: "POST",
+    });
+    if (res.ok) return { ok: true };
+    return { ok: false, reason: `Dashboard reload returned ${res.status}` };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Build an {@link AttachedDaemon} for an existing running daemon.
+ * Pure — does not perform any network/filesystem I/O until the returned
+ * handle's methods are called.
+ */
+export function attachToDaemon(running: RunningState): AttachedDaemon {
+  return {
+    outcome: "attached",
+    port: running.port,
+    pid: running.pid,
+    notifyProjectChange: () => postProjectsReload(running.port),
+  };
+}
+
+/**
+ * Stop a running daemon synchronously: SIGTERM, wait up to 5s, SIGKILL if
+ * still alive, wait another 3s. Throws if the process refuses to die.
+ * Always unregisters `running.json` on success so the next `ao start` can
+ * spawn a fresh daemon without hitting the "already running" gate.
+ */
+export async function killExistingDaemon(running: RunningState): Promise<void> {
+  try {
+    process.kill(running.pid, "SIGTERM");
+  } catch {
+    // already dead — fall through to wait/unregister
+  }
+  if (!(await waitForExit(running.pid, 5000))) {
+    console.log(chalk.yellow("  Process didn't exit cleanly, sending SIGKILL..."));
+    try {
+      process.kill(running.pid, "SIGKILL");
+    } catch {
+      // already dead
+    }
+    if (!(await waitForExit(running.pid, 3000))) {
+      throw new Error(
+        `Failed to stop AO process (PID ${running.pid}). Check permissions or stop it manually.`,
+      );
+    }
+  }
+  await unregister();
+}

--- a/packages/cli/src/lib/resolve-project.ts
+++ b/packages/cli/src/lib/resolve-project.ts
@@ -7,11 +7,11 @@
  * still has its own helper here, but they all return the same shape so
  * the caller can treat them uniformly.
  *
- * Today this module only covers the not-running path. The "AO is already
- * running" branch in start.ts still has its own inline clone+register
- * block (it intentionally avoids handleUrlStart's legacy wrapped local
- * config); migrating it to use resolveOrCreateProject is a follow-up
- * before PR B.2's daemon unification.
+ * The same resolver runs whether or not a daemon is already up. When a
+ * daemon is running, callers pass `targetGlobalRegistry: true` so URL/path
+ * args register the project in the global config (the daemon's source of
+ * truth) rather than into the cwd-local config a non-running fresh start
+ * would generate.
  */
 
 import { existsSync, writeFileSync } from "node:fs";
@@ -19,15 +19,19 @@ import { resolve } from "node:path";
 import { cwd } from "node:process";
 import {
   ConfigNotFoundError,
+  detectScmPlatform,
   findConfigFile,
   generateConfigFromUrl,
   configToYaml,
   isRepoUrl,
   loadConfig,
   parseRepoUrl,
+  registerProjectInGlobalConfig,
   resolveCloneTarget,
   isRepoAlreadyCloned,
   getGlobalConfigPath,
+  sanitizeProjectId,
+  writeLocalProjectConfig,
   type OrchestratorConfig,
   type ParsedRepoUrl,
   type ProjectConfig,
@@ -37,6 +41,7 @@ import ora from "ora";
 import { findFreePort } from "./web-dir.js";
 import { DEFAULT_PORT } from "./constants.js";
 import { ensureGit } from "./startup-preflight.js";
+import { git } from "./shell.js";
 
 export type ProjectSource = "url" | "path" | "cwd" | "existing-id";
 
@@ -99,6 +104,25 @@ export interface ResolveDeps {
 }
 
 /**
+ * Options that change how the resolver writes new state to disk.
+ *
+ * `targetGlobalRegistry`:
+ *   When `true`, URL and path arguments resolve and register against the
+ *   global config (`~/.agent-orchestrator/config.yaml`) rather than a cwd-
+ *   local one. Used when an `ao` daemon is already running — the daemon's
+ *   project supervisor reads from the global registry, so anything we
+ *   freshly clone or add must land there to be visible.
+ *
+ *   When `false` (default), the resolver behaves as if this were the very
+ *   first `ao start`: URL clones generate a wrapped (`projects:`) yaml in
+ *   the cloned repo, paths register against whatever config the cwd walks
+ *   up to find.
+ */
+export interface ResolveOptions {
+  targetGlobalRegistry?: boolean;
+}
+
+/**
  * Decide whether `arg` looks like a path (rather than a project id).
  * Matches start.ts's `isLocalPath`.
  */
@@ -106,7 +130,134 @@ function isLocalPath(arg: string): boolean {
   return arg.startsWith("/") || arg.startsWith("~") || arg.startsWith("./") || arg.startsWith("..");
 }
 
-async function fromUrl(arg: string, deps: ResolveDeps): Promise<Resolved> {
+/**
+ * Detect the actual default branch of a freshly cloned repo. Prefers
+ * `origin/HEAD` (the remote's default), falls back to the current local
+ * branch. Returns null for empty repos (no commits).
+ */
+async function detectClonedRepoDefaultBranch(repoPath: string): Promise<string | null> {
+  const symref = await git(["symbolic-ref", "refs/remotes/origin/HEAD"], repoPath);
+  if (symref) {
+    const match = symref.trim().match(/^refs\/remotes\/origin\/(.+)$/);
+    if (match) return match[1];
+  }
+  const head = await git(["symbolic-ref", "--short", "HEAD"], repoPath);
+  if (head) {
+    const trimmed = head.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return null;
+}
+
+/**
+ * Clone (or reuse) a URL and register the project in the global config.
+ * The repo gets a flat local config (behavior only — scm/tracker plugin
+ * choices); identity (path, repo, defaultBranch, sessionPrefix) lives in
+ * the global registry so the daemon's project supervisor can see it.
+ *
+ * Mirrors the inline clone+register block that previously lived in start.ts
+ * for the "AO already running + URL arg" case.
+ */
+async function fromUrlIntoGlobal(arg: string, deps: ResolveDeps): Promise<Resolved> {
+  const parsed = parseRepoUrl(arg);
+  const globalConfigPath = getGlobalConfigPath();
+  const globalConfig = existsSync(globalConfigPath) ? loadConfig(globalConfigPath) : loadConfig();
+
+  // Existing project with the same repo? Skip the clone entirely.
+  for (const [id, p] of Object.entries(globalConfig.projects)) {
+    if (p.repo === parsed.ownerRepo) {
+      return {
+        config: globalConfig,
+        projectId: id,
+        project: p,
+        source: "url",
+        justCreated: false,
+        parsed,
+      };
+    }
+  }
+
+  console.log(chalk.bold.cyan(`\n  Cloning ${parsed.ownerRepo} (${parsed.host})\n`));
+  await ensureGit("repository cloning");
+
+  const cwdDir = process.cwd();
+  const targetDir = resolveCloneTarget(parsed, cwdDir);
+  if (isRepoAlreadyCloned(targetDir, parsed.cloneUrl)) {
+    console.log(chalk.green(`  Reusing existing clone at ${targetDir}`));
+  } else {
+    try {
+      await deps.cloneRepo(parsed, targetDir, cwdDir);
+      console.log(chalk.green(`  Cloned to ${targetDir}`));
+    } catch (err) {
+      throw new Error(
+        `Failed to clone ${parsed.ownerRepo}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
+  }
+
+  // Empty repos can't host an orchestrator worktree — fail early with a
+  // clear message instead of a confusing "Unable to resolve base ref" later.
+  const detectedBranch = await detectClonedRepoDefaultBranch(targetDir);
+  if (!detectedBranch) {
+    throw new Error(
+      `Repository "${parsed.ownerRepo}" appears to be empty (no commits or refs).\n` +
+        `  AO needs at least one commit on the default branch to spawn an orchestrator.\n` +
+        `  Push an initial commit, then re-run \`ao start ${arg}\`.`,
+    );
+  }
+
+  const platform = detectScmPlatform(parsed.host);
+  const requestedProjectId = sanitizeProjectId(parsed.repo);
+  const registeredId = registerProjectInGlobalConfig(
+    requestedProjectId,
+    parsed.repo,
+    targetDir,
+    {
+      repo: parsed.ownerRepo,
+      defaultBranch: detectedBranch,
+    },
+    globalConfigPath,
+  );
+
+  // Write a flat local config (behavior only, no `projects:` wrapper, no
+  // identity fields). Identity lives in the global registry; this file
+  // holds plugin choices for the project. Skip if the upstream commits its
+  // own agent-orchestrator.yaml — leave it for the user to reconcile.
+  const hasCommittedConfig =
+    existsSync(resolve(targetDir, "agent-orchestrator.yaml")) ||
+    existsSync(resolve(targetDir, "agent-orchestrator.yml"));
+  if (!hasCommittedConfig) {
+    writeLocalProjectConfig(targetDir, {
+      scm: { plugin: platform !== "unknown" ? platform : "github" },
+      tracker: {
+        plugin: platform === "gitlab" ? "gitlab" : "github",
+      },
+    });
+  }
+
+  const refreshedConfig = loadConfig(globalConfigPath);
+  const project = refreshedConfig.projects[registeredId];
+  if (!project) {
+    throw new Error(
+      `Failed to register "${registeredId}" in the global config — aborting.`,
+    );
+  }
+  return {
+    config: refreshedConfig,
+    projectId: registeredId,
+    project,
+    source: "url",
+    justCreated: true,
+    parsed,
+  };
+}
+
+async function fromUrl(arg: string, deps: ResolveDeps, opts: ResolveOptions): Promise<Resolved> {
+  if (opts.targetGlobalRegistry) {
+    return fromUrlIntoGlobal(arg, deps);
+  }
+
   console.log(chalk.bold.cyan("\n  Agent Orchestrator — Quick Start\n"));
   const spinner = ora();
 
@@ -176,8 +327,39 @@ async function fromUrl(arg: string, deps: ResolveDeps): Promise<Resolved> {
   };
 }
 
-async function fromPath(arg: string, deps: ResolveDeps): Promise<Resolved> {
+async function fromPath(arg: string, deps: ResolveDeps, opts: ResolveOptions): Promise<Resolved> {
   const resolvedPath = resolve(arg.replace(/^~/, process.env["HOME"] || ""));
+
+  // When a daemon is already running, register against the global config
+  // (the daemon's source of truth) instead of whatever cwd-local config
+  // findConfigFile() walks up to. addProjectToConfig is canonical-global-
+  // aware, so handing it a config loaded from the global path routes the
+  // write through registerProjectInGlobalConfig.
+  if (opts.targetGlobalRegistry) {
+    const globalPath = getGlobalConfigPath();
+    const globalConfig = existsSync(globalPath) ? loadConfig(globalPath) : loadConfig();
+    const existingEntry = Object.entries(globalConfig.projects).find(
+      ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
+    );
+    if (existingEntry) {
+      return {
+        config: globalConfig,
+        projectId: existingEntry[0],
+        project: existingEntry[1],
+        source: "path",
+        justCreated: false,
+      };
+    }
+    const addedId = await deps.addProjectToConfig(globalConfig, resolvedPath);
+    const reloaded = loadConfig(globalConfig.configPath);
+    return {
+      config: reloaded,
+      projectId: addedId,
+      project: reloaded.projects[addedId],
+      source: "path",
+      justCreated: true,
+    };
+  }
 
   let configPath: string | undefined;
   try {
@@ -228,7 +410,34 @@ async function fromPath(arg: string, deps: ResolveDeps): Promise<Resolved> {
   };
 }
 
-async function fromCwdOrId(arg: string | undefined, deps: ResolveDeps): Promise<Resolved> {
+async function fromCwdOrId(
+  arg: string | undefined,
+  deps: ResolveDeps,
+  opts: ResolveOptions,
+): Promise<Resolved> {
+  // Daemon-running + project id: the global registry is the source of
+  // truth for project identity, so look there directly. Skipping the cwd-
+  // local loadConfig() also avoids first-run autoCreate prompts when the
+  // user just wants to attach to a known project.
+  if (opts.targetGlobalRegistry && arg) {
+    const globalPath = getGlobalConfigPath();
+    const config = existsSync(globalPath) ? loadConfig(globalPath) : loadConfig();
+    const project = config.projects[arg];
+    if (!project) {
+      throw new Error(
+        `Project "${arg}" is not registered in the global config (${config.configPath}).\n` +
+          `  Run \`ao project add\` or \`ao start <path|url>\` first.`,
+      );
+    }
+    return {
+      config,
+      projectId: arg,
+      project,
+      source: "existing-id",
+      justCreated: false,
+    };
+  }
+
   let config: OrchestratorConfig;
   let recovered = false;
   try {
@@ -283,12 +492,17 @@ async function fromCwdOrId(arg: string | undefined, deps: ResolveDeps): Promise<
  *
  * The same `Resolved` shape comes back regardless of source; callers use
  * `source` and `justCreated` for hints (e.g. dashboard cache invalidation).
+ *
+ * Pass `opts.targetGlobalRegistry: true` when an `ao` daemon is already
+ * running so URL/path args register the project in the global config the
+ * daemon supervises rather than into a fresh cwd-local one.
  */
 export async function resolveOrCreateProject(
   arg: string | undefined,
   deps: ResolveDeps,
+  opts: ResolveOptions = {},
 ): Promise<Resolved> {
-  if (arg && isRepoUrl(arg)) return fromUrl(arg, deps);
-  if (arg && isLocalPath(arg)) return fromPath(arg, deps);
-  return fromCwdOrId(arg, deps);
+  if (arg && isRepoUrl(arg)) return fromUrl(arg, deps, opts);
+  if (arg && isLocalPath(arg)) return fromPath(arg, deps, opts);
+  return fromCwdOrId(arg, deps, opts);
 }

--- a/packages/cli/src/lib/resolve-project.ts
+++ b/packages/cli/src/lib/resolve-project.ts
@@ -14,7 +14,7 @@
  * would generate.
  */
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, realpathSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { cwd } from "node:process";
 import {
@@ -128,6 +128,20 @@ export interface ResolveOptions {
  */
 function isLocalPath(arg: string): boolean {
   return arg.startsWith("/") || arg.startsWith("~") || arg.startsWith("./") || arg.startsWith("..");
+}
+
+/**
+ * Resolve symlink chains for canonical path comparison. Falls back to the
+ * input on any filesystem error so the caller can compare unreadable paths
+ * literally rather than crash. Mirrors the canonical-compare pattern used
+ * elsewhere in the CLI for global-registry dedup.
+ */
+function canonicalize(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
 }
 
 /**
@@ -338,9 +352,16 @@ async function fromPath(arg: string, deps: ResolveDeps, opts: ResolveOptions): P
   if (opts.targetGlobalRegistry) {
     const globalPath = getGlobalConfigPath();
     const globalConfig = existsSync(globalPath) ? loadConfig(globalPath) : loadConfig();
-    const existingEntry = Object.entries(globalConfig.projects).find(
-      ([, p]) => resolve(p.path.replace(/^~/, process.env["HOME"] || "")) === resolvedPath,
-    );
+    // Canonicalize via realpathSync so symlinked paths (e.g. macOS
+    // /tmp -> /private/tmp) match an entry stored under the resolved
+    // target. Without this, `ao start /tmp/foo` against a daemon whose
+    // global config has /private/tmp/foo would fail to dedupe and
+    // double-register the project.
+    const canonicalTarget = canonicalize(resolvedPath);
+    const existingEntry = Object.entries(globalConfig.projects).find(([, p]) => {
+      const expanded = resolve(p.path.replace(/^~/, process.env["HOME"] || ""));
+      return canonicalize(expanded) === canonicalTarget;
+    });
     if (existingEntry) {
       return {
         config: globalConfig,
@@ -352,10 +373,16 @@ async function fromPath(arg: string, deps: ResolveDeps, opts: ResolveOptions): P
     }
     const addedId = await deps.addProjectToConfig(globalConfig, resolvedPath);
     const reloaded = loadConfig(globalConfig.configPath);
+    const project = reloaded.projects[addedId];
+    if (!project) {
+      throw new Error(
+        `Failed to register "${addedId}" in the global config — aborting.`,
+      );
+    }
     return {
       config: reloaded,
       projectId: addedId,
-      project: reloaded.projects[addedId],
+      project,
       source: "path",
       justCreated: true,
     };


### PR DESCRIPTION
## Summary

Step 2 of PR B in [ao-118's `start.ts` refactor plan](https://github.com/ComposioHQ/agent-orchestrator/blob/main/packages/cli/src/commands/start.ts). Bundles the deferred B.1 follow-up (the §3.2 inline clone+register block was due to migrate to share `fromUrl`) — that block is now deleted outright by the fork collapse, so the follow-up disappears rather than landing as its own diff.

The three branches in `start.ts` that handled the daemon-already-running cases (§3.2 URL/path, §3.3 project-id, §3.5 non-human info dump) collapse into a single attach pipeline that runs after `resolveOrCreateProject`. The fork between attach and spawn becomes one post-resolve decision point.

## What changed

- New `packages/cli/src/lib/daemon.ts`:
  - `attachToDaemon(running) -> AttachedDaemon { port, pid, notifyProjectChange() }` — pure handle plus a typed `{ok} | {ok: false, reason}` cache-invalidation result, replacing the open-coded fetch + try/catch that lived in two places.
  - `killExistingDaemon(running)` — SIGTERM → `waitForExit` → SIGKILL → `unregister`, used by the "Restart everything" menu option. Replaces the inline restart code in §3.4.

- `resolve-project.ts` gains a `{ targetGlobalRegistry?: boolean }` option:
  - When `true`, `fromUrl` and `fromPath` register against the global config (the daemon's source of truth) rather than into a cwd-local one.
  - `fromUrl`'s global-registry branch is a near-verbatim move of the §3.2 inline clone+register block, including the global-registry dedup and the flat-local-config write that §3.2 deliberately preferred over `fromUrl`'s wrapped yaml.
  - `fromCwdOrId` short-circuits straight to the global registry for project-id args while running, with the same "not registered" error the original §3.3 raised.

- `start.ts` dispatch:
  - **Running + non-human + (no arg | URL | path)** → info dump, exit 0 (preserved §3.5; project-id args still fall through so automation can `ao start <id>` against a live daemon).
  - **Running + human + no arg** → menu preserved (open / quit / add / new / restart). `restart` now routes through `killExistingDaemon`; `new` sets `startNewOrchestrator` and falls through to the attach path.
  - `resolveOrCreateProject(arg, deps, { targetGlobalRegistry: !!running })`.
  - **Running** → `attachAndSpawnOrchestrator` helper. The §3.2 short-circuit (URL/path arg whose project is already in `running.projects` skips the orchestrator-spawn and just opens the dashboard) is preserved.
  - **Not running** → existing `runStartup` + `register` + janitor + `installShutdownHandlers`.

- `attachAndSpawnOrchestrator` unifies §3.2/§3.3 messaging behind a single `justCreated` discriminator:
  - `justCreated=true`: \"Spawning orchestrator session...\" → \"Project '...' registered in the global config.\" → \"Orchestrator session ready: ...\"
  - `justCreated=false`: \"Attaching to running AO instance...\" → \"Orchestrator session ready: ...\" → \"Project '...' reattached to running daemon (PID ...)\"
  - Both flows then `notifyProjectChange` (warns on failure, never throws — the dashboard might be down), print the lifecycle-attach notice when the project isn't yet supervised, and either `openUrl` (human) or print the URL (non-human).

## Behavior preservation

No behavior change. The unified pipeline matches the original §3.2/§3.3/§3.5 paths line-for-line on prints, prompts, exits, browser opens, and dashboard cache invalidation. The only intentional simplification is that agent selection (`--interactive`) is now explicit about being skipped when attaching — previously skipped accidentally because §3.2/§3.3 exited before it ran.

`startNewOrchestrator` and the §3.4 menu options remain intact. Those are user-visible feature changes that land in PR B.3.

## Diff sizes

- `start.ts`: -1126 / +131 lines (~390-line net deletion as forecast in the plan, after accounting for the new `attachAndSpawnOrchestrator` helper).
- New `daemon.ts`: 105 lines.
- `resolve-project.ts`: +167 lines (global-registry branch in `fromUrl`/`fromPath`/`fromCwdOrId` + a moved-from-start.ts `detectClonedRepoDefaultBranch` helper).
- 8 new tests in `daemon.test.ts`.

## Test plan

- [x] `pnpm typecheck` clean across all packages.
- [x] `pnpm lint` clean (only pre-existing warnings).
- [x] `pnpm test` — CLI: 602 pass, 8 fail. The 8 failures are stop-command tests pre-existing on `fad75b63` (verified by stashing this branch's changes and running the same tests on the bare upstream HEAD).
- [x] New `daemon.test.ts` (8 tests): attachToDaemon (port/pid wiring; notifyProjectChange success / non-2xx / fetch-throws); killExistingDaemon (SIGTERM happy path; SIGKILL escalation; throw on both-fail; ESRCH-on-already-dead).
- [x] Existing already-running suite (9 tests at `start.test.ts:2158-`) and global-registry-mutations suite (2 tests at `:2667-`) all pass against the new pipeline.

## Plan reference

[`~/.ao/agent-orchestrator/ao-118/plan.md`](https://github.com/ComposioHQ/agent-orchestrator/blob/main/) — Part 0 status table will be updated to mark B.1 follow-up + B.2 as shipped together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)