### PR TITLE
feat(pipeline): v0.1 — core types, state machine, flat-file store

### DIFF
--- a/packages/core/src/__tests__/pipeline-reducer.test.ts
+++ b/packages/core/src/__tests__/pipeline-reducer.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  emptyEngineState,
+  loopKey,
+  reduce,
+  type ArtifactInput,
+  type EngineState,
+  type Pipeline,
+  type PipelineEvent,
+  type RunId,
+  type StageRunId,
+  type Stage,
+  type StageTriggerEvent,
+} from "../pipeline/index.js";
+
+const NOW = 1_700_000_000_000;
+
+function makeStage(name: string, overrides: Partial<Stage> = {}): Stage {
+  return {
+    name,
+    trigger: { on: ["pr.opened", "pr.updated"] },
+    executor: {
+      kind: "agent",
+      plugin: "codex",
+      mode: "review",
+    },
+    task: { prompt: `run ${name}` },
+    ...overrides,
+  };
+}
+
+function makePipeline(overrides: Partial<Pipeline> = {}): Pipeline {
+  return {
+    id: asPipelineId("pl-1"),
+    name: "default",
+    stages: [makeStage("review")],
+    maxConcurrentStages: 1,
+    ...overrides,
+  };
+}
+
+function fireTrigger(
+  state: EngineState,
+  opts: {
+    runId?: RunId;
+    stageRunIds?: Record<string, StageRunId>;
+    pipeline?: Pipeline;
+    sessionId?: string;
+    headSha?: string;
+    trigger?: StageTriggerEvent;
+    now?: number;
+  } = {},
+) {
+  const pipeline = opts.pipeline ?? makePipeline();
+  const runId = opts.runId ?? asRunId("run-1");
+  const stageRunIds: Record<string, StageRunId> =
+    opts.stageRunIds ??
+    Object.fromEntries(
+      pipeline.stages.map((s, i) => [s.name, asStageRunId(`${runId}-${s.name}-${i}`)]),
+    );
+
+  const event: PipelineEvent = {
+    type: "TRIGGER_FIRED",
+    now: opts.now ?? NOW,
+    trigger: opts.trigger ?? "pr.opened",
+    sessionId: opts.sessionId ?? "ses-1",
+    pipeline,
+    headSha: opts.headSha ?? "sha-aaa",
+    runId,
+    stageRunIds,
+  };
+
+  return reduce(state, event);
+}
+
+describe("pipeline reducer — TRIGGER_FIRED", () => {
+  it("creates a run, persists it, and emits START_STAGE for the first stage", () => {
+    const { state, effects } = fireTrigger(emptyEngineState());
+
+    const runId = asRunId("run-1");
+    expect(state.runs[runId]).toBeDefined();
+    expect(state.runs[runId].loopState).toBe("running");
+    expect(state.runs[runId].stages.review.status).toBe("pending");
+    expect(state.currentRunByLoop[loopKey("ses-1", "default")]).toBe(runId);
+
+    const types = effects.map((e) => e.type);
+    expect(types).toContain("PERSIST_RUN");
+    expect(types).toContain("PERSIST_LOOP_STATE");
+    expect(types).toContain("START_STAGE");
+    expect(types).toContain("EMIT_OBSERVATION");
+
+    const startStage = effects.find((e) => e.type === "START_STAGE");
+    if (startStage?.type !== "START_STAGE") throw new Error("expected START_STAGE");
+    expect(startStage.stage.name).toBe("review");
+  });
+
+  it("ignores duplicate triggers when a run is already in flight for the loop", () => {
+    const first = fireTrigger(emptyEngineState());
+    const second = fireTrigger(first.state, { runId: asRunId("run-2") });
+    expect(second.state.runs[asRunId("run-2")]).toBeUndefined();
+    expect(second.effects).toEqual([]);
+  });
+
+  it("only schedules up to maxConcurrentStages effects", () => {
+    const pipeline = makePipeline({
+      stages: [makeStage("a"), makeStage("b"), makeStage("c")],
+      maxConcurrentStages: 2,
+    });
+    const { effects } = fireTrigger(emptyEngineState(), { pipeline });
+    const startEffects = effects.filter((e) => e.type === "START_STAGE");
+    expect(startEffects).toHaveLength(2);
+  });
+
+  it("emits invalid_transition observation when stageRunIds are missing", () => {
+    const pipeline = makePipeline({ stages: [makeStage("a"), makeStage("b")] });
+    const { state, effects } = fireTrigger(emptyEngineState(), {
+      pipeline,
+      stageRunIds: { a: asStageRunId("sr-a") },
+    });
+    expect(state.runs).toEqual({});
+    const obs = effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+});
+
+describe("pipeline reducer — STAGE_STARTED / STAGE_COMPLETED", () => {
+  it("transitions pending → running on STAGE_STARTED", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const { state } = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+    expect(state.runs[asRunId("run-1")].stages.review.status).toBe("running");
+    expect(state.runs[asRunId("run-1")].stages.review.startedAt).toBeDefined();
+  });
+
+  it("rejects STAGE_STARTED if stage isn't pending", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const started = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+    const dup = reduce(started.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+    expect(dup.state).toEqual(started.state);
+    const obs = dup.effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+
+  it("STAGE_COMPLETED on the last stage transitions run to done with APPEND_ARTIFACTS", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const started = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+
+    const findings: ArtifactInput[] = [
+      {
+        kind: "finding",
+        filePath: "src/x.ts",
+        startLine: 1,
+        endLine: 2,
+        title: "Possible null deref",
+        description: "...",
+        category: "correctness",
+        severity: "warning",
+        confidence: 0.8,
+      },
+    ];
+
+    const { state, effects } = reduce(started.state, {
+      type: "STAGE_COMPLETED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "review",
+      verdict: "fail",
+      artifacts: findings,
+    });
+
+    expect(state.runs[asRunId("run-1")].loopState).toBe("done");
+    expect(state.runs[asRunId("run-1")].terminationReason).toBe("completed");
+
+    const append = effects.find((e) => e.type === "APPEND_ARTIFACTS");
+    if (append?.type !== "APPEND_ARTIFACTS") throw new Error("expected APPEND_ARTIFACTS");
+    expect(append.artifacts).toHaveLength(1);
+    expect(append.artifacts[0].status).toBe("open");
+    expect(append.artifacts[0].pipelineRunId).toBe(asRunId("run-1"));
+
+    expect(state.currentRunByLoop[loopKey("ses-1", "default")]).toBeUndefined();
+    const summaries = state.historySummaries[loopKey("ses-1", "default")];
+    expect(summaries).toHaveLength(1);
+  });
+
+  it("STAGE_COMPLETED on a non-final stage starts the next stage", () => {
+    const pipeline = makePipeline({
+      stages: [makeStage("a"), makeStage("b")],
+      maxConcurrentStages: 1,
+    });
+    const triggered = fireTrigger(emptyEngineState(), { pipeline });
+    const started = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "a",
+    });
+    const { state, effects } = reduce(started.state, {
+      type: "STAGE_COMPLETED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      artifacts: [],
+    });
+
+    expect(state.runs[asRunId("run-1")].loopState).toBe("running");
+    expect(state.runs[asRunId("run-1")].stages.a.status).toBe("succeeded");
+    expect(state.runs[asRunId("run-1")].stages.b.status).toBe("pending");
+
+    const startB = effects.find(
+      (e) => e.type === "START_STAGE" && e.stage.name === "b",
+    );
+    expect(startB).toBeDefined();
+  });
+});
+
+describe("pipeline reducer — STAGE_FAILED", () => {
+  it("marks the run stalled and freezes remaining stages", () => {
+    const pipeline = makePipeline({
+      stages: [makeStage("a"), makeStage("b")],
+      maxConcurrentStages: 1,
+    });
+    const triggered = fireTrigger(emptyEngineState(), { pipeline });
+    const started = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "a",
+    });
+    const { state, effects } = reduce(started.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    expect(state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    expect(state.runs[asRunId("run-1")].terminationReason).toBe("stage_failure");
+    expect(state.runs[asRunId("run-1")].stages.a.status).toBe("failed");
+    expect(state.runs[asRunId("run-1")].stages.b.status).toBe("skipped");
+
+    const obs = effects
+      .filter((e) => e.type === "EMIT_OBSERVATION")
+      .map((e) => (e.type === "EMIT_OBSERVATION" ? e.event.name : ""));
+    expect(obs).toContain("pipeline.run.terminated");
+  });
+});
+
+describe("pipeline reducer — NEW_SHA_DETECTED", () => {
+  it("terminates an in-flight run as outdated and emits CANCEL_STAGE for running stages", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const started = reduce(triggered.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+    const { state, effects } = reduce(started.state, {
+      type: "NEW_SHA_DETECTED",
+      now: NOW + 2,
+      sessionId: "ses-1",
+      pipelineName: "default",
+      sha: "sha-bbb",
+    });
+
+    expect(state.runs[asRunId("run-1")].loopState).toBe("terminated");
+    expect(state.runs[asRunId("run-1")].terminationReason).toBe("outdated");
+    expect(state.runs[asRunId("run-1")].stages.review.status).toBe("outdated");
+    expect(state.currentRunByLoop[loopKey("ses-1", "default")]).toBeUndefined();
+
+    const cancel = effects.find((e) => e.type === "CANCEL_STAGE");
+    expect(cancel).toBeDefined();
+  });
+
+  it("ignores when the SHA is unchanged", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const { state } = reduce(triggered.state, {
+      type: "NEW_SHA_DETECTED",
+      now: NOW + 1,
+      sessionId: "ses-1",
+      pipelineName: "default",
+      sha: "sha-aaa",
+    });
+    expect(state).toEqual(triggered.state);
+  });
+
+  it("is a no-op when no run is active for the loop", () => {
+    const { state, effects } = reduce(emptyEngineState(), {
+      type: "NEW_SHA_DETECTED",
+      now: NOW,
+      sessionId: "ses-1",
+      pipelineName: "default",
+      sha: "sha-aaa",
+    });
+    expect(state).toEqual(emptyEngineState());
+    expect(effects).toEqual([]);
+  });
+});
+
+describe("pipeline reducer — RUN_CANCELLED / CONFIG_CHANGED", () => {
+  it("RUN_CANCELLED with manual reason ends the run as terminated", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const { state } = reduce(triggered.state, {
+      type: "RUN_CANCELLED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
+    });
+    expect(state.runs[asRunId("run-1")].loopState).toBe("terminated");
+    expect(state.runs[asRunId("run-1")].terminationReason).toBe("manual_cancel");
+  });
+
+  it("RUN_CANCELLED on already-terminal run is rejected", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const cancelled = reduce(triggered.state, {
+      type: "RUN_CANCELLED",
+      now: NOW + 1,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
+    });
+    const dup = reduce(cancelled.state, {
+      type: "RUN_CANCELLED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      reason: "manual_cancel",
+    });
+    const obs = dup.effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+
+  it("CONFIG_CHANGED terminates the active run with config_change", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const { state } = reduce(triggered.state, {
+      type: "CONFIG_CHANGED",
+      now: NOW + 1,
+      sessionId: "ses-1",
+      pipelineName: "default",
+    });
+    expect(state.runs[asRunId("run-1")].loopState).toBe("terminated");
+    expect(state.runs[asRunId("run-1")].terminationReason).toBe("config_change");
+  });
+});
+
+describe("pipeline reducer — purity", () => {
+  it("does not mutate the input state on TRIGGER_FIRED", () => {
+    const initial = emptyEngineState();
+    const snapshot = JSON.parse(JSON.stringify(initial));
+    fireTrigger(initial);
+    expect(initial).toEqual(snapshot);
+  });
+
+  it("does not call Date.now() (events provide `now`)", () => {
+    const realNow = Date.now;
+    let called = 0;
+    Date.now = () => {
+      called += 1;
+      return 0;
+    };
+    try {
+      fireTrigger(emptyEngineState());
+    } finally {
+      Date.now = realNow;
+    }
+    expect(called).toBe(0);
+  });
+});
+
+describe("pipeline reducer — loopRounds", () => {
+  it("increments loopRounds when a continuation trigger fires after a prior run", () => {
+    const first = fireTrigger(emptyEngineState());
+    const started = reduce(first.state, {
+      type: "STAGE_STARTED",
+      now: NOW + 5,
+      runId: asRunId("run-1"),
+      stageName: "review",
+    });
+    const completed = reduce(started.state, {
+      type: "STAGE_COMPLETED",
+      now: NOW + 10,
+      runId: asRunId("run-1"),
+      stageName: "review",
+      artifacts: [],
+    });
+    const second = fireTrigger(completed.state, {
+      runId: asRunId("run-2"),
+      trigger: "pr.updated",
+      now: NOW + 100,
+    });
+    expect(second.state.runs[asRunId("run-2")].loopRounds).toBe(2);
+  });
+
+  it("does not increment on the first run for a loop", () => {
+    const first = fireTrigger(emptyEngineState());
+    expect(first.state.runs[asRunId("run-1")].loopRounds).toBe(1);
+  });
+});

--- a/packages/core/src/__tests__/pipeline-store.test.ts
+++ b/packages/core/src/__tests__/pipeline-store.test.ts
@@ -1,0 +1,199 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  artifactsFilePath,
+  asArtifactId,
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  createPipelineStore,
+  loopFilePath,
+  runFilePath,
+  stageFilePath,
+  type Artifact,
+  type LoopState,
+  type PersistedStageRun,
+  type Pipeline,
+  type RunState,
+} from "../pipeline/index.js";
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "pipeline-store-"));
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function makePipeline(): Pipeline {
+  return {
+    id: asPipelineId("pl-1"),
+    name: "default",
+    stages: [
+      {
+        name: "review",
+        trigger: { on: ["pr.opened"] },
+        executor: { kind: "agent", plugin: "codex", mode: "review" },
+        task: { prompt: "review the diff" },
+      },
+    ],
+    maxConcurrentStages: 1,
+  };
+}
+
+function makeRun(): RunState {
+  return {
+    runId: asRunId("run-1"),
+    pipelineId: asPipelineId("pl-1"),
+    pipelineName: "default",
+    sessionId: "ses-1",
+    pipelineConfigSnapshot: makePipeline(),
+    headSha: "sha-aaa",
+    loopState: "running",
+    loopRounds: 1,
+    stages: {
+      review: {
+        stageRunId: asStageRunId("sr-1"),
+        status: "pending",
+        attempt: 1,
+        artifacts: [],
+      },
+    },
+    createdAt: "2026-05-04T00:00:00.000Z",
+    updatedAt: "2026-05-04T00:00:00.000Z",
+  };
+}
+
+describe("pipeline store — runs", () => {
+  it("roundtrips a RunState through saveRun/loadRun", () => {
+    const store = createPipelineStore(root);
+    const run = makeRun();
+    store.saveRun(run);
+    expect(existsSync(runFilePath(root, run.runId))).toBe(true);
+    expect(store.loadRun(run.runId)).toEqual(run);
+  });
+
+  it("returns null for unknown runId", () => {
+    const store = createPipelineStore(root);
+    expect(store.loadRun(asRunId("missing"))).toBeNull();
+  });
+
+  it("listRuns returns every saved run regardless of order", () => {
+    const store = createPipelineStore(root);
+    const a = makeRun();
+    const b: RunState = { ...makeRun(), runId: asRunId("run-2"), loopState: "done" };
+    store.saveRun(a);
+    store.saveRun(b);
+    const ids = store
+      .listRuns()
+      .map((r) => r.runId)
+      .sort();
+    expect(ids).toEqual([asRunId("run-1"), asRunId("run-2")].sort());
+  });
+
+  it("listRuns on an empty store returns an empty array (and creates layout)", () => {
+    const store = createPipelineStore(root);
+    expect(store.listRuns()).toEqual([]);
+  });
+});
+
+describe("pipeline store — stages", () => {
+  it("roundtrips a stage through saveStage/loadStage", () => {
+    const store = createPipelineStore(root);
+    const stage: PersistedStageRun = {
+      runId: asRunId("run-1"),
+      stageName: "review",
+      stageRunId: asStageRunId("sr-1"),
+      status: "running",
+      attempt: 1,
+      artifacts: [],
+      startedAt: "2026-05-04T00:00:01.000Z",
+    };
+    store.saveStage(stage);
+    expect(existsSync(stageFilePath(root, stage.stageRunId))).toBe(true);
+    expect(store.loadStage(stage.stageRunId)).toEqual(stage);
+  });
+});
+
+describe("pipeline store — artifacts (jsonl)", () => {
+  function makeArtifact(idSuffix: string): Artifact {
+    return {
+      kind: "finding",
+      filePath: "src/x.ts",
+      startLine: 1,
+      endLine: 2,
+      title: `f-${idSuffix}`,
+      description: "...",
+      category: "general",
+      severity: "info",
+      confidence: 0.9,
+      artifactId: asArtifactId(`art-${idSuffix}`),
+      pipelineRunId: asRunId("run-1"),
+      stageRunId: asStageRunId("sr-1"),
+      stageName: "review",
+      status: "open",
+      createdAt: "2026-05-04T00:00:00.000Z",
+    };
+  }
+
+  it("appends artifacts as JSONL and reads them back in order", () => {
+    const store = createPipelineStore(root);
+    const a = makeArtifact("1");
+    const b = makeArtifact("2");
+    store.appendArtifacts(asRunId("run-1"), asStageRunId("sr-1"), [a, b]);
+
+    const path = artifactsFilePath(root, asRunId("run-1"), asStageRunId("sr-1"));
+    const raw = readFileSync(path, "utf-8");
+    expect(raw.split("\n").filter(Boolean)).toHaveLength(2);
+
+    const out = store.listArtifacts(asRunId("run-1"), asStageRunId("sr-1"));
+    expect(out.map((x) => x.artifactId)).toEqual([a.artifactId, b.artifactId]);
+  });
+
+  it("appendArtifacts is additive across calls", () => {
+    const store = createPipelineStore(root);
+    store.appendArtifacts(asRunId("run-1"), asStageRunId("sr-1"), [makeArtifact("1")]);
+    store.appendArtifacts(asRunId("run-1"), asStageRunId("sr-1"), [makeArtifact("2")]);
+    expect(store.listArtifacts(asRunId("run-1"), asStageRunId("sr-1"))).toHaveLength(2);
+  });
+
+  it("listArtifacts returns [] for missing files", () => {
+    const store = createPipelineStore(root);
+    expect(store.listArtifacts(asRunId("nope"), asStageRunId("nope"))).toEqual([]);
+  });
+
+  it("appendArtifacts with empty list is a no-op", () => {
+    const store = createPipelineStore(root);
+    store.appendArtifacts(asRunId("run-1"), asStageRunId("sr-1"), []);
+    expect(store.listArtifacts(asRunId("run-1"), asStageRunId("sr-1"))).toEqual([]);
+  });
+});
+
+describe("pipeline store — loops", () => {
+  it("roundtrips a LoopState through saveLoopState/loadLoopState", () => {
+    const store = createPipelineStore(root);
+    const loop: LoopState = {
+      sessionId: "ses-1",
+      pipelineName: "default",
+      loopState: "running",
+      loopRounds: 2,
+      lastSha: "sha-aaa",
+      currentRunId: asRunId("run-1"),
+      updatedAt: "2026-05-04T00:00:00.000Z",
+    };
+    store.saveLoopState(asRunId("run-1"), loop);
+    expect(existsSync(loopFilePath(root, asRunId("run-1")))).toBe(true);
+    expect(store.loadLoopState(asRunId("run-1"))).toEqual(loop);
+  });
+
+  it("returns null for missing loop state", () => {
+    const store = createPipelineStore(root);
+    expect(store.loadLoopState(asRunId("nope"))).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -369,6 +369,80 @@ export type {
 
 export { atomicWriteFileSync } from "./atomic-write.js";
 
+// Pipeline subsystem — types, reducer, flat-file store (issue #1627)
+export {
+  // Branded ID factories
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  asArtifactId,
+  // Constants & helpers
+  PIPELINE_FINDINGS_FILENAME,
+  TERMINAL_STAGE_STATUSES,
+  TERMINAL_LOOP_STATES,
+  isTerminalStageStatus,
+  isTerminalLoopState,
+  loopKey,
+  emptyEngineState,
+  // Reducer
+  reduce,
+  // Store
+  createPipelineStore,
+  // Path helpers
+  pipelineLayout,
+  runFilePath,
+  stageFilePath,
+  artifactsDirForRun,
+  artifactsFilePath,
+  loopFilePath,
+} from "./pipeline/index.js";
+
+export type {
+  // IDs
+  PipelineId,
+  RunId,
+  StageRunId,
+  ArtifactId,
+  // Configuration
+  TaskMode,
+  StageTriggerEvent,
+  StageTrigger,
+  AgentExecutor,
+  CommandExecutor,
+  StageExecutor,
+  TaskSpec,
+  StagePolicy,
+  StageBudget,
+  Stage,
+  Pipeline,
+  // Artifacts
+  Severity,
+  ArtifactStatus,
+  FindingArtifactInput,
+  JsonArtifactInput,
+  ArtifactInput,
+  Artifact,
+  // Three-tier exit
+  StageStatus,
+  Verdict,
+  RunTerminationReason,
+  LoopStateName,
+  // Runtime state
+  StageState,
+  RunState,
+  LoopState,
+  RunSummary,
+  EngineState,
+  // Reducer surface
+  PipelineEvent,
+  PipelineEffect,
+  ReducerResult,
+  // Store surface
+  PipelineStore,
+  PersistedStageRun,
+  PipelineLayout,
+} from "./pipeline/index.js";
+
 // Activity event logging — structured diagnostic event trail
 export { recordActivityEvent, droppedEventCount } from "./activity-events.js";
 export { isActivityEventsFtsEnabled } from "./events-db.js";

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -130,7 +130,7 @@ export function getProjectFeedbackReportsDir(projectId: string): string {
   return join(getProjectDir(projectId), "feedback-reports");
 }
 
-/** Get the pipelines directory for a project (V2 layout). Holds runs/, stages/, artifacts/, loops/. */
+/** Get the pipelines directory for a project. Holds runs/, stages/, artifacts/, loops/. */
 export function getProjectPipelinesDir(projectId: string): string {
   return join(getProjectDir(projectId), "pipelines");
 }

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -130,6 +130,11 @@ export function getProjectFeedbackReportsDir(projectId: string): string {
   return join(getProjectDir(projectId), "feedback-reports");
 }
 
+/** Get the pipelines directory for a project (V2 layout). Holds runs/, stages/, artifacts/, loops/. */
+export function getProjectPipelinesDir(projectId: string): string {
+  return join(getProjectDir(projectId), "pipelines");
+}
+
 /** Get the orchestrator metadata file path for a project. */
 export function getOrchestratorPath(projectId: string): string {
   return join(getProjectDir(projectId), "orchestrator.json");

--- a/packages/core/src/pipeline/events.ts
+++ b/packages/core/src/pipeline/events.ts
@@ -1,0 +1,95 @@
+/**
+ * Event and effect (command) shapes consumed by the pipeline reducer.
+ *
+ * The reducer is pure: events carry `now` (driver-stamped), and the engine
+ * executes effects after each `reduce()` call.
+ */
+
+import type {
+  Artifact,
+  ArtifactInput,
+  EngineState,
+  LoopState,
+  Pipeline,
+  RunId,
+  RunState,
+  RunTerminationReason,
+  Stage,
+  StageRunId,
+  StageTriggerEvent,
+  Verdict,
+} from "./types.js";
+
+interface EventBase {
+  /** Driver-stamped timestamp (epoch ms). Reducer must not read the clock. */
+  now: number;
+}
+
+export type PipelineEvent =
+  | (EventBase & {
+      type: "TRIGGER_FIRED";
+      trigger: StageTriggerEvent;
+      sessionId: string;
+      pipeline: Pipeline;
+      headSha: string;
+      /** Driver-allocated run id; reducer uses verbatim. */
+      runId: RunId;
+      /** Driver-allocated stage run ids, keyed by stage name. */
+      stageRunIds: Record<string, StageRunId>;
+    })
+  | (EventBase & {
+      type: "STAGE_STARTED";
+      runId: RunId;
+      stageName: string;
+    })
+  | (EventBase & {
+      type: "STAGE_COMPLETED";
+      runId: RunId;
+      stageName: string;
+      verdict?: Verdict;
+      artifacts: ArtifactInput[];
+    })
+  | (EventBase & {
+      type: "STAGE_FAILED";
+      runId: RunId;
+      stageName: string;
+      errorMessage: string;
+    })
+  | (EventBase & {
+      type: "NEW_SHA_DETECTED";
+      sessionId: string;
+      pipelineName: string;
+      sha: string;
+    })
+  | (EventBase & {
+      type: "RUN_CANCELLED";
+      runId: RunId;
+      reason: RunTerminationReason;
+    })
+  | (EventBase & {
+      type: "CONFIG_CHANGED";
+      sessionId: string;
+      pipelineName: string;
+    })
+  | (EventBase & { type: "TICK" });
+
+export type PipelineEffect =
+  | { type: "START_STAGE"; runId: RunId; stageRunId: StageRunId; stage: Stage }
+  | { type: "CANCEL_STAGE"; runId: RunId; stageRunId: StageRunId; stageName: string }
+  | { type: "PERSIST_RUN"; runState: RunState }
+  | { type: "PERSIST_LOOP_STATE"; runId: RunId; loopState: LoopState }
+  | {
+      type: "APPEND_ARTIFACTS";
+      runId: RunId;
+      stageRunId: StageRunId;
+      artifacts: Artifact[];
+    }
+  | {
+      type: "EMIT_OBSERVATION";
+      event: { name: string; data: Record<string, unknown> };
+    };
+
+export interface ReducerResult {
+  state: EngineState;
+  effects: PipelineEffect[];
+}

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Pipeline subsystem — public re-exports.
+ *
+ * Consumers import from `@aoagents/ao-core` or, for granular bundles,
+ * `@aoagents/ao-core/pipeline` (when an export entry is added).
+ */
+
+export * from "./types.js";
+export type { PipelineEvent, PipelineEffect, ReducerResult } from "./events.js";
+export { reduce } from "./reducer.js";
+export {
+  createPipelineStore,
+  type PipelineStore,
+  type PersistedStageRun,
+} from "./store.js";
+export {
+  pipelineLayout,
+  runFilePath,
+  stageFilePath,
+  artifactsDirForRun,
+  artifactsFilePath,
+  loopFilePath,
+  type PipelineLayout,
+} from "./paths.js";

--- a/packages/core/src/pipeline/paths.ts
+++ b/packages/core/src/pipeline/paths.ts
@@ -1,0 +1,54 @@
+/**
+ * File-layout helpers for the flat-file pipeline store.
+ *
+ *   {root}/
+ *     runs/{runId}.json
+ *     stages/{stageRunId}.json
+ *     artifacts/{runId}/{stageRunId}.jsonl
+ *     loops/{runId}.json
+ *
+ * `root` is typically getProjectPipelinesDir(projectId) but the store accepts
+ * any root, which makes tests and isolation trivial.
+ */
+
+import { join } from "node:path";
+
+import type { RunId, StageRunId } from "./types.js";
+
+export interface PipelineLayout {
+  root: string;
+  runsDir: string;
+  stagesDir: string;
+  artifactsDir: string;
+  loopsDir: string;
+}
+
+export function pipelineLayout(root: string): PipelineLayout {
+  return {
+    root,
+    runsDir: join(root, "runs"),
+    stagesDir: join(root, "stages"),
+    artifactsDir: join(root, "artifacts"),
+    loopsDir: join(root, "loops"),
+  };
+}
+
+export function runFilePath(root: string, runId: RunId): string {
+  return join(root, "runs", `${runId}.json`);
+}
+
+export function stageFilePath(root: string, stageRunId: StageRunId): string {
+  return join(root, "stages", `${stageRunId}.json`);
+}
+
+export function artifactsDirForRun(root: string, runId: RunId): string {
+  return join(root, "artifacts", runId);
+}
+
+export function artifactsFilePath(root: string, runId: RunId, stageRunId: StageRunId): string {
+  return join(artifactsDirForRun(root, runId), `${stageRunId}.jsonl`);
+}
+
+export function loopFilePath(root: string, runId: RunId): string {
+  return join(root, "loops", `${runId}.json`);
+}

--- a/packages/core/src/pipeline/reducer-helpers.ts
+++ b/packages/core/src/pipeline/reducer-helpers.ts
@@ -1,0 +1,211 @@
+/**
+ * Internal helpers for the pipeline reducer.
+ *
+ * Pure: every function takes timestamps as parameters; nothing here reads the
+ * clock or performs I/O. Split out from reducer.ts to keep individual files
+ * within the project's 400-LOC ceiling.
+ */
+
+import type { PipelineEffect, ReducerResult } from "./events.js";
+import {
+  type Artifact,
+  type ArtifactInput,
+  type EngineState,
+  type LoopState,
+  type LoopStateName,
+  type RunId,
+  type RunState,
+  type RunSummary,
+  type RunTerminationReason,
+  type StageRunId,
+  type StageState,
+  isTerminalLoopState,
+  isTerminalStageStatus,
+  loopKey,
+} from "./types.js";
+
+export function iso(now: number): string {
+  return new Date(now).toISOString();
+}
+
+export function patchRun(
+  run: RunState,
+  stageDelta: Record<string, StageState>,
+  now: number,
+): RunState {
+  return {
+    ...run,
+    stages: { ...run.stages, ...stageDelta },
+    updatedAt: iso(now),
+  };
+}
+
+export function replaceRun(state: EngineState, run: RunState): EngineState {
+  return { ...state, runs: { ...state.runs, [run.runId]: run } };
+}
+
+export function deriveLoopStateFromRun(run: RunState, now: number): LoopState {
+  return {
+    sessionId: run.sessionId,
+    pipelineName: run.pipelineName,
+    loopState: run.loopState,
+    loopRounds: run.loopRounds,
+    lastSha: run.headSha,
+    currentRunId: isTerminalLoopState(run.loopState) ? undefined : run.runId,
+    updatedAt: iso(now),
+  };
+}
+
+export function summarizeRun(run: RunState): RunSummary {
+  return {
+    runId: run.runId,
+    loopState: run.loopState,
+    terminationReason: run.terminationReason,
+    headSha: run.headSha,
+    loopRounds: run.loopRounds,
+    fingerprints: [],
+    createdAt: run.createdAt,
+  };
+}
+
+export function materializeArtifact(
+  input: ArtifactInput,
+  runId: RunId,
+  stageRunId: StageRunId,
+  stageName: string,
+  index: number,
+  now: number,
+): Artifact {
+  const artifactId = `${stageRunId}-${index}` as Artifact["artifactId"];
+  return {
+    ...input,
+    artifactId,
+    pipelineRunId: runId,
+    stageRunId,
+    stageName,
+    status: "open",
+    createdAt: iso(now),
+  } as Artifact;
+}
+
+export function startableStageEffects(run: RunState): PipelineEffect[] {
+  const max = run.pipelineConfigSnapshot.maxConcurrentStages ?? 1;
+  const inflight = Object.values(run.stages).filter((s) => s.status === "running").length;
+  const remaining = Math.max(0, max - inflight);
+  if (remaining === 0) return [];
+
+  const pending = run.pipelineConfigSnapshot.stages
+    .map((stage) => ({ stage, state: run.stages[stage.name] }))
+    .filter(({ state }) => state.status === "pending")
+    .slice(0, remaining);
+
+  return pending.map(({ stage, state }) => ({
+    type: "START_STAGE" as const,
+    runId: run.runId,
+    stageRunId: state.stageRunId,
+    stage,
+  }));
+}
+
+export function invalidTransition(state: EngineState, message: string): ReducerResult {
+  return {
+    state,
+    effects: [
+      {
+        type: "EMIT_OBSERVATION",
+        event: { name: "pipeline.invalid_transition", data: { message } },
+      },
+    ],
+  };
+}
+
+export function terminateRunFromState(
+  state: EngineState,
+  run: RunState,
+  reason: RunTerminationReason,
+  now: number,
+  finalLoopState: LoopStateName,
+  preceding: PipelineEffect[],
+): ReducerResult {
+  const cancelEffects: PipelineEffect[] = [];
+  const terminatedStages: Record<string, StageState> = {};
+  for (const [name, stage] of Object.entries(run.stages)) {
+    if (!isTerminalStageStatus(stage.status)) {
+      terminatedStages[name] = {
+        ...stage,
+        status: stage.status === "running" ? "outdated" : "skipped",
+        completedAt: iso(now),
+      };
+      if (stage.status === "running") {
+        cancelEffects.push({
+          type: "CANCEL_STAGE",
+          runId: run.runId,
+          stageRunId: stage.stageRunId,
+          stageName: name,
+        });
+      }
+    } else {
+      terminatedStages[name] = stage;
+    }
+  }
+
+  const finalRun: RunState = {
+    ...run,
+    stages: terminatedStages,
+    loopState: finalLoopState,
+    terminationReason: reason,
+    updatedAt: iso(now),
+  };
+
+  const key = loopKey(run.sessionId, run.pipelineName);
+  const summaries = [...(state.historySummaries[key] ?? []), summarizeRun(finalRun)];
+
+  // Drop currentRunByLoop only when this run was the active one.
+  const nextCurrent: Record<string, RunId> = {};
+  for (const [k, v] of Object.entries(state.currentRunByLoop)) {
+    if (k === key && v === run.runId) continue;
+    nextCurrent[k] = v;
+  }
+
+  const nextState: EngineState = {
+    ...state,
+    runs: { ...state.runs, [run.runId]: finalRun },
+    currentRunByLoop: nextCurrent,
+    historySummaries: { ...state.historySummaries, [key]: summaries },
+  };
+
+  const effects: PipelineEffect[] = [
+    ...preceding,
+    ...cancelEffects,
+    { type: "PERSIST_RUN", runState: finalRun },
+    {
+      type: "PERSIST_LOOP_STATE",
+      runId: run.runId,
+      loopState: deriveLoopStateFromRun(finalRun, now),
+    },
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.run.terminated",
+        data: {
+          runId: run.runId,
+          pipelineName: run.pipelineName,
+          reason,
+          loopState: finalLoopState,
+        },
+      },
+    },
+  ];
+
+  return { state: nextState, effects };
+}
+
+export function terminateRun(
+  state: EngineState,
+  run: RunState,
+  reason: RunTerminationReason,
+  now: number,
+  runFinalState: LoopStateName,
+): ReducerResult {
+  return terminateRunFromState(state, run, reason, now, runFinalState, []);
+}

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -1,0 +1,389 @@
+/**
+ * Pure pipeline reducer.
+ *
+ * Signature: `reduce(state, event) → { state, effects }`. The reducer is
+ * synchronous and pure — never reads the clock, never performs I/O. Every
+ * event carries `now` so the driver stamps timestamps at enqueue time.
+ *
+ * Effects are intent-only — the engine (lands in a later sub-task) is
+ * responsible for executing them and feeding results back as new events.
+ *
+ * Event/effect shapes live in events.ts; common helpers live in
+ * reducer-helpers.ts.
+ */
+
+import type { PipelineEffect, PipelineEvent, ReducerResult } from "./events.js";
+import {
+  deriveLoopStateFromRun,
+  invalidTransition,
+  iso,
+  materializeArtifact,
+  patchRun,
+  replaceRun,
+  startableStageEffects,
+  terminateRun,
+  terminateRunFromState,
+} from "./reducer-helpers.js";
+import {
+  type ArtifactInput,
+  type EngineState,
+  type LoopStateName,
+  type Pipeline,
+  type RunId,
+  type RunState,
+  type RunTerminationReason,
+  type StageRunId,
+  type StageState,
+  type StageTriggerEvent,
+  type Verdict,
+  isTerminalStageStatus,
+  loopKey,
+} from "./types.js";
+
+export function reduce(state: EngineState, event: PipelineEvent): ReducerResult {
+  switch (event.type) {
+    case "TRIGGER_FIRED":
+      return reduceTriggerFired(state, event);
+    case "STAGE_STARTED":
+      return reduceStageStarted(state, event);
+    case "STAGE_COMPLETED":
+      return reduceStageCompleted(state, event);
+    case "STAGE_FAILED":
+      return reduceStageFailed(state, event);
+    case "NEW_SHA_DETECTED":
+      return reduceNewShaDetected(state, event);
+    case "RUN_CANCELLED":
+      return reduceRunCancelled(state, event);
+    case "CONFIG_CHANGED":
+      return reduceConfigChanged(state, event);
+    case "TICK":
+      return { state, effects: [] };
+  }
+}
+
+interface TriggerFiredEvent {
+  now: number;
+  trigger: StageTriggerEvent;
+  sessionId: string;
+  pipeline: Pipeline;
+  headSha: string;
+  runId: RunId;
+  stageRunIds: Record<string, StageRunId>;
+}
+
+function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): ReducerResult {
+  const { sessionId, pipeline, headSha, runId, stageRunIds, trigger, now } = event;
+  const key = loopKey(sessionId, pipeline.name);
+
+  if (state.currentRunByLoop[key] && state.runs[state.currentRunByLoop[key]]) {
+    // Active run already in flight for this loop — driver must cancel via
+    // NEW_SHA_DETECTED or RUN_CANCELLED before a new run can start.
+    return { state, effects: [] };
+  }
+
+  const stages = buildInitialStageStates(pipeline, stageRunIds);
+  if (!stages) {
+    return invalidTransition(state, "TRIGGER_FIRED missing stageRunIds for one or more stages");
+  }
+
+  const priorRound = state.historySummaries[key]?.length ?? 0;
+  const isContinuation = trigger === "pr.updated" || trigger === "manual";
+  const loopRounds = isContinuation ? priorRound + 1 : Math.max(priorRound, 1);
+
+  const runState: RunState = {
+    runId,
+    pipelineId: pipeline.id,
+    pipelineName: pipeline.name,
+    sessionId,
+    pipelineConfigSnapshot: pipeline,
+    headSha,
+    loopState: "running",
+    loopRounds,
+    stages,
+    createdAt: iso(now),
+    updatedAt: iso(now),
+  };
+
+  const nextState: EngineState = {
+    ...state,
+    runs: { ...state.runs, [runId]: runState },
+    currentRunByLoop: { ...state.currentRunByLoop, [key]: runId },
+  };
+
+  const effects: PipelineEffect[] = [
+    { type: "PERSIST_RUN", runState },
+    {
+      type: "PERSIST_LOOP_STATE",
+      runId,
+      loopState: deriveLoopStateFromRun(runState, now),
+    },
+    ...startableStageEffects(runState),
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.run.created",
+        data: {
+          runId,
+          pipelineName: pipeline.name,
+          sessionId,
+          trigger,
+          headSha,
+          loopRounds,
+        },
+      },
+    },
+  ];
+
+  return { state: nextState, effects };
+}
+
+interface StageStartedEvent {
+  now: number;
+  runId: RunId;
+  stageName: string;
+}
+
+function reduceStageStarted(state: EngineState, event: StageStartedEvent): ReducerResult {
+  const { runId, stageName, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `STAGE_STARTED for unknown runId=${runId}`);
+
+  const stage = run.stages[stageName];
+  if (!stage) return invalidTransition(state, `STAGE_STARTED for unknown stage=${stageName}`);
+  if (stage.status !== "pending") {
+    return invalidTransition(
+      state,
+      `STAGE_STARTED requires pending; got ${stage.status} for ${stageName}`,
+    );
+  }
+
+  const updatedStage: StageState = { ...stage, status: "running", startedAt: iso(now) };
+  const updatedRun = patchRun(run, { [stageName]: updatedStage }, now);
+
+  return {
+    state: replaceRun(state, updatedRun),
+    effects: [
+      { type: "PERSIST_RUN", runState: updatedRun },
+      {
+        type: "EMIT_OBSERVATION",
+        event: {
+          name: "pipeline.stage.started",
+          data: { runId, stageName, attempt: stage.attempt },
+        },
+      },
+    ],
+  };
+}
+
+interface StageCompletedEvent {
+  now: number;
+  runId: RunId;
+  stageName: string;
+  verdict?: Verdict;
+  artifacts: ArtifactInput[];
+}
+
+function reduceStageCompleted(state: EngineState, event: StageCompletedEvent): ReducerResult {
+  const { runId, stageName, verdict, artifacts: artifactInputs, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `STAGE_COMPLETED for unknown runId=${runId}`);
+
+  const stage = run.stages[stageName];
+  if (!stage) return invalidTransition(state, `STAGE_COMPLETED for unknown stage=${stageName}`);
+  if (stage.status !== "running") {
+    return invalidTransition(
+      state,
+      `STAGE_COMPLETED requires running; got ${stage.status} for ${stageName}`,
+    );
+  }
+
+  const newArtifacts = artifactInputs.map((input, idx) =>
+    materializeArtifact(input, runId, stage.stageRunId, stageName, idx, now),
+  );
+  const updatedStage: StageState = {
+    ...stage,
+    status: "succeeded",
+    completedAt: iso(now),
+    verdict,
+    artifacts: [...stage.artifacts, ...newArtifacts.map((a) => a.artifactId)],
+  };
+
+  return finalizeStageCompletion(state, run, stageName, updatedStage, newArtifacts, "success", now);
+}
+
+interface StageFailedEvent {
+  now: number;
+  runId: RunId;
+  stageName: string;
+  errorMessage: string;
+}
+
+function reduceStageFailed(state: EngineState, event: StageFailedEvent): ReducerResult {
+  const { runId, stageName, errorMessage, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `STAGE_FAILED for unknown runId=${runId}`);
+
+  const stage = run.stages[stageName];
+  if (!stage) return invalidTransition(state, `STAGE_FAILED for unknown stage=${stageName}`);
+  if (stage.status !== "running" && stage.status !== "pending") {
+    return invalidTransition(
+      state,
+      `STAGE_FAILED requires running|pending; got ${stage.status} for ${stageName}`,
+    );
+  }
+
+  const updatedStage: StageState = {
+    ...stage,
+    status: "failed",
+    completedAt: iso(now),
+    errorMessage,
+  };
+
+  return finalizeStageCompletion(state, run, stageName, updatedStage, [], "failure", now);
+}
+
+interface NewShaEvent {
+  now: number;
+  sessionId: string;
+  pipelineName: string;
+  sha: string;
+}
+
+function reduceNewShaDetected(state: EngineState, event: NewShaEvent): ReducerResult {
+  const { sessionId, pipelineName, sha, now } = event;
+  const key = loopKey(sessionId, pipelineName);
+  const runId = state.currentRunByLoop[key];
+  if (!runId) return { state, effects: [] };
+
+  const run = state.runs[runId];
+  if (!run || run.headSha === sha) return { state, effects: [] };
+
+  // Run becomes outdated; loop key is freed so the driver can spawn a new
+  // TRIGGER_FIRED for the new SHA.
+  return terminateRun(state, run, "outdated", now, "terminated");
+}
+
+interface RunCancelledEvent {
+  now: number;
+  runId: RunId;
+  reason: RunTerminationReason;
+}
+
+function reduceRunCancelled(state: EngineState, event: RunCancelledEvent): ReducerResult {
+  const { runId, reason, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `RUN_CANCELLED for unknown runId=${runId}`);
+  if (run.loopState !== "running" && run.loopState !== "awaiting_context") {
+    return invalidTransition(
+      state,
+      `RUN_CANCELLED requires running|awaiting_context; got ${run.loopState}`,
+    );
+  }
+
+  const runFinalState: LoopStateName = reason === "stage_failure" ? "stalled" : "terminated";
+  return terminateRun(state, run, reason, now, runFinalState);
+}
+
+interface ConfigChangedEvent {
+  now: number;
+  sessionId: string;
+  pipelineName: string;
+}
+
+function reduceConfigChanged(state: EngineState, event: ConfigChangedEvent): ReducerResult {
+  const { sessionId, pipelineName, now } = event;
+  const key = loopKey(sessionId, pipelineName);
+  const runId = state.currentRunByLoop[key];
+  if (!runId) return { state, effects: [] };
+  const run = state.runs[runId];
+  if (!run) return { state, effects: [] };
+
+  return terminateRun(state, run, "config_change", now, "terminated");
+}
+
+function buildInitialStageStates(
+  pipeline: Pipeline,
+  stageRunIds: Record<string, StageRunId>,
+): Record<string, StageState> | null {
+  const out: Record<string, StageState> = {};
+  for (const stage of pipeline.stages) {
+    const stageRunId = stageRunIds[stage.name];
+    if (!stageRunId) return null;
+    out[stage.name] = {
+      stageRunId,
+      status: "pending",
+      attempt: 1,
+      artifacts: [],
+    };
+  }
+  return out;
+}
+
+function finalizeStageCompletion(
+  state: EngineState,
+  run: RunState,
+  stageName: string,
+  updatedStage: StageState,
+  newArtifacts: ReturnType<typeof materializeArtifact>[],
+  outcome: "success" | "failure",
+  now: number,
+): ReducerResult {
+  const updatedRun = patchRun(run, { [stageName]: updatedStage }, now);
+
+  const allTerminal = run.pipelineConfigSnapshot.stages.every((s) => {
+    const candidate = s.name === stageName ? updatedStage : updatedRun.stages[s.name];
+    return isTerminalStageStatus(candidate.status);
+  });
+
+  const effects: PipelineEffect[] = [];
+
+  if (newArtifacts.length > 0) {
+    effects.push({
+      type: "APPEND_ARTIFACTS",
+      runId: run.runId,
+      stageRunId: updatedStage.stageRunId,
+      artifacts: newArtifacts,
+    });
+  }
+
+  effects.push({
+    type: "EMIT_OBSERVATION",
+    event: {
+      name: "pipeline.stage.terminated",
+      data: {
+        runId: run.runId,
+        stageName,
+        status: updatedStage.status,
+        verdict: updatedStage.verdict,
+        artifactCount: updatedStage.artifacts.length,
+      },
+    },
+  });
+
+  if (outcome === "failure") {
+    return terminateRunFromState(
+      replaceRun(state, updatedRun),
+      updatedRun,
+      "stage_failure",
+      now,
+      "stalled",
+      effects,
+    );
+  }
+
+  if (allTerminal) {
+    return terminateRunFromState(
+      replaceRun(state, updatedRun),
+      updatedRun,
+      "completed",
+      now,
+      "done",
+      effects,
+    );
+  }
+
+  effects.unshift({ type: "PERSIST_RUN", runState: updatedRun });
+  effects.push(...startableStageEffects(updatedRun));
+
+  return { state: replaceRun(state, updatedRun), effects };
+}

--- a/packages/core/src/pipeline/store.ts
+++ b/packages/core/src/pipeline/store.ts
@@ -1,0 +1,145 @@
+/**
+ * Flat-file pipeline store.
+ *
+ * File layout (rooted at any directory; v0 wires it to
+ * getProjectPipelinesDir(projectId)):
+ *
+ *   runs/{runId}.json
+ *   stages/{stageRunId}.json
+ *   artifacts/{runId}/{stageRunId}.jsonl
+ *   loops/{runId}.json
+ *
+ * All writes go through atomicWriteFileSync so concurrent writers never produce
+ * torn data. Reads are best-effort: missing files return null; corrupt JSON
+ * raises.
+ */
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+} from "node:fs";
+
+import { atomicWriteFileSync } from "../atomic-write.js";
+import {
+  artifactsDirForRun,
+  artifactsFilePath,
+  loopFilePath,
+  pipelineLayout,
+  runFilePath,
+  stageFilePath,
+} from "./paths.js";
+import type {
+  Artifact,
+  LoopState,
+  RunId,
+  RunState,
+  StageRunId,
+  StageState,
+} from "./types.js";
+
+export interface PersistedStageRun extends StageState {
+  runId: RunId;
+  stageName: string;
+}
+
+export interface PipelineStore {
+  saveRun(run: RunState): void;
+  loadRun(runId: RunId): RunState | null;
+  listRuns(): RunState[];
+
+  saveStage(run: PersistedStageRun): void;
+  loadStage(stageRunId: StageRunId): PersistedStageRun | null;
+
+  appendArtifacts(runId: RunId, stageRunId: StageRunId, artifacts: Artifact[]): void;
+  listArtifacts(runId: RunId, stageRunId: StageRunId): Artifact[];
+
+  saveLoopState(runId: RunId, loopState: LoopState): void;
+  loadLoopState(runId: RunId): LoopState | null;
+}
+
+export function createPipelineStore(root: string): PipelineStore {
+  const layout = pipelineLayout(root);
+
+  function ensureDir(path: string): void {
+    if (!existsSync(path)) mkdirSync(path, { recursive: true });
+  }
+
+  function ensureLayout(): void {
+    ensureDir(layout.runsDir);
+    ensureDir(layout.stagesDir);
+    ensureDir(layout.artifactsDir);
+    ensureDir(layout.loopsDir);
+  }
+
+  return {
+    saveRun(run) {
+      ensureDir(layout.runsDir);
+      atomicWriteFileSync(runFilePath(root, run.runId), JSON.stringify(run, null, 2));
+    },
+
+    loadRun(runId) {
+      return readJsonOrNull<RunState>(runFilePath(root, runId));
+    },
+
+    listRuns() {
+      ensureLayout();
+      const out: RunState[] = [];
+      for (const file of readdirSync(layout.runsDir)) {
+        if (!file.endsWith(".json")) continue;
+        const run = readJsonOrNull<RunState>(`${layout.runsDir}/${file}`);
+        if (run) out.push(run);
+      }
+      return out;
+    },
+
+    saveStage(stage) {
+      ensureDir(layout.stagesDir);
+      atomicWriteFileSync(
+        stageFilePath(root, stage.stageRunId),
+        JSON.stringify(stage, null, 2),
+      );
+    },
+
+    loadStage(stageRunId) {
+      return readJsonOrNull<PersistedStageRun>(stageFilePath(root, stageRunId));
+    },
+
+    appendArtifacts(runId, stageRunId, artifacts) {
+      if (artifacts.length === 0) return;
+      ensureDir(artifactsDirForRun(root, runId));
+      const lines = artifacts.map((a) => JSON.stringify(a)).join("\n") + "\n";
+      appendFileSync(artifactsFilePath(root, runId, stageRunId), lines, "utf-8");
+    },
+
+    listArtifacts(runId, stageRunId) {
+      const path = artifactsFilePath(root, runId, stageRunId);
+      if (!existsSync(path)) return [];
+      const body = readFileSync(path, "utf-8");
+      const out: Artifact[] = [];
+      for (const line of body.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        out.push(JSON.parse(trimmed) as Artifact);
+      }
+      return out;
+    },
+
+    saveLoopState(runId, loopState) {
+      ensureDir(layout.loopsDir);
+      atomicWriteFileSync(loopFilePath(root, runId), JSON.stringify(loopState, null, 2));
+    },
+
+    loadLoopState(runId) {
+      return readJsonOrNull<LoopState>(loopFilePath(root, runId));
+    },
+  };
+}
+
+function readJsonOrNull<T>(path: string): T | null {
+  if (!existsSync(path)) return null;
+  const body = readFileSync(path, "utf-8");
+  return JSON.parse(body) as T;
+}

--- a/packages/core/src/pipeline/store.ts
+++ b/packages/core/src/pipeline/store.ts
@@ -9,9 +9,16 @@
  *   artifacts/{runId}/{stageRunId}.jsonl
  *   loops/{runId}.json
  *
- * All writes go through atomicWriteFileSync so concurrent writers never produce
- * torn data. Reads are best-effort: missing files return null; corrupt JSON
- * raises.
+ * Durability:
+ * - JSON writes (runs, stages, loops) go through atomicWriteFileSync so
+ *   concurrent writers never produce torn data.
+ * - JSONL artifact appends use appendFileSync — atomic semantics aren't
+ *   available for append, so a process crash mid-write can leave a partial
+ *   line. listArtifacts is therefore NOT crash-safe: it JSON.parses each
+ *   non-empty line and will throw on a torn final record. Callers that need
+ *   to tolerate crashes should wrap the read or repair the file out-of-band.
+ *
+ * Reads are best-effort: missing files return null; corrupt JSON raises.
  */
 
 import {
@@ -21,6 +28,7 @@ import {
   readFileSync,
   readdirSync,
 } from "node:fs";
+import { join } from "node:path";
 
 import { atomicWriteFileSync } from "../atomic-write.js";
 import {
@@ -89,7 +97,7 @@ export function createPipelineStore(root: string): PipelineStore {
       const out: RunState[] = [];
       for (const file of readdirSync(layout.runsDir)) {
         if (!file.endsWith(".json")) continue;
-        const run = readJsonOrNull<RunState>(`${layout.runsDir}/${file}`);
+        const run = readJsonOrNull<RunState>(join(layout.runsDir, file));
         if (run) out.push(run);
       }
       return out;

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -1,0 +1,294 @@
+/**
+ * Pipeline core types — branded IDs, configuration shapes, runtime state,
+ * artifacts, and the three-tier exit model (stage / run / loop).
+ *
+ * v0.1 scope: pure data shapes only. No I/O, no executors. Consumed by the
+ * reducer (pipeline/reducer.ts) and the flat-file store (pipeline/store.ts).
+ *
+ * Design decisions locked from cluster planning (see issue #1627):
+ *  - No Agent.executeTask plugin contract; stages run via existing session machinery.
+ *  - Findings via convention: stages drop {workspacePath}/.ao/pipeline-findings.jsonl.
+ *  - supportedTaskModes is a manifest field on agent plugins, not an interface method.
+ *  - maxLoopRounds is per-stage, not pipeline-global.
+ *  - maxConcurrentStages defaults to 1 in v0.
+ *  - command executor stages are NOT talk-to-able.
+ */
+
+// ============================================================================
+// Branded IDs
+// ============================================================================
+
+export type PipelineId = string & { readonly __brand: "PipelineId" };
+export type RunId = string & { readonly __brand: "RunId" };
+export type StageRunId = string & { readonly __brand: "StageRunId" };
+export type ArtifactId = string & { readonly __brand: "ArtifactId" };
+
+export const asPipelineId = (id: string): PipelineId => id as PipelineId;
+export const asRunId = (id: string): RunId => id as RunId;
+export const asStageRunId = (id: string): StageRunId => id as StageRunId;
+export const asArtifactId = (id: string): ArtifactId => id as ArtifactId;
+
+// ============================================================================
+// Pipeline configuration
+// ============================================================================
+
+/** Modes an agent plugin advertises in its manifest's `supportedTaskModes` field. */
+export type TaskMode = "review" | "code" | "answer";
+
+export type StageTriggerEvent =
+  | "pr.opened"
+  | "pr.updated"
+  | "pr.merge_ready"
+  | "pr.merged"
+  | "manual";
+
+export interface StageTrigger {
+  on: StageTriggerEvent[];
+}
+
+export interface AgentExecutor {
+  kind: "agent";
+  /** Plugin name from the agent slot registry (e.g. "claude-code", "codex"). */
+  plugin: string;
+  /** Must appear in the plugin manifest's `supportedTaskModes`. */
+  mode: TaskMode;
+  config?: Record<string, unknown>;
+}
+
+export interface CommandExecutor {
+  kind: "command";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  /** Working directory relative to the stage workspace. */
+  cwd?: string;
+}
+
+export type StageExecutor = AgentExecutor | CommandExecutor;
+
+export interface TaskSpec {
+  /** Prompt text injected into the spawned agent session, or main script body for command. */
+  prompt?: string;
+  /** Optional schema describing the expected JSON outputs of the stage. */
+  outputSchema?: Record<string, unknown>;
+  /** Free-form named inputs available to the stage. */
+  inputs?: Record<string, unknown>;
+}
+
+export interface StagePolicy {
+  blocksMerge?: boolean;
+  /** Convergence window: number of recent runs whose findings must be unchanged. */
+  stallWindow?: number;
+}
+
+export interface StageBudget {
+  maxUsd?: number;
+  maxDurationMs?: number;
+}
+
+export interface Stage {
+  name: string;
+  trigger: StageTrigger;
+  executor: StageExecutor;
+  task: TaskSpec;
+  policy?: StagePolicy;
+  budget?: StageBudget;
+  /** ISO 8601 duration string or millisecond count. Engine treats as advisory. */
+  timeoutMs?: number;
+  retries?: number;
+  /** Per-stage loop cap (locked decision: not pipeline-global). */
+  maxLoopRounds?: number;
+}
+
+export interface Pipeline {
+  id: PipelineId;
+  name: string;
+  stages: Stage[];
+  /** Default 1 in v0; engine enforces serial execution when unset. */
+  maxConcurrentStages?: number;
+}
+
+// ============================================================================
+// Artifacts
+// ============================================================================
+
+export type Severity = "error" | "warning" | "info";
+
+export type ArtifactStatus = "open" | "dismissed" | "sent_to_agent" | "resolved";
+
+export interface FindingArtifactInput {
+  kind: "finding";
+  filePath: string;
+  startLine: number;
+  endLine: number;
+  title: string;
+  description: string;
+  /** "security" | "correctness" | "style" | ... | "general". */
+  category: string;
+  severity: Severity;
+  /** 0.0–1.0. */
+  confidence: number;
+  /** Structural anchor (function/class name) for fingerprint stability. */
+  anchorSignature?: string;
+}
+
+export interface JsonArtifactInput {
+  kind: "json";
+  data: Record<string, unknown>;
+}
+
+export type ArtifactInput = FindingArtifactInput | JsonArtifactInput;
+
+export type Artifact = ArtifactInput & {
+  artifactId: ArtifactId;
+  pipelineRunId: RunId;
+  stageRunId: StageRunId;
+  stageName: string;
+  fingerprint?: string;
+  status: ArtifactStatus;
+  createdAt: string;
+  sentToAgentAt?: string;
+  /** Reducer-set when finding.confidence < pipeline/stage threshold. */
+  belowConfidenceThreshold?: boolean;
+};
+
+/** Filename stages drop in {workspacePath}/.ao/ for findings discovery. */
+export const PIPELINE_FINDINGS_FILENAME = "pipeline-findings.jsonl";
+
+// ============================================================================
+// Three-tier exit model
+// ============================================================================
+//
+// Tier 1 — Stage exit: a single stage execution finishes (StageStatus terminal).
+// Tier 2 — Run exit:   a pipeline run terminates (RunTerminationReason).
+// Tier 3 — Loop exit:  the persistent per-session loop terminates (LoopState terminal).
+//
+// Each tier composes upward: a stage exit may cause a run exit, which may cause a
+// loop exit. The reducer is the single point that performs these escalations.
+
+export type StageStatus =
+  | "pending"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "skipped"
+  | "outdated";
+
+export const TERMINAL_STAGE_STATUSES: readonly StageStatus[] = [
+  "succeeded",
+  "failed",
+  "skipped",
+  "outdated",
+] as const;
+
+export type Verdict = "pass" | "fail" | "neutral";
+
+export type RunTerminationReason =
+  | "completed"
+  | "stage_failure"
+  | "manual_cancel"
+  | "config_change"
+  | "outdated"
+  | "worker_dead";
+
+export type LoopStateName =
+  | "running"
+  | "awaiting_context"
+  | "done"
+  | "stalled"
+  | "terminated";
+
+export const TERMINAL_LOOP_STATES: readonly LoopStateName[] = [
+  "done",
+  "stalled",
+  "terminated",
+] as const;
+
+export function isTerminalStageStatus(s: StageStatus): boolean {
+  return TERMINAL_STAGE_STATUSES.includes(s);
+}
+
+export function isTerminalLoopState(s: LoopStateName): boolean {
+  return TERMINAL_LOOP_STATES.includes(s);
+}
+
+// ============================================================================
+// Runtime state
+// ============================================================================
+
+export interface StageState {
+  stageRunId: StageRunId;
+  status: StageStatus;
+  attempt: number;
+  verdict?: Verdict;
+  artifacts: ArtifactId[];
+  startedAt?: string;
+  completedAt?: string;
+  errorMessage?: string;
+}
+
+export interface RunState {
+  runId: RunId;
+  pipelineId: PipelineId;
+  pipelineName: string;
+  sessionId: string;
+  /** Frozen at run-create — config changes during a run terminate the run. */
+  pipelineConfigSnapshot: Pipeline;
+  headSha: string;
+  loopState: LoopStateName;
+  terminationReason?: RunTerminationReason;
+  loopRounds: number;
+  /** Keyed by stage name. v0 has at most one entry per stage. */
+  stages: Record<string, StageState>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LoopState {
+  sessionId: string;
+  pipelineName: string;
+  loopState: LoopStateName;
+  loopRounds: number;
+  lastSha: string;
+  currentRunId?: RunId;
+  updatedAt: string;
+}
+
+/** Compact run record used for stalled-detection across runs. */
+export interface RunSummary {
+  runId: RunId;
+  loopState: LoopStateName;
+  terminationReason?: RunTerminationReason;
+  headSha: string;
+  loopRounds: number;
+  /** Sorted list of artifact fingerprints from the run, used by convergence. */
+  fingerprints: string[];
+  createdAt: string;
+}
+
+/**
+ * Engine-global state. Multiple in-flight runs may exist (e.g. an old run is
+ * being torn down while a new SHA spawns its replacement), so we key by RunId.
+ *
+ * Two-level state: this top-level structure holds engine-global counters /
+ * indices; per-run details live in the keyed RunState entries.
+ */
+export interface EngineState {
+  runs: Record<RunId, RunState>;
+  /** Loop key ("{sessionId}:{pipelineName}") → currently-active runId. */
+  currentRunByLoop: Record<string, RunId>;
+  /** Loop key → ordered history (oldest first), used by convergence detection. */
+  historySummaries: Record<string, RunSummary[]>;
+}
+
+export function loopKey(sessionId: string, pipelineName: string): string {
+  return `${sessionId}:${pipelineName}`;
+}
+
+export function emptyEngineState(): EngineState {
+  return {
+    runs: {},
+    currentRunByLoop: {},
+    historySummaries: {},
+  };
+}


### PR DESCRIPTION
Closes #1627. Sub-task of #1346 (v0). First in the build order — no dependencies.

## Summary

Implements the v0 foundation of the pipeline engine: pure data shapes, a synchronous reducer that returns intent-only effects, and a flat-file store. No I/O, no executors, no driver — those land in follow-up sub-tasks.

## What's in this PR

**Core types** (`packages/core/src/pipeline/types.ts`):
- Branded IDs: `PipelineId`, `RunId`, `StageRunId`, `ArtifactId`
- `Pipeline`, `Stage`, `Artifact`, `LoopState`, `RunState`, `EngineState`
- Three-tier exit:
  - Stage tier — `StageStatus` (pending → running → succeeded/failed/skipped/outdated)
  - Run tier   — `RunTerminationReason` (completed / stage_failure / manual_cancel / config_change / outdated / worker_dead)
  - Loop tier  — `LoopStateName` (running / awaiting_context / done / stalled / terminated)
- Two-level state: `EngineState` engine-global indices + `RunState` per run.

**Reducer + effects** (`reducer.ts`, `reducer-helpers.ts`, `events.ts`):
- Signature: `reduce(state, event) → { state, effects }`. Pure, synchronous, never reads the clock — every event carries `now`.
- Events handled: `TRIGGER_FIRED`, `STAGE_STARTED`, `STAGE_COMPLETED`, `STAGE_FAILED`, `NEW_SHA_DETECTED`, `RUN_CANCELLED`, `CONFIG_CHANGED`, `TICK`.
- Effects emitted: `START_STAGE`, `CANCEL_STAGE`, `PERSIST_RUN`, `PERSIST_LOOP_STATE`, `APPEND_ARTIFACTS`, `EMIT_OBSERVATION`.

**Flat-file store** (`store.ts`, `paths.ts`):
- Layout under any root (callers pass `getProjectPipelinesDir(projectId)`):
  - `runs/{runId}.json`
  - `stages/{stageRunId}.json`
  - `artifacts/{runId}/{stageRunId}.jsonl`
  - `loops/{runId}.json`
- All writes go through `atomicWriteFileSync`; artifacts are append-only JSONL.

**Locked design decisions from cluster planning** (encoded in types):
- `maxLoopRounds` is per-stage (not pipeline-global).
- `maxConcurrentStages` defaults to 1 in v0.
- `supportedTaskModes` is a manifest field on agent plugins — no `executeTask` interface method (decision 4).
- Findings surfaced via convention at `{workspacePath}/.ao/pipeline-findings.jsonl` — exported as `PIPELINE_FINDINGS_FILENAME`.

## Tests

30 new tests, all green:
- `pipeline-reducer.test.ts` (19 cases): happy path; invalid transitions emit `pipeline.invalid_transition` observations without state mutation; `NEW_SHA_DETECTED` outdates the in-flight run; `STAGE_FAILED` stalls the run and skips remaining stages; `CONFIG_CHANGED` terminates active runs; `loopRounds` increments on continuation triggers; reducer purity (no `Date.now()` calls, input state unmutated).
- `pipeline-store.test.ts` (11 cases): run/stage/loop save+load roundtrips; JSONL append semantics across calls; null returns for missing files; layout creation for empty stores.

## Out of scope (subsequent sub-tasks)

Executors, CLI commands, lifecycle integration / engine ticking, web UI, plugin contract changes.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` clean
- [x] `pnpm --filter @aoagents/ao-core test` green (1089 tests, +30 new)
- [x] `pnpm typecheck` clean across core and dependents (after `pnpm build`)
- [x] Lint clean on new files (no errors; pre-existing warnings unchanged)
- [x] No imports from `@aoagents/ao-cli` or `@aoagents/ao-web`
- [x] All source files ≤400 LOC
- [x] PR base is `pipelines` (not `main`)

## Notes for reviewers

- This PR's spec lives in #1627. The current issue's "Design decisions (locked)" supersede the parent #1346 where they conflict — most notably `maxLoopRounds` moved from pipeline to stage, and there is no `Agent.executeTask` plugin interface change.
- Store root is parameterized intentionally — the engine sub-task will wire it to `getProjectPipelinesDir(projectId)` (helper added in this PR).