### PR TITLE
fix(web): bound PTY re-attach loop with grace-period counter reset

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -284,6 +284,58 @@ describe("mux terminal open", () => {
     ws.close();
   });
 
+  it("retry budget recovers after PTY survives the grace period (issue #1639)", async () => {
+    // Complements the runaway-loop test below. That one proves the counter
+    // does NOT reset when the PTY crashes inside REATTACH_RESET_GRACE_MS.
+    // This one proves the counter DOES reset once the PTY survives the
+    // grace period — without which a transient blip during startup would
+    // permanently consume the retry budget and prevent any later recovery.
+    //
+    // Test shape:
+    //   1. Open a terminal against a healthy tmux session (PTY 1 attaches).
+    //   2. Wait > REATTACH_RESET_GRACE_MS so the grace timer fires and
+    //      resets reattachAttempts to 0 on the still-attached PTY 1.
+    //   3. Kill the tmux session — PTY 1 exits, the server burns the full
+    //      MAX_REATTACH_ATTEMPTS=3 budget trying to re-attach, then emits
+    //      "exited". A 2 s window is comfortably more than 3 × ~50 ms.
+    //   4. Per-test timeout raised to 15 s to accommodate the 5+ s wait.
+    //
+    // If the grace timer or its closure guard ever regresses (e.g. is
+    // unref'd in a way that prevents firing, or the wrong reference is
+    // compared, or a future change clears it too eagerly), step 3 will
+    // either time out waiting for "exited" or never reach the cap.
+    const RECOVERY_TEST_SESSION = `ao-test-recovery-${process.pid}`;
+    execFileSync(TMUX, ["new-session", "-d", "-s", RECOVERY_TEST_SESSION, "-x", "80", "-y", "24"], {
+      timeout: 5000,
+    });
+
+    try {
+      const ws = await connectMux();
+      ws.send(JSON.stringify({ ch: "terminal", id: RECOVERY_TEST_SESSION, type: "open" }));
+      await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+
+      // Sleep past REATTACH_RESET_GRACE_MS (5 s in production).
+      await new Promise((r) => setTimeout(r, 5500));
+
+      execFileSync(TMUX, ["kill-session", "-t", RECOVERY_TEST_SESSION], { timeout: 5000 });
+
+      const exitedMsg = await waitForMessage(
+        ws,
+        (m) => m.ch === "terminal" && m.type === "exited",
+        2000,
+      );
+      expect(exitedMsg.id).toBe(RECOVERY_TEST_SESSION);
+
+      ws.close();
+    } finally {
+      try {
+        execFileSync(TMUX, ["kill-session", "-t", RECOVERY_TEST_SESSION], { timeout: 5000 });
+      } catch {
+        /* already gone */
+      }
+    }
+  }, 15_000);
+
   it("bounds re-attach attempts when tmux session dies mid-subscription (issue #1639)", async () => {
     // Reproduces the runaway re-attach loop that exhausts the system PTY
     // pool in seconds when `ao stop` kills the tmux session out from

--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -283,6 +283,53 @@ describe("mux terminal open", () => {
 
     ws.close();
   });
+
+  it("bounds re-attach attempts when tmux session dies mid-subscription (issue #1639)", async () => {
+    // Reproduces the runaway re-attach loop that exhausts the system PTY
+    // pool in seconds when `ao stop` kills the tmux session out from
+    // under a still-subscribed dashboard.
+    //
+    // Pre-fix behaviour: each "successful" re-attach reset reattachAttempts
+    // to 0, so MAX_REATTACH_ATTEMPTS=3 never engaged; the loop ran at
+    // ~80 spawns/sec and "exited" was never emitted, so this test would
+    // hang until the 2-second timeout.
+    //
+    // Post-fix: the counter is only reset by a 5-second grace timer, so a
+    // PTY that exits in ~40 ms can never reset it. After 3 attempts the
+    // server gives up and emits "exited".
+    const RUNAWAY_TEST_SESSION = `ao-test-runaway-${process.pid}`;
+    execFileSync(TMUX, ["new-session", "-d", "-s", RUNAWAY_TEST_SESSION, "-x", "80", "-y", "24"], {
+      timeout: 5000,
+    });
+
+    try {
+      const ws = await connectMux();
+
+      ws.send(JSON.stringify({ ch: "terminal", id: RUNAWAY_TEST_SESSION, type: "open" }));
+      await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+
+      // Kill the tmux session externally — the attached PTY now has nothing
+      // to attach to and will exit ~40 ms after each re-attach attempt.
+      execFileSync(TMUX, ["kill-session", "-t", RUNAWAY_TEST_SESSION], { timeout: 5000 });
+
+      // 3 re-attach attempts × ~50 ms each = ~150 ms; allow generous margin.
+      const exitedMsg = await waitForMessage(
+        ws,
+        (m) => m.ch === "terminal" && m.type === "exited",
+        2000,
+      );
+      expect(exitedMsg.id).toBe(RUNAWAY_TEST_SESSION);
+
+      ws.close();
+    } finally {
+      // Best-effort cleanup if test fails before kill-session ran
+      try {
+        execFileSync(TMUX, ["kill-session", "-t", RUNAWAY_TEST_SESSION], { timeout: 5000 });
+      } catch {
+        /* already gone */
+      }
+    }
+  });
 });
 
 // =============================================================================

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -197,6 +197,18 @@ interface ManagedTerminal {
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
 const WS_BUFFER_HIGH_WATERMARK = 64 * 1024; // 64KB
 const MAX_REATTACH_ATTEMPTS = 3;
+/**
+ * Grace period a freshly-attached PTY must survive before its successful
+ * attach is allowed to reset the re-attach counter. Prevents tight crash
+ * loops (e.g. attaching to a tmux session that no longer exists) from
+ * gaming the MAX_REATTACH_ATTEMPTS cap by resetting the counter to 0
+ * between every failed attempt.
+ *
+ * 5 s is comfortably longer than the ~40 ms a doomed `tmux attach-session`
+ * takes to exit, while still being short enough that a healthy PTY which
+ * crashes hours later gets a fresh retry budget.
+ */
+const REATTACH_RESET_GRACE_MS = 5_000;
 
 /**
  * TerminalManager manages PTY processes independently of WebSocket connections.
@@ -296,6 +308,18 @@ class TerminalManager {
 
     terminal.pty = pty;
 
+    // Schedule a grace-period reset of the re-attach counter. We only
+    // consider an attach "really successful" if the PTY survives long
+    // enough to suggest the underlying tmux session is actually usable.
+    // The closure-captured `pty` reference is compared with terminal.pty
+    // so a stale timer cannot reset the counter for a PTY that has
+    // already exited or been replaced by re-attach.
+    setTimeout(() => {
+      if (terminal.pty === pty) {
+        terminal.reattachAttempts = 0;
+      }
+    }, REATTACH_RESET_GRACE_MS).unref();
+
     // Wire up data events
     pty.onData((data: string) => {
       // Push to all subscribers — isolate each callback so a throw in one
@@ -327,6 +351,12 @@ class TerminalManager {
       // Re-attach if subscribers are still present, up to MAX_REATTACH_ATTEMPTS.
       // The cap prevents an unbounded respawn loop when the PTY crashes immediately
       // after every attach (e.g. resource exhaustion or a broken tmux session).
+      // The counter is reset by a delayed timer in open() once the new PTY has
+      // survived REATTACH_RESET_GRACE_MS — see the comment on that constant.
+      // Resetting here would defeat the cap: when ao stop kills the tmux session
+      // out from under a still-subscribed dashboard, attach-session exits ~40 ms
+      // after spawn and the loop runs at ~80 spawns/sec, exhausting the system
+      // PTY pool in seconds (issue #1639).
       if (terminal.subscribers.size > 0 && terminal.reattachAttempts < MAX_REATTACH_ATTEMPTS) {
         terminal.reattachAttempts += 1;
         console.log(
@@ -334,7 +364,6 @@ class TerminalManager {
         );
         try {
           this.open(id, projectId, tmuxSessionId);
-          terminal.reattachAttempts = 0; // reset on successful attach
           return; // re-attached — don't notify exit
         } catch (err) {
           console.error(`[MuxServer] Failed to re-attach ${id}:`, err);

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -192,6 +192,14 @@ interface ManagedTerminal {
   buffer: string[];
   bufferBytes: number;
   reattachAttempts: number;
+  /**
+   * Pending grace-period timer that resets reattachAttempts when the
+   * currently-attached PTY survives REATTACH_RESET_GRACE_MS. Tracked so
+   * cleanup paths (last-subscriber unsubscribe, subsequent re-attach) can
+   * clear it and avoid keeping the dead PTY/terminal closure references
+   * reachable for up to 5 s after teardown.
+   */
+  resetTimer?: ReturnType<typeof setTimeout>;
 }
 
 const RING_BUFFER_MAX = 50 * 1024; // 50KB max per terminal
@@ -313,12 +321,19 @@ class TerminalManager {
     // enough to suggest the underlying tmux session is actually usable.
     // The closure-captured `pty` reference is compared with terminal.pty
     // so a stale timer cannot reset the counter for a PTY that has
-    // already exited or been replaced by re-attach.
-    setTimeout(() => {
+    // already exited or been replaced by re-attach. Any previously-
+    // scheduled timer (from a now-replaced PTY) is cleared so we don't
+    // keep its closure references reachable until the timer fires.
+    if (terminal.resetTimer) {
+      clearTimeout(terminal.resetTimer);
+    }
+    terminal.resetTimer = setTimeout(() => {
+      terminal.resetTimer = undefined;
       if (terminal.pty === pty) {
         terminal.reattachAttempts = 0;
       }
-    }, REATTACH_RESET_GRACE_MS).unref();
+    }, REATTACH_RESET_GRACE_MS);
+    terminal.resetTimer.unref();
 
     // Wire up data events
     pty.onData((data: string) => {
@@ -431,6 +446,10 @@ class TerminalManager {
       if (onExit) terminal.exitCallbacks.delete(onExit);
       // Kill PTY and clean up when the last subscriber leaves
       if (terminal.subscribers.size === 0) {
+        if (terminal.resetTimer) {
+          clearTimeout(terminal.resetTimer);
+          terminal.resetTimer = undefined;
+        }
         if (terminal.pty) {
           terminal.pty.kill();
           terminal.pty = null;


### PR DESCRIPTION
## Summary

Fixes the runaway PTY re-attach loop in the dashboard mux server that exhausts the macOS system PTY pool in seconds when a tmux session dies out from under a still-subscribed dashboard (most commonly: running `ao stop` while a dashboard tab is open).

Fixes #1639.

## Root cause

The `MAX_REATTACH_ATTEMPTS=3` cap in `mux-websocket.ts` was supposed to prevent unbounded respawning, but it was never engaging. The counter was reset to `0` immediately after each "successful" `open()` — where success only meant the new PTY was *spawned*, not that it *survived*. When the underlying tmux session is gone, `tmux attach-session` exits ~40 ms after spawn, the exit handler fires again with counter=0, retries, "succeeds", resets to 0, exits, retries... infinite loop.

## Evidence

Captured on the diagnostic branch ([commit log](https://github.com/ComposioHQ/agent-orchestrator/issues/1639#issuecomment-4371029091)):

- A single 1.5-second burst produced **119 spawn↔exit cycles** for one terminal id
- Process PTY fd count rose **from ~15 to ~153 in <1 minute**
- `MAX_REATTACH_ATTEMPTS=3` provably never engaged: 506 of 527 spawns were re-attaches, all 506 followed by `pty_reattach_counter_reset`
- Sustained for a few seconds, this exhausts macOS `kern.tty.ptmx_max=511`, after which **nothing on the system** can spawn a new PTY (tmux, VS Code terminal, `ao spawn`, etc.) until the leaking process is killed

## Fix

- Remove the `terminal.reattachAttempts = 0` reset inside the exit handler.
- Schedule a delayed reset in `open()` via `setTimeout`, gated on the closure-captured `pty` reference still being `terminal.pty` after `REATTACH_RESET_GRACE_MS` (5 s).

Effect:
- Tight crash loops can't reset the counter (PTY exits before grace expires) → hit `MAX_REATTACH_ATTEMPTS` within ~150 ms → server emits `"exited"` and stops respawning.
- A long-lived PTY that crashes hours later still gets a fresh retry budget.

## Note on the residual ~1 fd/cycle leak

This PR addresses the dominant runaway behaviour. A separate, much slower leak in node-pty 1.1.0 itself (each spawn opens 3 PTY-class fds in the parent, each exit releases only 2 — observed deterministically across 553 spawn cycles in two independent runs) remains and is tracked in #1639. It will be addressed separately, likely by a node-pty upgrade.

Without this PR's fix, the residual leak still becomes catastrophic the moment the runaway loop kicks in. With it, the residual leak's worst case is bounded by user navigation (~50–70 cycles/hour) instead of ~80 cycles/sec.

## Test plan

New integration test in `direct-terminal-ws.integration.test.ts`:
- Creates a tmux session
- Opens it via the mux WebSocket
- Kills the tmux session externally
- Asserts `"exited"` is emitted within 2 s

Without this PR, the test hangs and times out — the exact symptom of the runaway bug.

- [x] `pnpm --filter @aoagents/ao-web typecheck`
- [x] `pnpm --filter @aoagents/ao-web exec eslint server/mux-websocket.ts server/__tests__/direct-terminal-ws.integration.test.ts`
- [x] `pnpm --filter @aoagents/ao-web test -- --run server/__tests__/mux-websocket.test.ts server/__tests__/direct-terminal-ws.integration.test.ts` — 28/28 pass
- [x] Verified the 3 failing tests in the full web test suite (`api-routes.test.ts`, `page.test.tsx`) are pre-existing on clean upstream `main` and unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)