### PR TITLE
feat(pipeline): v0.2 — agent executor (fresh session per stage, talk-to-able)

### DIFF
--- a/packages/core/src/__tests__/pipeline-agent-executor.test.ts
+++ b/packages/core/src/__tests__/pipeline-agent-executor.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Tests for the agent executor — the bridge between the pipeline engine and
+ * a real AO session. The session manager is mocked; everything else (file I/O
+ * for findings, prompt assembly) runs for real against tmpdir.
+ */
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createInitialCanonicalLifecycle } from "../lifecycle-state.js";
+import {
+  AgentExecutorSpawnError,
+  asRunId,
+  asStageRunId,
+  createAgentExecutor,
+  STAGE_FINDINGS_RELATIVE_PATH,
+  type Stage,
+  type StartStageInput,
+} from "../pipeline/index.js";
+import type {
+  Session,
+  SessionId,
+  SessionManager,
+  SessionSpawnConfig,
+  KillResult,
+} from "../types.js";
+
+let workspaceRoot: string;
+
+beforeEach(() => {
+  workspaceRoot = mkdtempSync(join(tmpdir(), "agent-executor-"));
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+});
+
+function makeStage(overrides: Partial<Stage> = {}): Stage {
+  return {
+    name: "review",
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: "review the diff" },
+    ...overrides,
+  };
+}
+
+function makeStartInput(overrides: Partial<StartStageInput> = {}): StartStageInput {
+  return {
+    pipelineName: "default",
+    projectId: "proj-a",
+    runId: asRunId("run-1"),
+    stageRunId: asStageRunId("sr-1"),
+    stage: makeStage(),
+    loopRound: 1,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "ses-1" as SessionId,
+    projectId: "proj-a",
+    status: "working",
+    activity: "active",
+    activitySignal: {
+      state: "valid",
+      activity: "active",
+      source: "runtime",
+      timestamp: new Date(),
+    },
+    lifecycle: createInitialCanonicalLifecycle("worker", new Date()),
+    branch: "feat/x",
+    issueId: null,
+    pr: null,
+    workspacePath: workspaceRoot,
+    runtimeHandle: { id: "tmux-1", runtimeName: "tmux", data: {} },
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeMockSessionManager(initial?: Partial<Session>): {
+  sm: SessionManager;
+  spawn: ReturnType<typeof vi.fn>;
+  get: ReturnType<typeof vi.fn>;
+  kill: ReturnType<typeof vi.fn>;
+  setSession: (s: Session | null) => void;
+} {
+  let current: Session | null = makeSession(initial);
+  const spawn = vi.fn(async (_: SessionSpawnConfig): Promise<Session> => {
+    if (!current) throw new Error("session manager mock has no session staged");
+    return current;
+  });
+  const get = vi.fn(async (_id: SessionId): Promise<Session | null> => current);
+  const kill = vi.fn(
+    async (_id: SessionId): Promise<KillResult> => ({ cleaned: true, alreadyTerminated: false }),
+  );
+
+  const sm: SessionManager = {
+    spawn,
+    spawnOrchestrator: vi.fn(),
+    ensureOrchestrator: vi.fn(),
+    restore: vi.fn(),
+    list: vi.fn(),
+    get,
+    kill,
+    cleanup: vi.fn(),
+    send: vi.fn(),
+    claimPR: vi.fn(),
+  } as unknown as SessionManager;
+
+  return {
+    sm,
+    spawn,
+    get,
+    kill,
+    setSession: (s) => {
+      current = s;
+    },
+  };
+}
+
+function writeFindingsFile(path: string, lines: string[]): void {
+  mkdirSync(join(path, ".ao"), { recursive: true });
+  writeFileSync(join(path, STAGE_FINDINGS_RELATIVE_PATH), lines.join("\n") + "\n", "utf-8");
+}
+
+describe("agent executor — startStage", () => {
+  it("spawns a fresh session with the requested agent and a Layer 4 stage prompt", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    const handle = await exec.startStage(
+      makeStartInput({
+        issueId: "ISSUE-7",
+        stage: makeStage({
+          executor: { kind: "agent", plugin: "claude-code", mode: "code" },
+          task: { prompt: "implement feature X" },
+        }),
+      }),
+    );
+
+    expect(mock.spawn).toHaveBeenCalledTimes(1);
+    const spawnArgs = mock.spawn.mock.calls[0]?.[0] as SessionSpawnConfig;
+    expect(spawnArgs.projectId).toBe("proj-a");
+    expect(spawnArgs.agent).toBe("claude-code");
+    expect(spawnArgs.issueId).toBe("ISSUE-7");
+    // Prompt must include stage descriptor + findings instructions
+    expect(spawnArgs.prompt).toContain("Pipeline: default");
+    expect(spawnArgs.prompt).toContain("Stage: review");
+    expect(spawnArgs.prompt).toContain("implement feature X");
+    expect(spawnArgs.prompt).toContain(STAGE_FINDINGS_RELATIVE_PATH);
+
+    expect(handle.sessionId).toBe("ses-1");
+    expect(handle.workspacePath).toBe(workspaceRoot);
+    expect(handle.stageName).toBe("review");
+  });
+
+  it("rejects non-agent stages with AgentExecutorSpawnError", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await expect(
+      exec.startStage(
+        makeStartInput({
+          stage: makeStage({
+            executor: { kind: "command", command: "echo hi" },
+          }),
+        }),
+      ),
+    ).rejects.toBeInstanceOf(AgentExecutorSpawnError);
+    expect(mock.spawn).not.toHaveBeenCalled();
+  });
+
+  it("wraps session manager spawn failures in AgentExecutorSpawnError", async () => {
+    const mock = makeMockSessionManager();
+    mock.spawn.mockRejectedValueOnce(new Error("runtime unreachable"));
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await expect(exec.startStage(makeStartInput())).rejects.toMatchObject({
+      name: "AgentExecutorSpawnError",
+      message: expect.stringContaining("runtime unreachable"),
+    });
+  });
+
+  it("kills the session and throws if spawn returns no workspacePath", async () => {
+    const mock = makeMockSessionManager({ workspacePath: null });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+
+    await expect(exec.startStage(makeStartInput())).rejects.toBeInstanceOf(AgentExecutorSpawnError);
+    expect(mock.kill).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("agent executor — pollStage", () => {
+  it("returns running while session is not idle", async () => {
+    const mock = makeMockSessionManager({ activity: "active" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome).toEqual({ status: "running" });
+    expect(mock.kill).not.toHaveBeenCalled();
+  });
+
+  it("returns running when session is idle but findings file is missing", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome).toEqual({ status: "running" });
+    expect(mock.kill).not.toHaveBeenCalled();
+  });
+
+  it("harvests findings and kills the session when idle + findings file exists", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, [
+      JSON.stringify({
+        kind: "finding",
+        filePath: "src/foo.ts",
+        startLine: 10,
+        endLine: 12,
+        title: "potential null deref",
+        description: "x.bar may be null",
+        category: "correctness",
+        severity: "warning",
+        confidence: 0.8,
+      }),
+      JSON.stringify({ kind: "json", data: { summary: "looks fine" } }),
+    ]);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("completed");
+    if (outcome.status !== "completed") throw new Error("unreachable");
+    expect(outcome.artifacts).toHaveLength(2);
+    expect(outcome.artifacts[0]).toMatchObject({ kind: "finding", title: "potential null deref" });
+    expect(outcome.artifacts[1]).toMatchObject({ kind: "json", data: { summary: "looks fine" } });
+    expect(mock.kill).toHaveBeenCalledWith(handle.sessionId, { reason: "auto_cleanup" });
+  });
+
+  it("treats an empty findings file as a successful completion with zero artifacts", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, []);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome).toEqual({ status: "completed", artifacts: [] });
+    expect(mock.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns failed (without killing) when findings file has invalid JSON", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, ["not-json {{{"]);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("unparseable findings");
+    // Bad findings file: leave session up for human inspection
+    expect(mock.kill).not.toHaveBeenCalled();
+  });
+
+  it("returns failed when the underlying session has vanished between polls", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    mock.setSession(null);
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("no longer exists");
+  });
+
+  it("returns failed when the session has exited without producing findings", async () => {
+    const mock = makeMockSessionManager({ activity: "exited", status: "killed" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("terminated without findings");
+  });
+});
+
+describe("agent executor — cancelStage", () => {
+  it("kills the underlying session", async () => {
+    const mock = makeMockSessionManager();
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    await exec.cancelStage(handle);
+    expect(mock.kill).toHaveBeenCalledWith(handle.sessionId, { reason: "auto_cleanup" });
+  });
+
+  it("does not throw when the session manager kill fails", async () => {
+    const mock = makeMockSessionManager();
+    mock.kill.mockRejectedValueOnce(new Error("already gone"));
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    await expect(exec.cancelStage(handle)).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/__tests__/pipeline-agent-executor.test.ts
+++ b/packages/core/src/__tests__/pipeline-agent-executor.test.ts
@@ -313,6 +313,32 @@ describe("agent executor — pollStage", () => {
     expect(outcome.errorMessage).toContain("terminated without findings");
   });
 
+  it("rejects findings whose confidence is outside [0, 1]", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, [
+      JSON.stringify({
+        kind: "finding",
+        filePath: "src/foo.ts",
+        startLine: 1,
+        endLine: 1,
+        title: "x",
+        description: "y",
+        category: "general",
+        severity: "info",
+        confidence: 7, // out of [0,1]
+      }),
+    ]);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("confidence");
+    expect(outcome.errorMessage).toContain("[0, 1]");
+  });
+
   it("rejects findings whose severity is not in the enum", async () => {
     const mock = makeMockSessionManager({ activity: "idle" });
     const exec = createAgentExecutor({ sessionManager: mock.sm });

--- a/packages/core/src/__tests__/pipeline-agent-executor.test.ts
+++ b/packages/core/src/__tests__/pipeline-agent-executor.test.ts
@@ -298,6 +298,46 @@ describe("agent executor — pollStage", () => {
     if (outcome.status !== "failed") throw new Error("unreachable");
     expect(outcome.errorMessage).toContain("terminated without findings");
   });
+
+  it("returns failed when session reaches `done` before findings are harvested", async () => {
+    // Regression: stages should never reach `done` ahead of findings — `done`
+    // is reserved for post-merge / explicit completion. Treating it as a still-
+    // running state would hang the stage forever.
+    const mock = makeMockSessionManager({ activity: "idle", status: "done" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("terminated without findings");
+  });
+
+  it("rejects findings whose severity is not in the enum", async () => {
+    const mock = makeMockSessionManager({ activity: "idle" });
+    const exec = createAgentExecutor({ sessionManager: mock.sm });
+    const handle = await exec.startStage(makeStartInput());
+
+    writeFindingsFile(workspaceRoot, [
+      JSON.stringify({
+        kind: "finding",
+        filePath: "src/foo.ts",
+        startLine: 1,
+        endLine: 1,
+        title: "x",
+        description: "y",
+        category: "general",
+        severity: "critical", // not in {"error","warning","info"}
+        confidence: 0.5,
+      }),
+    ]);
+
+    const outcome = await exec.pollStage(handle);
+    expect(outcome.status).toBe("failed");
+    if (outcome.status !== "failed") throw new Error("unreachable");
+    expect(outcome.errorMessage).toContain("severity");
+    expect(outcome.errorMessage).toContain("critical");
+  });
 });
 
 describe("agent executor — cancelStage", () => {

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -289,6 +289,104 @@ describe("pipeline engine — end-to-end", () => {
     expect(pollSpy).not.toHaveBeenCalled();
   });
 
+  it("runs a multi-stage pipeline sequentially (serial scheduling, maxConcurrentStages=1)", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review", "code"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    const pipeline = makePipeline([
+      makeStage({ name: "review" }),
+      makeStage({
+        name: "fix",
+        executor: { kind: "agent", plugin: "codex", mode: "code" },
+      }),
+    ]);
+
+    const runId = await engine.startRun({
+      pipeline,
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha-aaa",
+    });
+
+    // Only the first stage should be running at this point — maxConcurrentStages=1
+    expect(executor.startCalls).toHaveLength(1);
+    expect(executor.startCalls[0]?.stage.name).toBe("review");
+
+    // Complete stage 1 — engine should immediately schedule stage 2
+    executor.setNextOutcome({ status: "completed", artifacts: [] });
+    await engine.tick();
+
+    expect(executor.startCalls).toHaveLength(2);
+    expect(executor.startCalls[1]?.stage.name).toBe("fix");
+
+    // Complete stage 2 — run reaches `done`
+    executor.setNextOutcome({ status: "completed", artifacts: [] });
+    await engine.tick();
+
+    const finalRun = store.loadRun(runId)!;
+    expect(finalRun.stages["review"]?.status).toBe("succeeded");
+    expect(finalRun.stages["fix"]?.status).toBe("succeeded");
+    expect(finalRun.loopState).toBe("done");
+  });
+
+  it("serializes top-level dispatches: cancelRun launched mid-tick observes the post-tick state", async () => {
+    // Without serialization, cancelRun's reduce() reads `state` while tick's
+    // reduce() is mid-update. With the lock, cancel waits for tick to finish
+    // its dispatchInline chain — so the state cancel sees is the one tick
+    // produced (run already in `done`), and cancel becomes a no-op.
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+
+    let pollResolve: (() => void) | null = null;
+    const executor: AgentStageExecutor = {
+      async startStage(input) {
+        return {
+          runId: input.runId,
+          stageRunId: input.stageRunId,
+          stageName: input.stage.name,
+          sessionId: "ses-1",
+          workspacePath: "/tmp",
+          startedAt: Date.now(),
+          input,
+        };
+      },
+      async pollStage(_handle): Promise<StageOutcome> {
+        await new Promise<void>((resolve) => {
+          pollResolve = resolve;
+        });
+        return { status: "completed", artifacts: [] };
+      },
+      async cancelStage() {},
+    };
+
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+    const runId = await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha-aaa",
+    });
+
+    // Kick off a tick that will block on pollStage
+    const tickPromise = engine.tick();
+    // Yield so the tick's `pollStage` is actually awaiting
+    await new Promise((r) => setTimeout(r, 0));
+    // Now fire cancelRun — must NOT execute until tick releases the lock
+    const cancelPromise = engine.cancelRun(runId);
+    // Release pollStage → tick completes → run reaches `done` → cancel runs
+    pollResolve!();
+    await tickPromise;
+    await cancelPromise;
+
+    const finalRun = store.loadRun(runId)!;
+    // Tick completed first (lock acquired first) so the run is `done`,
+    // not `terminated`. Cancel ran on a terminal run — no-op.
+    expect(finalRun.loopState).toBe("done");
+    expect(finalRun.terminationReason).toBe("completed");
+  });
+
   it("subsequent runs against the same loop key still receive their projectId after the prior run terminated", async () => {
     // Regression: the engine prunes its run-metadata side-table when a run
     // reaches a terminal loop state. A naive implementation that pruned the

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -1,0 +1,291 @@
+/**
+ * End-to-end pipeline engine test: a 1-stage pipeline triggered programmatically
+ * runs through start → poll → completion, and findings are persisted to the
+ * artifact store. The agent executor is mocked so the engine can be exercised
+ * without spinning up a real session.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  asPipelineId,
+  createPipelineEngine,
+  createPipelineStore,
+  loopKey,
+  PipelineConfigError,
+  type AgentStageExecutor,
+  type ArtifactInput,
+  type Pipeline,
+  type RunningAgentStage,
+  type Stage,
+  type StageOutcome,
+  type StartStageInput,
+  type TaskMode,
+} from "../pipeline/index.js";
+import { createPluginRegistry } from "../plugin-registry.js";
+import type { Agent, PluginManifest, PluginModule, PluginRegistry } from "../types.js";
+
+let storeRoot: string;
+
+beforeEach(() => {
+  storeRoot = mkdtempSync(join(tmpdir(), "pipeline-engine-"));
+});
+
+afterEach(() => {
+  rmSync(storeRoot, { recursive: true, force: true });
+});
+
+function makeAgentPlugin(name: string, modes: TaskMode[]): PluginModule<Agent> {
+  const manifest: PluginManifest = {
+    name,
+    slot: "agent",
+    description: "test",
+    version: "0.0.0",
+    supportedTaskModes: modes,
+  };
+  return {
+    manifest,
+    create: () =>
+      ({
+        name,
+        processName: name,
+        getLaunchCommand: () => "true",
+        getEnvironment: () => ({}),
+        detectActivity: () => "idle",
+        getActivityState: async () => null,
+        isProcessRunning: async () => true,
+        getSessionInfo: async () => null,
+      }) as Agent,
+  };
+}
+
+function withRegistry(plugins: PluginModule[]): PluginRegistry {
+  const r = createPluginRegistry();
+  for (const p of plugins) r.register(p);
+  return r;
+}
+
+function makeStage(overrides: Partial<Stage> = {}): Stage {
+  return {
+    name: "review",
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: "review" },
+    ...overrides,
+  };
+}
+
+function makePipeline(stages: Stage[] = [makeStage()]): Pipeline {
+  return { id: asPipelineId("pl-1"), name: "default", stages, maxConcurrentStages: 1 };
+}
+
+interface MockExecutor extends AgentStageExecutor {
+  startCalls: StartStageInput[];
+  killed: string[];
+  setNextOutcome: (outcome: StageOutcome) => void;
+}
+
+function makeMockExecutor(): MockExecutor {
+  let nextOutcome: StageOutcome = { status: "running" };
+  const startCalls: StartStageInput[] = [];
+  const killed: string[] = [];
+
+  const exec: MockExecutor = {
+    startCalls,
+    killed,
+    setNextOutcome: (o) => {
+      nextOutcome = o;
+    },
+    async startStage(input: StartStageInput): Promise<RunningAgentStage> {
+      startCalls.push(input);
+      return {
+        runId: input.runId,
+        stageRunId: input.stageRunId,
+        stageName: input.stage.name,
+        sessionId: `mock-ses-${startCalls.length}`,
+        workspacePath: "/tmp/mock",
+        startedAt: Date.now(),
+        input,
+      };
+    },
+    async pollStage(_handle: RunningAgentStage): Promise<StageOutcome> {
+      return nextOutcome;
+    },
+    async cancelStage(handle: RunningAgentStage): Promise<void> {
+      killed.push(handle.sessionId);
+    },
+  };
+  return exec;
+}
+
+describe("pipeline engine — end-to-end", () => {
+  it("runs a 1-stage pipeline from trigger → completion → artifact persistence", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+    });
+
+    const runId = await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha-aaa",
+    });
+
+    // After startRun, the stage should be running (executor was called)
+    expect(executor.startCalls).toHaveLength(1);
+    expect(executor.startCalls[0]?.projectId).toBe("proj-a");
+    expect(executor.startCalls[0]?.stage.name).toBe("review");
+
+    // The reducer marked the stage as running and persisted the run
+    const persistedAfterStart = store.loadRun(runId);
+    expect(persistedAfterStart?.stages["review"]?.status).toBe("running");
+
+    // Stage still running on tick — engine state unchanged
+    await engine.tick();
+    expect(store.loadRun(runId)?.stages["review"]?.status).toBe("running");
+
+    // Stage completes — engine harvests on next tick
+    const finding: ArtifactInput = {
+      kind: "finding",
+      filePath: "src/foo.ts",
+      startLine: 1,
+      endLine: 1,
+      title: "x",
+      description: "y",
+      category: "general",
+      severity: "info",
+      confidence: 1,
+    };
+    executor.setNextOutcome({ status: "completed", artifacts: [finding] });
+    await engine.tick();
+
+    const finalRun = store.loadRun(runId)!;
+    expect(finalRun.stages["review"]?.status).toBe("succeeded");
+    expect(finalRun.loopState).toBe("done");
+    expect(finalRun.terminationReason).toBe("completed");
+
+    // Findings landed on disk via APPEND_ARTIFACTS
+    const stageRunId = finalRun.stages["review"]!.stageRunId;
+    const stored = store.listArtifacts(runId, stageRunId);
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({ kind: "finding", title: "x", status: "open" });
+
+    // Loop key freed after run terminates
+    expect(engine.state().currentRunByLoop[loopKey("ses-1", "default")]).toBeUndefined();
+  });
+
+  it("propagates executor failures as STAGE_FAILED → run stalled", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+
+    const engine = createPipelineEngine({
+      store,
+      registry,
+      agentExecutor: executor,
+    });
+
+    const runId = await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha-aaa",
+    });
+
+    executor.setNextOutcome({ status: "failed", errorMessage: "agent crashed" });
+    await engine.tick();
+
+    const run = store.loadRun(runId)!;
+    expect(run.stages["review"]?.status).toBe("failed");
+    expect(run.stages["review"]?.errorMessage).toBe("agent crashed");
+    expect(run.loopState).toBe("stalled");
+    expect(run.terminationReason).toBe("stage_failure");
+  });
+
+  it("rejects pipelines whose agent does not advertise the requested mode", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["code"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    await expect(
+      engine.startRun({
+        pipeline: makePipeline(),
+        projectId: "proj-a",
+        sessionId: "ses-1",
+        headSha: "sha",
+      }),
+    ).rejects.toBeInstanceOf(PipelineConfigError);
+    expect(executor.startCalls).toHaveLength(0);
+  });
+
+  it("synthesizes STAGE_FAILED for non-agent executor kinds (v0.2 only supports agent)", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    const pipeline = makePipeline([
+      makeStage({
+        name: "lint",
+        trigger: { on: ["pr.opened"] },
+        executor: { kind: "command", command: "eslint" },
+        task: {},
+      }),
+    ]);
+
+    const runId = await engine.startRun({
+      pipeline,
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha",
+    });
+
+    const run = store.loadRun(runId)!;
+    expect(run.stages["lint"]?.status).toBe("failed");
+    expect(run.stages["lint"]?.errorMessage).toContain("not supported in v0.2");
+    expect(executor.startCalls).toHaveLength(0);
+  });
+
+  it("cancelRun terminates an in-flight run and cancels the executor", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    const runId = await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha",
+    });
+
+    await engine.cancelRun(runId);
+
+    const run = store.loadRun(runId)!;
+    expect(run.terminationReason).toBe("manual_cancel");
+    expect(run.loopState).toBe("terminated");
+    expect(executor.killed).toHaveLength(1);
+  });
+
+  it("tick is a no-op when nothing is in flight", async () => {
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const pollSpy = vi.spyOn(executor, "pollStage");
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    await engine.tick();
+    expect(pollSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -288,4 +288,38 @@ describe("pipeline engine — end-to-end", () => {
     await engine.tick();
     expect(pollSpy).not.toHaveBeenCalled();
   });
+
+  it("subsequent runs against the same loop key still receive their projectId after the prior run terminated", async () => {
+    // Regression: the engine prunes its run-metadata side-table when a run
+    // reaches a terminal loop state. A naive implementation that pruned the
+    // map immediately on dispatch would also wipe the *next* run's entry
+    // before START_STAGE could read it. Verify that a second run started
+    // after the first completes still spawns with the correct projectId.
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    // Run 1: start, complete, tick to terminal
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-a",
+      sessionId: "ses-1",
+      headSha: "sha-aaa",
+    });
+    executor.setNextOutcome({ status: "completed", artifacts: [] });
+    await engine.tick();
+
+    // Run 2: same loop key, fresh SHA
+    executor.setNextOutcome({ status: "running" });
+    await engine.startRun({
+      pipeline: makePipeline(),
+      projectId: "proj-b",
+      sessionId: "ses-1",
+      headSha: "sha-bbb",
+    });
+
+    expect(executor.startCalls).toHaveLength(2);
+    expect(executor.startCalls[1]?.projectId).toBe("proj-b");
+  });
 });

--- a/packages/core/src/__tests__/pipeline-stage-prompt.test.ts
+++ b/packages/core/src/__tests__/pipeline-stage-prompt.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import { buildStagePrompt, PIPELINE_FINDINGS_FILENAME, type Stage } from "../pipeline/index.js";
+
+function reviewStage(overrides: Partial<Stage> = {}): Stage {
+  return {
+    name: "review",
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: "review the diff" },
+    ...overrides,
+  };
+}
+
+describe("buildStagePrompt", () => {
+  it("includes pipeline / stage / mode / loop round in the header", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage(),
+      loopRound: 3,
+    });
+    expect(out).toContain("Pipeline: default");
+    expect(out).toContain("Stage: review");
+    expect(out).toContain("Mode: review");
+    expect(out).toContain("Loop round: 3");
+  });
+
+  it("renders the stage task body when present", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage({ task: { prompt: "look for race conditions" } }),
+    });
+    expect(out).toContain("look for race conditions");
+  });
+
+  it("specs the atomic write contract for the findings file", () => {
+    // Regression: the executor harvests on first sight of the final file,
+    // so the prompt MUST tell the agent to write a tmp file then rename.
+    // A torn jsonl write would otherwise be classified as `failed`.
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage(),
+    });
+    const path = `.ao/${PIPELINE_FINDINGS_FILENAME}`;
+    expect(out).toContain(path);
+    expect(out).toContain(`${path}.tmp`);
+    expect(out.toLowerCase()).toContain("rename");
+  });
+
+  it("emits review-shape instructions for mode=review", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage(),
+    });
+    expect(out).toContain('kind: "finding"');
+    expect(out).toContain("severity");
+    expect(out).toContain("confidence");
+  });
+
+  it("emits json-shape instructions for mode=answer", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage({
+        executor: { kind: "agent", plugin: "codex", mode: "answer" },
+      }),
+    });
+    expect(out).toContain('kind: "json"');
+    expect(out).toContain("outputSchema");
+  });
+
+  it("softens the blocks-merge wording (advisory, not enforcement)", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage({ policy: { blocksMerge: true } }),
+    });
+    expect(out).toContain("block merge");
+    // The stale wording — "fail on critical findings" — implied an
+    // engine-side enforcement that doesn't exist. Make sure it's gone.
+    expect(out).not.toContain("fail on critical");
+  });
+
+  it("includes inputs as a fenced JSON block when present", () => {
+    const out = buildStagePrompt({
+      pipelineName: "default",
+      stage: reviewStage({ task: { prompt: "x", inputs: { focus: "auth" } } }),
+    });
+    expect(out).toContain("## Inputs");
+    expect(out).toContain('"focus": "auth"');
+  });
+});

--- a/packages/core/src/__tests__/pipeline-validation.test.ts
+++ b/packages/core/src/__tests__/pipeline-validation.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PipelineConfigError,
+  asPipelineId,
+  getSupportedTaskModes,
+  validatePipelineAgentModes,
+  type Pipeline,
+  type Stage,
+  type TaskMode,
+} from "../pipeline/index.js";
+import { createPluginRegistry } from "../plugin-registry.js";
+import type { Agent, PluginManifest, PluginModule, PluginRegistry } from "../types.js";
+
+function makeAgentPlugin(name: string, modes?: TaskMode[]): PluginModule<Agent> {
+  const manifest: PluginManifest = {
+    name,
+    slot: "agent",
+    description: `${name} test plugin`,
+    version: "0.0.0",
+    ...(modes ? { supportedTaskModes: modes } : {}),
+  };
+  return {
+    manifest,
+    create: () =>
+      ({
+        name,
+        processName: name,
+        getLaunchCommand: () => "true",
+        getEnvironment: () => ({}),
+        detectActivity: () => "idle",
+        getActivityState: async () => null,
+        isProcessRunning: async () => true,
+        getSessionInfo: async () => null,
+      }) as Agent,
+  };
+}
+
+function withRegistry(plugins: PluginModule[]): PluginRegistry {
+  const r = createPluginRegistry();
+  for (const p of plugins) r.register(p);
+  return r;
+}
+
+function makeStage(overrides: Partial<Stage>): Stage {
+  return {
+    name: "review",
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: "review" },
+    ...overrides,
+  };
+}
+
+function makePipeline(stages: Stage[]): Pipeline {
+  return { id: asPipelineId("pl-1"), name: "default", stages, maxConcurrentStages: 1 };
+}
+
+describe("getSupportedTaskModes", () => {
+  it("returns the manifest's supportedTaskModes when set", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["review", "code"])]);
+    expect(getSupportedTaskModes(r, "codex")).toEqual(["review", "code"]);
+  });
+
+  it("returns [] when the agent plugin omits supportedTaskModes", () => {
+    const r = withRegistry([makeAgentPlugin("codex")]);
+    expect(getSupportedTaskModes(r, "codex")).toEqual([]);
+  });
+
+  it("returns null when the agent plugin is unknown", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    expect(getSupportedTaskModes(r, "no-such-plugin")).toBeNull();
+  });
+});
+
+describe("validatePipelineAgentModes", () => {
+  it("accepts a pipeline whose agent supports the requested mode", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const pipeline = makePipeline([
+      makeStage({ executor: { kind: "agent", plugin: "codex", mode: "review" } }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).not.toThrow();
+  });
+
+  it("rejects a stage routed to an agent that does not advertise the mode", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["code"])]);
+    const pipeline = makePipeline([
+      makeStage({
+        name: "review",
+        executor: { kind: "agent", plugin: "codex", mode: "review" },
+      }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).toThrow(PipelineConfigError);
+    try {
+      validatePipelineAgentModes(pipeline, r);
+    } catch (err) {
+      expect((err as Error).message).toContain('agent "codex"');
+      expect((err as Error).message).toContain('mode "review"');
+      expect((err as Error).message).toContain('"code"');
+    }
+  });
+
+  it("rejects an agent that omits supportedTaskModes (defaults to [])", () => {
+    const r = withRegistry([makeAgentPlugin("codex")]);
+    const pipeline = makePipeline([
+      makeStage({ executor: { kind: "agent", plugin: "codex", mode: "review" } }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).toThrow(PipelineConfigError);
+  });
+
+  it("rejects unknown agent plugins with a clear message", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const pipeline = makePipeline([
+      makeStage({ executor: { kind: "agent", plugin: "nonexistent", mode: "review" } }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).toThrow(/unknown agent plugin/);
+  });
+
+  it("ignores command stages — they have no mode", () => {
+    const r = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const pipeline = makePipeline([
+      makeStage({ name: "lint", executor: { kind: "command", command: "eslint" } }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).not.toThrow();
+  });
+
+  it("validates every stage in a multi-stage pipeline and fails on the first mismatch", () => {
+    const r = withRegistry([
+      makeAgentPlugin("codex", ["review"]),
+      makeAgentPlugin("aider", ["code"]),
+    ]);
+    const pipeline = makePipeline([
+      makeStage({ name: "review", executor: { kind: "agent", plugin: "codex", mode: "review" } }),
+      makeStage({
+        name: "fix",
+        executor: { kind: "agent", plugin: "aider", mode: "review" },
+      }),
+    ]);
+    expect(() => validatePipelineAgentModes(pipeline, r)).toThrow(/stage "fix"/);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,10 +161,7 @@ export {
   resetOpenCodeSessionListCache,
 } from "./opencode-shared.js";
 export type { OpenCodeSessionListEntry } from "./opencode-shared.js";
-export {
-  getWorkspaceAgentsMdPath,
-  writeWorkspaceOpenCodeAgentsMd,
-} from "./opencode-agents-md.js";
+export { getWorkspaceAgentsMdPath, writeWorkspaceOpenCodeAgentsMd } from "./opencode-agents-md.js";
 export { writeOpenCodeConfig } from "./opencode-config.js";
 export {
   getOrchestratorSessionId,
@@ -395,6 +392,15 @@ export {
   artifactsDirForRun,
   artifactsFilePath,
   loopFilePath,
+  // v0.2: validation, prompt, executor, engine
+  PipelineConfigError,
+  getSupportedTaskModes,
+  validatePipelineAgentModes,
+  buildStagePrompt,
+  createAgentExecutor,
+  AgentExecutorSpawnError,
+  STAGE_FINDINGS_RELATIVE_PATH,
+  createPipelineEngine,
 } from "./pipeline/index.js";
 
 export type {
@@ -441,6 +447,18 @@ export type {
   PipelineStore,
   PersistedStageRun,
   PipelineLayout,
+} from "./pipeline/index.js";
+
+export type {
+  StagePromptInput,
+  AgentStageExecutor,
+  AgentExecutorDeps,
+  RunningAgentStage,
+  StageOutcome,
+  StartStageInput,
+  PipelineEngine,
+  PipelineEngineDeps,
+  StartRunInput,
 } from "./pipeline/index.js";
 
 // Activity event logging — structured diagnostic event trail

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -19,6 +19,13 @@
  * Tick frequency: there is no internal timer. The caller (lifecycle manager
  * piggybacks on its existing 5s SSE poll, per C-14) drives tick() — no new
  * polling loop is introduced.
+ *
+ * Concurrency: top-level `dispatch` and `tick` calls are serialized through
+ * a single promise-chain lock so concurrent callers (e.g. `cancelRun()`
+ * landing while a tick is mid-flight) cannot interleave reads/writes of the
+ * in-memory `state`. The engine-internal saga (e.g. START_STAGE → STAGE_STARTED
+ * → STAGE_FAILED) routes through `dispatchInline`, which bypasses the lock
+ * because it's already running inside it.
  */
 
 import { randomUUID } from "node:crypto";
@@ -32,11 +39,9 @@ import {
   asStageRunId,
   emptyEngineState,
   isTerminalLoopState,
-  isTerminalStageStatus,
   type EngineState,
   type Pipeline,
   type RunId,
-  type RunState,
   type StageRunId,
   type StageTriggerEvent,
 } from "./types.js";
@@ -81,15 +86,15 @@ export interface PipelineEngine {
   startRun(input: StartRunInput): Promise<RunId>;
 
   /**
-   * Drive forward any in-flight agent stages. Safe to call on a fixed
-   * interval — re-entrancy guarded so concurrent ticks no-op.
+   * Drive forward any in-flight agent stages. Serialized against `dispatch`
+   * and `cancelRun` so concurrent callers cannot race state mutations.
    */
   tick(): Promise<void>;
 
   /**
    * Dispatch a single event through the reducer and execute its effects.
    * Exposed for tests and for callers that want to inject events directly
-   * (e.g. CONFIG_CHANGED from a config watcher).
+   * (e.g. CONFIG_CHANGED from a config watcher). Serialized.
    */
   dispatch(event: PipelineEvent): Promise<void>;
 
@@ -103,9 +108,37 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   let state: EngineState = deps.initialState ?? emptyEngineState();
   /** stageRunId → executor handle for stages we own. */
   const inflight = new Map<StageRunId, RunningAgentStage>();
-  let ticking = false;
+  /**
+   * Side-table for projectId/issueId, keyed by RunId. The persisted RunState
+   * shape was locked by v0.1 and doesn't carry these, so the engine threads
+   * them out-of-band into START_STAGE inputs. Pruned by
+   * `pruneTerminatedRunMetadata` after every dispatch.
+   */
+  const runMetadata = new Map<RunId, { projectId: string; issueId?: string }>();
+
+  /**
+   * Serialization lock for top-level dispatches. Each public dispatch chains
+   * onto `lockTail`; engine-internal recursive dispatches use `dispatchInline`
+   * directly because they're already running inside this lock.
+   */
+  let lockTail: Promise<void> = Promise.resolve();
+
+  function withLock<T>(work: () => Promise<T>): Promise<T> {
+    const result = lockTail.then(work);
+    // Swallow errors on the chain so one failure doesn't poison subsequent
+    // waiters; the original promise (`result`) still rejects to its caller.
+    lockTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
 
   async function dispatch(event: PipelineEvent): Promise<void> {
+    return withLock(() => dispatchInline(event));
+  }
+
+  async function dispatchInline(event: PipelineEvent): Promise<void> {
     const result = reduce(state, event);
     state = result.state;
     for (const effect of result.effects) {
@@ -152,7 +185,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
         if (effect.stage.executor.kind !== "agent") {
           // command/builtin executors are out of scope for v0.2 — synthesize
           // a STAGE_FAILED so the run terminates cleanly instead of hanging.
-          await dispatch({
+          await dispatchInline({
             type: "STAGE_FAILED",
             now: now(),
             runId: effect.runId,
@@ -164,7 +197,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
 
         // Mark the stage as running BEFORE starting the executor — failures
         // during spawn translate to STAGE_FAILED, which requires running|pending.
-        await dispatch({
+        await dispatchInline({
           type: "STAGE_STARTED",
           now: now(),
           runId: effect.runId,
@@ -186,7 +219,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
           const handle = await agentExecutor.startStage(startInput);
           inflight.set(effect.stageRunId, handle);
         } catch (err) {
-          await dispatch({
+          await dispatchInline({
             type: "STAGE_FAILED",
             now: now(),
             runId: effect.runId,
@@ -219,10 +252,8 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   }
 
   async function tick(): Promise<void> {
-    if (ticking) return;
-    if (inflight.size === 0) return;
-    ticking = true;
-    try {
+    return withLock(async () => {
+      if (inflight.size === 0) return;
       const handles = [...inflight.values()];
       for (const handle of handles) {
         const outcome = await agentExecutor.pollStage(handle);
@@ -231,7 +262,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
         inflight.delete(handle.stageRunId);
 
         if (outcome.status === "completed") {
-          await dispatch({
+          await dispatchInline({
             type: "STAGE_COMPLETED",
             now: now(),
             runId: handle.runId,
@@ -239,7 +270,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
             artifacts: outcome.artifacts,
           });
         } else {
-          await dispatch({
+          await dispatchInline({
             type: "STAGE_FAILED",
             now: now(),
             runId: handle.runId,
@@ -248,9 +279,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
           });
         }
       }
-    } finally {
-      ticking = false;
-    }
+    });
   }
 
   async function startRun(input: StartRunInput): Promise<RunId> {
@@ -292,13 +321,6 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
     await dispatch({ type: "RUN_CANCELLED", now: now(), runId, reason });
   }
 
-  /**
-   * Look up the project a run was started for. Reducer-state doesn't carry
-   * projectId (the persisted RunState is locked from v0.1), so the engine
-   * keeps a side-table populated by startRun().
-   */
-  const runMetadata = new Map<RunId, { projectId: string; issueId?: string }>();
-
   return {
     state: () => state,
     startRun,
@@ -306,26 +328,4 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
     dispatch,
     cancelRun,
   };
-}
-
-/** Internal: utility for resuming engine state from disk (v0.3 will use this). */
-export function rebuildStateFromStore(store: PipelineStore): EngineState {
-  const runs: Record<RunId, RunState> = {};
-  for (const run of store.listRuns()) {
-    runs[run.runId] = run;
-  }
-  // currentRunByLoop and historySummaries can be derived deterministically from
-  // the RunStates above, but the v0.1 store doesn't persist either index. We
-  // rebuild as much as we can; the rest will be repopulated as events flow.
-  const currentRunByLoop: Record<string, RunId> = {};
-  for (const run of Object.values(runs)) {
-    if (!isAllStagesTerminal(run)) {
-      currentRunByLoop[`${run.sessionId}:${run.pipelineName}`] = run.runId;
-    }
-  }
-  return { runs, currentRunByLoop, historySummaries: {} };
-}
-
-function isAllStagesTerminal(run: RunState): boolean {
-  return Object.values(run.stages).every((s) => isTerminalStageStatus(s.status));
 }

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -1,0 +1,314 @@
+/**
+ * Pipeline engine — minimum wiring to drive the reducer + agent executor
+ * end-to-end for v0.2.
+ *
+ * Responsibilities:
+ *  - Hold engine state in memory (mirrors what's persisted by the store).
+ *  - Translate `PipelineEffect`s coming out of the reducer into real I/O:
+ *    persistence (PERSIST_RUN, PERSIST_LOOP_STATE, APPEND_ARTIFACTS) and
+ *    stage execution (START_STAGE, CANCEL_STAGE).
+ *  - On `tick()`, poll every running agent stage; when a stage completes,
+ *    dispatch STAGE_COMPLETED back through the reducer.
+ *
+ * Out of scope for v0.2 (lands later in the pipeline cluster):
+ *  - DAG / parallel scheduling (v1.1)
+ *  - Command + builtin executors (v1.2)
+ *  - SHA / merge-ready trigger detection
+ *  - SCM webhook ingestion
+ *
+ * Tick frequency: there is no internal timer. The caller (lifecycle manager
+ * piggybacks on its existing 5s SSE poll, per C-14) drives tick() — no new
+ * polling loop is introduced.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { PluginRegistry } from "../types.js";
+import type { PipelineEffect, PipelineEvent } from "./events.js";
+import { reduce } from "./reducer.js";
+import type { PipelineStore } from "./store.js";
+import {
+  asRunId,
+  asStageRunId,
+  emptyEngineState,
+  isTerminalStageStatus,
+  type EngineState,
+  type Pipeline,
+  type RunId,
+  type RunState,
+  type StageRunId,
+  type StageTriggerEvent,
+} from "./types.js";
+import { validatePipelineAgentModes } from "./validation.js";
+import {
+  type AgentStageExecutor,
+  type RunningAgentStage,
+  type StartStageInput,
+} from "./executors/agent.js";
+
+export interface PipelineEngineDeps {
+  store: PipelineStore;
+  registry: PluginRegistry;
+  agentExecutor: AgentStageExecutor;
+  /** Optional initial state (e.g. restored from disk on startup). Defaults to empty. */
+  initialState?: EngineState;
+  /** Override clock for tests. */
+  now?: () => number;
+}
+
+export interface StartRunInput {
+  pipeline: Pipeline;
+  projectId: string;
+  sessionId: string;
+  /** Trigger event that caused this run; defaults to "manual". */
+  trigger?: StageTriggerEvent;
+  /** SHA tracked for `NEW_SHA_DETECTED` reconciliation. Use "manual" if unknown. */
+  headSha: string;
+  /** Optional issue id forwarded into spawned sessions. */
+  issueId?: string;
+}
+
+export interface PipelineEngine {
+  /** Current engine state (read-only snapshot). */
+  state(): EngineState;
+
+  /**
+   * Validate the pipeline against the plugin registry, then dispatch a
+   * TRIGGER_FIRED event. Throws PipelineConfigError on validation failure.
+   * Returns the allocated run id.
+   */
+  startRun(input: StartRunInput): Promise<RunId>;
+
+  /**
+   * Drive forward any in-flight agent stages. Safe to call on a fixed
+   * interval — re-entrancy guarded so concurrent ticks no-op.
+   */
+  tick(): Promise<void>;
+
+  /**
+   * Dispatch a single event through the reducer and execute its effects.
+   * Exposed for tests and for callers that want to inject events directly
+   * (e.g. CONFIG_CHANGED from a config watcher).
+   */
+  dispatch(event: PipelineEvent): Promise<void>;
+
+  /** Cancel an in-flight run via RUN_CANCELLED. Idempotent. */
+  cancelRun(runId: RunId, reason?: "manual_cancel" | "config_change"): Promise<void>;
+}
+
+export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
+  const { store, registry, agentExecutor, now = Date.now } = deps;
+
+  let state: EngineState = deps.initialState ?? emptyEngineState();
+  /** stageRunId → executor handle for stages we own. */
+  const inflight = new Map<StageRunId, RunningAgentStage>();
+  let ticking = false;
+
+  async function dispatch(event: PipelineEvent): Promise<void> {
+    const result = reduce(state, event);
+    state = result.state;
+    for (const effect of result.effects) {
+      await executeEffect(effect);
+    }
+  }
+
+  async function executeEffect(effect: PipelineEffect): Promise<void> {
+    switch (effect.type) {
+      case "PERSIST_RUN":
+        store.saveRun(effect.runState);
+        for (const [stageName, stageState] of Object.entries(effect.runState.stages)) {
+          store.saveStage({ ...stageState, runId: effect.runState.runId, stageName });
+        }
+        break;
+
+      case "PERSIST_LOOP_STATE":
+        store.saveLoopState(effect.runId, effect.loopState);
+        break;
+
+      case "APPEND_ARTIFACTS":
+        store.appendArtifacts(effect.runId, effect.stageRunId, effect.artifacts);
+        break;
+
+      case "START_STAGE": {
+        const run = state.runs[effect.runId];
+        if (!run) break;
+        if (effect.stage.executor.kind !== "agent") {
+          // command/builtin executors are out of scope for v0.2 — synthesize
+          // a STAGE_FAILED so the run terminates cleanly instead of hanging.
+          await dispatch({
+            type: "STAGE_FAILED",
+            now: now(),
+            runId: effect.runId,
+            stageName: effect.stage.name,
+            errorMessage: `Executor kind "${effect.stage.executor.kind}" is not supported in v0.2 (agent executor only).`,
+          });
+          break;
+        }
+
+        // Mark the stage as running BEFORE starting the executor — failures
+        // during spawn translate to STAGE_FAILED, which requires running|pending.
+        await dispatch({
+          type: "STAGE_STARTED",
+          now: now(),
+          runId: effect.runId,
+          stageName: effect.stage.name,
+        });
+
+        const meta = runMetadata.get(run.runId);
+        const startInput: StartStageInput = {
+          pipelineName: run.pipelineName,
+          projectId: meta?.projectId ?? "",
+          runId: effect.runId,
+          stageRunId: effect.stageRunId,
+          stage: effect.stage,
+          loopRound: run.loopRounds,
+          ...(meta?.issueId ? { issueId: meta.issueId } : {}),
+        };
+
+        try {
+          const handle = await agentExecutor.startStage(startInput);
+          inflight.set(effect.stageRunId, handle);
+        } catch (err) {
+          await dispatch({
+            type: "STAGE_FAILED",
+            now: now(),
+            runId: effect.runId,
+            stageName: effect.stage.name,
+            errorMessage:
+              err instanceof Error ? err.message : `agent executor failed: ${String(err)}`,
+          });
+        }
+        break;
+      }
+
+      case "CANCEL_STAGE": {
+        const handle = inflight.get(effect.stageRunId);
+        if (handle) {
+          inflight.delete(effect.stageRunId);
+          try {
+            await agentExecutor.cancelStage(handle);
+          } catch {
+            // Best-effort — handle may already be gone.
+          }
+        }
+        break;
+      }
+
+      case "EMIT_OBSERVATION":
+        // Engine doesn't own observation routing. v0.2 leaves this as a no-op;
+        // a later sub-task (#1629/#1630) wires it into the activity-event log.
+        break;
+    }
+  }
+
+  async function tick(): Promise<void> {
+    if (ticking) return;
+    if (inflight.size === 0) return;
+    ticking = true;
+    try {
+      const handles = [...inflight.values()];
+      for (const handle of handles) {
+        const outcome = await agentExecutor.pollStage(handle);
+        if (outcome.status === "running") continue;
+
+        inflight.delete(handle.stageRunId);
+
+        if (outcome.status === "completed") {
+          await dispatch({
+            type: "STAGE_COMPLETED",
+            now: now(),
+            runId: handle.runId,
+            stageName: handle.stageName,
+            artifacts: outcome.artifacts,
+          });
+        } else {
+          await dispatch({
+            type: "STAGE_FAILED",
+            now: now(),
+            runId: handle.runId,
+            stageName: handle.stageName,
+            errorMessage: outcome.errorMessage,
+          });
+        }
+      }
+    } finally {
+      ticking = false;
+    }
+  }
+
+  async function startRun(input: StartRunInput): Promise<RunId> {
+    validatePipelineAgentModes(input.pipeline, registry);
+
+    const runId = asRunId(`run-${randomUUID()}`);
+    const stageRunIds: Record<string, StageRunId> = {};
+    for (const stage of input.pipeline.stages) {
+      stageRunIds[stage.name] = asStageRunId(`sr-${randomUUID()}`);
+    }
+
+    // Stash projectId/issueId BEFORE dispatch so the START_STAGE effect — which
+    // fires synchronously inside the same dispatch — can read them. The
+    // persisted RunState shape was locked by v0.1, so we carry these out-of-band.
+    runMetadata.set(runId, {
+      projectId: input.projectId,
+      issueId: input.issueId,
+    });
+
+    await dispatch({
+      type: "TRIGGER_FIRED",
+      now: now(),
+      trigger: input.trigger ?? "manual",
+      sessionId: input.sessionId,
+      pipeline: input.pipeline,
+      headSha: input.headSha,
+      runId,
+      stageRunIds,
+    });
+
+    return runId;
+  }
+
+  async function cancelRun(
+    runId: RunId,
+    reason: "manual_cancel" | "config_change" = "manual_cancel",
+  ): Promise<void> {
+    if (!state.runs[runId]) return;
+    await dispatch({ type: "RUN_CANCELLED", now: now(), runId, reason });
+  }
+
+  /**
+   * Look up the project a run was started for. Reducer-state doesn't carry
+   * projectId (the persisted RunState is locked from v0.1), so the engine
+   * keeps a side-table populated by startRun().
+   */
+  const runMetadata = new Map<RunId, { projectId: string; issueId?: string }>();
+
+  return {
+    state: () => state,
+    startRun,
+    tick,
+    dispatch,
+    cancelRun,
+  };
+}
+
+/** Internal: utility for resuming engine state from disk (v0.3 will use this). */
+export function rebuildStateFromStore(store: PipelineStore): EngineState {
+  const runs: Record<RunId, RunState> = {};
+  for (const run of store.listRuns()) {
+    runs[run.runId] = run;
+  }
+  // currentRunByLoop and historySummaries can be derived deterministically from
+  // the RunStates above, but the v0.1 store doesn't persist either index. We
+  // rebuild as much as we can; the rest will be repopulated as events flow.
+  const currentRunByLoop: Record<string, RunId> = {};
+  for (const run of Object.values(runs)) {
+    if (!isAllStagesTerminal(run)) {
+      currentRunByLoop[`${run.sessionId}:${run.pipelineName}`] = run.runId;
+    }
+  }
+  return { runs, currentRunByLoop, historySummaries: {} };
+}
+
+function isAllStagesTerminal(run: RunState): boolean {
+  return Object.values(run.stages).every((s) => isTerminalStageStatus(s.status));
+}

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -31,6 +31,7 @@ import {
   asRunId,
   asStageRunId,
   emptyEngineState,
+  isTerminalLoopState,
   isTerminalStageStatus,
   type EngineState,
   type Pipeline,
@@ -109,6 +110,22 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
     state = result.state;
     for (const effect of result.effects) {
       await executeEffect(effect);
+    }
+    pruneTerminatedRunMetadata();
+  }
+
+  /**
+   * Drop side-table entries for runs the reducer has already moved into a
+   * terminal loop state. Without this, `runMetadata` grows for the lifetime of
+   * the engine — one entry per pipeline run ever started — even though the
+   * data is only consumed by START_STAGE on a non-terminal run.
+   */
+  function pruneTerminatedRunMetadata(): void {
+    for (const runId of runMetadata.keys()) {
+      const run = state.runs[runId];
+      if (!run || isTerminalLoopState(run.loopState)) {
+        runMetadata.delete(runId);
+      }
     }
   }
 

--- a/packages/core/src/pipeline/executors/agent.ts
+++ b/packages/core/src/pipeline/executors/agent.ts
@@ -1,0 +1,296 @@
+/**
+ * Agent executor — bridge between the pipeline engine and a real AO session.
+ *
+ * For each stage:
+ *   1. Spawn a fresh AO session (its own worktree, runtime, dashboard card)
+ *      via the existing session manager.
+ *   2. Inject the task as the initial prompt by stitching Layer 4 onto the
+ *      caller-provided prompt.
+ *   3. Wait until the session reaches `idle` AND a `findings.jsonl` artifact
+ *      exists at `{workspacePath}/.ao/pipeline-findings.jsonl`.
+ *   4. Harvest findings, parse them as ArtifactInput records, return them.
+ *   5. Kill the session — worktree cleanup goes through the normal
+ *      session-archive path inside SessionManager.kill().
+ *
+ * The executor is intentionally thin: it does not touch the reducer or the
+ * pipeline store. Engine-side wiring (calling `startStage`, polling, dispatching
+ * STAGE_COMPLETED / STAGE_FAILED) lives in pipeline/engine.ts.
+ *
+ * The session is fully talk-to-able for its entire lifetime: `ao send`,
+ * dashboard chat, terminal attach all work as for any session, since this
+ * executor leans on the standard SessionManager.spawn() path.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { type SessionId, type SessionManager } from "../../types.js";
+import { buildStagePrompt } from "../stage-prompt.js";
+import {
+  PIPELINE_FINDINGS_FILENAME,
+  type ArtifactInput,
+  type RunId,
+  type Stage,
+  type StageRunId,
+} from "../types.js";
+
+export interface AgentExecutorDeps {
+  sessionManager: SessionManager;
+}
+
+export interface StartStageInput {
+  /** Pipeline name — used for prompt context only. */
+  pipelineName: string;
+  /** Project the stage executes in. */
+  projectId: string;
+  /** Run/stage ids the engine has allocated; passed through to results. */
+  runId: RunId;
+  stageRunId: StageRunId;
+  stage: Stage;
+  /** Issue id this run is scoped to, if any. Threaded into session metadata. */
+  issueId?: string;
+  /** Loop counter from the engine. Surfaced in the prompt only. */
+  loopRound?: number;
+}
+
+/**
+ * Handle for a stage that's running. Treat as opaque — the engine just keeps
+ * it around and threads it back into pollStage / cancelStage.
+ */
+export interface RunningAgentStage {
+  runId: RunId;
+  stageRunId: StageRunId;
+  stageName: string;
+  sessionId: SessionId;
+  workspacePath: string;
+  startedAt: number;
+  /** Snapshot of the inputs used to start, for diagnostic logging. */
+  input: StartStageInput;
+}
+
+export type StageOutcome =
+  | { status: "running" }
+  | { status: "completed"; artifacts: ArtifactInput[] }
+  | { status: "failed"; errorMessage: string };
+
+export interface AgentStageExecutor {
+  startStage(input: StartStageInput): Promise<RunningAgentStage>;
+  /**
+   * Poll a running stage. Returns `{ status: "running" }` until the session
+   * reaches `idle` AND the findings file exists. On completion, harvests
+   * findings, kills the session, and returns the artifacts.
+   *
+   * Side effect: when status transitions to `completed` or `failed`, the
+   * underlying session is killed before returning.
+   */
+  pollStage(handle: RunningAgentStage): Promise<StageOutcome>;
+  /** Kill the underlying session early. Idempotent. */
+  cancelStage(handle: RunningAgentStage): Promise<void>;
+}
+
+/**
+ * Thrown when the executor cannot construct a fresh session for a stage —
+ * usually because the stage's executor is not `agent` or the session manager
+ * spawn fails. Caller (engine) maps this to STAGE_FAILED.
+ */
+export class AgentExecutorSpawnError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "AgentExecutorSpawnError";
+  }
+}
+
+/** File name of the conventional findings drop, exposed for tests/UI. */
+export const STAGE_FINDINGS_RELATIVE_PATH = join(".ao", PIPELINE_FINDINGS_FILENAME);
+
+export function createAgentExecutor(deps: AgentExecutorDeps): AgentStageExecutor {
+  const { sessionManager } = deps;
+
+  async function startStage(input: StartStageInput): Promise<RunningAgentStage> {
+    if (input.stage.executor.kind !== "agent") {
+      throw new AgentExecutorSpawnError(
+        `agent executor cannot start stage "${input.stage.name}" with executor.kind=${input.stage.executor.kind}`,
+      );
+    }
+
+    const stagePrompt = buildStagePrompt({
+      pipelineName: input.pipelineName,
+      stage: input.stage,
+      loopRound: input.loopRound,
+    });
+
+    let session;
+    try {
+      session = await sessionManager.spawn({
+        projectId: input.projectId,
+        issueId: input.issueId,
+        prompt: stagePrompt,
+        agent: input.stage.executor.plugin,
+      });
+    } catch (err) {
+      throw new AgentExecutorSpawnError(
+        `Failed to spawn session for stage "${input.stage.name}": ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        err,
+      );
+    }
+
+    if (!session.workspacePath) {
+      // Belt-and-suspenders: the session manager always materializes a
+      // workspace for spawn(), but if a non-default workspace plugin returns
+      // a session without one we cannot harvest findings from a known path.
+      await safeKill(sessionManager, session.id);
+      throw new AgentExecutorSpawnError(
+        `Spawned session ${session.id} for stage "${input.stage.name}" has no workspacePath; cannot harvest findings`,
+      );
+    }
+
+    return {
+      runId: input.runId,
+      stageRunId: input.stageRunId,
+      stageName: input.stage.name,
+      sessionId: session.id,
+      workspacePath: session.workspacePath,
+      startedAt: Date.now(),
+      input,
+    };
+  }
+
+  async function pollStage(handle: RunningAgentStage): Promise<StageOutcome> {
+    const session = await sessionManager.get(handle.sessionId);
+    if (!session) {
+      // Session vanished between polls — treat as failure so the engine can
+      // record an error rather than spinning forever waiting for an idle
+      // signal that will never come.
+      return {
+        status: "failed",
+        errorMessage: `Stage "${handle.stageName}" session ${handle.sessionId} no longer exists`,
+      };
+    }
+
+    // The runtime/lifecycle escaping `idle` (e.g. session crashed, was killed
+    // out-of-band, or the agent exited without producing findings) is treated
+    // as a failure. The session is already terminal; nothing more to harvest.
+    if (isFailedTerminalSession(session)) {
+      const reason = session.lifecycle?.session.reason ?? session.status;
+      return {
+        status: "failed",
+        errorMessage: `Stage "${handle.stageName}" session ${handle.sessionId} terminated without findings (reason=${reason})`,
+      };
+    }
+
+    const findingsPath = join(handle.workspacePath, STAGE_FINDINGS_RELATIVE_PATH);
+    const findingsReady = existsSync(findingsPath);
+    const isIdle = session.activity === "idle";
+
+    if (!isIdle || !findingsReady) {
+      return { status: "running" };
+    }
+
+    let artifacts: ArtifactInput[];
+    try {
+      artifacts = parseFindingsFile(findingsPath);
+    } catch (err) {
+      // Don't kill: leave the session up so a human can inspect the bad
+      // findings file. Engine will mark the stage failed.
+      return {
+        status: "failed",
+        errorMessage: `Stage "${handle.stageName}" produced unparseable findings at ${findingsPath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      };
+    }
+
+    await safeKill(sessionManager, handle.sessionId);
+    return { status: "completed", artifacts };
+  }
+
+  async function cancelStage(handle: RunningAgentStage): Promise<void> {
+    await safeKill(sessionManager, handle.sessionId);
+  }
+
+  return { startStage, pollStage, cancelStage };
+}
+
+function isFailedTerminalSession(session: {
+  status: string;
+  activity: string | null;
+  lifecycle?: { session: { state: string } };
+}): boolean {
+  if (session.activity === "exited") return true;
+  if (session.lifecycle?.session.state === "terminated") return true;
+  // `done` is a healthy terminal — but for stages we never expect a session to
+  // reach `done` before findings are harvested, so treat it as a failure too.
+  // (Sessions only transition to `done` after PR merge / explicit completion.)
+  if (session.status === "killed" || session.status === "errored") return true;
+  return false;
+}
+
+function parseFindingsFile(path: string): ArtifactInput[] {
+  const body = readFileSync(path, "utf-8");
+  const out: ArtifactInput[] = [];
+  for (const [lineNo, raw] of body.split("\n").entries()) {
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      throw new Error(`line ${lineNo + 1}: ${err instanceof Error ? err.message : String(err)}`, {
+        cause: err,
+      });
+    }
+    out.push(coerceArtifactInput(parsed, lineNo + 1));
+  }
+  return out;
+}
+
+function coerceArtifactInput(value: unknown, lineNo: number): ArtifactInput {
+  if (!value || typeof value !== "object") {
+    throw new Error(`line ${lineNo}: expected object`);
+  }
+  const obj = value as Record<string, unknown>;
+  if (obj["kind"] === "finding") {
+    requireString(obj, "filePath", lineNo);
+    requireNumber(obj, "startLine", lineNo);
+    requireNumber(obj, "endLine", lineNo);
+    requireString(obj, "title", lineNo);
+    requireString(obj, "description", lineNo);
+    requireString(obj, "category", lineNo);
+    requireString(obj, "severity", lineNo);
+    requireNumber(obj, "confidence", lineNo);
+    return obj as unknown as ArtifactInput;
+  }
+  if (obj["kind"] === "json") {
+    if (!obj["data"] || typeof obj["data"] !== "object") {
+      throw new Error(`line ${lineNo}: "json" artifact requires object \`data\``);
+    }
+    return obj as unknown as ArtifactInput;
+  }
+  throw new Error(`line ${lineNo}: unknown artifact kind=${JSON.stringify(obj["kind"])}`);
+}
+
+function requireString(obj: Record<string, unknown>, key: string, lineNo: number): void {
+  if (typeof obj[key] !== "string") {
+    throw new Error(`line ${lineNo}: missing string field "${key}"`);
+  }
+}
+
+function requireNumber(obj: Record<string, unknown>, key: string, lineNo: number): void {
+  if (typeof obj[key] !== "number") {
+    throw new Error(`line ${lineNo}: missing numeric field "${key}"`);
+  }
+}
+
+async function safeKill(sm: SessionManager, sessionId: SessionId): Promise<void> {
+  try {
+    await sm.kill(sessionId, { reason: "auto_cleanup" });
+  } catch {
+    // Best-effort. Engine has no useful response to a kill failure here —
+    // the next poll cycle in lifecycle-manager will reconcile dead runtimes.
+  }
+}

--- a/packages/core/src/pipeline/executors/agent.ts
+++ b/packages/core/src/pipeline/executors/agent.ts
@@ -91,14 +91,12 @@ export interface AgentStageExecutor {
 /**
  * Thrown when the executor cannot construct a fresh session for a stage —
  * usually because the stage's executor is not `agent` or the session manager
- * spawn fails. Caller (engine) maps this to STAGE_FAILED.
+ * spawn fails. Caller (engine) maps this to STAGE_FAILED. Underlying error is
+ * attached as `Error.cause` (TS5+ / Node 16.9+).
  */
 export class AgentExecutorSpawnError extends Error {
-  constructor(
-    message: string,
-    public readonly cause?: unknown,
-  ) {
-    super(message);
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
     this.name = "AgentExecutorSpawnError";
   }
 }
@@ -135,7 +133,7 @@ export function createAgentExecutor(deps: AgentExecutorDeps): AgentStageExecutor
         `Failed to spawn session for stage "${input.stage.name}": ${
           err instanceof Error ? err.message : String(err)
         }`,
-        err,
+        { cause: err },
       );
     }
 
@@ -233,6 +231,10 @@ function isFailedTerminalSession(session: {
 }
 
 function parseFindingsFile(path: string): ArtifactInput[] {
+  // TODO(v1.x): readFileSync is unbounded — a misbehaving agent could OOM the
+  // engine by dumping its full reasoning trace into findings. Fine for v0.2
+  // since the engine and agent are co-located, but stream-and-cap once the
+  // engine moves out-of-process or runs untrusted plugins.
   const body = readFileSync(path, "utf-8");
   const out: ArtifactInput[] = [];
   for (const [lineNo, raw] of body.split("\n").entries()) {
@@ -266,7 +268,7 @@ function coerceArtifactInput(value: unknown, lineNo: number): ArtifactInput {
     requireString(obj, "description", lineNo);
     requireString(obj, "category", lineNo);
     requireEnum(obj, "severity", VALID_SEVERITIES, lineNo);
-    requireNumber(obj, "confidence", lineNo);
+    requireNumberInRange(obj, "confidence", 0, 1, lineNo);
     return obj as unknown as ArtifactInput;
   }
   if (obj["kind"] === "json") {
@@ -287,6 +289,21 @@ function requireString(obj: Record<string, unknown>, key: string, lineNo: number
 function requireNumber(obj: Record<string, unknown>, key: string, lineNo: number): void {
   if (typeof obj[key] !== "number") {
     throw new Error(`line ${lineNo}: missing numeric field "${key}"`);
+  }
+}
+
+function requireNumberInRange(
+  obj: Record<string, unknown>,
+  key: string,
+  min: number,
+  max: number,
+  lineNo: number,
+): void {
+  const value = obj[key];
+  if (typeof value !== "number" || value < min || value > max) {
+    throw new Error(
+      `line ${lineNo}: field "${key}" must be a number in [${min}, ${max}], got ${JSON.stringify(value)}`,
+    );
   }
 }
 

--- a/packages/core/src/pipeline/executors/agent.ts
+++ b/packages/core/src/pipeline/executors/agent.ts
@@ -226,7 +226,9 @@ function isFailedTerminalSession(session: {
   // `done` is a healthy terminal — but for stages we never expect a session to
   // reach `done` before findings are harvested, so treat it as a failure too.
   // (Sessions only transition to `done` after PR merge / explicit completion.)
-  if (session.status === "killed" || session.status === "errored") return true;
+  if (session.status === "killed" || session.status === "errored" || session.status === "done") {
+    return true;
+  }
   return false;
 }
 
@@ -249,6 +251,8 @@ function parseFindingsFile(path: string): ArtifactInput[] {
   return out;
 }
 
+const VALID_SEVERITIES = ["error", "warning", "info"] as const;
+
 function coerceArtifactInput(value: unknown, lineNo: number): ArtifactInput {
   if (!value || typeof value !== "object") {
     throw new Error(`line ${lineNo}: expected object`);
@@ -261,7 +265,7 @@ function coerceArtifactInput(value: unknown, lineNo: number): ArtifactInput {
     requireString(obj, "title", lineNo);
     requireString(obj, "description", lineNo);
     requireString(obj, "category", lineNo);
-    requireString(obj, "severity", lineNo);
+    requireEnum(obj, "severity", VALID_SEVERITIES, lineNo);
     requireNumber(obj, "confidence", lineNo);
     return obj as unknown as ArtifactInput;
   }
@@ -283,6 +287,22 @@ function requireString(obj: Record<string, unknown>, key: string, lineNo: number
 function requireNumber(obj: Record<string, unknown>, key: string, lineNo: number): void {
   if (typeof obj[key] !== "number") {
     throw new Error(`line ${lineNo}: missing numeric field "${key}"`);
+  }
+}
+
+function requireEnum<T extends string>(
+  obj: Record<string, unknown>,
+  key: string,
+  allowed: readonly T[],
+  lineNo: number,
+): void {
+  const value = obj[key];
+  if (typeof value !== "string" || !(allowed as readonly string[]).includes(value)) {
+    throw new Error(
+      `line ${lineNo}: field "${key}" must be one of ${allowed
+        .map((v) => `"${v}"`)
+        .join(", ")}, got ${JSON.stringify(value)}`,
+    );
   }
 }
 

--- a/packages/core/src/pipeline/executors/index.ts
+++ b/packages/core/src/pipeline/executors/index.ts
@@ -1,0 +1,10 @@
+export {
+  createAgentExecutor,
+  AgentExecutorSpawnError,
+  STAGE_FINDINGS_RELATIVE_PATH,
+  type AgentStageExecutor,
+  type AgentExecutorDeps,
+  type RunningAgentStage,
+  type StageOutcome,
+  type StartStageInput,
+} from "./agent.js";

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -8,11 +8,7 @@
 export * from "./types.js";
 export type { PipelineEvent, PipelineEffect, ReducerResult } from "./events.js";
 export { reduce } from "./reducer.js";
-export {
-  createPipelineStore,
-  type PipelineStore,
-  type PersistedStageRun,
-} from "./store.js";
+export { createPipelineStore, type PipelineStore, type PersistedStageRun } from "./store.js";
 export {
   pipelineLayout,
   runFilePath,
@@ -22,3 +18,29 @@ export {
   loopFilePath,
   type PipelineLayout,
 } from "./paths.js";
+
+export {
+  PipelineConfigError,
+  getSupportedTaskModes,
+  validatePipelineAgentModes,
+} from "./validation.js";
+
+export { buildStagePrompt, type StagePromptInput } from "./stage-prompt.js";
+
+export {
+  createAgentExecutor,
+  AgentExecutorSpawnError,
+  STAGE_FINDINGS_RELATIVE_PATH,
+  type AgentStageExecutor,
+  type AgentExecutorDeps,
+  type RunningAgentStage,
+  type StageOutcome,
+  type StartStageInput,
+} from "./executors/index.js";
+
+export {
+  createPipelineEngine,
+  type PipelineEngine,
+  type PipelineEngineDeps,
+  type StartRunInput,
+} from "./engine.js";

--- a/packages/core/src/pipeline/stage-prompt.ts
+++ b/packages/core/src/pipeline/stage-prompt.ts
@@ -35,7 +35,9 @@ export function buildStagePrompt(input: StagePromptInput): string {
   lines.push(`Stage: ${stage.name}`);
   if (mode) lines.push(`Mode: ${mode}`);
   if (typeof loopRound === "number") lines.push(`Loop round: ${loopRound}`);
-  if (stage.policy?.blocksMerge) lines.push(`This stage blocks merge — fail on critical findings.`);
+  if (stage.policy?.blocksMerge) {
+    lines.push(`This stage's findings will block merge until they are resolved.`);
+  }
 
   if (stage.task.prompt) {
     lines.push(``);
@@ -60,10 +62,18 @@ export function buildStagePrompt(input: StagePromptInput): string {
 
 function formatFindingsInstructions(mode: TaskMode | null): string {
   const path = `.ao/${PIPELINE_FINDINGS_FILENAME}`;
+  const tmpPath = `${path}.tmp`;
   const blocks: string[] = [];
 
   blocks.push(
-    `When this stage is complete, append your findings to \`${path}\` (one JSON object per line).`,
+    `When this stage is complete, write your findings to \`${path}\` (one JSON object per line, JSONL).`,
+  );
+  // Atomicity contract: the executor polls for the final file's existence
+  // and parses it on first sight. A torn write (partial JSONL line) would
+  // be classified as `failed` and stall the run. Mandate write-then-rename
+  // so the executor only ever sees a fully-written file.
+  blocks.push(
+    `Write the JSONL to \`${tmpPath}\` first, then rename it to \`${path}\` so the orchestrator never observes a partial file (e.g. \`mv ${tmpPath} ${path}\`).`,
   );
   blocks.push(
     `The orchestrator harvests this file once you go idle — without it the stage cannot complete.`,
@@ -84,7 +94,7 @@ function formatFindingsInstructions(mode: TaskMode | null): string {
   }
 
   blocks.push(
-    `If there are no findings, write an empty file. The file's existence — not its contents — is the completion signal.`,
+    `If there are no findings, rename an empty file. The file's existence — not its contents — is the completion signal.`,
   );
 
   return blocks.join(" ");

--- a/packages/core/src/pipeline/stage-prompt.ts
+++ b/packages/core/src/pipeline/stage-prompt.ts
@@ -1,0 +1,91 @@
+/**
+ * Layer 4 of the prompt assembly: stage task descriptor + findings instructions.
+ *
+ * Layers 1–3 (base + config + rules) are produced by prompt-builder.ts at
+ * session-spawn time. Layer 4 is pipeline-specific: it tells the agent which
+ * stage it's executing, what mode it's running in, and where to drop
+ * structured findings so the executor can harvest them.
+ *
+ * Returned as a single string the agent executor concatenates into the
+ * spawn-time `prompt` field. Keep it terse — agents read it once.
+ */
+
+import { PIPELINE_FINDINGS_FILENAME, type Stage, type TaskMode } from "./types.js";
+
+export interface StagePromptInput {
+  pipelineName: string;
+  stage: Stage;
+  /** Loop counter from the engine — included so prompts surface progress. */
+  loopRound?: number;
+}
+
+/**
+ * Compose the Layer 4 prompt for a single stage execution.
+ *
+ * The findings file path is documented relative to the workspace root so the
+ * agent doesn't need to know the absolute path.
+ */
+export function buildStagePrompt(input: StagePromptInput): string {
+  const { pipelineName, stage, loopRound } = input;
+  const mode = stage.executor.kind === "agent" ? stage.executor.mode : null;
+  const lines: string[] = [];
+
+  lines.push(`## Pipeline Stage`);
+  lines.push(`Pipeline: ${pipelineName}`);
+  lines.push(`Stage: ${stage.name}`);
+  if (mode) lines.push(`Mode: ${mode}`);
+  if (typeof loopRound === "number") lines.push(`Loop round: ${loopRound}`);
+  if (stage.policy?.blocksMerge) lines.push(`This stage blocks merge — fail on critical findings.`);
+
+  if (stage.task.prompt) {
+    lines.push(``);
+    lines.push(`## Task`);
+    lines.push(stage.task.prompt);
+  }
+
+  if (stage.task.inputs && Object.keys(stage.task.inputs).length > 0) {
+    lines.push(``);
+    lines.push(`## Inputs`);
+    lines.push("```json");
+    lines.push(JSON.stringify(stage.task.inputs, null, 2));
+    lines.push("```");
+  }
+
+  lines.push(``);
+  lines.push(`## Reporting Findings`);
+  lines.push(formatFindingsInstructions(mode));
+
+  return lines.join("\n");
+}
+
+function formatFindingsInstructions(mode: TaskMode | null): string {
+  const path = `.ao/${PIPELINE_FINDINGS_FILENAME}`;
+  const blocks: string[] = [];
+
+  blocks.push(
+    `When this stage is complete, append your findings to \`${path}\` (one JSON object per line).`,
+  );
+  blocks.push(
+    `The orchestrator harvests this file once you go idle — without it the stage cannot complete.`,
+  );
+
+  if (mode === "review") {
+    blocks.push(
+      `Each line must be a "finding" record with: { kind: "finding", filePath, startLine, endLine, title, description, category, severity ("error" | "warning" | "info"), confidence (0–1) }.`,
+    );
+  } else if (mode === "answer") {
+    blocks.push(
+      `Each line must be a "json" record: { kind: "json", data: { ... } } where \`data\` matches the task's outputSchema (if any).`,
+    );
+  } else {
+    blocks.push(
+      `Each line must be either a "finding" or a "json" record (see ArtifactInput in the orchestrator types).`,
+    );
+  }
+
+  blocks.push(
+    `If there are no findings, write an empty file. The file's existence — not its contents — is the completion signal.`,
+  );
+
+  return blocks.join(" ");
+}

--- a/packages/core/src/pipeline/validation.ts
+++ b/packages/core/src/pipeline/validation.ts
@@ -1,0 +1,65 @@
+/**
+ * Pipeline configuration validation.
+ *
+ * Runs at config load (not at runtime). Today the only check is the
+ * `supportedTaskModes` contract on agent stages: if a stage routes
+ * `executor.kind === "agent"` with `mode = "review"`, the named agent plugin
+ * must advertise `"review"` in its manifest's `supportedTaskModes`.
+ *
+ * Failures throw PipelineConfigError with a message that names the offending
+ * stage, agent, and mode — the engine never sees a misconfigured pipeline.
+ */
+
+import type { PluginManifest, PluginRegistry } from "../types.js";
+import type { Pipeline, TaskMode } from "./types.js";
+
+export class PipelineConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PipelineConfigError";
+  }
+}
+
+/**
+ * Resolve the `supportedTaskModes` advertised by an agent plugin's manifest.
+ * Returns `null` when the plugin is not registered (caller decides whether a
+ * missing plugin is a hard error — usually it is at config load).
+ */
+export function getSupportedTaskModes(
+  registry: PluginRegistry,
+  agentName: string,
+): TaskMode[] | null {
+  const manifests = registry.list("agent");
+  const manifest = manifests.find((m: PluginManifest) => m.name === agentName);
+  if (!manifest) return null;
+  return manifest.supportedTaskModes ?? [];
+}
+
+/**
+ * Validate that every agent-stage in a pipeline routes to a registered agent
+ * plugin whose manifest advertises the requested `task.mode`.
+ *
+ * Throws PipelineConfigError on the first failure. Caller is expected to wrap
+ * pipelines individually so error messages can include pipeline context.
+ */
+export function validatePipelineAgentModes(pipeline: Pipeline, registry: PluginRegistry): void {
+  for (const stage of pipeline.stages) {
+    if (stage.executor.kind !== "agent") continue;
+    const { plugin: agentName, mode } = stage.executor;
+
+    const supported = getSupportedTaskModes(registry, agentName);
+    if (supported === null) {
+      throw new PipelineConfigError(
+        `Pipeline "${pipeline.name}" stage "${stage.name}" references unknown agent plugin "${agentName}".`,
+      );
+    }
+
+    if (!supported.includes(mode)) {
+      throw new PipelineConfigError(
+        `Pipeline "${pipeline.name}" stage "${stage.name}" requires agent "${agentName}" to support task mode "${mode}", but its manifest declares supportedTaskModes=[${supported
+          .map((m) => `"${m}"`)
+          .join(", ")}].`,
+      );
+    }
+  }
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -263,10 +263,7 @@ export function isRestorable(session: {
   lifecycle?: CanonicalSessionLifecycle;
 }): boolean {
   if (session.lifecycle) {
-    return (
-      isTerminalSession(session) &&
-      !NON_RESTORABLE_STATUSES.has(session.status)
-    );
+    return isTerminalSession(session) && !NON_RESTORABLE_STATUSES.has(session.status);
   }
   return isTerminalSession(session) && !NON_RESTORABLE_STATUSES.has(session.status);
 }
@@ -346,11 +343,7 @@ export function isOrchestratorSession(
   if (allSessionPrefixes) {
     for (const prefix of allSessionPrefixes) {
       if (prefix === sessionPrefix) continue;
-      if (
-        new RegExp(
-          `^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`,
-        ).test(session.id)
-      ) {
+      if (new RegExp(`^${prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}-\\d+$`).test(session.id)) {
         return false;
       }
     }
@@ -833,7 +826,11 @@ export interface SCM {
    * @param observer - Optional observer for batch operation metrics
    * @returns Map keyed by "${owner}/${repo}#${number}" containing enrichment data
    */
-  enrichSessionsPRBatch?(prs: PRInfo[], observer?: BatchObserver, repos?: string[]): Promise<Map<string, PREnrichmentData>>;
+  enrichSessionsPRBatch?(
+    prs: PRInfo[],
+    observer?: BatchObserver,
+    repos?: string[],
+  ): Promise<Map<string, PREnrichmentData>>;
 }
 
 /**
@@ -1277,7 +1274,7 @@ export interface LifecycleConfig {
 /** Top-level orchestrator configuration (from agent-orchestrator.yaml) */
 export interface OrchestratorConfig {
   /** Optional JSON Schema hint for editor autocomplete/validation. */
-  "$schema"?: string;
+  $schema?: string;
 
   /**
    * Path to the config file (set automatically during load).
@@ -1653,6 +1650,15 @@ export interface PluginManifest {
 
   /** Human-readable display name (e.g. "Claude Code") */
   displayName?: string;
+
+  /**
+   * Pipeline task modes this agent plugin advertises support for.
+   * Only meaningful for slot === "agent". Defaults to [] when unset.
+   * Pipeline configs that route a stage with `task.mode = "review"` to an
+   * agent that doesn't claim "review" fail at config load, not runtime.
+   * See pipeline/validation.ts.
+   */
+  supportedTaskModes?: ("review" | "code" | "answer")[];
 }
 
 /** What a plugin module must export */
@@ -1913,40 +1919,44 @@ export class ProjectResolveError extends Error {
 
 /** A project entry in the portfolio index (merged from discovery + registration + preferences) */
 export interface PortfolioProject {
-  id: string;                          // Stable portfolio identity (configProjectKey, with collision suffix if needed)
-  name: string;                        // Human-readable display name
-  configPath: string;                  // Absolute path to agent-orchestrator.yaml
-  configProjectKey: string;            // Key in config.projects map
-  repoPath: string;                    // Absolute local filesystem path
-  repo?: string;                       // "owner/repo" for SCM
+  id: string; // Stable portfolio identity (configProjectKey, with collision suffix if needed)
+  name: string; // Human-readable display name
+  configPath: string; // Absolute path to agent-orchestrator.yaml
+  configProjectKey: string; // Key in config.projects map
+  repoPath: string; // Absolute local filesystem path
+  repo?: string; // "owner/repo" for SCM
   defaultBranch?: string;
   sessionPrefix: string;
   source: "discovered" | "registered" | "config"; // How this entry was found
-  enabled: boolean;                    // User can disable without removing
-  pinned: boolean;                     // User preference for ordering
-  lastSeenAt: string;                  // ISO timestamp
-  resolveError?: string;               // Present only when the project is degraded
+  enabled: boolean; // User can disable without removing
+  pinned: boolean; // User preference for ordering
+  lastSeenAt: string; // ISO timestamp
+  resolveError?: string; // Present only when the project is degraded
 }
 
 /** User preferences overlay (canonical, small file) */
 export interface PortfolioPreferences {
   version: 1;
   defaultProjectId?: string;
-  projectOrder?: string[];             // Ordered project IDs for display
-  projects?: Record<string, {          // Per-project preferences
-    pinned?: boolean;
-    enabled?: boolean;
-    displayName?: string;
-  }>;
+  projectOrder?: string[]; // Ordered project IDs for display
+  projects?: Record<
+    string,
+    {
+      // Per-project preferences
+      pinned?: boolean;
+      enabled?: boolean;
+      displayName?: string;
+    }
+  >;
 }
 
 /** Registered projects (explicit `ao project add`) */
 export interface PortfolioRegistered {
   version: 1;
   projects: Array<{
-    path: string;                      // Repo path
-    configProjectKey?: string;         // Key in config if multi-project YAML
-    addedAt: string;                   // ISO timestamp
+    path: string; // Repo path
+    configProjectKey?: string; // Key in config if multi-project YAML
+    addedAt: string; // ISO timestamp
   }>;
 }
 


### PR DESCRIPTION
Closes #1628. Depends on v0.1 (#1636). Targets `pipelines`.

## Summary

Bridges the v0.1 reducer / store to a real AO session so a 1-stage pipeline can run end-to-end and produce findings.

- **Agent executor** (`packages/core/src/pipeline/executors/agent.ts`)
  - For each stage: spawn a fresh session via the existing `SessionManager` (own worktree, runtime, dashboard card), inject the task as the initial prompt, wait until the session reaches `idle` AND `{workspacePath}/.ao/pipeline-findings.jsonl` exists, parse the file as `ArtifactInput` records, kill the session through the normal archive path.
  - Sessions are fully talk-to-able for their entire lifetime: `ao send`, dashboard chat, terminal attach all work as for any session, since this leans on the standard `SessionManager.spawn()` path.
- **Pipeline engine** (`packages/core/src/pipeline/engine.ts`)
  - Holds `EngineState`, dispatches events through the v0.1 reducer, executes effects (persist, append artifacts, START_STAGE, CANCEL_STAGE), and exposes a re-entrant `tick()` the caller drives off the existing 5s SSE poll. No new polling loop introduced (per C-14).
  - `command` / `builtin` executors are v1.2 — `START_STAGE` for those kinds synthesizes `STAGE_FAILED` so runs terminate cleanly instead of hanging.
- **Layer 4 prompt assembly** (`packages/core/src/pipeline/stage-prompt.ts`)
  - Stage descriptor + mode + loop round + task body + schema-aware findings instructions, concatenated with the existing system/config/rules layers.
- **`supportedTaskModes` validation** (`packages/core/src/pipeline/validation.ts` + new optional `PluginManifest.supportedTaskModes`)
  - Agent plugins advertise the modes they handle; defaults to `[]`. Pipelines fail at config load with `PipelineConfigError` when a stage routes to an agent that doesn't claim the requested mode — never at runtime.

## Out of scope (later sub-tasks)
- `command` / `builtin` executors (v1.2)
- DAG / parallel scheduling (v1.1)
- CLI surface (v0.3)
- UI (v2.x)

## Test plan
- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` — 1117 tests pass
  - 13 executor tests against mocked `SessionManager` (start, poll, harvest, cancel, error paths)
  - 6 validation tests (mode matching, missing plugin, multi-stage rejection, command stage skip)
  - 6 end-to-end engine tests (1-stage run, executor failure, cancellation, mode mismatch, command stub, no-op tick)
- [x] `pnpm lint` — 0 errors (48 unrelated pre-existing warnings)
- [ ] Programmatic 1-stage pipeline end-to-end against a real Claude Code session (deferred — orchestrator wiring lands with v0.3 CLI sub-task)

## Acceptance criteria mapping
- [x] A 1-stage pipeline can be triggered programmatically and runs end-to-end (engine.startRun → tick → findings persisted)
- [x] Stage's session shows up in the dashboard during execution and accepts `ao send` mid-flight (uses the standard SessionManager.spawn path; talk-to-able is inherited)
- [x] Findings appear in the run's artifacts when the agent writes to the conventional path (`APPEND_ARTIFACTS` effect → `store.appendArtifacts`)
- [x] `supportedTaskModes` validation rejects mismatched configs at load time with a clear error
- [x] Vitest coverage on the executor (mocked session manager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)