### PR TITLE
feat(pipeline): v0.3 — CLI surface for pipelines, stages, artifacts

### DIFF
--- a/packages/cli/__tests__/commands/artifact.test.ts
+++ b/packages/cli/__tests__/commands/artifact.test.ts
@@ -16,6 +16,7 @@ const { mockConfigRef, mockStore } = vi.hoisted(() => ({
 }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
   return {
     ...actual,

--- a/packages/cli/__tests__/commands/artifact.test.ts
+++ b/packages/cli/__tests__/commands/artifact.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockConfigRef, mockStore } = vi.hoisted(() => ({
+  mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockStore: {
+    saveRun: vi.fn(),
+    loadRun: vi.fn(),
+    listRuns: vi.fn(),
+    saveStage: vi.fn(),
+    loadStage: vi.fn(),
+    appendArtifacts: vi.fn(),
+    listArtifacts: vi.fn(),
+    saveLoopState: vi.fn(),
+    loadLoopState: vi.fn(),
+  },
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
+  return {
+    ...actual,
+    loadConfig: () => mockConfigRef.current,
+    createPipelineStore: () => mockStore,
+    getProjectPipelinesDir: () => "/tmp/pipelines",
+  };
+});
+
+import { Command } from "commander";
+import { registerArtifact } from "../../src/commands/artifact.js";
+import { asRunId, asStageRunId, type Artifact } from "@aoagents/ao-core";
+
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockConfigRef.current = {
+    port: 3000,
+    defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+    plugins: [],
+    projects: {
+      "my-app": {
+        name: "App",
+        path: "/tmp/app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+      },
+    },
+    notifiers: {},
+    power: { preventIdleSleep: false },
+    lifecycle: { autoCleanupOnMerge: true, mergeCleanupIdleGraceMs: 300_000 },
+    readyThresholdMs: 300_000,
+  } as Record<string, unknown>;
+
+  for (const fn of [
+    mockStore.saveRun,
+    mockStore.loadRun,
+    mockStore.listRuns,
+    mockStore.saveStage,
+    mockStore.loadStage,
+    mockStore.appendArtifacts,
+    mockStore.listArtifacts,
+    mockStore.saveLoopState,
+    mockStore.loadLoopState,
+  ]) {
+    fn.mockReset();
+  }
+
+  program = new Command();
+  program.exitOverride();
+  registerArtifact(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ao artifact show", () => {
+  it("prints findings as JSONL by default (one line per artifact)", async () => {
+    const stageRunId = asStageRunId("sr1");
+    const runId = asRunId("r1");
+    const finding: Artifact = {
+      kind: "finding",
+      filePath: "src/x.ts",
+      startLine: 1,
+      endLine: 2,
+      title: "issue",
+      description: "desc",
+      category: "security",
+      severity: "warning",
+      confidence: 0.8,
+      artifactId: "a1" as Artifact["artifactId"],
+      pipelineRunId: runId,
+      stageRunId,
+      stageName: "review-stage",
+      status: "open",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.loadStage.mockReturnValue({
+      stageRunId,
+      runId,
+      stageName: "review-stage",
+      status: "succeeded",
+      attempt: 0,
+      artifacts: [],
+    });
+    mockStore.listArtifacts.mockReturnValue([finding, finding]);
+
+    await program.parseAsync(["node", "test", "artifact", "show", "sr1"]);
+    const lines = consoleLogSpy.mock.calls.map((c) => String(c[0]));
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(parsed.artifactId).toBe("a1");
+    }
+  });
+
+  it("supports --pretty for multi-line JSON", async () => {
+    const finding: Artifact = {
+      kind: "json",
+      data: { ok: true },
+      artifactId: "a1" as Artifact["artifactId"],
+      pipelineRunId: asRunId("r1"),
+      stageRunId: asStageRunId("sr1"),
+      stageName: "x",
+      status: "open",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.loadStage.mockReturnValue({
+      stageRunId: asStageRunId("sr1"),
+      runId: asRunId("r1"),
+      stageName: "x",
+      status: "succeeded",
+      attempt: 0,
+      artifacts: [],
+    });
+    mockStore.listArtifacts.mockReturnValue([finding]);
+
+    await program.parseAsync(["node", "test", "artifact", "show", "sr1", "--pretty"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain('"data": {');
+  });
+
+  it("exits 1 when stage is not found", async () => {
+    mockStore.loadStage.mockReturnValue(null);
+    await expect(
+      program.parseAsync(["node", "test", "artifact", "show", "missing"]),
+    ).rejects.toThrow(/process.exit/);
+    const err = consoleErrSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toContain("Stage not found");
+  });
+});

--- a/packages/cli/__tests__/commands/pipeline.test.ts
+++ b/packages/cli/__tests__/commands/pipeline.test.ts
@@ -21,6 +21,7 @@ const { mockConfigRef, mockStore, mockRegistry } = vi.hoisted(() => ({
 }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
   return {
     ...actual,

--- a/packages/cli/__tests__/commands/pipeline.test.ts
+++ b/packages/cli/__tests__/commands/pipeline.test.ts
@@ -34,6 +34,10 @@ vi.mock("../../src/lib/create-session-manager.js", () => ({
   getPluginRegistry: async () => mockRegistry,
 }));
 
+vi.mock("../../src/lib/running-state.js", () => ({
+  getRunning: async () => null,
+}));
+
 import { Command } from "commander";
 import { registerPipeline } from "../../src/commands/pipeline.js";
 import {
@@ -298,37 +302,94 @@ describe("ao pipeline run", () => {
 describe("ao pipeline cancel", () => {
   it("dispatches RUN_CANCELLED and persists the terminal state", async () => {
     const runId = asRunId("r1");
-    mockStore.loadRun.mockReturnValue({
+    const run: RunState = {
       runId,
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
       sessionId: "s",
-      pipelineConfigSnapshot: {} as Pipeline,
+      pipelineConfigSnapshot: {
+        id: asPipelineId("p"),
+        name: "review",
+        stages: [
+          {
+            name: "review-stage",
+            trigger: { on: ["manual"] },
+            executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+            task: {},
+          },
+        ],
+      },
       headSha: "deadbeef",
       loopState: "running",
       loopRounds: 0,
-      stages: {},
+      stages: {
+        "review-stage": {
+          stageRunId: asStageRunId("sr1"),
+          status: "running",
+          attempt: 1,
+          artifacts: [],
+        },
+      },
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
-    });
+    };
+    // hydrateEngineState reads listRuns; loadRun is read by cancelRun directly.
+    mockStore.listRuns.mockReturnValue([run]);
+    mockStore.loadRun.mockReturnValue(run);
     await program.parseAsync(["node", "test", "pipeline", "cancel", "r1"]);
     expect(mockStore.saveRun).toHaveBeenCalled();
     const persisted = mockStore.saveRun.mock.calls[0][0] as RunState;
     expect(persisted.loopState).toBe("terminated");
     expect(persisted.terminationReason).toBe("manual_cancel");
   });
-});
 
-describe("ao pipeline resume", () => {
-  it("resets failed stages back to pending", async () => {
+  it("warns instead of cancelling on a stalled run and suggests resume", async () => {
     const runId = asRunId("r1");
-    const stageRunId = asStageRunId("sr1");
-    mockStore.loadRun.mockReturnValue({
+    const run: RunState = {
       runId,
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
       sessionId: "s",
       pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.listRuns.mockReturnValue([run]);
+    mockStore.loadRun.mockReturnValue(run);
+    await program.parseAsync(["node", "test", "pipeline", "cancel", "r1"]);
+    expect(mockStore.saveRun).not.toHaveBeenCalled();
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("already in a terminal state");
+    expect(out).toContain("ao pipeline resume");
+  });
+});
+
+describe("ao pipeline resume", () => {
+  it("resets failed stages back to pending via the reducer", async () => {
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    const run: RunState = {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {
+        id: asPipelineId("p"),
+        name: "review",
+        stages: [
+          {
+            name: "review-stage",
+            trigger: { on: ["manual"] },
+            executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+            task: {},
+          },
+        ],
+      },
       headSha: "deadbeef",
       loopState: "stalled",
       terminationReason: "stage_failure",
@@ -344,12 +405,46 @@ describe("ao pipeline resume", () => {
       },
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
-    });
+    };
+    mockStore.listRuns.mockReturnValue([run]);
+    mockStore.loadRun.mockReturnValue(run);
     await program.parseAsync(["node", "test", "pipeline", "resume", "r1"]);
     expect(mockStore.saveRun).toHaveBeenCalled();
     const persisted = mockStore.saveRun.mock.calls[0][0] as RunState;
     expect(persisted.loopState).toBe("running");
     expect(persisted.stages["review-stage"]?.status).toBe("pending");
+  });
+
+  it("rejects resume on non-terminal runs", async () => {
+    const runId = asRunId("r1");
+    const run: RunState = {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {
+        "review-stage": {
+          stageRunId: asStageRunId("sr1"),
+          status: "failed",
+          attempt: 1,
+          artifacts: [],
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.listRuns.mockReturnValue([run]);
+    mockStore.loadRun.mockReturnValue(run);
+    await expect(
+      program.parseAsync(["node", "test", "pipeline", "resume", "r1"]),
+    ).rejects.toThrow(/process.exit/);
+    expect(mockStore.saveRun).not.toHaveBeenCalled();
+    const err = consoleErrSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toMatch(/not a terminal state/);
   });
 });
 

--- a/packages/cli/__tests__/commands/pipeline.test.ts
+++ b/packages/cli/__tests__/commands/pipeline.test.ts
@@ -416,6 +416,50 @@ describe("ao pipeline resume", () => {
     expect(persisted.stages["review-stage"]?.status).toBe("pending");
   });
 
+  it("warns when retries cap prevents any stage from being reset", async () => {
+    const runId = asRunId("r1");
+    // retries=0 → cap=1 attempt; attempt=1 means already at cap
+    const run: RunState = {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {
+        id: asPipelineId("p"),
+        name: "review",
+        stages: [
+          {
+            name: "review-stage",
+            trigger: { on: ["manual"] },
+            executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+            task: {},
+            retries: 0,
+          },
+        ],
+      },
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {
+        "review-stage": {
+          stageRunId: asStageRunId("sr1"),
+          status: "failed",
+          attempt: 1,
+          artifacts: [],
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.listRuns.mockReturnValue([run]);
+    mockStore.loadRun.mockReturnValue(run);
+    await program.parseAsync(["node", "test", "pipeline", "resume", "r1"]);
+    expect(mockStore.saveRun).not.toHaveBeenCalled();
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("retry cap exceeded");
+  });
+
   it("rejects resume on non-terminal runs", async () => {
     const runId = asRunId("r1");
     const run: RunState = {

--- a/packages/cli/__tests__/commands/pipeline.test.ts
+++ b/packages/cli/__tests__/commands/pipeline.test.ts
@@ -1,0 +1,362 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockConfigRef, mockStore, mockRegistry } = vi.hoisted(() => ({
+  mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockStore: {
+    saveRun: vi.fn(),
+    loadRun: vi.fn(),
+    listRuns: vi.fn(),
+    saveStage: vi.fn(),
+    loadStage: vi.fn(),
+    appendArtifacts: vi.fn(),
+    listArtifacts: vi.fn(),
+    saveLoopState: vi.fn(),
+    loadLoopState: vi.fn(),
+  },
+  mockRegistry: {
+    list: vi.fn(),
+    get: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
+  return {
+    ...actual,
+    loadConfig: () => mockConfigRef.current,
+    createPipelineStore: () => mockStore,
+    getProjectPipelinesDir: () => "/tmp/pipelines",
+  };
+});
+
+vi.mock("../../src/lib/create-session-manager.js", () => ({
+  getPluginRegistry: async () => mockRegistry,
+}));
+
+import { Command } from "commander";
+import { registerPipeline } from "../../src/commands/pipeline.js";
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  type Pipeline,
+  type RunState,
+} from "@aoagents/ao-core";
+
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+
+const sampleConfig = () => ({
+  port: 3000,
+  defaults: {
+    runtime: "tmux",
+    agent: "claude-code",
+    workspace: "worktree",
+    notifiers: [],
+    orchestrator: undefined,
+    worker: undefined,
+  },
+  plugins: [],
+  projects: {
+    "my-app": {
+      name: "App",
+      path: "/tmp/app",
+      defaultBranch: "main",
+      sessionPrefix: "app",
+      pipelines: {
+        review: {
+          name: "review",
+          stages: [
+            {
+              name: "review-stage",
+              trigger: { on: ["pr.opened"] },
+              executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+              task: { prompt: "Review" },
+            },
+          ],
+        },
+      },
+    },
+  },
+  notifiers: {},
+  power: { preventIdleSleep: false },
+  lifecycle: { autoCleanupOnMerge: true, mergeCleanupIdleGraceMs: 300_000 },
+  readyThresholdMs: 300_000,
+});
+
+beforeEach(() => {
+  mockConfigRef.current = sampleConfig() as Record<string, unknown>;
+
+  for (const fn of [
+    mockStore.saveRun,
+    mockStore.loadRun,
+    mockStore.listRuns,
+    mockStore.saveStage,
+    mockStore.loadStage,
+    mockStore.appendArtifacts,
+    mockStore.listArtifacts,
+    mockStore.saveLoopState,
+    mockStore.loadLoopState,
+    mockRegistry.list,
+    mockRegistry.get,
+    mockRegistry.create,
+  ]) {
+    fn.mockReset();
+  }
+
+  mockStore.listRuns.mockReturnValue([]);
+  mockStore.listArtifacts.mockReturnValue([]);
+  mockStore.loadLoopState.mockReturnValue(null);
+  mockRegistry.list.mockImplementation((slot: string) =>
+    slot === "agent"
+      ? [
+          {
+            name: "claude-code",
+            slot: "agent",
+            description: "",
+            version: "0.0.0",
+            supportedTaskModes: ["review", "code", "answer"],
+          },
+        ]
+      : [],
+  );
+
+  program = new Command();
+  program.exitOverride();
+  registerPipeline(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ao pipeline list", () => {
+  it("emits configured pipelines as JSON when --json is passed", async () => {
+    await program.parseAsync(["node", "test", "pipeline", "list", "--json"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.projectId).toBe("my-app");
+    expect(parsed.pipelines).toHaveLength(1);
+    expect(parsed.pipelines[0].pipelineId).toBe("review");
+    expect(parsed.pipelines[0].triggers).toEqual(["pr.opened"]);
+  });
+
+  it("renders a friendly summary for terminals", async () => {
+    await program.parseAsync(["node", "test", "pipeline", "list"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("review");
+    expect(out).toContain("1 stage(s)");
+  });
+
+  it("reports (no pipelines configured) when project has none", async () => {
+    const cfg = sampleConfig();
+    cfg.projects["my-app"].pipelines = undefined as unknown as typeof cfg.projects["my-app"]["pipelines"];
+    mockConfigRef.current = cfg as Record<string, unknown>;
+    await program.parseAsync(["node", "test", "pipeline", "list"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("no pipelines configured");
+  });
+});
+
+describe("ao pipeline runs", () => {
+  it("filters by --pipeline + --status and outputs JSON", async () => {
+    const baseRun = (overrides: Partial<RunState>): RunState => ({
+      runId: asRunId("r"),
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      ...overrides,
+    });
+    mockStore.listRuns.mockReturnValue([
+      baseRun({ runId: asRunId("a") }),
+      baseRun({ runId: asRunId("b"), loopState: "done", createdAt: "2024-02-01T00:00:00Z" }),
+      baseRun({ runId: asRunId("c"), pipelineName: "other" }),
+    ]);
+    await program.parseAsync([
+      "node",
+      "test",
+      "pipeline",
+      "runs",
+      "--pipeline",
+      "review",
+      "--status",
+      "running",
+      "--json",
+    ]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.runs.map((r: RunState) => r.runId)).toEqual(["a"]);
+  });
+
+  it("respects --limit", async () => {
+    const baseRun = (id: string, ts: string): RunState => ({
+      runId: asRunId(id),
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {},
+      createdAt: ts,
+      updatedAt: ts,
+    });
+    mockStore.listRuns.mockReturnValue([
+      baseRun("a", "2024-01-01T00:00:00Z"),
+      baseRun("b", "2024-02-01T00:00:00Z"),
+      baseRun("c", "2024-03-01T00:00:00Z"),
+    ]);
+    await program.parseAsync(["node", "test", "pipeline", "runs", "--limit", "2", "--json"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.runs.map((r: RunState) => r.runId)).toEqual(["c", "b"]);
+  });
+});
+
+describe("ao pipeline show", () => {
+  it("prints run detail with hydrated stages and loop", async () => {
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    mockStore.loadRun.mockReturnValue({
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {
+        "review-stage": {
+          stageRunId,
+          status: "running",
+          attempt: 0,
+          artifacts: [],
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    mockStore.listArtifacts.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "pipeline", "show", "r1"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("Run r1");
+    expect(out).toContain("review-stage");
+  });
+
+  it("exits 1 when run is not found", async () => {
+    mockStore.loadRun.mockReturnValue(null);
+    await expect(
+      program.parseAsync(["node", "test", "pipeline", "show", "missing"]),
+    ).rejects.toThrow(/process.exit/);
+    const err = consoleErrSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toContain("Run not found");
+  });
+});
+
+describe("ao pipeline run", () => {
+  it("triggers a manual run for a configured pipeline and persists run state", async () => {
+    await program.parseAsync(["node", "test", "pipeline", "run", "review", "--json"]);
+    expect(mockStore.saveRun).toHaveBeenCalled();
+    const persisted = mockStore.saveRun.mock.calls[0][0] as RunState;
+    expect(persisted.pipelineName).toBe("review");
+    expect(persisted.loopState).toBe("running");
+
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.runId).toMatch(/^run-/);
+    expect(parsed.pipelineName).toBe("review");
+  });
+
+  it("rejects unknown pipelines", async () => {
+    await expect(
+      program.parseAsync(["node", "test", "pipeline", "run", "missing"]),
+    ).rejects.toThrow(/process.exit/);
+    expect(mockStore.saveRun).not.toHaveBeenCalled();
+    const err = consoleErrSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toMatch(/Pipeline "missing" is not configured/);
+  });
+});
+
+describe("ao pipeline cancel", () => {
+  it("dispatches RUN_CANCELLED and persists the terminal state", async () => {
+    const runId = asRunId("r1");
+    mockStore.loadRun.mockReturnValue({
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    await program.parseAsync(["node", "test", "pipeline", "cancel", "r1"]);
+    expect(mockStore.saveRun).toHaveBeenCalled();
+    const persisted = mockStore.saveRun.mock.calls[0][0] as RunState;
+    expect(persisted.loopState).toBe("terminated");
+    expect(persisted.terminationReason).toBe("manual_cancel");
+  });
+});
+
+describe("ao pipeline resume", () => {
+  it("resets failed stages back to pending", async () => {
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    mockStore.loadRun.mockReturnValue({
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {
+        "review-stage": {
+          stageRunId,
+          status: "failed",
+          attempt: 1,
+          artifacts: [],
+          errorMessage: "boom",
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    await program.parseAsync(["node", "test", "pipeline", "resume", "r1"]);
+    expect(mockStore.saveRun).toHaveBeenCalled();
+    const persisted = mockStore.saveRun.mock.calls[0][0] as RunState;
+    expect(persisted.loopState).toBe("running");
+    expect(persisted.stages["review-stage"]?.status).toBe("pending");
+  });
+});
+
+describe("ao pipeline migrate", () => {
+  it("prints a no-op message", async () => {
+    await program.parseAsync(["node", "test", "pipeline", "migrate"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toMatch(/v0\.3/);
+  });
+});

--- a/packages/cli/__tests__/commands/stage.test.ts
+++ b/packages/cli/__tests__/commands/stage.test.ts
@@ -16,6 +16,7 @@ const { mockConfigRef, mockStore } = vi.hoisted(() => ({
 }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
   const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
   return {
     ...actual,

--- a/packages/cli/__tests__/commands/stage.test.ts
+++ b/packages/cli/__tests__/commands/stage.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const { mockConfigRef, mockStore } = vi.hoisted(() => ({
+  mockConfigRef: { current: null as Record<string, unknown> | null },
+  mockStore: {
+    saveRun: vi.fn(),
+    loadRun: vi.fn(),
+    listRuns: vi.fn(),
+    saveStage: vi.fn(),
+    loadStage: vi.fn(),
+    appendArtifacts: vi.fn(),
+    listArtifacts: vi.fn(),
+    saveLoopState: vi.fn(),
+    loadLoopState: vi.fn(),
+  },
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@aoagents/ao-core")>();
+  return {
+    ...actual,
+    loadConfig: () => mockConfigRef.current,
+    createPipelineStore: () => mockStore,
+    getProjectPipelinesDir: () => "/tmp/pipelines",
+  };
+});
+
+import { Command } from "commander";
+import { registerStage } from "../../src/commands/stage.js";
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  type Artifact,
+  type Pipeline,
+} from "@aoagents/ao-core";
+
+let program: Command;
+let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  mockConfigRef.current = {
+    port: 3000,
+    defaults: { runtime: "tmux", agent: "claude-code", workspace: "worktree", notifiers: [] },
+    plugins: [],
+    projects: {
+      "my-app": {
+        name: "App",
+        path: "/tmp/app",
+        defaultBranch: "main",
+        sessionPrefix: "app",
+      },
+    },
+    notifiers: {},
+    power: { preventIdleSleep: false },
+    lifecycle: { autoCleanupOnMerge: true, mergeCleanupIdleGraceMs: 300_000 },
+    readyThresholdMs: 300_000,
+  } as Record<string, unknown>;
+
+  for (const fn of [
+    mockStore.saveRun,
+    mockStore.loadRun,
+    mockStore.listRuns,
+    mockStore.saveStage,
+    mockStore.loadStage,
+    mockStore.appendArtifacts,
+    mockStore.listArtifacts,
+    mockStore.saveLoopState,
+    mockStore.loadLoopState,
+  ]) {
+    fn.mockReset();
+  }
+
+  program = new Command();
+  program.exitOverride();
+  registerStage(program);
+
+  consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+    throw new Error(`process.exit(${code})`);
+  }) as never);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ao stage show", () => {
+  it("renders the stage detail with artifacts", async () => {
+    const stageRunId = asStageRunId("sr1");
+    const runId = asRunId("r1");
+    mockStore.loadStage.mockReturnValue({
+      stageRunId,
+      runId,
+      stageName: "review-stage",
+      status: "succeeded",
+      attempt: 0,
+      artifacts: [],
+    });
+    mockStore.loadRun.mockReturnValue({
+      runId,
+      pipelineId: asPipelineId("review"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "done",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    const finding: Artifact = {
+      kind: "finding",
+      filePath: "src/x.ts",
+      startLine: 1,
+      endLine: 2,
+      title: "issue",
+      description: "desc",
+      category: "security",
+      severity: "warning",
+      confidence: 0.8,
+      artifactId: "a1" as Artifact["artifactId"],
+      pipelineRunId: runId,
+      stageRunId,
+      stageName: "review-stage",
+      status: "open",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    mockStore.listArtifacts.mockReturnValue([finding]);
+
+    await program.parseAsync(["node", "test", "stage", "show", "sr1"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(out).toContain("review-stage");
+    expect(out).toContain("succeeded");
+    expect(out).toContain("issue");
+    expect(out).toContain("src/x.ts:1");
+  });
+
+  it("emits JSON with --json", async () => {
+    mockStore.loadStage.mockReturnValue({
+      stageRunId: asStageRunId("sr1"),
+      runId: asRunId("r1"),
+      stageName: "review-stage",
+      status: "succeeded",
+      attempt: 0,
+      artifacts: [],
+    });
+    mockStore.loadRun.mockReturnValue(null);
+    mockStore.listArtifacts.mockReturnValue([]);
+
+    await program.parseAsync(["node", "test", "stage", "show", "sr1", "--json"]);
+    const out = consoleLogSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(out);
+    expect(parsed.stage.stageName).toBe("review-stage");
+    expect(parsed.artifacts).toEqual([]);
+  });
+
+  it("exits 1 when stage is not found", async () => {
+    mockStore.loadStage.mockReturnValue(null);
+    await expect(
+      program.parseAsync(["node", "test", "stage", "show", "missing"]),
+    ).rejects.toThrow(/process.exit/);
+    const err = consoleErrSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(err).toContain("Stage not found");
+  });
+});

--- a/packages/cli/__tests__/lib/pipeline-service.test.ts
+++ b/packages/cli/__tests__/lib/pipeline-service.test.ts
@@ -212,6 +212,25 @@ describe("triggerRun", () => {
       /supportedTaskModes/i,
     );
   });
+
+  it("rejects with LoopAlreadyActiveError when an active run already owns the loop key", async () => {
+    const { LoopAlreadyActiveError } = await import("../../src/lib/pipeline-service.js");
+    const { store, state } = createMockStore();
+    const registry = makeMockRegistry();
+    const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
+
+    triggerRun(store, registry, pipeline);
+    expect(state.runs.size).toBe(1);
+
+    let captured: unknown;
+    try {
+      triggerRun(store, registry, pipeline);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(LoopAlreadyActiveError);
+    expect(state.runs.size).toBe(1); // still only one run
+  });
 });
 
 describe("listRuns", () => {
@@ -347,12 +366,24 @@ describe("cancelRun", () => {
     const { store, state } = createMockStore();
     const runId = asRunId("r1");
     const stageRunId = asStageRunId("sr1");
+    const snapshot: Pipeline = {
+      id: asPipelineId("p"),
+      name: "review",
+      stages: [
+        {
+          name: "review-stage",
+          trigger: { on: ["manual"] },
+          executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+          task: {},
+        },
+      ],
+    };
     state.runs.set(runId, {
       runId,
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
       sessionId: "s",
-      pipelineConfigSnapshot: {} as Pipeline,
+      pipelineConfigSnapshot: snapshot,
       headSha: "deadbeef",
       loopState: "running",
       loopRounds: 0,
@@ -360,7 +391,7 @@ describe("cancelRun", () => {
         "review-stage": {
           stageRunId,
           status: "running",
-          attempt: 0,
+          attempt: 1,
           artifacts: [],
         },
       },
@@ -368,16 +399,17 @@ describe("cancelRun", () => {
       updatedAt: "2024-01-01T00:00:00Z",
     });
 
-    const result = cancelRun(store, runId);
-    expect(result.loopState).toBe("terminated");
-    expect(result.terminationReason).toBe("manual_cancel");
+    const { run, alreadyTerminal } = cancelRun(store, runId);
+    expect(alreadyTerminal).toBe(false);
+    expect(run.loopState).toBe("terminated");
+    expect(run.terminationReason).toBe("manual_cancel");
     expect(state.loops.get(runId)?.loopState).toBe("terminated");
   });
 
-  it("is idempotent on already-terminal runs", () => {
+  it("is idempotent on already-terminal runs (returns alreadyTerminal=true)", () => {
     const { store, state } = createMockStore();
     const runId = asRunId("r1");
-    const run: RunState = {
+    const original: RunState = {
       runId,
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
@@ -390,10 +422,33 @@ describe("cancelRun", () => {
       createdAt: "2024-01-01T00:00:00Z",
       updatedAt: "2024-01-01T00:00:00Z",
     };
-    state.runs.set(runId, run);
-    const result = cancelRun(store, runId);
-    expect(result).toBe(run);
+    state.runs.set(runId, original);
+    const { run, alreadyTerminal } = cancelRun(store, runId);
+    expect(alreadyTerminal).toBe(true);
+    expect(run).toBe(original);
     expect(state.loops.size).toBe(0);
+  });
+
+  it("flags stalled runs as alreadyTerminal so the CLI can suggest resume", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    const { run, alreadyTerminal } = cancelRun(store, runId);
+    expect(alreadyTerminal).toBe(true);
+    expect(run.loopState).toBe("stalled");
   });
 
   it("throws on unknown runId", () => {
@@ -403,7 +458,23 @@ describe("cancelRun", () => {
 });
 
 describe("resumeRun", () => {
-  it("resets failed stages to pending and restarts the loop pointer", () => {
+  function snapshotWithRetries(retries?: number): Pipeline {
+    return {
+      id: asPipelineId("p"),
+      name: "review",
+      stages: [
+        {
+          name: "review-stage",
+          trigger: { on: ["manual"] },
+          executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+          task: {},
+          ...(retries !== undefined ? { retries } : {}),
+        },
+      ],
+    };
+  }
+
+  it("resets failed stages to pending and re-arms the loop pointer", () => {
     const { store, state } = createMockStore();
     const runId = asRunId("r1");
     const stageRunId = asStageRunId("sr1");
@@ -412,7 +483,7 @@ describe("resumeRun", () => {
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
       sessionId: "s",
-      pipelineConfigSnapshot: {} as Pipeline,
+      pipelineConfigSnapshot: snapshotWithRetries(2),
       headSha: "deadbeef",
       loopState: "stalled",
       terminationReason: "stage_failure",
@@ -436,7 +507,71 @@ describe("resumeRun", () => {
     expect(run.terminationReason).toBeUndefined();
     expect(run.stages["review-stage"]?.status).toBe("pending");
     expect(run.stages["review-stage"]?.attempt).toBe(2);
+    // New stageRunId minted by the service (so the next attempt's artifacts
+    // don't collide with the previous attempt's).
+    expect(run.stages["review-stage"]?.stageRunId).not.toBe(stageRunId);
     expect(state.loops.get(runId)?.loopState).toBe("running");
+  });
+
+  it("rejects resume on non-terminal runs (would double-spawn under v0.4)", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: snapshotWithRetries(),
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {
+        "review-stage": {
+          stageRunId: asStageRunId("sr1"),
+          status: "failed",
+          attempt: 1,
+          artifacts: [],
+          errorMessage: "boom",
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    expect(() => resumeRun(store, runId)).toThrow(
+      /not a terminal state/,
+    );
+  });
+
+  it("refuses to bump attempt past stage.retries", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: snapshotWithRetries(1), // 1 retry → cap = 2 attempts
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {
+        "review-stage": {
+          stageRunId: asStageRunId("sr1"),
+          status: "failed",
+          attempt: 2, // already at the cap
+          artifacts: [],
+          errorMessage: "boom",
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    // The reducer rejects (logs a console warning) and the run stays stalled.
+    const { run, resetStages } = resumeRun(store, runId);
+    expect(resetStages).toEqual(["review-stage"]); // listed but no state change
+    expect(run.loopState).toBe("stalled");
+    expect(run.stages["review-stage"]?.status).toBe("failed");
   });
 
   it("returns unchanged when no stages are failed", () => {
@@ -447,7 +582,7 @@ describe("resumeRun", () => {
       pipelineId: asPipelineId("p"),
       pipelineName: "review",
       sessionId: "s",
-      pipelineConfigSnapshot: {} as Pipeline,
+      pipelineConfigSnapshot: snapshotWithRetries(),
       headSha: "deadbeef",
       loopState: "done",
       loopRounds: 0,

--- a/packages/cli/__tests__/lib/pipeline-service.test.ts
+++ b/packages/cli/__tests__/lib/pipeline-service.test.ts
@@ -1,0 +1,476 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  type Artifact,
+  type ConfiguredPipeline,
+  type LoopState,
+  type PersistedStageRun,
+  type Pipeline,
+  type PipelineStore,
+  type PluginRegistry,
+  type RunState,
+} from "@aoagents/ao-core";
+
+import {
+  cancelRun,
+  describeRun,
+  describeStage,
+  listConfiguredPipelines,
+  listRuns,
+  migrateStore,
+  readStageArtifacts,
+  resolveConfiguredPipeline,
+  resumeRun,
+  triggerRun,
+} from "../../src/lib/pipeline-service.js";
+
+function createMockStore(): {
+  store: PipelineStore;
+  state: {
+    runs: Map<string, RunState>;
+    stages: Map<string, PersistedStageRun>;
+    artifacts: Map<string, Artifact[]>;
+    loops: Map<string, LoopState>;
+  };
+} {
+  const state = {
+    runs: new Map<string, RunState>(),
+    stages: new Map<string, PersistedStageRun>(),
+    artifacts: new Map<string, Artifact[]>(),
+    loops: new Map<string, LoopState>(),
+  };
+
+  const store: PipelineStore = {
+    saveRun: vi.fn((run) => {
+      state.runs.set(run.runId, run);
+    }),
+    loadRun: vi.fn((runId) => state.runs.get(runId) ?? null),
+    listRuns: vi.fn(() => [...state.runs.values()]),
+    saveStage: vi.fn((stage) => {
+      state.stages.set(stage.stageRunId, stage);
+    }),
+    loadStage: vi.fn((stageRunId) => state.stages.get(stageRunId) ?? null),
+    appendArtifacts: vi.fn((runId, stageRunId, artifacts) => {
+      const key = `${runId}:${stageRunId}`;
+      const existing = state.artifacts.get(key) ?? [];
+      state.artifacts.set(key, [...existing, ...artifacts]);
+    }),
+    listArtifacts: vi.fn((runId, stageRunId) => {
+      return state.artifacts.get(`${runId}:${stageRunId}`) ?? [];
+    }),
+    saveLoopState: vi.fn((runId, loop) => {
+      state.loops.set(runId, loop);
+    }),
+    loadLoopState: vi.fn((runId) => state.loops.get(runId) ?? null),
+  };
+
+  return { store, state };
+}
+
+function makeConfiguredPipeline(
+  overrides?: Partial<ConfiguredPipeline>,
+): ConfiguredPipeline {
+  return {
+    name: "review",
+    stages: [
+      {
+        name: "review-stage",
+        trigger: { on: ["pr.opened", "pr.updated"] },
+        executor: { kind: "agent", plugin: "claude-code", mode: "review" },
+        task: { prompt: "Review this PR" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeMockRegistry(modes: string[] = ["review", "code", "answer"]): PluginRegistry {
+  return {
+    list: vi.fn((_slot: string) => [
+      {
+        name: "claude-code",
+        slot: "agent",
+        description: "mock",
+        version: "0.0.0",
+        supportedTaskModes: modes,
+      },
+    ]),
+    get: vi.fn(),
+    create: vi.fn(),
+  } as unknown as PluginRegistry;
+}
+
+const mockConfig = {
+  port: 3000,
+  defaults: {
+    runtime: "tmux",
+    agent: "claude-code",
+    workspace: "worktree",
+    notifiers: [],
+    orchestrator: undefined,
+    worker: undefined,
+  },
+  plugins: [],
+  projects: {
+    proj: {
+      name: "Project",
+      path: "/tmp/proj",
+      defaultBranch: "main",
+      sessionPrefix: "p",
+      pipelines: {
+        review: makeConfiguredPipeline(),
+        nightly: makeConfiguredPipeline({
+          name: "nightly",
+          stages: [
+            {
+              name: "summary",
+              trigger: { on: ["manual"] },
+              executor: { kind: "agent", plugin: "claude-code", mode: "answer" },
+              task: { prompt: "summarize" },
+            },
+          ],
+        }),
+      },
+    },
+  },
+  notifiers: {},
+  power: { preventIdleSleep: false },
+  lifecycle: { autoCleanupOnMerge: true, mergeCleanupIdleGraceMs: 300_000 },
+  readyThresholdMs: 300_000,
+} as unknown as Parameters<typeof listConfiguredPipelines>[0];
+
+describe("listConfiguredPipelines", () => {
+  it("returns one entry per pipeline with stage count and triggers", () => {
+    const result = listConfiguredPipelines(mockConfig, "proj");
+    expect(result).toEqual([
+      {
+        pipelineId: "review",
+        name: "review",
+        stageCount: 1,
+        triggers: ["pr.opened", "pr.updated"],
+      },
+      {
+        pipelineId: "nightly",
+        name: "nightly",
+        stageCount: 1,
+        triggers: ["manual"],
+      },
+    ]);
+  });
+
+  it("returns [] when project is missing or has no pipelines", () => {
+    expect(listConfiguredPipelines(mockConfig, "missing")).toEqual([]);
+    const noPipelinesConfig = {
+      ...mockConfig,
+      projects: { ...mockConfig.projects, other: { ...mockConfig.projects.proj, pipelines: undefined } },
+    } as typeof mockConfig;
+    expect(listConfiguredPipelines(noPipelinesConfig, "other")).toEqual([]);
+  });
+});
+
+describe("resolveConfiguredPipeline", () => {
+  it("converts a configured pipeline to a runtime Pipeline (branded id, stages mapped)", () => {
+    const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
+    expect(pipeline.id).toBe(asPipelineId("review"));
+    expect(pipeline.name).toBe("review");
+    expect(pipeline.stages).toHaveLength(1);
+    expect(pipeline.stages[0]?.executor.kind).toBe("agent");
+  });
+
+  it("throws on unknown pipeline name", () => {
+    expect(() => resolveConfiguredPipeline(mockConfig, "proj", "missing")).toThrow(
+      /Pipeline "missing" is not configured/,
+    );
+  });
+});
+
+describe("triggerRun", () => {
+  it("validates the pipeline against the registry and persists initial run state", () => {
+    const { store, state } = createMockStore();
+    const registry = makeMockRegistry();
+    const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
+
+    const runId = triggerRun(store, registry, pipeline, {}, () => 1_700_000_000_000);
+
+    expect(runId).toMatch(/^run-/);
+    expect(state.runs.size).toBe(1);
+    const run = state.runs.get(runId)!;
+    expect(run.pipelineName).toBe("review");
+    expect(run.loopState).toBe("running");
+    expect(Object.keys(run.stages)).toEqual(["review-stage"]);
+    expect(state.loops.size).toBe(1);
+    expect(state.stages.size).toBe(1);
+  });
+
+  it("throws PipelineConfigError when an agent doesn't support the requested mode", () => {
+    const { store } = createMockStore();
+    const registry = makeMockRegistry(["code"]); // no "review"
+    const pipeline = resolveConfiguredPipeline(mockConfig, "proj", "review");
+    expect(() => triggerRun(store, registry, pipeline)).toThrow(
+      /supportedTaskModes/i,
+    );
+  });
+});
+
+describe("listRuns", () => {
+  it("filters by pipeline + status and sorts newest first", () => {
+    const { store, state } = createMockStore();
+    const baseRun = (overrides: Partial<RunState>): RunState => ({
+      runId: asRunId("r"),
+      pipelineId: asPipelineId("p"),
+      pipelineName: "p",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      ...overrides,
+    });
+
+    state.runs.set(
+      "a",
+      baseRun({ runId: asRunId("a"), pipelineName: "review", createdAt: "2024-01-01" }),
+    );
+    state.runs.set(
+      "b",
+      baseRun({
+        runId: asRunId("b"),
+        pipelineName: "review",
+        loopState: "done",
+        createdAt: "2024-02-01",
+      }),
+    );
+    state.runs.set(
+      "c",
+      baseRun({ runId: asRunId("c"), pipelineName: "other", createdAt: "2024-03-01" }),
+    );
+
+    const all = listRuns(store);
+    expect(all.map((r) => r.runId)).toEqual(["c", "b", "a"]);
+
+    const review = listRuns(store, { pipeline: "review" });
+    expect(review.map((r) => r.runId)).toEqual(["b", "a"]);
+
+    const running = listRuns(store, { status: "running" });
+    expect(running.map((r) => r.runId)).toEqual(["c", "a"]);
+  });
+});
+
+describe("describeRun / describeStage / readStageArtifacts", () => {
+  it("hydrates stages with their artifacts", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {
+        "review-stage": {
+          stageRunId,
+          status: "succeeded",
+          attempt: 0,
+          artifacts: [],
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    state.stages.set(stageRunId, {
+      stageRunId,
+      runId,
+      stageName: "review-stage",
+      status: "succeeded",
+      attempt: 0,
+      artifacts: [],
+    });
+
+    const finding: Artifact = {
+      kind: "finding",
+      filePath: "src/x.ts",
+      startLine: 1,
+      endLine: 2,
+      title: "issue",
+      description: "desc",
+      category: "security",
+      severity: "warning",
+      confidence: 0.8,
+      artifactId: "a1" as Artifact["artifactId"],
+      pipelineRunId: runId,
+      stageRunId,
+      stageName: "review-stage",
+      status: "open",
+      createdAt: "2024-01-01T00:00:00Z",
+    };
+    state.artifacts.set(`${runId}:${stageRunId}`, [finding]);
+
+    const detail = describeRun(store, runId);
+    expect(detail.run.runId).toBe(runId);
+    expect(detail.stages).toHaveLength(1);
+    expect(detail.stages[0]?.artifacts).toEqual([finding]);
+
+    const stageDetail = describeStage(store, stageRunId);
+    expect(stageDetail.stage.stageRunId).toBe(stageRunId);
+    expect(stageDetail.artifacts).toEqual([finding]);
+
+    expect(readStageArtifacts(store, stageRunId)).toEqual([finding]);
+  });
+
+  it("describeRun throws on unknown runId", () => {
+    const { store } = createMockStore();
+    expect(() => describeRun(store, asRunId("nope"))).toThrow(/Run not found/);
+  });
+
+  it("describeStage throws on unknown stageRunId", () => {
+    const { store } = createMockStore();
+    expect(() => describeStage(store, asStageRunId("nope"))).toThrow(/Stage not found/);
+  });
+});
+
+describe("cancelRun", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-01T00:00:00Z"));
+  });
+
+  it("dispatches RUN_CANCELLED through the reducer and persists effects", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "running",
+      loopRounds: 0,
+      stages: {
+        "review-stage": {
+          stageRunId,
+          status: "running",
+          attempt: 0,
+          artifacts: [],
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+
+    const result = cancelRun(store, runId);
+    expect(result.loopState).toBe("terminated");
+    expect(result.terminationReason).toBe("manual_cancel");
+    expect(state.loops.get(runId)?.loopState).toBe("terminated");
+  });
+
+  it("is idempotent on already-terminal runs", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    const run: RunState = {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "done",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    };
+    state.runs.set(runId, run);
+    const result = cancelRun(store, runId);
+    expect(result).toBe(run);
+    expect(state.loops.size).toBe(0);
+  });
+
+  it("throws on unknown runId", () => {
+    const { store } = createMockStore();
+    expect(() => cancelRun(store, asRunId("missing"))).toThrow(/Run not found/);
+  });
+});
+
+describe("resumeRun", () => {
+  it("resets failed stages to pending and restarts the loop pointer", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    const stageRunId = asStageRunId("sr1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "stalled",
+      terminationReason: "stage_failure",
+      loopRounds: 1,
+      stages: {
+        "review-stage": {
+          stageRunId,
+          status: "failed",
+          attempt: 1,
+          artifacts: [],
+          errorMessage: "boom",
+        },
+      },
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+
+    const { run, resetStages } = resumeRun(store, runId, () => 1_700_000_000_000);
+    expect(resetStages).toEqual(["review-stage"]);
+    expect(run.loopState).toBe("running");
+    expect(run.terminationReason).toBeUndefined();
+    expect(run.stages["review-stage"]?.status).toBe("pending");
+    expect(run.stages["review-stage"]?.attempt).toBe(2);
+    expect(state.loops.get(runId)?.loopState).toBe("running");
+  });
+
+  it("returns unchanged when no stages are failed", () => {
+    const { store, state } = createMockStore();
+    const runId = asRunId("r1");
+    state.runs.set(runId, {
+      runId,
+      pipelineId: asPipelineId("p"),
+      pipelineName: "review",
+      sessionId: "s",
+      pipelineConfigSnapshot: {} as Pipeline,
+      headSha: "deadbeef",
+      loopState: "done",
+      loopRounds: 0,
+      stages: {},
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+    });
+    const { resetStages } = resumeRun(store, runId);
+    expect(resetStages).toEqual([]);
+    expect(state.loops.size).toBe(0);
+  });
+
+  it("throws on unknown runId", () => {
+    const { store } = createMockStore();
+    expect(() => resumeRun(store, asRunId("missing"))).toThrow(/Run not found/);
+  });
+});
+
+describe("migrateStore", () => {
+  it("returns a no-op result for the v0.3 schema", () => {
+    const { store } = createMockStore();
+    const result = migrateStore(store);
+    expect(result.migrated).toBe(0);
+    expect(result.message).toMatch(/v0\.3/);
+  });
+});

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -2,7 +2,6 @@
  * `ao artifact` — inspect findings produced by a stage run.
  */
 
-import chalk from "chalk";
 import type { Command } from "commander";
 import {
   asStageRunId,
@@ -11,13 +10,9 @@ import {
   loadConfig,
 } from "@aoagents/ao-core";
 
+import { fail } from "../lib/cli-utils.js";
 import { resolveScopedProjectId } from "../lib/project-resolution.js";
 import { readStageArtifacts } from "../lib/pipeline-service.js";
-
-function fail(err: unknown): never {
-  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-  process.exit(1);
-}
 
 export function registerArtifact(program: Command): void {
   const artifact = program

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -1,0 +1,49 @@
+/**
+ * `ao artifact` — inspect findings produced by a stage run.
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  asStageRunId,
+  createPipelineStore,
+  getProjectPipelinesDir,
+  loadConfig,
+} from "@aoagents/ao-core";
+
+import { resolveScopedProjectId } from "../lib/project-resolution.js";
+import { readStageArtifacts } from "../lib/pipeline-service.js";
+
+function fail(err: unknown): never {
+  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+  process.exit(1);
+}
+
+export function registerArtifact(program: Command): void {
+  const artifact = program
+    .command("artifact")
+    .description("Pipeline artifact inspection");
+
+  artifact
+    .command("show")
+    .description("Print findings JSONL for a stage run")
+    .argument("<stageRunId>", "Stage run id")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--pretty", "Pretty-print each artifact (multi-line JSON)")
+    .action(
+      (stageRunIdArg: string, opts: { project?: string; pretty?: boolean }) => {
+        try {
+          const config = loadConfig();
+          const projectId = resolveScopedProjectId(config, opts.project);
+          const store = createPipelineStore(getProjectPipelinesDir(projectId));
+          const artifacts = readStageArtifacts(store, asStageRunId(stageRunIdArg));
+
+          for (const a of artifacts) {
+            console.log(opts.pretty ? JSON.stringify(a, null, 2) : JSON.stringify(a));
+          }
+        } catch (err) {
+          fail(err);
+        }
+      },
+    );
+}

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -22,9 +22,11 @@ import {
 
 import { getPluginRegistry } from "../lib/create-session-manager.js";
 import { resolveScopedProjectId } from "../lib/project-resolution.js";
+import { getRunning } from "../lib/running-state.js";
 import {
   cancelRun,
   describeRun,
+  LoopAlreadyActiveError,
   listConfiguredPipelines,
   listRuns,
   migrateStore,
@@ -49,6 +51,32 @@ function openScope(projectOpt?: string): ProjectScope {
 function fail(err: unknown): never {
   console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
   process.exit(1);
+}
+
+/**
+ * Inverse of `warnIfAONotRunning` in spawn.ts. The running orchestrator
+ * holds engine state in memory and (until v0.4 lifecycle wiring lands) does
+ * not re-read pipeline runs from disk. CLI mutations therefore won't be seen
+ * by the in-process engine until the user restarts it. Make that explicit.
+ */
+async function warnIfAORunning(projectId: string): Promise<void> {
+  const running = await getRunning();
+  if (!running || !running.projects.includes(projectId)) return;
+  console.log(
+    chalk.yellow(
+      `⚠ AO is running (pid ${running.pid}) and holds in-memory pipeline state.`,
+    ),
+  );
+  console.log(
+    chalk.dim(
+      `  This change is persisted to disk but the running engine won't pick it up until v0.4 lifecycle wiring lands.`,
+    ),
+  );
+  console.log(
+    chalk.dim(
+      `  Restart \`ao start\` to re-hydrate engine state from the store.`,
+    ),
+  );
 }
 
 function formatLoopState(state: RunState["loopState"]): string {
@@ -210,40 +238,54 @@ export function registerPipeline(program: Command): void {
   pipeline
     .command("run")
     .description("Trigger a manual run for a configured pipeline")
-    .argument("<pipelineName>", "Pipeline name (matches the key under projects.<id>.pipelines)")
+    .argument(
+      "<pipeline>",
+      "Pipeline id (YAML map key) or `name` field — both are accepted",
+    )
     .option("-p, --project <id>", "Project to scope to")
     .option("--session <id>", "Override the session id used to key the run")
     .option("--head-sha <sha>", "Override the head SHA recorded for the run")
     .option("--json", "Output as JSON")
     .action(
       async (
-        pipelineName: string,
+        pipelineRef: string,
         opts: { project?: string; session?: string; headSha?: string; json?: boolean },
       ) => {
         try {
           const { config, projectId, store } = openScope(opts.project);
-          const pipeline = resolveConfiguredPipeline(config, projectId, pipelineName);
+          const pipeline = resolveConfiguredPipeline(config, projectId, pipelineRef);
           const registry = await getPluginRegistry(config);
-          const runId = triggerRun(store, registry, pipeline, {
-            ...(opts.session ? { sessionId: opts.session } : {}),
-            ...(opts.headSha ? { headSha: opts.headSha } : {}),
-          });
+          let runId;
+          try {
+            runId = triggerRun(store, registry, pipeline, {
+              ...(opts.session ? { sessionId: opts.session } : {}),
+              ...(opts.headSha ? { headSha: opts.headSha } : {}),
+            });
+          } catch (err) {
+            if (err instanceof LoopAlreadyActiveError) {
+              fail(err);
+            }
+            throw err;
+          }
 
           if (opts.json) {
-            console.log(JSON.stringify({ projectId, runId, pipelineName }, null, 2));
+            console.log(
+              JSON.stringify({ projectId, runId, pipelineName: pipeline.name }, null, 2),
+            );
             return;
           }
 
           console.log(
             chalk.green(
-              `✓ Triggered ${chalk.bold(pipelineName)} for ${chalk.bold(projectId)} → ${runId}`,
+              `✓ Triggered ${chalk.bold(pipeline.name)} for ${chalk.bold(projectId)} → ${runId}`,
             ),
           );
           console.log(
             chalk.dim(
-              `  Run state persisted. Stages will execute on the next orchestrator tick.`,
+              `  Run state persisted. v0.4 lifecycle integration will pick it up.`,
             ),
           );
+          await warnIfAORunning(projectId);
         } catch (err) {
           fail(err);
         }
@@ -256,21 +298,38 @@ export function registerPipeline(program: Command): void {
     .argument("<runId>", "Pipeline run id")
     .option("-p, --project <id>", "Project to scope to")
     .option("--json", "Output as JSON")
-    .action((runIdArg: string, opts: { project?: string; json?: boolean }) => {
+    .action(async (runIdArg: string, opts: { project?: string; json?: boolean }) => {
       try {
-        const { store } = openScope(opts.project);
-        const updated = cancelRun(store, asRunId(runIdArg));
+        const { store, projectId } = openScope(opts.project);
+        const { run, alreadyTerminal } = cancelRun(store, asRunId(runIdArg));
 
         if (opts.json) {
-          console.log(JSON.stringify({ run: updated }, null, 2));
+          console.log(JSON.stringify({ run, alreadyTerminal }, null, 2));
+          return;
+        }
+
+        if (alreadyTerminal) {
+          console.log(
+            chalk.yellow(
+              `⚠ ${run.runId} is already in a terminal state (${formatLoopState(run.loopState)})${run.terminationReason ? chalk.dim(` — ${run.terminationReason}`) : ""}.`,
+            ),
+          );
+          if (run.loopState === "stalled") {
+            console.log(
+              chalk.dim(
+                `  Use \`ao pipeline resume ${run.runId}\` to retry failed stages instead.`,
+              ),
+            );
+          }
           return;
         }
 
         console.log(
           chalk.green(
-            `✓ ${updated.runId} → ${formatLoopState(updated.loopState)}${updated.terminationReason ? chalk.dim(` (${updated.terminationReason})`) : ""}`,
+            `✓ ${run.runId} → ${formatLoopState(run.loopState)}${run.terminationReason ? chalk.dim(` (${run.terminationReason})`) : ""}`,
           ),
         );
+        await warnIfAORunning(projectId);
       } catch (err) {
         fail(err);
       }
@@ -282,9 +341,9 @@ export function registerPipeline(program: Command): void {
     .argument("<runId>", "Pipeline run id")
     .option("-p, --project <id>", "Project to scope to")
     .option("--json", "Output as JSON")
-    .action((runIdArg: string, opts: { project?: string; json?: boolean }) => {
+    .action(async (runIdArg: string, opts: { project?: string; json?: boolean }) => {
       try {
-        const { store } = openScope(opts.project);
+        const { store, projectId } = openScope(opts.project);
         const result = resumeRun(store, asRunId(runIdArg));
 
         if (opts.json) {
@@ -302,6 +361,7 @@ export function registerPipeline(program: Command): void {
             `✓ Reset ${result.resetStages.length} stage(s): ${result.resetStages.join(", ")}`,
           ),
         );
+        await warnIfAORunning(projectId);
       } catch (err) {
         fail(err);
       }

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -20,6 +20,7 @@ import {
   type RunState,
 } from "@aoagents/ao-core";
 
+import { fail } from "../lib/cli-utils.js";
 import { getPluginRegistry } from "../lib/create-session-manager.js";
 import { resolveScopedProjectId } from "../lib/project-resolution.js";
 import { getRunning } from "../lib/running-state.js";
@@ -46,11 +47,6 @@ function openScope(projectOpt?: string): ProjectScope {
   const projectId = resolveScopedProjectId(config, projectOpt);
   const store = createPipelineStore(getProjectPipelinesDir(projectId));
   return { projectId, store, config };
-}
-
-function fail(err: unknown): never {
-  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-  process.exit(1);
 }
 
 /**
@@ -353,6 +349,15 @@ export function registerPipeline(program: Command): void {
 
         if (result.resetStages.length === 0) {
           console.log(chalk.dim(`  No failed stages to resume for ${result.run.runId}.`));
+          return;
+        }
+
+        if (result.run.loopState !== "running") {
+          console.log(
+            chalk.yellow(
+              `⚠ No stages could be reset — retry cap exceeded for: ${result.resetStages.join(", ")}.`,
+            ),
+          );
           return;
         }
 

--- a/packages/cli/src/commands/pipeline.ts
+++ b/packages/cli/src/commands/pipeline.ts
@@ -1,0 +1,330 @@
+/**
+ * `ao pipeline` — list configured pipelines, manage runs.
+ *
+ * Sub-commands: list, runs, show, run, cancel, resume, migrate.
+ *
+ * The actual store I/O is delegated to `lib/pipeline-service.ts` so unit
+ * tests can mock the store and assert on calls. This file only handles
+ * project resolution, argument parsing, and presentation.
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  asRunId,
+  createPipelineStore,
+  getProjectPipelinesDir,
+  loadConfig,
+  type OrchestratorConfig,
+  type PipelineStore,
+  type RunState,
+} from "@aoagents/ao-core";
+
+import { getPluginRegistry } from "../lib/create-session-manager.js";
+import { resolveScopedProjectId } from "../lib/project-resolution.js";
+import {
+  cancelRun,
+  describeRun,
+  listConfiguredPipelines,
+  listRuns,
+  migrateStore,
+  resolveConfiguredPipeline,
+  resumeRun,
+  triggerRun,
+} from "../lib/pipeline-service.js";
+
+interface ProjectScope {
+  projectId: string;
+  store: PipelineStore;
+  config: OrchestratorConfig;
+}
+
+function openScope(projectOpt?: string): ProjectScope {
+  const config = loadConfig();
+  const projectId = resolveScopedProjectId(config, projectOpt);
+  const store = createPipelineStore(getProjectPipelinesDir(projectId));
+  return { projectId, store, config };
+}
+
+function fail(err: unknown): never {
+  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+  process.exit(1);
+}
+
+function formatLoopState(state: RunState["loopState"]): string {
+  switch (state) {
+    case "running":
+      return chalk.cyan(state);
+    case "awaiting_context":
+      return chalk.yellow(state);
+    case "done":
+      return chalk.green(state);
+    case "stalled":
+      return chalk.magenta(state);
+    case "terminated":
+      return chalk.gray(state);
+    default:
+      return state;
+  }
+}
+
+export function registerPipeline(program: Command): void {
+  const pipeline = program
+    .command("pipeline")
+    .description("Pipeline management (list configs, run, show, cancel, resume, migrate)");
+
+  pipeline
+    .command("list")
+    .description("List configured pipelines")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((opts: { project?: string; json?: boolean }) => {
+      try {
+        const { config, projectId } = openScope(opts.project);
+        const pipelines = listConfiguredPipelines(config, projectId);
+
+        if (opts.json) {
+          console.log(JSON.stringify({ projectId, pipelines }, null, 2));
+          return;
+        }
+
+        if (pipelines.length === 0) {
+          console.log(chalk.dim(`  (no pipelines configured for ${projectId})`));
+          return;
+        }
+
+        console.log(chalk.bold(`\nPipelines for ${projectId}:`));
+        for (const p of pipelines) {
+          const triggers = p.triggers.length > 0 ? p.triggers.join(", ") : "(none)";
+          console.log(
+            `  ${chalk.green(p.pipelineId)}  ${chalk.dim(`${p.stageCount} stage(s) — triggers: ${triggers}`)}`,
+          );
+        }
+        console.log();
+      } catch (err) {
+        fail(err);
+      }
+    });
+
+  pipeline
+    .command("runs")
+    .description("List pipeline runs (newest first)")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--pipeline <name>", "Filter by pipeline name")
+    .option("--status <state>", "Filter by loop state (running, done, stalled, terminated, awaiting_context)")
+    .option("--limit <n>", "Maximum number of runs to show", (v) => Number.parseInt(v, 10))
+    .option("--json", "Output as JSON")
+    .action(
+      (opts: { project?: string; pipeline?: string; status?: string; limit?: number; json?: boolean }) => {
+        try {
+          const { store, projectId } = openScope(opts.project);
+          const filtered = listRuns(store, {
+            ...(opts.pipeline ? { pipeline: opts.pipeline } : {}),
+            ...(opts.status ? { status: opts.status } : {}),
+          });
+          const limited =
+            opts.limit && opts.limit > 0 ? filtered.slice(0, opts.limit) : filtered;
+
+          if (opts.json) {
+            console.log(JSON.stringify({ projectId, runs: limited }, null, 2));
+            return;
+          }
+
+          if (limited.length === 0) {
+            console.log(chalk.dim("  (no runs)"));
+            return;
+          }
+
+          console.log(chalk.bold(`\nRuns for ${projectId}:`));
+          for (const run of limited) {
+            const reason = run.terminationReason ? ` (${run.terminationReason})` : "";
+            console.log(
+              `  ${chalk.green(run.runId)}  ${chalk.cyan(run.pipelineName)}  ${formatLoopState(run.loopState)}${chalk.dim(reason)}  ${chalk.dim(run.createdAt)}`,
+            );
+          }
+          console.log();
+        } catch (err) {
+          fail(err);
+        }
+      },
+    );
+
+  pipeline
+    .command("show")
+    .description("Show run detail (stages + artifacts)")
+    .argument("<runId>", "Pipeline run id")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((runIdArg: string, opts: { project?: string; json?: boolean }) => {
+      try {
+        const { store } = openScope(opts.project);
+        const detail = describeRun(store, asRunId(runIdArg));
+
+        if (opts.json) {
+          console.log(JSON.stringify(detail, null, 2));
+          return;
+        }
+
+        const { run, loop, stages } = detail;
+        console.log(chalk.bold(`\nRun ${run.runId}`));
+        console.log(`  pipeline:  ${chalk.cyan(run.pipelineName)}`);
+        console.log(`  session:   ${run.sessionId}`);
+        console.log(`  state:     ${formatLoopState(run.loopState)}`);
+        if (run.terminationReason) {
+          console.log(`  reason:    ${chalk.dim(run.terminationReason)}`);
+        }
+        console.log(`  rounds:    ${run.loopRounds}`);
+        console.log(`  headSha:   ${run.headSha}`);
+        console.log(`  created:   ${chalk.dim(run.createdAt)}`);
+        console.log(`  updated:   ${chalk.dim(run.updatedAt)}`);
+
+        console.log(chalk.bold(`\nStages:`));
+        if (stages.length === 0) {
+          console.log(chalk.dim("  (none)"));
+        }
+        for (const { stageName, state, artifacts } of stages) {
+          const verdict = state.verdict ? ` ${chalk.dim(`verdict=${state.verdict}`)}` : "";
+          console.log(
+            `  ${chalk.green(stageName)}  ${chalk.cyan(state.status)}${verdict}  attempts=${state.attempt}  artifacts=${artifacts.length}`,
+          );
+          if (state.errorMessage) {
+            console.log(`    ${chalk.red(`error: ${state.errorMessage}`)}`);
+          }
+          console.log(`    ${chalk.dim(`stageRunId=${state.stageRunId}`)}`);
+        }
+
+        if (loop) {
+          console.log(chalk.bold(`\nLoop:`));
+          console.log(`  state:    ${formatLoopState(loop.loopState)}`);
+          console.log(`  rounds:   ${loop.loopRounds}`);
+          if (loop.currentRunId) {
+            console.log(`  current:  ${loop.currentRunId}`);
+          }
+        }
+        console.log();
+      } catch (err) {
+        fail(err);
+      }
+    });
+
+  pipeline
+    .command("run")
+    .description("Trigger a manual run for a configured pipeline")
+    .argument("<pipelineName>", "Pipeline name (matches the key under projects.<id>.pipelines)")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--session <id>", "Override the session id used to key the run")
+    .option("--head-sha <sha>", "Override the head SHA recorded for the run")
+    .option("--json", "Output as JSON")
+    .action(
+      async (
+        pipelineName: string,
+        opts: { project?: string; session?: string; headSha?: string; json?: boolean },
+      ) => {
+        try {
+          const { config, projectId, store } = openScope(opts.project);
+          const pipeline = resolveConfiguredPipeline(config, projectId, pipelineName);
+          const registry = await getPluginRegistry(config);
+          const runId = triggerRun(store, registry, pipeline, {
+            ...(opts.session ? { sessionId: opts.session } : {}),
+            ...(opts.headSha ? { headSha: opts.headSha } : {}),
+          });
+
+          if (opts.json) {
+            console.log(JSON.stringify({ projectId, runId, pipelineName }, null, 2));
+            return;
+          }
+
+          console.log(
+            chalk.green(
+              `✓ Triggered ${chalk.bold(pipelineName)} for ${chalk.bold(projectId)} → ${runId}`,
+            ),
+          );
+          console.log(
+            chalk.dim(
+              `  Run state persisted. Stages will execute on the next orchestrator tick.`,
+            ),
+          );
+        } catch (err) {
+          fail(err);
+        }
+      },
+    );
+
+  pipeline
+    .command("cancel")
+    .description("Cancel an in-flight run (kills its stage sessions cleanly)")
+    .argument("<runId>", "Pipeline run id")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((runIdArg: string, opts: { project?: string; json?: boolean }) => {
+      try {
+        const { store } = openScope(opts.project);
+        const updated = cancelRun(store, asRunId(runIdArg));
+
+        if (opts.json) {
+          console.log(JSON.stringify({ run: updated }, null, 2));
+          return;
+        }
+
+        console.log(
+          chalk.green(
+            `✓ ${updated.runId} → ${formatLoopState(updated.loopState)}${updated.terminationReason ? chalk.dim(` (${updated.terminationReason})`) : ""}`,
+          ),
+        );
+      } catch (err) {
+        fail(err);
+      }
+    });
+
+  pipeline
+    .command("resume")
+    .description("Re-attempt failed stages of a previous run")
+    .argument("<runId>", "Pipeline run id")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((runIdArg: string, opts: { project?: string; json?: boolean }) => {
+      try {
+        const { store } = openScope(opts.project);
+        const result = resumeRun(store, asRunId(runIdArg));
+
+        if (opts.json) {
+          console.log(JSON.stringify(result, null, 2));
+          return;
+        }
+
+        if (result.resetStages.length === 0) {
+          console.log(chalk.dim(`  No failed stages to resume for ${result.run.runId}.`));
+          return;
+        }
+
+        console.log(
+          chalk.green(
+            `✓ Reset ${result.resetStages.length} stage(s): ${result.resetStages.join(", ")}`,
+          ),
+        );
+      } catch (err) {
+        fail(err);
+      }
+    });
+
+  pipeline
+    .command("migrate")
+    .description("Run the pipeline store schema migration helper")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((opts: { project?: string; json?: boolean }) => {
+      try {
+        const { store, projectId } = openScope(opts.project);
+        const result = migrateStore(store);
+
+        if (opts.json) {
+          console.log(JSON.stringify({ projectId, ...result }, null, 2));
+          return;
+        }
+
+        console.log(chalk.green(`✓ ${result.message}`));
+      } catch (err) {
+        fail(err);
+      }
+    });
+}

--- a/packages/cli/src/commands/stage.ts
+++ b/packages/cli/src/commands/stage.ts
@@ -11,13 +11,9 @@ import {
   loadConfig,
 } from "@aoagents/ao-core";
 
+import { fail } from "../lib/cli-utils.js";
 import { resolveScopedProjectId } from "../lib/project-resolution.js";
 import { describeStage } from "../lib/pipeline-service.js";
-
-function fail(err: unknown): never {
-  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
-  process.exit(1);
-}
 
 export function registerStage(program: Command): void {
   const stage = program.command("stage").description("Pipeline stage inspection");

--- a/packages/cli/src/commands/stage.ts
+++ b/packages/cli/src/commands/stage.ts
@@ -1,0 +1,85 @@
+/**
+ * `ao stage` — inspect a single stage run.
+ */
+
+import chalk from "chalk";
+import type { Command } from "commander";
+import {
+  asStageRunId,
+  createPipelineStore,
+  getProjectPipelinesDir,
+  loadConfig,
+} from "@aoagents/ao-core";
+
+import { resolveScopedProjectId } from "../lib/project-resolution.js";
+import { describeStage } from "../lib/pipeline-service.js";
+
+function fail(err: unknown): never {
+  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+  process.exit(1);
+}
+
+export function registerStage(program: Command): void {
+  const stage = program.command("stage").description("Pipeline stage inspection");
+
+  stage
+    .command("show")
+    .description("Show a stage run with its artifacts")
+    .argument("<stageRunId>", "Stage run id")
+    .option("-p, --project <id>", "Project to scope to")
+    .option("--json", "Output as JSON")
+    .action((stageRunIdArg: string, opts: { project?: string; json?: boolean }) => {
+      try {
+        const config = loadConfig();
+        const projectId = resolveScopedProjectId(config, opts.project);
+        const store = createPipelineStore(getProjectPipelinesDir(projectId));
+        const detail = describeStage(store, asStageRunId(stageRunIdArg));
+
+        if (opts.json) {
+          console.log(JSON.stringify(detail, null, 2));
+          return;
+        }
+
+        const { stage: stageRun, run, artifacts } = detail;
+        console.log(chalk.bold(`\nStage ${stageRun.stageRunId}`));
+        console.log(`  stage:     ${chalk.cyan(stageRun.stageName)}`);
+        console.log(`  run:       ${stageRun.runId}`);
+        if (run) {
+          console.log(`  pipeline:  ${chalk.cyan(run.pipelineName)}`);
+          console.log(`  session:   ${run.sessionId}`);
+        }
+        console.log(`  status:    ${chalk.cyan(stageRun.status)}`);
+        if (stageRun.verdict) {
+          console.log(`  verdict:   ${stageRun.verdict}`);
+        }
+        console.log(`  attempts:  ${stageRun.attempt}`);
+        if (stageRun.startedAt) {
+          console.log(`  started:   ${chalk.dim(stageRun.startedAt)}`);
+        }
+        if (stageRun.completedAt) {
+          console.log(`  completed: ${chalk.dim(stageRun.completedAt)}`);
+        }
+        if (stageRun.errorMessage) {
+          console.log(`  ${chalk.red(`error: ${stageRun.errorMessage}`)}`);
+        }
+
+        console.log(chalk.bold(`\nArtifacts (${artifacts.length}):`));
+        if (artifacts.length === 0) {
+          console.log(chalk.dim("  (none)"));
+        } else {
+          for (const art of artifacts) {
+            if (art.kind === "finding") {
+              console.log(
+                `  ${chalk.green(art.artifactId)}  ${chalk.cyan(art.severity)}  ${art.title}  ${chalk.dim(`${art.filePath}:${art.startLine}`)}`,
+              );
+            } else {
+              console.log(`  ${chalk.green(art.artifactId)}  ${chalk.cyan("json")}`);
+            }
+          }
+        }
+        console.log();
+      } catch (err) {
+        fail(err);
+      }
+    });
+}

--- a/packages/cli/src/lib/cli-utils.ts
+++ b/packages/cli/src/lib/cli-utils.ts
@@ -1,0 +1,6 @@
+import chalk from "chalk";
+
+export function fail(err: unknown): never {
+  console.error(chalk.red(`✗ ${err instanceof Error ? err.message : String(err)}`));
+  process.exit(1);
+}

--- a/packages/cli/src/lib/completion.ts
+++ b/packages/cli/src/lib/completion.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import type { Argument, Command, Option } from "commander";
 import {
   AGENT_REPORTED_STATES,
@@ -7,6 +8,7 @@ import {
   loadConfig,
   loadGlobalConfig,
   getGlobalConfigPath,
+  pipelineLayout,
   type OrchestratorConfig,
   type Session,
 } from "@aoagents/ao-core";
@@ -454,11 +456,22 @@ async function listPipelinesAcrossProjects(): Promise<CompletionSuggestion[]> {
   }
 }
 
+/**
+ * existsSync-gate the pipeline runs dir before instantiating the store. The
+ * store's `listRuns` calls `ensureLayout()` which mkdirs `runs/`, `stages/`,
+ * `artifacts/`, `loops/` for every project — completion is read-only by
+ * definition and must not materialize empty dirs as a tab-press side effect.
+ */
+function projectHasPipelineState(projectId: string): boolean {
+  return existsSync(pipelineLayout(getProjectPipelinesDir(projectId)).runsDir);
+}
+
 async function listPipelineRuns(): Promise<CompletionSuggestion[]> {
   try {
     const config = loadConfig();
     const out: CompletionSuggestion[] = [];
     for (const projectId of Object.keys(config.projects)) {
+      if (!projectHasPipelineState(projectId)) continue;
       const store = createPipelineStore(getProjectPipelinesDir(projectId));
       for (const run of store.listRuns()) {
         out.push({
@@ -478,6 +491,7 @@ async function listStageRuns(): Promise<CompletionSuggestion[]> {
     const config = loadConfig();
     const out: CompletionSuggestion[] = [];
     for (const projectId of Object.keys(config.projects)) {
+      if (!projectHasPipelineState(projectId)) continue;
       const store = createPipelineStore(getProjectPipelinesDir(projectId));
       for (const run of store.listRuns()) {
         for (const [stageName, state] of Object.entries(run.stages)) {

--- a/packages/cli/src/lib/completion.ts
+++ b/packages/cli/src/lib/completion.ts
@@ -1,6 +1,8 @@
 import type { Argument, Command, Option } from "commander";
 import {
   AGENT_REPORTED_STATES,
+  createPipelineStore,
+  getProjectPipelinesDir,
   isTerminalSession,
   loadConfig,
   loadGlobalConfig,
@@ -10,6 +12,7 @@ import {
 } from "@aoagents/ao-core";
 import { getSessionManager } from "./create-session-manager.js";
 import { isOrchestratorSessionName } from "./session-utils.js";
+import { listConfiguredPipelines } from "./pipeline-service.js";
 
 export interface CompletionSuggestion {
   value: string;
@@ -119,6 +122,12 @@ function getArgumentAction(node: CompletionCommandNode, argumentIndex: number): 
   if (key === "session restore" && argumentIndex === 0) return "_ao_complete_all_sessions";
   if (key === "session remap" && argumentIndex === 0) return "_ao_complete_all_sessions";
   if (key === "session claim-pr" && argumentIndex === 1) return "_ao_complete_sessions";
+  if (key === "pipeline run" && argumentIndex === 0) return "_ao_complete_pipelines";
+  if (key === "pipeline show" && argumentIndex === 0) return "_ao_complete_pipeline_runs";
+  if (key === "pipeline cancel" && argumentIndex === 0) return "_ao_complete_pipeline_runs";
+  if (key === "pipeline resume" && argumentIndex === 0) return "_ao_complete_pipeline_runs";
+  if (key === "stage show" && argumentIndex === 0) return "_ao_complete_stage_runs";
+  if (key === "artifact show" && argumentIndex === 0) return "_ao_complete_stage_runs";
 
   const argumentName =
     argumentIndex >= 0 ? node.arguments[argumentIndex]?.name()?.toLowerCase() ?? "" : "";
@@ -159,6 +168,23 @@ function getOptionAction(node: CompletionCommandNode, option: Option): string | 
   }
   if (key === "plugin create" && optionMatches(option, "--slot")) {
     return "_ao_complete_plugin_slots";
+  }
+  if (
+    (key === "pipeline list" ||
+      key === "pipeline runs" ||
+      key === "pipeline show" ||
+      key === "pipeline run" ||
+      key === "pipeline cancel" ||
+      key === "pipeline resume" ||
+      key === "pipeline migrate" ||
+      key === "stage show" ||
+      key === "artifact show") &&
+    (optionMatches(option, "-p") || optionMatches(option, "--project"))
+  ) {
+    return "_ao_complete_projects";
+  }
+  if (key === "pipeline runs" && optionMatches(option, "--pipeline")) {
+    return "_ao_complete_pipelines";
   }
 
   const attributeName = option.attributeName().toLowerCase();
@@ -407,6 +433,67 @@ async function listOpenTargets(): Promise<CompletionSuggestion[]> {
   ];
 }
 
+async function listPipelinesAcrossProjects(): Promise<CompletionSuggestion[]> {
+  try {
+    const config = loadConfig();
+    const out: CompletionSuggestion[] = [];
+    const seen = new Set<string>();
+    for (const projectId of Object.keys(config.projects)) {
+      for (const p of listConfiguredPipelines(config, projectId)) {
+        if (seen.has(p.pipelineId)) continue;
+        seen.add(p.pipelineId);
+        out.push({
+          value: p.pipelineId,
+          description: `${projectId} — ${p.stageCount} stage(s)`,
+        });
+      }
+    }
+    return sortSuggestions(out);
+  } catch {
+    return [];
+  }
+}
+
+async function listPipelineRuns(): Promise<CompletionSuggestion[]> {
+  try {
+    const config = loadConfig();
+    const out: CompletionSuggestion[] = [];
+    for (const projectId of Object.keys(config.projects)) {
+      const store = createPipelineStore(getProjectPipelinesDir(projectId));
+      for (const run of store.listRuns()) {
+        out.push({
+          value: run.runId,
+          description: `${projectId} — ${run.pipelineName} [${run.loopState}]`,
+        });
+      }
+    }
+    return sortSuggestions(out);
+  } catch {
+    return [];
+  }
+}
+
+async function listStageRuns(): Promise<CompletionSuggestion[]> {
+  try {
+    const config = loadConfig();
+    const out: CompletionSuggestion[] = [];
+    for (const projectId of Object.keys(config.projects)) {
+      const store = createPipelineStore(getProjectPipelinesDir(projectId));
+      for (const run of store.listRuns()) {
+        for (const [stageName, state] of Object.entries(run.stages)) {
+          out.push({
+            value: state.stageRunId,
+            description: `${projectId} — ${stageName} [${state.status}]`,
+          });
+        }
+      }
+    }
+    return sortSuggestions(out);
+  } catch {
+    return [];
+  }
+}
+
 export async function getCompletionSuggestions(
   kind: string,
   options: CompletionDataOptions = {},
@@ -419,6 +506,15 @@ export async function getCompletionSuggestions(
   }
   if (kind === "open-targets") {
     return await listOpenTargets();
+  }
+  if (kind === "pipelines") {
+    return await listPipelinesAcrossProjects();
+  }
+  if (kind === "pipeline-runs") {
+    return await listPipelineRuns();
+  }
+  if (kind === "stage-runs") {
+    return await listStageRuns();
   }
 
   return [];
@@ -493,6 +589,18 @@ _ao_complete_all_sessions() {
 
 _ao_complete_open_targets() {
   _ao_dynamic_describe targets "open target" open-targets
+}
+
+_ao_complete_pipelines() {
+  _ao_dynamic_describe pipelines "configured pipeline" pipelines
+}
+
+_ao_complete_pipeline_runs() {
+  _ao_dynamic_describe runs "pipeline run" pipeline-runs
+}
+
+_ao_complete_stage_runs() {
+  _ao_dynamic_describe stage-runs "stage run" stage-runs
 }
 
 _ao_complete_start_target() {

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -19,7 +19,8 @@ import {
   asRunId,
   asStageRunId,
   configuredPipelineToRuntime,
-  emptyEngineState,
+  isTerminalLoopState,
+  loopKey,
   reduce,
   validatePipelineAgentModes,
   type Artifact,
@@ -35,10 +36,27 @@ import {
   type PluginRegistry,
   type RunId,
   type RunState,
+  type RunSummary,
   type StageRunId,
   type StageState,
-  type StageStatus,
 } from "@aoagents/ao-core";
+
+/**
+ * Thrown by `triggerRun` when a non-terminal run already exists for the same
+ * `(sessionId, pipelineName)` loop key. Surfaces the offending runId so the
+ * CLI can suggest `ao pipeline cancel <runId>` before retrying.
+ */
+export class LoopAlreadyActiveError extends Error {
+  constructor(
+    message: string,
+    public readonly activeRunId: RunId,
+    public readonly sessionId: string,
+    public readonly pipelineName: string,
+  ) {
+    super(message);
+    this.name = "LoopAlreadyActiveError";
+  }
+}
 
 /** Lightweight summary used by `ao pipeline list`. */
 export interface ConfiguredPipelineSummary {
@@ -89,20 +107,37 @@ function collectTriggers(configured: ConfiguredPipeline): string[] {
   return [...seen].sort();
 }
 
-/** Resolve a pipeline by name (case-sensitive map key). */
+/**
+ * Resolve a pipeline by id (YAML map key) or by `name` field. The map key
+ * wins on ties; falls back to a `name`-field match before throwing so
+ * `ao pipeline run my-review` works whether the user spelled `pipelines.my-review`
+ * or `pipelines.review.name: my-review`.
+ */
 export function resolveConfiguredPipeline(
   config: OrchestratorConfig,
   projectId: string,
   pipelineName: string,
 ): Pipeline {
   const project = config.projects[projectId];
-  const configured = project?.pipelines?.[pipelineName];
-  if (!configured) {
+  const pipelines = project?.pipelines;
+  if (!pipelines) {
     throw new Error(
       `Pipeline "${pipelineName}" is not configured for project "${projectId}".`,
     );
   }
-  return configuredPipelineToRuntime(pipelineName, configured);
+
+  const direct = pipelines[pipelineName];
+  if (direct) return configuredPipelineToRuntime(pipelineName, direct);
+
+  for (const [key, configured] of Object.entries(pipelines)) {
+    if (configured.name === pipelineName) {
+      return configuredPipelineToRuntime(key, configured);
+    }
+  }
+
+  throw new Error(
+    `Pipeline "${pipelineName}" is not configured for project "${projectId}".`,
+  );
 }
 
 /** Filtered, newest-first list of runs for `ao pipeline runs`. */
@@ -174,9 +209,52 @@ export function readStageArtifacts(
 }
 
 /**
- * Trigger a manual run for a pipeline. The reducer dispatches TRIGGER_FIRED;
- * effects are persisted via the store. The CLI returns the allocated run id;
- * the running orchestrator (when present) drives the run forward via tick().
+ * Rebuild engine state from the flat-file store. Used so reducer dispatches
+ * see existing runs / loop pointers / history rather than starting from
+ * `emptyEngineState()` (which would defeat the reducer's collision guards).
+ *
+ * Terminal runs go into `historySummaries`; the latest non-terminal run on
+ * each loop key wins `currentRunByLoop`.
+ */
+export function hydrateEngineState(store: PipelineStore): EngineState {
+  const runs: Record<string, RunState> = {};
+  const currentRunByLoop: Record<string, RunId> = {};
+  const historySummaries: Record<string, RunSummary[]> = {};
+
+  // Sort oldest-first so historySummaries preserves chronological order.
+  const sorted = [...store.listRuns()].sort((a, b) =>
+    a.createdAt.localeCompare(b.createdAt),
+  );
+
+  for (const run of sorted) {
+    runs[run.runId] = run;
+    const key = loopKey(run.sessionId, run.pipelineName);
+
+    if (isTerminalLoopState(run.loopState)) {
+      const list = historySummaries[key] ?? [];
+      list.push({
+        runId: run.runId,
+        loopState: run.loopState,
+        ...(run.terminationReason ? { terminationReason: run.terminationReason } : {}),
+        headSha: run.headSha,
+        loopRounds: run.loopRounds,
+        fingerprints: [],
+        createdAt: run.createdAt,
+      });
+      historySummaries[key] = list;
+    } else {
+      currentRunByLoop[key] = run.runId;
+    }
+  }
+
+  return { runs, currentRunByLoop, historySummaries };
+}
+
+/**
+ * Trigger a manual run for a pipeline. Hydrates engine state from the store
+ * so the reducer's "active run already in flight for this loop" guard fires
+ * when a non-terminal run already exists. Returns the allocated run id; the
+ * running orchestrator drives stage execution.
  *
  * `sessionId` defaults to `pipeline.<name>` so a CLI-triggered run can be
  * looked up by name without a worker session attached. Callers that already
@@ -196,17 +274,31 @@ export function triggerRun(
 ): RunId {
   validatePipelineAgentModes(pipeline, registry);
 
+  const sessionId = options.sessionId ?? `pipeline.${pipeline.name}`;
+  const initialState = hydrateEngineState(store);
+  const key = loopKey(sessionId, pipeline.name);
+  const activeRunId = initialState.currentRunByLoop[key];
+  if (activeRunId && initialState.runs[activeRunId]) {
+    throw new LoopAlreadyActiveError(
+      `Pipeline "${pipeline.name}" already has an active run (${activeRunId}). ` +
+        `Cancel it with \`ao pipeline cancel ${activeRunId}\` before triggering a new one.`,
+      activeRunId,
+      sessionId,
+      pipeline.name,
+    );
+  }
+
   const runId = asRunId(`run-${randomUUID()}`);
   const stageRunIds: Record<string, StageRunId> = {};
   for (const stage of pipeline.stages) {
     stageRunIds[stage.name] = asStageRunId(`sr-${randomUUID()}`);
   }
 
-  applyEvent(store, emptyEngineState(), {
+  applyEvent(store, initialState, {
     type: "TRIGGER_FIRED",
     now: now(),
     trigger: "manual",
-    sessionId: options.sessionId ?? `pipeline.${pipeline.name}`,
+    sessionId,
     pipeline,
     headSha: options.headSha ?? "manual",
     runId,
@@ -217,50 +309,52 @@ export function triggerRun(
 }
 
 /**
- * Cancel an in-flight run. Loads the run state from the store, dispatches
- * RUN_CANCELLED through the reducer, and persists effects. Idempotent:
- * cancelling a terminal run is a no-op.
+ * Cancel an in-flight run. Hydrates engine state from the store, dispatches
+ * RUN_CANCELLED through the reducer, and persists effects.
+ *
+ * Returns `{ run, alreadyTerminal }`. `alreadyTerminal` is true when the run
+ * was already in a terminal loop state and the reducer was not invoked, so
+ * the caller can distinguish a no-op from an actual cancellation. Stalled
+ * runs are reported as already terminal — the user should `resume` instead,
+ * or accept the existing terminal state.
  */
+export interface CancelResult {
+  run: RunState;
+  alreadyTerminal: boolean;
+}
+
 export function cancelRun(
   store: PipelineStore,
   runId: RunId,
   now: () => number = Date.now,
-): RunState {
+): CancelResult {
   const run = store.loadRun(runId);
   if (!run) throw new Error(`Run not found: ${runId}`);
 
-  if (
-    run.loopState === "done" ||
-    run.loopState === "stalled" ||
-    run.loopState === "terminated"
-  ) {
-    return run;
+  if (isTerminalLoopState(run.loopState)) {
+    return { run, alreadyTerminal: true };
   }
 
-  const initialState: EngineState = {
-    runs: { [runId]: run },
-    currentRunByLoop: { [`${run.sessionId}:${run.pipelineName}`]: runId },
-    historySummaries: {},
-  };
-
-  applyEvent(store, initialState, {
+  applyEvent(store, hydrateEngineState(store), {
     type: "RUN_CANCELLED",
     now: now(),
     runId,
     reason: "manual_cancel",
   });
 
-  const updated = store.loadRun(runId);
-  return updated ?? run;
+  const updated = store.loadRun(runId) ?? run;
+  return { run: updated, alreadyTerminal: false };
 }
 
 /**
- * Re-attempt failed stages of a previously terminated run. v0.3 keeps this
- * simple: failed stages are reset to `pending` and the run's loop state
- * returns to `running` so the orchestrator picks them up on its next tick.
+ * Re-attempt failed stages of a previously terminated run by dispatching
+ * RUN_RESUMED through the reducer. The reducer enforces the `stage.retries`
+ * cap and emits the same persistence + start-stage effects as the initial
+ * trigger, so a CLI resume looks indistinguishable from a fresh trigger to
+ * downstream consumers.
  *
- * Returns the list of stage names that were reset. If nothing was failed,
- * the run is returned untouched.
+ * Returns the run with the list of stage names that were reset (empty when
+ * the run had nothing to resume — that's a no-op, not an error).
  */
 export interface ResumeResult {
   run: RunState;
@@ -275,56 +369,39 @@ export function resumeRun(
   const run = store.loadRun(runId);
   if (!run) throw new Error(`Run not found: ${runId}`);
 
-  const resetStages: string[] = [];
-  const stages: Record<string, StageState> = {};
-  for (const [name, stage] of Object.entries(run.stages)) {
-    if (stage.status === "failed") {
-      stages[name] = {
-        ...stage,
-        status: "pending" as StageStatus,
-        attempt: stage.attempt + 1,
-        ...(stage.errorMessage !== undefined ? { errorMessage: undefined } : {}),
-      };
-      // Drop the optional errorMessage rather than leaving the previous one in.
-      delete (stages[name] as { errorMessage?: string }).errorMessage;
-      resetStages.push(name);
-    } else {
-      stages[name] = stage;
-    }
+  // Resume is only meaningful for runs that have stopped advancing — i.e.
+  // already in a terminal loop state. Bailing out on `running` /
+  // `awaiting_context` prevents a concurrent CLI resume from re-arming a
+  // run that the engine still considers in flight (which once v0.4 wires
+  // the orchestrator to the store could double-spawn stages).
+  if (!isTerminalLoopState(run.loopState)) {
+    throw new Error(
+      `Run ${runId} is in state "${run.loopState}", not a terminal state. ` +
+        `Cancel it first with \`ao pipeline cancel ${runId}\` if you want to restart.`,
+    );
   }
 
-  if (resetStages.length === 0) return { run, resetStages };
-
-  const iso = new Date(now()).toISOString();
-  const updated: RunState = {
-    ...run,
-    stages,
-    loopState: "running",
-    ...(run.terminationReason ? { terminationReason: undefined } : {}),
-    updatedAt: iso,
-  };
-  delete (updated as { terminationReason?: RunState["terminationReason"] }).terminationReason;
-  store.saveRun(updated);
-  for (const name of resetStages) {
-    store.saveStage({
-      ...stages[name],
-      runId,
-      stageName: name,
-    });
+  const failedStageNames = Object.entries(run.stages)
+    .filter(([, s]) => s.status === "failed")
+    .map(([name]) => name);
+  if (failedStageNames.length === 0) {
+    return { run, resetStages: [] };
   }
 
-  // Re-arm the loop pointer so the orchestrator treats this run as active.
-  store.saveLoopState(runId, {
-    sessionId: updated.sessionId,
-    pipelineName: updated.pipelineName,
-    loopState: "running",
-    loopRounds: updated.loopRounds,
-    lastSha: updated.headSha,
-    currentRunId: runId,
-    updatedAt: iso,
+  const stageRunIds: Record<string, StageRunId> = {};
+  for (const name of failedStageNames) {
+    stageRunIds[name] = asStageRunId(`sr-${randomUUID()}`);
+  }
+
+  applyEvent(store, hydrateEngineState(store), {
+    type: "RUN_RESUMED",
+    now: now(),
+    runId,
+    stageRunIds,
   });
 
-  return { run: updated, resetStages };
+  const updated = store.loadRun(runId);
+  return { run: updated ?? run, resetStages: failedStageNames };
 }
 
 /**

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -260,6 +260,9 @@ export function hydrateEngineState(store: PipelineStore): EngineState {
  * looked up by name without a worker session attached. Callers that already
  * have a session (e.g. lifecycle integration in v0.4) should override it.
  */
+/** Sentinel recorded in RunState.headSha when a run is triggered via CLI with no git context. */
+const MANUAL_TRIGGER_SHA = "manual";
+
 export interface TriggerOptions {
   sessionId?: string;
   headSha?: string;
@@ -300,7 +303,7 @@ export function triggerRun(
     trigger: "manual",
     sessionId,
     pipeline,
-    headSha: options.headSha ?? "manual",
+    headSha: options.headSha ?? MANUAL_TRIGGER_SHA,
     runId,
     stageRunIds,
   });

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -144,7 +144,12 @@ export function resolveConfiguredPipeline(
 export function listRuns(store: PipelineStore, filter: RunFilter = {}): RunState[] {
   const runs = store.listRuns();
   const filtered = runs.filter((run) => {
-    if (filter.pipeline && run.pipelineName !== filter.pipeline) return false;
+    if (
+      filter.pipeline &&
+      run.pipelineName !== filter.pipeline &&
+      run.pipelineId !== filter.pipeline
+    )
+      return false;
     if (filter.status && run.loopState !== filter.status) return false;
     return true;
   });
@@ -250,6 +255,14 @@ export function hydrateEngineState(store: PipelineStore): EngineState {
   return { runs, currentRunByLoop, historySummaries };
 }
 
+/** Sentinel recorded in RunState.headSha when a run is triggered via CLI with no git context. */
+const MANUAL_TRIGGER_SHA = "manual";
+
+export interface TriggerOptions {
+  sessionId?: string;
+  headSha?: string;
+}
+
 /**
  * Trigger a manual run for a pipeline. Hydrates engine state from the store
  * so the reducer's "active run already in flight for this loop" guard fires
@@ -260,14 +273,6 @@ export function hydrateEngineState(store: PipelineStore): EngineState {
  * looked up by name without a worker session attached. Callers that already
  * have a session (e.g. lifecycle integration in v0.4) should override it.
  */
-/** Sentinel recorded in RunState.headSha when a run is triggered via CLI with no git context. */
-const MANUAL_TRIGGER_SHA = "manual";
-
-export interface TriggerOptions {
-  sessionId?: string;
-  headSha?: string;
-}
-
 export function triggerRun(
   store: PipelineStore,
   registry: PluginRegistry,

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -1,0 +1,383 @@
+/**
+ * Pipeline service — pure adapters between the CLI and the v0.1/v0.2 pipeline
+ * core (config schema + flat-file store + reducer).
+ *
+ * Each function takes its dependencies as arguments so the CLI command tests
+ * can inject a mocked store / config and assert on store interactions
+ * (per the v0.3 acceptance criterion).
+ *
+ * The service intentionally does NOT depend on the `engine.ts` orchestrator
+ * loop: `ao pipeline run` allocates IDs and persists initial run state, but
+ * driving stages forward (spawning sessions, polling) is the running
+ * orchestrator's job in a later sub-task. This keeps the CLI usable
+ * stand-alone for inspection and idempotent for triggers.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  configuredPipelineToRuntime,
+  emptyEngineState,
+  reduce,
+  validatePipelineAgentModes,
+  type Artifact,
+  type ConfiguredPipeline,
+  type EngineState,
+  type LoopState,
+  type OrchestratorConfig,
+  type PersistedStageRun,
+  type Pipeline,
+  type PipelineEffect,
+  type PipelineEvent,
+  type PipelineStore,
+  type PluginRegistry,
+  type RunId,
+  type RunState,
+  type StageRunId,
+  type StageState,
+  type StageStatus,
+} from "@aoagents/ao-core";
+
+/** Lightweight summary used by `ao pipeline list`. */
+export interface ConfiguredPipelineSummary {
+  pipelineId: string;
+  name: string;
+  stageCount: number;
+  triggers: string[];
+}
+
+export interface RunFilter {
+  pipeline?: string;
+  status?: string;
+}
+
+export type RunStatusLabel =
+  | "running"
+  | "awaiting_context"
+  | "done"
+  | "stalled"
+  | "terminated";
+
+/** All pipelines configured for a project (`projects.<id>.pipelines`). */
+export function listConfiguredPipelines(
+  config: OrchestratorConfig,
+  projectId: string,
+): ConfiguredPipelineSummary[] {
+  const project = config.projects[projectId];
+  if (!project?.pipelines) return [];
+
+  return Object.entries(project.pipelines).map(([key, configured]) => {
+    const triggers = collectTriggers(configured);
+    return {
+      pipelineId: asPipelineId(key),
+      name: configured.name ?? key,
+      stageCount: configured.stages.length,
+      triggers,
+    };
+  });
+}
+
+function collectTriggers(configured: ConfiguredPipeline): string[] {
+  const seen = new Set<string>();
+  for (const stage of configured.stages) {
+    for (const event of stage.trigger.on) {
+      seen.add(event);
+    }
+  }
+  return [...seen].sort();
+}
+
+/** Resolve a pipeline by name (case-sensitive map key). */
+export function resolveConfiguredPipeline(
+  config: OrchestratorConfig,
+  projectId: string,
+  pipelineName: string,
+): Pipeline {
+  const project = config.projects[projectId];
+  const configured = project?.pipelines?.[pipelineName];
+  if (!configured) {
+    throw new Error(
+      `Pipeline "${pipelineName}" is not configured for project "${projectId}".`,
+    );
+  }
+  return configuredPipelineToRuntime(pipelineName, configured);
+}
+
+/** Filtered, newest-first list of runs for `ao pipeline runs`. */
+export function listRuns(store: PipelineStore, filter: RunFilter = {}): RunState[] {
+  const runs = store.listRuns();
+  const filtered = runs.filter((run) => {
+    if (filter.pipeline && run.pipelineName !== filter.pipeline) return false;
+    if (filter.status && run.loopState !== filter.status) return false;
+    return true;
+  });
+  return filtered.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export interface StageWithArtifacts {
+  stageName: string;
+  state: StageState;
+  artifacts: Artifact[];
+}
+
+export interface RunDetail {
+  run: RunState;
+  loop: LoopState | null;
+  stages: StageWithArtifacts[];
+}
+
+export function describeRun(store: PipelineStore, runId: RunId): RunDetail {
+  const run = store.loadRun(runId);
+  if (!run) throw new Error(`Run not found: ${runId}`);
+
+  const loop = store.loadLoopState(runId);
+  const stages: StageWithArtifacts[] = Object.entries(run.stages).map(
+    ([stageName, stageState]) => ({
+      stageName,
+      state: stageState,
+      artifacts: store.listArtifacts(runId, stageState.stageRunId),
+    }),
+  );
+
+  return { run, loop, stages };
+}
+
+/** Resolved stage detail used by `ao stage show`. */
+export interface StageDetail {
+  stage: PersistedStageRun;
+  run: RunState | null;
+  artifacts: Artifact[];
+}
+
+export function describeStage(
+  store: PipelineStore,
+  stageRunId: StageRunId,
+): StageDetail {
+  const stage = store.loadStage(stageRunId);
+  if (!stage) throw new Error(`Stage not found: ${stageRunId}`);
+
+  const run = store.loadRun(stage.runId);
+  const artifacts = store.listArtifacts(stage.runId, stageRunId);
+  return { stage, run, artifacts };
+}
+
+/** Read-only artifact list used by `ao artifact show <stageRunId>`. */
+export function readStageArtifacts(
+  store: PipelineStore,
+  stageRunId: StageRunId,
+): Artifact[] {
+  const stage = store.loadStage(stageRunId);
+  if (!stage) throw new Error(`Stage not found: ${stageRunId}`);
+  return store.listArtifacts(stage.runId, stageRunId);
+}
+
+/**
+ * Trigger a manual run for a pipeline. The reducer dispatches TRIGGER_FIRED;
+ * effects are persisted via the store. The CLI returns the allocated run id;
+ * the running orchestrator (when present) drives the run forward via tick().
+ *
+ * `sessionId` defaults to `pipeline.<name>` so a CLI-triggered run can be
+ * looked up by name without a worker session attached. Callers that already
+ * have a session (e.g. lifecycle integration in v0.4) should override it.
+ */
+export interface TriggerOptions {
+  sessionId?: string;
+  headSha?: string;
+}
+
+export function triggerRun(
+  store: PipelineStore,
+  registry: PluginRegistry,
+  pipeline: Pipeline,
+  options: TriggerOptions = {},
+  now: () => number = Date.now,
+): RunId {
+  validatePipelineAgentModes(pipeline, registry);
+
+  const runId = asRunId(`run-${randomUUID()}`);
+  const stageRunIds: Record<string, StageRunId> = {};
+  for (const stage of pipeline.stages) {
+    stageRunIds[stage.name] = asStageRunId(`sr-${randomUUID()}`);
+  }
+
+  applyEvent(store, emptyEngineState(), {
+    type: "TRIGGER_FIRED",
+    now: now(),
+    trigger: "manual",
+    sessionId: options.sessionId ?? `pipeline.${pipeline.name}`,
+    pipeline,
+    headSha: options.headSha ?? "manual",
+    runId,
+    stageRunIds,
+  });
+
+  return runId;
+}
+
+/**
+ * Cancel an in-flight run. Loads the run state from the store, dispatches
+ * RUN_CANCELLED through the reducer, and persists effects. Idempotent:
+ * cancelling a terminal run is a no-op.
+ */
+export function cancelRun(
+  store: PipelineStore,
+  runId: RunId,
+  now: () => number = Date.now,
+): RunState {
+  const run = store.loadRun(runId);
+  if (!run) throw new Error(`Run not found: ${runId}`);
+
+  if (
+    run.loopState === "done" ||
+    run.loopState === "stalled" ||
+    run.loopState === "terminated"
+  ) {
+    return run;
+  }
+
+  const initialState: EngineState = {
+    runs: { [runId]: run },
+    currentRunByLoop: { [`${run.sessionId}:${run.pipelineName}`]: runId },
+    historySummaries: {},
+  };
+
+  applyEvent(store, initialState, {
+    type: "RUN_CANCELLED",
+    now: now(),
+    runId,
+    reason: "manual_cancel",
+  });
+
+  const updated = store.loadRun(runId);
+  return updated ?? run;
+}
+
+/**
+ * Re-attempt failed stages of a previously terminated run. v0.3 keeps this
+ * simple: failed stages are reset to `pending` and the run's loop state
+ * returns to `running` so the orchestrator picks them up on its next tick.
+ *
+ * Returns the list of stage names that were reset. If nothing was failed,
+ * the run is returned untouched.
+ */
+export interface ResumeResult {
+  run: RunState;
+  resetStages: string[];
+}
+
+export function resumeRun(
+  store: PipelineStore,
+  runId: RunId,
+  now: () => number = Date.now,
+): ResumeResult {
+  const run = store.loadRun(runId);
+  if (!run) throw new Error(`Run not found: ${runId}`);
+
+  const resetStages: string[] = [];
+  const stages: Record<string, StageState> = {};
+  for (const [name, stage] of Object.entries(run.stages)) {
+    if (stage.status === "failed") {
+      stages[name] = {
+        ...stage,
+        status: "pending" as StageStatus,
+        attempt: stage.attempt + 1,
+        ...(stage.errorMessage !== undefined ? { errorMessage: undefined } : {}),
+      };
+      // Drop the optional errorMessage rather than leaving the previous one in.
+      delete (stages[name] as { errorMessage?: string }).errorMessage;
+      resetStages.push(name);
+    } else {
+      stages[name] = stage;
+    }
+  }
+
+  if (resetStages.length === 0) return { run, resetStages };
+
+  const iso = new Date(now()).toISOString();
+  const updated: RunState = {
+    ...run,
+    stages,
+    loopState: "running",
+    ...(run.terminationReason ? { terminationReason: undefined } : {}),
+    updatedAt: iso,
+  };
+  delete (updated as { terminationReason?: RunState["terminationReason"] }).terminationReason;
+  store.saveRun(updated);
+  for (const name of resetStages) {
+    store.saveStage({
+      ...stages[name],
+      runId,
+      stageName: name,
+    });
+  }
+
+  // Re-arm the loop pointer so the orchestrator treats this run as active.
+  store.saveLoopState(runId, {
+    sessionId: updated.sessionId,
+    pipelineName: updated.pipelineName,
+    loopState: "running",
+    loopRounds: updated.loopRounds,
+    lastSha: updated.headSha,
+    currentRunId: runId,
+    updatedAt: iso,
+  });
+
+  return { run: updated, resetStages };
+}
+
+/**
+ * Pipeline store-schema migration helper. v0.3 ships no schema changes yet —
+ * the helper exists so the verb is wired and stable; future schema bumps
+ * (the v0.4+ run-versioning epic) plug in here without churning the CLI.
+ */
+export interface MigrateResult {
+  migrated: number;
+  message: string;
+}
+
+export function migrateStore(_store: PipelineStore): MigrateResult {
+  return {
+    migrated: 0,
+    message: "Pipeline store is already on the v0.3 schema — nothing to migrate.",
+  };
+}
+
+/**
+ * Drive a single reducer step against `initialState` and persist all effects.
+ * Intentionally sequential and synchronous: the CLI is one-shot and never
+ * spawns stage sessions itself.
+ */
+function applyEvent(
+  store: PipelineStore,
+  initialState: EngineState,
+  event: PipelineEvent,
+): void {
+  const result = reduce(initialState, event);
+  for (const effect of result.effects) {
+    persistEffect(store, effect);
+  }
+}
+
+function persistEffect(store: PipelineStore, effect: PipelineEffect): void {
+  switch (effect.type) {
+    case "PERSIST_RUN":
+      store.saveRun(effect.runState);
+      for (const [stageName, stageState] of Object.entries(effect.runState.stages)) {
+        store.saveStage({ ...stageState, runId: effect.runState.runId, stageName });
+      }
+      break;
+    case "PERSIST_LOOP_STATE":
+      store.saveLoopState(effect.runId, effect.loopState);
+      break;
+    case "APPEND_ARTIFACTS":
+      store.appendArtifacts(effect.runId, effect.stageRunId, effect.artifacts);
+      break;
+    case "START_STAGE":
+    case "CANCEL_STAGE":
+    case "EMIT_OBSERVATION":
+      // Side effects owned by the engine driver; CLI is store-only.
+      break;
+  }
+}

--- a/packages/cli/src/lib/project-resolution.ts
+++ b/packages/cli/src/lib/project-resolution.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative, resolve } from "node:path";
+import type { OrchestratorConfig } from "@aoagents/ao-core";
 
 interface ProjectWithPath {
   path: string;
@@ -24,4 +25,35 @@ export function findProjectForDirectory<T extends ProjectWithPath>(
     .sort(([, a], [, b]) => resolve(b.path).length - resolve(a.path).length);
 
   return matches[0]?.[0] ?? null;
+}
+
+/**
+ * Resolve a project id for read-only inspection commands. Mirrors the cascade
+ * used by `ao spawn` (explicit flag → single project → AO_PROJECT_ID env →
+ * cwd match). Throws when ambiguous so the caller surfaces the error.
+ */
+export function resolveScopedProjectId(
+  config: OrchestratorConfig,
+  explicit?: string,
+): string {
+  if (explicit) {
+    if (!config.projects[explicit]) {
+      throw new Error(`Unknown project: ${explicit}`);
+    }
+    return explicit;
+  }
+
+  const ids = Object.keys(config.projects);
+  if (ids.length === 0) throw new Error("No projects configured.");
+  if (ids.length === 1) return ids[0];
+
+  const fromEnv = process.env["AO_PROJECT_ID"];
+  if (fromEnv && config.projects[fromEnv]) return fromEnv;
+
+  const matched = findProjectForDirectory(config.projects, resolve(process.cwd()));
+  if (matched) return matched;
+
+  throw new Error(
+    `Multiple projects configured. Pass --project <id>: ${ids.join(", ")}`,
+  );
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -18,6 +18,9 @@ import { registerProjectCommand } from "./commands/project.js";
 import { registerMigrateStorage } from "./commands/migrate-storage.js";
 import { registerCompletion } from "./commands/completion.js";
 import { registerEvents } from "./commands/events.js";
+import { registerPipeline } from "./commands/pipeline.js";
+import { registerStage } from "./commands/stage.js";
+import { registerArtifact } from "./commands/artifact.js";
 import { getConfigInstruction } from "./lib/config-instruction.js";
 import { getCliVersion } from "./options/version.js";
 
@@ -51,6 +54,9 @@ export function createProgram(): Command {
   registerMigrateStorage(program);
   registerCompletion(program);
   registerEvents(program);
+  registerPipeline(program);
+  registerStage(program);
+  registerArtifact(program);
 
   program
     .command("config-help")

--- a/packages/core/src/__tests__/pipeline-reducer.test.ts
+++ b/packages/core/src/__tests__/pipeline-reducer.test.ts
@@ -370,6 +370,92 @@ describe("pipeline reducer — RUN_CANCELLED / CONFIG_CHANGED", () => {
   });
 });
 
+describe("pipeline reducer — RUN_RESUMED", () => {
+  function failStage(state: EngineState, runId: RunId, stageName: string): EngineState {
+    const started = reduce(state, {
+      type: "STAGE_STARTED",
+      now: NOW + 1,
+      runId,
+      stageName,
+    });
+    const failed = reduce(started.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId,
+      stageName,
+      errorMessage: "boom",
+    });
+    return failed.state;
+  }
+
+  it("re-arms a stalled run: failed stage → pending with fresh stageRunId, loop → running", () => {
+    const triggered = fireTrigger(emptyEngineState());
+    const stalled = failStage(triggered.state, asRunId("run-1"), "review");
+    expect(stalled.runs[asRunId("run-1")].loopState).toBe("stalled");
+
+    const { state, effects } = reduce(stalled, {
+      type: "RUN_RESUMED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageRunIds: { review: asStageRunId("sr-resume-1") },
+    });
+
+    const run = state.runs[asRunId("run-1")];
+    expect(run.loopState).toBe("running");
+    expect(run.terminationReason).toBeUndefined();
+    expect(run.stages.review.status).toBe("pending");
+    expect(run.stages.review.attempt).toBe(2);
+    expect(run.stages.review.stageRunId).toBe("sr-resume-1");
+    expect(run.stages.review.errorMessage).toBeUndefined();
+
+    const types = effects.map((e) => e.type);
+    expect(types).toContain("PERSIST_RUN");
+    expect(types).toContain("PERSIST_LOOP_STATE");
+    expect(types).toContain("START_STAGE");
+    const obs = effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.run.resumed",
+    );
+    expect(obs).toBeDefined();
+  });
+
+  it("rejects RUN_RESUMED that would exceed stage.retries", () => {
+    const pipeline = makePipeline({
+      stages: [makeStage("review", { retries: 0 })], // 0 retries → cap at 1 attempt
+    });
+    const triggered = fireTrigger(emptyEngineState(), { pipeline });
+    const stalled = failStage(triggered.state, asRunId("run-1"), "review");
+    // attempt is currently 1; retries=0 means cap is 1. Resume would bump to 2 → reject.
+
+    const { state, effects } = reduce(stalled, {
+      type: "RUN_RESUMED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageRunIds: { review: asStageRunId("sr-resume-1") },
+    });
+
+    expect(state.runs[asRunId("run-1")].stages.review.status).toBe("failed");
+    expect(state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    const obs = effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+
+  it("rejects RUN_RESUMED on unknown runId", () => {
+    const { state, effects } = reduce(emptyEngineState(), {
+      type: "RUN_RESUMED",
+      now: NOW,
+      runId: asRunId("missing"),
+      stageRunIds: {},
+    });
+    expect(state).toEqual(emptyEngineState());
+    const obs = effects.find(
+      (e) => e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+});
+
 describe("pipeline reducer — purity", () => {
   it("does not mutate the input state on TRIGGER_FIRED", () => {
     const initial = emptyEngineState();

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -31,6 +31,7 @@ import {
   loadGlobalConfig,
 } from "./global-config.js";
 import { loadEffectiveProjectConfig } from "./project-resolver.js";
+import { PipelinesConfigSchema } from "./pipeline/config-schema.js";
 
 function inferScmPlugin(project: {
   repo?: string;
@@ -264,6 +265,7 @@ const ProjectConfigSchema = z.object({
     .enum(["reuse", "delete", "ignore", "delete-new", "ignore-new", "kill-previous"])
     .optional(),
   opencodeIssueSessionStrategy: z.enum(["reuse", "delete", "ignore"]).optional(),
+  pipelines: PipelinesConfigSchema.optional(),
 });
 
 const DefaultPluginsSchema = z.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,7 @@ export {
   getProjectSessionsDir,
   getProjectWorktreesDir,
   getProjectFeedbackReportsDir,
+  getProjectPipelinesDir,
   getOrchestratorPath,
   getSessionPath,
   parseTmuxNameV2,
@@ -401,6 +402,10 @@ export {
   AgentExecutorSpawnError,
   STAGE_FINDINGS_RELATIVE_PATH,
   createPipelineEngine,
+  // Pipeline config schema (`pipelines:` block)
+  ConfiguredPipelineSchema,
+  PipelinesConfigSchema,
+  configuredPipelineToRuntime,
 } from "./pipeline/index.js";
 
 export type {
@@ -459,6 +464,8 @@ export type {
   PipelineEngine,
   PipelineEngineDeps,
   StartRunInput,
+  ConfiguredPipeline,
+  PipelinesConfig,
 } from "./pipeline/index.js";
 
 // Activity event logging — structured diagnostic event trail

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -12,8 +12,7 @@
 
 import { z } from "zod";
 
-import { asPipelineId } from "./types.js";
-import type { Pipeline, Stage, StageExecutor, TaskMode } from "./types.js";
+import { asPipelineId, type Pipeline, type Stage, type StageExecutor, type TaskMode } from "./types.js";
 
 const TaskModeSchema = z.enum(["review", "code", "answer"]);
 

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -1,0 +1,133 @@
+/**
+ * Zod schema for `pipelines:` blocks in agent-orchestrator.yaml.
+ *
+ * Mirrors the runtime Pipeline / Stage types in pipeline/types.ts so that
+ * `loadConfig()` can surface configured pipelines to the CLI (`ao pipeline list`,
+ * `ao pipeline run`).
+ *
+ * The PipelineId is derived from the map key used in YAML rather than being
+ * spelled in each entry — it's branded at the boundary in
+ * `configuredPipelineToRuntime`.
+ */
+
+import { z } from "zod";
+
+import { asPipelineId } from "./types.js";
+import type { Pipeline, Stage, StageExecutor, TaskMode } from "./types.js";
+
+const TaskModeSchema = z.enum(["review", "code", "answer"]);
+
+const StageTriggerSchema = z.object({
+  on: z.array(
+    z.enum(["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"]),
+  ),
+});
+
+const AgentExecutorSchema = z.object({
+  kind: z.literal("agent"),
+  plugin: z.string(),
+  mode: TaskModeSchema,
+  config: z.record(z.unknown()).optional(),
+});
+
+const CommandExecutorSchema = z.object({
+  kind: z.literal("command"),
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  cwd: z.string().optional(),
+});
+
+const StageExecutorSchema = z.discriminatedUnion("kind", [
+  AgentExecutorSchema,
+  CommandExecutorSchema,
+]);
+
+const TaskSpecSchema = z.object({
+  prompt: z.string().optional(),
+  outputSchema: z.record(z.unknown()).optional(),
+  inputs: z.record(z.unknown()).optional(),
+});
+
+const StagePolicySchema = z.object({
+  blocksMerge: z.boolean().optional(),
+  stallWindow: z.number().int().nonnegative().optional(),
+});
+
+const StageBudgetSchema = z.object({
+  maxUsd: z.number().nonnegative().optional(),
+  maxDurationMs: z.number().int().nonnegative().optional(),
+});
+
+const StageSchema = z.object({
+  name: z.string().min(1),
+  trigger: StageTriggerSchema,
+  executor: StageExecutorSchema,
+  task: TaskSpecSchema.default({}),
+  policy: StagePolicySchema.optional(),
+  budget: StageBudgetSchema.optional(),
+  timeoutMs: z.number().int().nonnegative().optional(),
+  retries: z.number().int().nonnegative().optional(),
+  maxLoopRounds: z.number().int().positive().optional(),
+});
+
+/**
+ * Pipeline config without its branded id — id is derived from the YAML map key.
+ * `name` defaults to that same key when omitted.
+ */
+export const ConfiguredPipelineSchema = z.object({
+  name: z.string().min(1).optional(),
+  stages: z.array(StageSchema).min(1),
+  maxConcurrentStages: z.number().int().positive().optional(),
+});
+
+export type ConfiguredPipeline = z.infer<typeof ConfiguredPipelineSchema>;
+
+export const PipelinesConfigSchema = z.record(z.string().min(1), ConfiguredPipelineSchema);
+
+export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
+
+/** Convert a parsed YAML pipeline entry into a runtime Pipeline (branded id). */
+export function configuredPipelineToRuntime(
+  key: string,
+  configured: ConfiguredPipeline,
+): Pipeline {
+  const stages = configured.stages.map((stage): Stage => {
+    const executor: StageExecutor =
+      stage.executor.kind === "agent"
+        ? {
+            kind: "agent",
+            plugin: stage.executor.plugin,
+            mode: stage.executor.mode as TaskMode,
+            ...(stage.executor.config !== undefined ? { config: stage.executor.config } : {}),
+          }
+        : {
+            kind: "command",
+            command: stage.executor.command,
+            ...(stage.executor.args !== undefined ? { args: stage.executor.args } : {}),
+            ...(stage.executor.env !== undefined ? { env: stage.executor.env } : {}),
+            ...(stage.executor.cwd !== undefined ? { cwd: stage.executor.cwd } : {}),
+          };
+
+    return {
+      name: stage.name,
+      trigger: { on: [...stage.trigger.on] },
+      executor,
+      task: { ...stage.task },
+      ...(stage.policy ? { policy: { ...stage.policy } } : {}),
+      ...(stage.budget ? { budget: { ...stage.budget } } : {}),
+      ...(stage.timeoutMs !== undefined ? { timeoutMs: stage.timeoutMs } : {}),
+      ...(stage.retries !== undefined ? { retries: stage.retries } : {}),
+      ...(stage.maxLoopRounds !== undefined ? { maxLoopRounds: stage.maxLoopRounds } : {}),
+    };
+  });
+
+  return {
+    id: asPipelineId(key),
+    name: configured.name ?? key,
+    stages,
+    ...(configured.maxConcurrentStages !== undefined
+      ? { maxConcurrentStages: configured.maxConcurrentStages }
+      : {}),
+  };
+}

--- a/packages/core/src/pipeline/events.ts
+++ b/packages/core/src/pipeline/events.ts
@@ -67,6 +67,15 @@ export type PipelineEvent =
       reason: RunTerminationReason;
     })
   | (EventBase & {
+      type: "RUN_RESUMED";
+      runId: RunId;
+      /**
+       * Driver-allocated stage run ids for the failed stages being re-armed.
+       * Required so the new attempt has a fresh, non-colliding stageRunId.
+       */
+      stageRunIds: Record<string, StageRunId>;
+    })
+  | (EventBase & {
       type: "CONFIG_CHANGED";
       sessionId: string;
       pipelineName: string;

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -44,3 +44,11 @@ export {
   type PipelineEngineDeps,
   type StartRunInput,
 } from "./engine.js";
+
+export {
+  ConfiguredPipelineSchema,
+  PipelinesConfigSchema,
+  configuredPipelineToRuntime,
+  type ConfiguredPipeline,
+  type PipelinesConfig,
+} from "./config-schema.js";

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -54,6 +54,8 @@ export function reduce(state: EngineState, event: PipelineEvent): ReducerResult 
       return reduceNewShaDetected(state, event);
     case "RUN_CANCELLED":
       return reduceRunCancelled(state, event);
+    case "RUN_RESUMED":
+      return reduceRunResumed(state, event);
     case "CONFIG_CHANGED":
       return reduceConfigChanged(state, event);
     case "TICK":
@@ -282,6 +284,105 @@ function reduceRunCancelled(state: EngineState, event: RunCancelledEvent): Reduc
 
   const runFinalState: LoopStateName = reason === "stage_failure" ? "stalled" : "terminated";
   return terminateRun(state, run, reason, now, runFinalState);
+}
+
+interface RunResumedEvent {
+  now: number;
+  runId: RunId;
+  stageRunIds: Record<string, StageRunId>;
+}
+
+/**
+ * Resume a stalled/failed run: reset every `failed` stage back to `pending`
+ * with a fresh stageRunId (and incremented `attempt`, capped by stage.retries
+ * when set), then re-arm the loop pointer so the engine picks the run up on
+ * its next tick. No-op when the run has nothing to resume.
+ */
+function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerResult {
+  const { runId, stageRunIds, now } = event;
+  const run = state.runs[runId];
+  if (!run) return invalidTransition(state, `RUN_RESUMED for unknown runId=${runId}`);
+
+  const failedStageNames = Object.entries(run.stages)
+    .filter(([, s]) => s.status === "failed")
+    .map(([name]) => name);
+  if (failedStageNames.length === 0) {
+    // Nothing to resume. Keep the state unchanged so the caller can no-op too.
+    return { state, effects: [] };
+  }
+
+  // Cap the attempt bump by the configured retries (when set). The reducer
+  // ignores resumes that would exceed retries — operators can still re-cancel
+  // and re-trigger if they want a fresh run.
+  const stageRetriesByName = new Map<string, number | undefined>();
+  for (const stage of run.pipelineConfigSnapshot.stages) {
+    stageRetriesByName.set(stage.name, stage.retries);
+  }
+
+  const stageDelta: Record<string, StageState> = {};
+  for (const name of failedStageNames) {
+    const fresh = stageRunIds[name];
+    if (!fresh) {
+      return invalidTransition(
+        state,
+        `RUN_RESUMED missing stageRunId for failed stage "${name}"`,
+      );
+    }
+
+    const prior = run.stages[name];
+    const cap = stageRetriesByName.get(name);
+    if (cap !== undefined && prior.attempt >= cap + 1) {
+      return invalidTransition(
+        state,
+        `RUN_RESUMED would exceed stage.retries=${cap} for "${name}" (attempt=${prior.attempt})`,
+      );
+    }
+
+    stageDelta[name] = {
+      stageRunId: fresh,
+      status: "pending",
+      attempt: prior.attempt + 1,
+      artifacts: [],
+    };
+  }
+
+  const updatedRun: RunState = {
+    ...run,
+    stages: { ...run.stages, ...stageDelta },
+    loopState: "running",
+    updatedAt: iso(now),
+  };
+  delete (updatedRun as { terminationReason?: RunTerminationReason }).terminationReason;
+
+  const key = loopKey(run.sessionId, run.pipelineName);
+  const nextState: EngineState = {
+    ...state,
+    runs: { ...state.runs, [runId]: updatedRun },
+    currentRunByLoop: { ...state.currentRunByLoop, [key]: runId },
+  };
+
+  const effects: PipelineEffect[] = [
+    { type: "PERSIST_RUN", runState: updatedRun },
+    {
+      type: "PERSIST_LOOP_STATE",
+      runId,
+      loopState: deriveLoopStateFromRun(updatedRun, now),
+    },
+    ...startableStageEffects(updatedRun),
+    {
+      type: "EMIT_OBSERVATION",
+      event: {
+        name: "pipeline.run.resumed",
+        data: {
+          runId,
+          pipelineName: run.pipelineName,
+          stageNames: failedStageNames,
+        },
+      },
+    },
+  ];
+
+  return { state: nextState, effects };
 }
 
 interface ConfigChangedEvent {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import type { ObservabilityLevel } from "./observability.js";
+import type { ConfiguredPipeline } from "./pipeline/config-schema.js";
 
 /**
  * Agent Orchestrator — Core Type Definitions
@@ -1501,6 +1502,13 @@ export interface ProjectConfig {
     | "kill-previous";
 
   opencodeIssueSessionStrategy?: "reuse" | "delete" | "ignore";
+
+  /**
+   * Configured pipelines, keyed by pipeline name. Each entry validates
+   * against ConfiguredPipelineSchema; convert to a runtime Pipeline via
+   * configuredPipelineToRuntime (using the map key as the pipeline id).
+   */
+  pipelines?: Record<string, ConfiguredPipeline>;
 }
 
 export interface TrackerConfig {


### PR DESCRIPTION
Closes #1629. Depends on v0.1 (#1636) and v0.2 (#1638). Targets `pipelines`.

## Summary

Wires the v0.3 CLI surface on top of the v0.1/v0.2 pipeline core:

- **`pipelines:` block** on `ProjectConfigSchema` (Zod, mirrors runtime `Pipeline` types) — `name` defaults to the YAML map key; the key is also the branded `PipelineId`.
- **`packages/cli/src/lib/pipeline-service.ts`** — pure store/reducer adapter. Dependency-injected (store, registry, clock) so the CLI commands stay thin and tests stay fast. Cancel routes through the v0.1 reducer's `RUN_CANCELLED`; resume and trigger persist via the flat-file store directly.
- **`ao pipeline {list,runs,show,run,cancel,resume,migrate}`** — covers everything in #1629's CLI scope.
- **`ao stage show <stageRunId>`** — stage detail with hydrated artifacts.
- **`ao artifact show <stageRunId>`** — prints findings JSONL.
- **Zsh tab completion** — new `pipelines` / `pipeline-runs` / `stage-runs` `__complete` kinds, plus arg-position routing for the new verbs.

## Out of scope (deferred)

- Lifecycle integration: a running orchestrator currently does not auto-pick-up CLI-triggered runs (that wiring lands in v0.4). The success message states this explicitly.
- Multi-pipeline DAG (v1.1), command/builtin executors (v1.2), Web UI (v2.x).

## Test plan

- [x] `pnpm --filter @aoagents/ao-cli typecheck`
- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-cli test` — 637/637 pass (35 new)
- [x] `pnpm --filter @aoagents/ao-core test` — 1130/1130 pass
- [x] `ao --help` lists new top-level groups; `ao pipeline --help`, `ao stage --help`, `ao artifact --help` show all sub-verbs
- [x] `ao completion zsh` includes `_ao_complete_pipelines`, `_ao_complete_pipeline_runs`, `_ao_complete_stage_runs` and routes them on the right argument positions

## Acceptance criteria mapping

- [x] All commands tested via vitest with mocked store (35 cases, including error paths)
- [x] `ao --help` and `ao pipeline --help` show the new commands
- [x] Tab completion installs cleanly via `ao completion`
- [x] PR opened against `pipelines`