### PR TITLE
feat(pipeline): v1.1 — DAG, parallel scheduling, Stage.routes

### DIFF
--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -23,6 +23,7 @@ import {
   loopKey,
   reduce,
   validatePipelineAgentModes,
+  validatePipelineDag,
   type Artifact,
   type ConfiguredPipeline,
   type EngineState,
@@ -281,6 +282,7 @@ export function triggerRun(
   now: () => number = Date.now,
 ): RunId {
   validatePipelineAgentModes(pipeline, registry);
+  validatePipelineDag(pipeline);
 
   const sessionId = options.sessionId ?? `pipeline.${pipeline.name}`;
   const initialState = hydrateEngineState(store);

--- a/packages/cli/src/lib/pipeline-service.ts
+++ b/packages/cli/src/lib/pipeline-service.ts
@@ -391,15 +391,20 @@ export function resumeRun(
     );
   }
 
-  const failedStageNames = Object.entries(run.stages)
-    .filter(([, s]) => s.status === "failed")
+  // Both `failed` and `outdated` stages need a fresh stageRunId on resume.
+  // `failed` is a real retry; `outdated` is the running-at-terminate state
+  // (e.g. parallel sibling cancelled by `terminateRunFromState`) whose work
+  // was thrown away. Without including outdated, parallel branches lost
+  // when a sibling fails would never be recoverable via resume.
+  const retriedStageNames = Object.entries(run.stages)
+    .filter(([, s]) => s.status === "failed" || s.status === "outdated")
     .map(([name]) => name);
-  if (failedStageNames.length === 0) {
+  if (retriedStageNames.length === 0) {
     return { run, resetStages: [] };
   }
 
   const stageRunIds: Record<string, StageRunId> = {};
-  for (const name of failedStageNames) {
+  for (const name of retriedStageNames) {
     stageRunIds[name] = asStageRunId(`sr-${randomUUID()}`);
   }
 
@@ -411,7 +416,7 @@ export function resumeRun(
   });
 
   const updated = store.loadRun(runId);
-  return { run: updated ?? run, resetStages: failedStageNames };
+  return { run: updated ?? run, resetStages: retriedStageNames };
 }
 
 /**

--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -1,0 +1,394 @@
+/**
+ * v1.1 DAG scheduler coverage. Verifies:
+ *  - Cycle detection at config load (clear error naming the cycle)
+ *  - Two independent stages run concurrently when maxConcurrentStages >= 2
+ *  - A stage with unmet dependsOn does not start
+ *  - A stage with an unsatisfied routes predicate is skipped, with cascade
+ *  - Multiple pipelines can coexist within a single project config
+ *
+ * The reducer-event helpers (`fireTrigger`, `completeStage`) mirror the style
+ * used by the existing pipeline reducer suite so tests read consistently.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  ConfiguredPipelineSchema,
+  PipelinesConfigSchema,
+  asPipelineId,
+  asRunId,
+  asStageRunId,
+  emptyEngineState,
+  reduce,
+  type EngineState,
+  type Pipeline,
+  type PipelineEvent,
+  type RunId,
+  type Stage,
+  type StageRunId,
+} from "../pipeline/index.js";
+
+const NOW = 1_700_000_000_000;
+
+function makeStage(name: string, overrides: Partial<Stage> = {}): Stage {
+  return {
+    name,
+    trigger: { on: ["pr.opened"] },
+    executor: { kind: "agent", plugin: "codex", mode: "review" },
+    task: { prompt: `run ${name}` },
+    ...overrides,
+  };
+}
+
+function makePipeline(stages: Stage[], maxConcurrentStages = 1): Pipeline {
+  return {
+    id: asPipelineId("pl-1"),
+    name: "default",
+    stages,
+    maxConcurrentStages,
+  };
+}
+
+function fireTrigger(pipeline: Pipeline, runId = asRunId("run-1")) {
+  const stageRunIds: Record<string, StageRunId> = Object.fromEntries(
+    pipeline.stages.map((s, i) => [s.name, asStageRunId(`sr-${s.name}-${i}`)]),
+  );
+  const event: PipelineEvent = {
+    type: "TRIGGER_FIRED",
+    now: NOW,
+    trigger: "manual",
+    sessionId: "ses-1",
+    pipeline,
+    headSha: "sha-aaa",
+    runId,
+    stageRunIds,
+  };
+  return reduce(emptyEngineState(), event);
+}
+
+function startStage(state: EngineState, runId: RunId, stageName: string, t = NOW + 1) {
+  return reduce(state, { type: "STAGE_STARTED", now: t, runId, stageName });
+}
+
+function completeStage(state: EngineState, runId: RunId, stageName: string, t = NOW + 2) {
+  return reduce(state, {
+    type: "STAGE_COMPLETED",
+    now: t,
+    runId,
+    stageName,
+    artifacts: [],
+  });
+}
+
+describe("pipeline DAG — cycle detection (config load)", () => {
+  it("rejects a 2-cycle and names both stages in order", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        { ...makeStage("a"), dependsOn: ["b"] },
+        { ...makeStage("b"), dependsOn: ["a"] },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain("dependsOn cycle");
+    expect(messages).toContain("a → b → a");
+  });
+
+  it("rejects a 3-cycle with a clear path", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        { ...makeStage("a"), dependsOn: ["c"] },
+        { ...makeStage("b"), dependsOn: ["a"] },
+        { ...makeStage("c"), dependsOn: ["b"] },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toMatch(/dependsOn cycle.*a.*c|c.*b.*a/);
+  });
+
+  it("rejects self-dependency", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [{ ...makeStage("a"), dependsOn: ["a"] }],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain('"a" cannot depend on itself');
+  });
+
+  it("rejects unknown stage names in dependsOn", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [makeStage("a"), { ...makeStage("b"), dependsOn: ["nonexistent"] }],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain('unknown stage "nonexistent"');
+  });
+
+  it("rejects unknown stage names in routes predicates", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "allSucceeded", stages: ["nope"] } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain('routes references unknown stage "nope"');
+  });
+
+  it("accepts a valid acyclic DAG with mixed dependsOn and routes", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        makeStage("a"),
+        { ...makeStage("b"), dependsOn: ["a"] },
+        {
+          ...makeStage("c"),
+          dependsOn: ["a", "b"],
+          routes: { when: { kind: "allSucceeded", stages: ["a", "b"] } },
+        },
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects duplicate stage names", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [makeStage("a"), makeStage("a")],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain('Duplicate stage name "a"');
+  });
+});
+
+describe("pipeline DAG — parallel scheduling", () => {
+  it("starts two independent stages concurrently when maxConcurrentStages=2", () => {
+    const pipeline = makePipeline([makeStage("a"), makeStage("b")], 2);
+    const { effects } = fireTrigger(pipeline);
+    const startEffects = effects.filter((e) => e.type === "START_STAGE");
+    expect(startEffects).toHaveLength(2);
+    const names = startEffects.map((e) => (e.type === "START_STAGE" ? e.stage.name : "")).sort();
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("respects declaration order when slots < eligible stages", () => {
+    const pipeline = makePipeline([makeStage("a"), makeStage("b"), makeStage("c")], 2);
+    const { effects } = fireTrigger(pipeline);
+    const names = effects
+      .filter((e) => e.type === "START_STAGE")
+      .map((e) => (e.type === "START_STAGE" ? e.stage.name : ""))
+      .sort();
+    expect(names).toEqual(["a", "b"]);
+  });
+
+  it("a stage with unmet dependsOn does not start at trigger time", () => {
+    const pipeline = makePipeline([makeStage("a"), { ...makeStage("b"), dependsOn: ["a"] }], 2);
+    const { state, effects } = fireTrigger(pipeline);
+    const starts = effects.filter((e) => e.type === "START_STAGE");
+    expect(starts).toHaveLength(1);
+    if (starts[0].type !== "START_STAGE") throw new Error();
+    expect(starts[0].stage.name).toBe("a");
+    expect(state.runs[asRunId("run-1")].stages.b.status).toBe("pending");
+  });
+
+  it("starts a dependent stage after its dependsOn succeeds", () => {
+    const pipeline = makePipeline([makeStage("a"), { ...makeStage("b"), dependsOn: ["a"] }], 1);
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { state, effects } = completeStage(started.state, asRunId("run-1"), "a");
+    expect(state.runs[asRunId("run-1")].stages.b.status).toBe("pending");
+    const startB = effects.find((e) => e.type === "START_STAGE" && e.stage.name === "b");
+    expect(startB).toBeDefined();
+  });
+
+  it("starts multiple downstream branches concurrently when both deps succeed", () => {
+    // a → {b, c} (b and c both depend on a only, no inter-branch dependency)
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        { ...makeStage("b"), dependsOn: ["a"] },
+        { ...makeStage("c"), dependsOn: ["a"] },
+      ],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { effects } = completeStage(started.state, asRunId("run-1"), "a");
+    const starts = effects
+      .filter((e) => e.type === "START_STAGE")
+      .map((e) => (e.type === "START_STAGE" ? e.stage.name : ""))
+      .sort();
+    expect(starts).toEqual(["b", "c"]);
+  });
+
+  it("does not exceed maxConcurrentStages when many branches unlock at once", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        { ...makeStage("b"), dependsOn: ["a"] },
+        { ...makeStage("c"), dependsOn: ["a"] },
+        { ...makeStage("d"), dependsOn: ["a"] },
+      ],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { effects } = completeStage(started.state, asRunId("run-1"), "a");
+    const starts = effects.filter((e) => e.type === "START_STAGE");
+    expect(starts).toHaveLength(2);
+  });
+});
+
+describe("pipeline DAG — routes predicate", () => {
+  it("skips a stage whose allSucceeded routes references a non-succeeded upstream", () => {
+    // This shape uses routes to express "only run b when a succeeded AND
+    // some other parallel stage `c` succeeded". When c is skipped (because
+    // its own routes are unsatisfied), b's routes also fail and b is skipped.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        // c skips itself by requiring a stage that won't succeed.
+        {
+          ...makeStage("c"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+        // b only runs when both a AND c succeeded.
+        {
+          ...makeStage("b"),
+          dependsOn: ["a", "c"],
+          routes: { when: { kind: "allSucceeded", stages: ["a", "c"] } },
+        },
+      ],
+      2,
+    );
+
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { state } = completeStage(started.state, asRunId("run-1"), "a");
+
+    const run = state.runs[asRunId("run-1")];
+    expect(run.stages.a.status).toBe("succeeded");
+    expect(run.stages.c.status).toBe("skipped");
+    expect(run.stages.b.status).toBe("skipped");
+    expect(run.loopState).toBe("done");
+  });
+
+  it("emits pipeline.stage.terminated observations for cascade-skipped stages", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+      1,
+    );
+
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { effects } = completeStage(started.state, asRunId("run-1"), "a");
+
+    const skipObs = effects.find(
+      (e) =>
+        e.type === "EMIT_OBSERVATION" &&
+        e.event.name === "pipeline.stage.terminated" &&
+        (e.event.data as { stageName?: string; status?: string }).stageName === "b" &&
+        (e.event.data as { stageName?: string; status?: string }).status === "skipped",
+    );
+    expect(skipObs).toBeDefined();
+  });
+
+  it("runs the stage when its routes predicate is satisfied", () => {
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        {
+          ...makeStage("b"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "allSucceeded", stages: ["a"] } },
+        },
+      ],
+      1,
+    );
+    const triggered = fireTrigger(pipeline);
+    const started = startStage(triggered.state, asRunId("run-1"), "a");
+    const { state, effects } = completeStage(started.state, asRunId("run-1"), "a");
+
+    expect(state.runs[asRunId("run-1")].stages.b.status).toBe("pending");
+    const startB = effects.find((e) => e.type === "START_STAGE" && e.stage.name === "b");
+    expect(startB).toBeDefined();
+  });
+
+  it("anySucceeded predicate runs the stage if any upstream succeeded", () => {
+    // Two independent producers feed a fan-in: c only needs one to succeed.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        makeStage("b"),
+        {
+          ...makeStage("c"),
+          dependsOn: ["a", "b"],
+          routes: { when: { kind: "anySucceeded", stages: ["a", "b"] } },
+        },
+      ],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
+    s = completeStage(s, asRunId("run-1"), "a", NOW + 3).state;
+    const finalRes = completeStage(s, asRunId("run-1"), "b", NOW + 4);
+
+    const startC = finalRes.effects.find((e) => e.type === "START_STAGE" && e.stage.name === "c");
+    expect(startC).toBeDefined();
+    expect(finalRes.state.runs[asRunId("run-1")].stages.c.status).toBe("pending");
+  });
+});
+
+describe("pipeline DAG — multi-pipeline support", () => {
+  it("validates and parses a config with multiple named pipelines", () => {
+    const result = PipelinesConfigSchema.safeParse({
+      review: {
+        stages: [makeStage("review")],
+      },
+      ship: {
+        stages: [makeStage("build"), { ...makeStage("deploy"), dependsOn: ["build"] }],
+        maxConcurrentStages: 2,
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(Object.keys(result.data).sort()).toEqual(["review", "ship"]);
+    expect(result.data.ship.stages).toHaveLength(2);
+  });
+
+  it("rejects a multi-pipeline config when one pipeline has a cycle", () => {
+    const result = PipelinesConfigSchema.safeParse({
+      good: { stages: [makeStage("a")] },
+      bad: {
+        stages: [
+          { ...makeStage("x"), dependsOn: ["y"] },
+          { ...makeStage("y"), dependsOn: ["x"] },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain("dependsOn cycle");
+  });
+});

--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -599,7 +599,10 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
     const run = resumed.state.runs[asRunId("run-1")];
     expect(run.stages.a.status).toBe("pending");
     expect(run.stages.b.status).toBe("pending");
-    expect(run.stages.b.attempt).toBe(2);
+    // `failed` stages bump attempt (real retry against the cap).
+    expect(run.stages.a.attempt).toBe(2);
+    // `outdated` stages keep attempt — external cancellation, not a retry.
+    expect(run.stages.b.attempt).toBe(1);
     expect(run.stages.b.stageRunId).toBe(asStageRunId("sr-b-2"));
     expect(run.stages.d.status).toBe("pending");
 
@@ -608,6 +611,88 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
       .map((e) => (e.type === "START_STAGE" ? e.stage.name : ""))
       .sort();
     expect(startNames).toEqual(["a", "b"]);
+  });
+
+  it("outdated revival does not consume the stage.retries budget", () => {
+    // With retries=1 (cap=1, max attempt=2): one real failure plus one
+    // mid-flight CONFIG_CHANGED (which marks the stage outdated) used to
+    // burn the retry budget. Reviving outdated must not consume the cap so
+    // the user retains their failure-retry allowance.
+    const pipeline = makePipeline(
+      [makeStage("a"), makeStage("b", { retries: 1 })],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
+    // a fails -> run terminates, b is marked outdated (it was running).
+    const failed = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+    expect(failed.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
+    expect(failed.state.runs[asRunId("run-1")].stages.b.attempt).toBe(1);
+
+    // Resume #1: a (failed) -> attempt 2; b (outdated) -> attempt 1.
+    const resumed1 = reduce(failed.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-2"), b: asStageRunId("sr-b-2") },
+    });
+    expect(resumed1.state.runs[asRunId("run-1")].stages.a.attempt).toBe(2);
+    expect(resumed1.state.runs[asRunId("run-1")].stages.b.attempt).toBe(1);
+
+    // Now simulate a -> succeeds, b -> running -> mid-flight terminate again.
+    let s2 = startStage(resumed1.state, asRunId("run-1"), "a", NOW + 5).state;
+    s2 = completeStage(s2, asRunId("run-1"), "a", NOW + 6).state;
+    s2 = startStage(s2, asRunId("run-1"), "b", NOW + 7).state;
+    const cancelled = reduce(s2, {
+      type: "RUN_CANCELLED",
+      now: NOW + 8,
+      runId: asRunId("run-1"),
+      reason: "config_change",
+    });
+    // b is outdated again. attempt is still 1 (never bumped on revival).
+    expect(cancelled.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
+    expect(cancelled.state.runs[asRunId("run-1")].stages.b.attempt).toBe(1);
+
+    // Resume #2: b retries WITHOUT exceeding cap=1. With the previous behavior
+    // (attempt bumped on every revival), this would have rejected with
+    // "would exceed stage.retries=1".
+    const resumed2 = reduce(cancelled.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 9,
+      runId: asRunId("run-1"),
+      stageRunIds: { b: asStageRunId("sr-b-3") },
+    });
+    expect(resumed2.state.runs[asRunId("run-1")].loopState).toBe("running");
+    expect(resumed2.state.runs[asRunId("run-1")].stages.b.status).toBe("pending");
+    expect(resumed2.state.runs[asRunId("run-1")].stages.b.attempt).toBe(1);
+  });
+
+  it("rejects direct RUN_RESUMED on a non-terminal run", () => {
+    // CLI rejects this at the service layer; the reducer guard catches
+    // direct dispatch (config-watcher / tests / programmatic injection).
+    const pipeline = makePipeline([makeStage("a")], 1);
+    const triggered = fireTrigger(pipeline);
+    const startedA = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    // run is "running" (non-terminal). Resume must be rejected.
+    const resumed = reduce(startedA.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-2") },
+    });
+    expect(resumed.state.runs[asRunId("run-1")].stages.a.status).toBe("running");
+    const obs = resumed.effects.find(
+      (e) =>
+        e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
   });
 
   it("rejects RUN_RESUMED that omits a stageRunId for an outdated stage", () => {

--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -95,7 +95,9 @@ describe("pipeline DAG — cycle detection (config load)", () => {
     expect(messages).toContain("a → b → a");
   });
 
-  it("rejects a 3-cycle with a clear path", () => {
+  it("rejects a 3-cycle with the exact path in declaration order", () => {
+    // Adjacency: a→c, b→a, c→b. DFS from `a` (first-declared) traces
+    // a→c→b→a, so the reported cycle path is exact, not just "contains a, b, c".
     const result = ConfiguredPipelineSchema.safeParse({
       stages: [
         { ...makeStage("a"), dependsOn: ["c"] },
@@ -106,7 +108,7 @@ describe("pipeline DAG — cycle detection (config load)", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
-    expect(messages).toMatch(/stage dependency cycle.*a.*c|c.*b.*a/);
+    expect(messages).toContain("stage dependency cycle: a → c → b → a");
   });
 
   it("rejects routes-only cycles (would deadlock at runtime)", () => {
@@ -472,5 +474,131 @@ describe("pipeline DAG — multi-pipeline support", () => {
     if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
     expect(messages).toContain("stage dependency cycle");
+  });
+});
+
+describe("pipeline DAG — failure path (parallel)", () => {
+  it("STAGE_FAILED on a parallel branch terminates the run and marks sibling stages outdated/skipped", () => {
+    // Two independent branches running concurrently; the running sibling
+    // should transition `running → outdated` and emit a CANCEL_STAGE effect,
+    // while a not-yet-started downstream stage transitions `pending → skipped`.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        makeStage("b"),
+        { ...makeStage("c"), dependsOn: ["a"] },
+      ],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
+    const failed = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    const run = failed.state.runs[asRunId("run-1")];
+    expect(run.loopState).toBe("stalled");
+    expect(run.terminationReason).toBe("stage_failure");
+    expect(run.stages.a.status).toBe("failed");
+    expect(run.stages.b.status).toBe("outdated");
+    expect(run.stages.c.status).toBe("skipped");
+
+    const cancelB = failed.effects.find(
+      (e) => e.type === "CANCEL_STAGE" && e.stageName === "b",
+    );
+    expect(cancelB).toBeDefined();
+  });
+});
+
+describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
+  it("revives cascade-skipped downstream stages so they can run after retry", () => {
+    // a fails, terminate cascade-skips b (deps=[a]) and c (deps=[b]).
+    // Resume must revive b and c too — otherwise the DAG branch is lost.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        { ...makeStage("b"), dependsOn: ["a"] },
+        { ...makeStage("c"), dependsOn: ["b"] },
+      ],
+      1,
+    );
+
+    const triggered = fireTrigger(pipeline);
+    const startedA = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    const failedA = reduce(startedA.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    expect(failedA.state.runs[asRunId("run-1")].stages.b.status).toBe("skipped");
+    expect(failedA.state.runs[asRunId("run-1")].stages.c.status).toBe("skipped");
+
+    const resumed = reduce(failedA.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-2") },
+    });
+    const run = resumed.state.runs[asRunId("run-1")];
+    expect(run.loopState).toBe("running");
+    expect(run.stages.a.status).toBe("pending");
+    expect(run.stages.b.status).toBe("pending");
+    expect(run.stages.c.status).toBe("pending");
+
+    // a is the only startable stage; b and c wait on their dependsOn.
+    const starts = resumed.effects.filter((e) => e.type === "START_STAGE");
+    expect(starts).toHaveLength(1);
+    if (starts[0].type !== "START_STAGE") throw new Error();
+    expect(starts[0].stage.name).toBe("a");
+  });
+
+  it("revived stages still get re-skipped when their routes predicate is unsatisfied", () => {
+    // c had `routes: { anyFailed: [a] }` — it was skipped via routes (not
+    // cascade) before the failure, then double-skipped by terminate. After
+    // resume + a-succeeds, c must re-skip because a no longer matches anyFailed.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        { ...makeStage("b"), dependsOn: ["a"] },
+        {
+          ...makeStage("c"),
+          dependsOn: ["a"],
+          routes: { when: { kind: "anyFailed", stages: ["a"] } },
+        },
+      ],
+      1,
+    );
+    const triggered = fireTrigger(pipeline);
+    const startedA = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1);
+    // a fails → terminate marks b, c skipped.
+    const failedA = reduce(startedA.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    const resumed = reduce(failedA.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-2") },
+    });
+    const startedRetry = startStage(resumed.state, asRunId("run-1"), "a", NOW + 4);
+    const completed = completeStage(startedRetry.state, asRunId("run-1"), "a", NOW + 5);
+
+    const run = completed.state.runs[asRunId("run-1")];
+    expect(run.stages.a.status).toBe("succeeded");
+    // b ran (deps satisfied, no routes), c re-skipped (anyFailed false).
+    expect(run.stages.c.status).toBe("skipped");
   });
 });

--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -91,7 +91,7 @@ describe("pipeline DAG — cycle detection (config load)", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
-    expect(messages).toContain("dependsOn cycle");
+    expect(messages).toContain("stage dependency cycle");
     expect(messages).toContain("a → b → a");
   });
 
@@ -106,17 +106,99 @@ describe("pipeline DAG — cycle detection (config load)", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
-    expect(messages).toMatch(/dependsOn cycle.*a.*c|c.*b.*a/);
+    expect(messages).toMatch(/stage dependency cycle.*a.*c|c.*b.*a/);
   });
 
-  it("rejects self-dependency", () => {
+  it("rejects routes-only cycles (would deadlock at runtime)", () => {
+    // Without dependsOn edges in the cycle graph, a→b→a via routes alone
+    // would leave both stages waiting on each other in `arePreconditionsTerminal`.
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        {
+          ...makeStage("a"),
+          routes: { when: { kind: "allSucceeded", stages: ["b"] } },
+        },
+        {
+          ...makeStage("b"),
+          routes: { when: { kind: "allSucceeded", stages: ["a"] } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain("stage dependency cycle");
+    expect(messages).toContain("a → b → a");
+  });
+
+  it("rejects mixed dependsOn + routes cycles", () => {
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        { ...makeStage("a"), dependsOn: ["b"] },
+        {
+          ...makeStage("b"),
+          routes: { when: { kind: "allSucceeded", stages: ["a"] } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages).toContain("stage dependency cycle");
+  });
+
+  it("rejects self-dependency without emitting a duplicate cycle error", () => {
     const result = ConfiguredPipelineSchema.safeParse({
       stages: [{ ...makeStage("a"), dependsOn: ["a"] }],
     });
     expect(result.success).toBe(false);
     if (result.success) return;
+    const messages = result.error.issues.map((i) => i.message);
+    expect(messages.some((m) => m.includes('"a" cannot depend on itself'))).toBe(true);
+    // Trivial self-loops are owned by the explicit self-ref check; the cycle
+    // detector must NOT emit an additional "stage dependency cycle: a → a".
+    expect(messages.some((m) => m.includes("stage dependency cycle"))).toBe(false);
+  });
+
+  it("rejects routes self-reference (would deadlock at runtime)", () => {
+    // A stage whose routes reference itself never sees its own state become
+    // terminal, so `arePreconditionsTerminal` returns false forever.
+    const result = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        {
+          ...makeStage("a"),
+          routes: { when: { kind: "allSucceeded", stages: ["a"] } },
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
-    expect(messages).toContain('"a" cannot depend on itself');
+    expect(messages).toContain('"a" cannot route to itself');
+  });
+
+  it("rejects empty stages arrays in route predicates", () => {
+    // Vacuous truth/falsity on empty stage lists is surprising — every
+    // predicate kind must name at least one upstream stage.
+    const allEmpty = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        {
+          ...makeStage("a"),
+          routes: { when: { kind: "allSucceeded", stages: [] } },
+        },
+      ],
+    });
+    expect(allEmpty.success).toBe(false);
+
+    const anyEmpty = ConfiguredPipelineSchema.safeParse({
+      stages: [
+        {
+          ...makeStage("a"),
+          routes: { when: { kind: "anyFailed", stages: [] } },
+        },
+      ],
+    });
+    expect(anyEmpty.success).toBe(false);
   });
 
   it("rejects unknown stage names in dependsOn", () => {
@@ -389,6 +471,6 @@ describe("pipeline DAG — multi-pipeline support", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     const messages = result.error.issues.map((i) => i.message).join("\n");
-    expect(messages).toContain("dependsOn cycle");
+    expect(messages).toContain("stage dependency cycle");
   });
 });

--- a/packages/core/src/__tests__/pipeline-dag.test.ts
+++ b/packages/core/src/__tests__/pipeline-dag.test.ts
@@ -560,6 +560,131 @@ describe("pipeline DAG — RUN_RESUMED with cascade-skipped stages", () => {
     expect(starts[0].stage.name).toBe("a");
   });
 
+  it("revives `outdated` stages (running-at-terminate) so parallel branches recover", () => {
+    // a and b run concurrently; a fails and `terminateRunFromState` marks b
+    // `outdated` (because b was running). Without reviving outdated, b would
+    // never recover and any downstream stage on b (here d) would cascade-skip
+    // after resume.
+    const pipeline = makePipeline(
+      [
+        makeStage("a"),
+        makeStage("b"),
+        { ...makeStage("d"), dependsOn: ["b"] },
+      ],
+      2,
+    );
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
+    const failed = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+    expect(failed.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
+
+    // Resume: caller must allocate fresh stageRunIds for BOTH a (failed) and
+    // b (outdated). The reducer rejects resumes that miss either.
+    const resumed = reduce(failed.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageRunIds: {
+        a: asStageRunId("sr-a-2"),
+        b: asStageRunId("sr-b-2"),
+      },
+    });
+    const run = resumed.state.runs[asRunId("run-1")];
+    expect(run.stages.a.status).toBe("pending");
+    expect(run.stages.b.status).toBe("pending");
+    expect(run.stages.b.attempt).toBe(2);
+    expect(run.stages.b.stageRunId).toBe(asStageRunId("sr-b-2"));
+    expect(run.stages.d.status).toBe("pending");
+
+    const startNames = resumed.effects
+      .filter((e) => e.type === "START_STAGE")
+      .map((e) => (e.type === "START_STAGE" ? e.stage.name : ""))
+      .sort();
+    expect(startNames).toEqual(["a", "b"]);
+  });
+
+  it("rejects RUN_RESUMED that omits a stageRunId for an outdated stage", () => {
+    const pipeline = makePipeline([makeStage("a"), makeStage("b")], 2);
+    const triggered = fireTrigger(pipeline);
+    let s = startStage(triggered.state, asRunId("run-1"), "a", NOW + 1).state;
+    s = startStage(s, asRunId("run-1"), "b", NOW + 2).state;
+    const failed = reduce(s, {
+      type: "STAGE_FAILED",
+      now: NOW + 3,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+    const resumed = reduce(failed.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-2") }, // missing b
+    });
+    const obs = resumed.effects.find(
+      (e) =>
+        e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+    // State must not have advanced — the b stage is still outdated.
+    expect(resumed.state.runs[asRunId("run-1")].stages.b.status).toBe("outdated");
+  });
+
+  it("refuses to resume a run whose loop key is owned by a newer active run", () => {
+    // First run fails → stalled → loop key freed. A second TRIGGER_FIRED
+    // claims the key with run-2. Calling RUN_RESUMED for run-1 must NOT
+    // dispossess run-2 of the loop pointer.
+    const pipeline = makePipeline([makeStage("a")], 1);
+    const first = fireTrigger(pipeline, asRunId("run-1"));
+    const startedA = startStage(first.state, asRunId("run-1"), "a", NOW + 1);
+    const failedA = reduce(startedA.state, {
+      type: "STAGE_FAILED",
+      now: NOW + 2,
+      runId: asRunId("run-1"),
+      stageName: "a",
+      errorMessage: "boom",
+    });
+
+    // Trigger run-2 for the same loop (sessionId/pipelineName) — uses the
+    // freed loop key.
+    const stageRunIds2: Record<string, StageRunId> = { a: asStageRunId("sr-2-a") };
+    const second = reduce(failedA.state, {
+      type: "TRIGGER_FIRED",
+      now: NOW + 3,
+      trigger: "manual",
+      sessionId: "ses-1",
+      pipeline,
+      headSha: "sha-bbb",
+      runId: asRunId("run-2"),
+      stageRunIds: stageRunIds2,
+    });
+    expect(second.state.currentRunByLoop["ses-1:default"]).toBe(asRunId("run-2"));
+
+    // Now try resuming run-1: must be refused.
+    const resumed = reduce(second.state, {
+      type: "RUN_RESUMED",
+      now: NOW + 4,
+      runId: asRunId("run-1"),
+      stageRunIds: { a: asStageRunId("sr-a-resumed") },
+    });
+    // Loop ownership unchanged.
+    expect(resumed.state.currentRunByLoop["ses-1:default"]).toBe(asRunId("run-2"));
+    // run-1 still stalled (not revived).
+    expect(resumed.state.runs[asRunId("run-1")].loopState).toBe("stalled");
+    const obs = resumed.effects.find(
+      (e) =>
+        e.type === "EMIT_OBSERVATION" && e.event.name === "pipeline.invalid_transition",
+    );
+    expect(obs).toBeDefined();
+  });
+
   it("revived stages still get re-skipped when their routes predicate is unsatisfied", () => {
     // c had `routes: { anyFailed: [a] }` — it was skipped via routes (not
     // cascade) before the failure, then double-skipped by terminate. After

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -229,6 +229,36 @@ describe("pipeline engine — end-to-end", () => {
     expect(executor.startCalls).toHaveLength(0);
   });
 
+  it("rejects programmatic pipelines with a stage dependency cycle", async () => {
+    // Programmatic Pipeline construction skips Zod, so the engine must defend
+    // against cycles itself — otherwise the run would deadlock with every
+    // cycle member stuck `pending` forever.
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    const cyclic: Pipeline = {
+      id: asPipelineId("cyclic"),
+      name: "cyclic",
+      stages: [
+        makeStage({ name: "a", dependsOn: ["b"] }),
+        makeStage({ name: "b", dependsOn: ["a"] }),
+      ],
+      maxConcurrentStages: 1,
+    };
+
+    await expect(
+      engine.startRun({
+        pipeline: cyclic,
+        projectId: "proj-a",
+        sessionId: "ses-1",
+        headSha: "sha",
+      }),
+    ).rejects.toBeInstanceOf(PipelineConfigError);
+    expect(executor.startCalls).toHaveLength(0);
+  });
+
   it("synthesizes STAGE_FAILED for non-agent executor kinds (v0.2 only supports agent)", async () => {
     const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
     const store = createPipelineStore(storeRoot);

--- a/packages/core/src/__tests__/pipeline-engine.test.ts
+++ b/packages/core/src/__tests__/pipeline-engine.test.ts
@@ -259,6 +259,40 @@ describe("pipeline engine — end-to-end", () => {
     expect(executor.startCalls).toHaveLength(0);
   });
 
+  it("validates pipelines on direct engine.dispatch(TRIGGER_FIRED)", async () => {
+    // Tests and a future config-watcher path can dispatch arbitrary events.
+    // engine.dispatch must apply the same validation as engine.startRun so
+    // callers can't silently inject a deadlocked TRIGGER_FIRED.
+    const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
+    const store = createPipelineStore(storeRoot);
+    const executor = makeMockExecutor();
+    const engine = createPipelineEngine({ store, registry, agentExecutor: executor });
+
+    const cyclic: Pipeline = {
+      id: asPipelineId("cyclic-dispatch"),
+      name: "cyclic-dispatch",
+      stages: [
+        makeStage({ name: "a", dependsOn: ["b"] }),
+        makeStage({ name: "b", dependsOn: ["a"] }),
+      ],
+      maxConcurrentStages: 1,
+    };
+
+    await expect(
+      engine.dispatch({
+        type: "TRIGGER_FIRED",
+        now: Date.now(),
+        trigger: "manual",
+        sessionId: "ses-1",
+        pipeline: cyclic,
+        headSha: "sha",
+        runId: "run-x" as ReturnType<typeof asPipelineId> as never,
+        stageRunIds: {},
+      } as never),
+    ).rejects.toBeInstanceOf(PipelineConfigError);
+    expect(executor.startCalls).toHaveLength(0);
+  });
+
   it("synthesizes STAGE_FAILED for non-agent executor kinds (v0.2 only supports agent)", async () => {
     const registry = withRegistry([makeAgentPlugin("codex", ["review"])]);
     const store = createPipelineStore(storeRoot);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -402,6 +402,10 @@ export {
   AgentExecutorSpawnError,
   STAGE_FINDINGS_RELATIVE_PATH,
   createPipelineEngine,
+  // v1.1: DAG scheduler + runtime validation defense-in-depth
+  findFirstStageCycle,
+  scheduleAfterChange,
+  validatePipelineDag,
   // Pipeline config schema (`pipelines:` block)
   ConfiguredPipelineSchema,
   PipelinesConfigSchema,

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -12,6 +12,7 @@
 
 import { z } from "zod";
 
+import { findFirstStageCycle } from "./dag.js";
 import {
   asPipelineId,
   type Pipeline,
@@ -180,74 +181,6 @@ export const ConfiguredPipelineSchema = z
       });
     }
   });
-
-/**
- * Find the first cycle in the combined `dependsOn` + `routes.when.stages`
- * graph and return it as `[stage, ..., stage]` (first and last names equal).
- * Trivial self-loops (`[X, X]`) are excluded so the explicit self-reference
- * checks own that error message; multi-node cycles are reported here.
- *
- * Iterative DFS — pure, allocation-bounded, suitable for running inside Zod
- * refinements at config load. Both edge types contribute because the runtime
- * scheduler waits for either kind of reference before evaluating a stage, so
- * a cycle in either graph deadlocks the run.
- */
-function findFirstStageCycle(
-  stages: Array<{
-    name: string;
-    dependsOn?: string[];
-    routes?: { when: { stages: string[] } };
-  }>,
-): string[] | null {
-  const adjacency = new Map<string, string[]>();
-  for (const stage of stages) {
-    const edges = new Set<string>([
-      ...(stage.dependsOn ?? []),
-      ...(stage.routes?.when.stages ?? []),
-    ]);
-    adjacency.set(stage.name, [...edges]);
-  }
-  const WHITE = 0;
-  const GRAY = 1;
-  const BLACK = 2;
-  const color = new Map<string, number>();
-  for (const stage of stages) color.set(stage.name, WHITE);
-
-  for (const stage of stages) {
-    if (color.get(stage.name) !== WHITE) continue;
-    const stack: Array<{ node: string; iter: number }> = [{ node: stage.name, iter: 0 }];
-    const path: string[] = [];
-    color.set(stage.name, GRAY);
-    path.push(stage.name);
-
-    while (stack.length > 0) {
-      const top = stack[stack.length - 1];
-      const neighbors = adjacency.get(top.node) ?? [];
-      if (top.iter >= neighbors.length) {
-        color.set(top.node, BLACK);
-        stack.pop();
-        path.pop();
-        continue;
-      }
-      const next = neighbors[top.iter];
-      top.iter += 1;
-      const nextColor = color.get(next);
-      if (nextColor === GRAY) {
-        const cycleStart = path.indexOf(next);
-        // Skip trivial self-loops; the explicit self-reference checks above
-        // already produced a clearer error for those.
-        if (cycleStart === path.length - 1) continue;
-        return [...path.slice(cycleStart), next];
-      }
-      if (nextColor === WHITE) {
-        color.set(next, GRAY);
-        path.push(next);
-        stack.push({ node: next, iter: 0 });
-      }
-    }
-  }
-  return null;
-}
 
 export type ConfiguredPipeline = z.infer<typeof ConfiguredPipelineSchema>;
 

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -12,14 +12,20 @@
 
 import { z } from "zod";
 
-import { asPipelineId, type Pipeline, type Stage, type StageExecutor, type TaskMode } from "./types.js";
+import {
+  asPipelineId,
+  type Pipeline,
+  type Stage,
+  type StageExecutor,
+  type StageRoutePredicate,
+  type StageRoutes,
+  type TaskMode,
+} from "./types.js";
 
 const TaskModeSchema = z.enum(["review", "code", "answer"]);
 
 const StageTriggerSchema = z.object({
-  on: z.array(
-    z.enum(["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"]),
-  ),
+  on: z.array(z.enum(["pr.opened", "pr.updated", "pr.merge_ready", "pr.merged", "manual"])),
 });
 
 const AgentExecutorSchema = z.object({
@@ -58,6 +64,16 @@ const StageBudgetSchema = z.object({
   maxDurationMs: z.number().int().nonnegative().optional(),
 });
 
+const StageRoutePredicateSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("allSucceeded"), stages: z.array(z.string().min(1)) }),
+  z.object({ kind: z.literal("anySucceeded"), stages: z.array(z.string().min(1)) }),
+  z.object({ kind: z.literal("anyFailed"), stages: z.array(z.string().min(1)) }),
+]);
+
+const StageRoutesSchema = z.object({
+  when: StageRoutePredicateSchema,
+});
+
 const StageSchema = z.object({
   name: z.string().min(1),
   trigger: StageTriggerSchema,
@@ -68,17 +84,139 @@ const StageSchema = z.object({
   timeoutMs: z.number().int().nonnegative().optional(),
   retries: z.number().int().nonnegative().optional(),
   maxLoopRounds: z.number().int().positive().optional(),
+  dependsOn: z.array(z.string().min(1)).optional(),
+  routes: StageRoutesSchema.optional(),
 });
 
 /**
  * Pipeline config without its branded id — id is derived from the YAML map key.
  * `name` defaults to that same key when omitted.
+ *
+ * Cross-stage validations (unknown `dependsOn`/`routes` references and
+ * `dependsOn` cycles) run via `superRefine` so they surface alongside the
+ * normal Zod errors at config load — operators see one consolidated failure
+ * instead of a runtime crash later.
  */
-export const ConfiguredPipelineSchema = z.object({
-  name: z.string().min(1).optional(),
-  stages: z.array(StageSchema).min(1),
-  maxConcurrentStages: z.number().int().positive().optional(),
-});
+export const ConfiguredPipelineSchema = z
+  .object({
+    name: z.string().min(1).optional(),
+    stages: z.array(StageSchema).min(1),
+    maxConcurrentStages: z.number().int().positive().optional(),
+  })
+  .superRefine((pipeline, ctx) => {
+    const stageNames = new Set(pipeline.stages.map((s) => s.name));
+
+    // Duplicate stage names break dependency resolution and the reducer's
+    // per-stage state map; reject early with a precise pointer.
+    const seen = new Set<string>();
+    for (let i = 0; i < pipeline.stages.length; i++) {
+      const name = pipeline.stages[i].name;
+      if (seen.has(name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["stages", i, "name"],
+          message: `Duplicate stage name "${name}" — every stage in a pipeline must have a unique name.`,
+        });
+      }
+      seen.add(name);
+    }
+
+    // dependsOn / routes references must point to known stage names.
+    for (let i = 0; i < pipeline.stages.length; i++) {
+      const stage = pipeline.stages[i];
+      for (const dep of stage.dependsOn ?? []) {
+        if (!stageNames.has(dep)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["stages", i, "dependsOn"],
+            message: `Stage "${stage.name}" depends on unknown stage "${dep}".`,
+          });
+        }
+        if (dep === stage.name) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["stages", i, "dependsOn"],
+            message: `Stage "${stage.name}" cannot depend on itself.`,
+          });
+        }
+      }
+      const routes = stage.routes;
+      if (routes) {
+        for (const ref of routes.when.stages) {
+          if (!stageNames.has(ref)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["stages", i, "routes", "when", "stages"],
+              message: `Stage "${stage.name}" routes references unknown stage "${ref}".`,
+            });
+          }
+        }
+      }
+    }
+
+    // Cycle detection on the dependsOn graph (Tarjan's SCC).
+    // Returns the first cycle found, in the order the stages appear so the
+    // error message reads naturally (e.g. "a → b → c → a").
+    const cycle = findFirstDependencyCycle(pipeline.stages);
+    if (cycle) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["stages"],
+        message: `Pipeline has a dependsOn cycle: ${cycle.join(" → ")}.`,
+      });
+    }
+  });
+
+/**
+ * Find the first dependsOn cycle and return it as `[stage, ..., stage]` (first
+ * and last names equal). Iterative DFS — pure, allocation-bounded, suitable
+ * for running inside Zod refinements at config load.
+ */
+function findFirstDependencyCycle(
+  stages: Array<{ name: string; dependsOn?: string[] }>,
+): string[] | null {
+  const adjacency = new Map<string, string[]>();
+  for (const stage of stages) {
+    adjacency.set(stage.name, [...(stage.dependsOn ?? [])]);
+  }
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const stage of stages) color.set(stage.name, WHITE);
+
+  for (const stage of stages) {
+    if (color.get(stage.name) !== WHITE) continue;
+    const stack: Array<{ node: string; iter: number }> = [{ node: stage.name, iter: 0 }];
+    const path: string[] = [];
+    color.set(stage.name, GRAY);
+    path.push(stage.name);
+
+    while (stack.length > 0) {
+      const top = stack[stack.length - 1];
+      const neighbors = adjacency.get(top.node) ?? [];
+      if (top.iter >= neighbors.length) {
+        color.set(top.node, BLACK);
+        stack.pop();
+        path.pop();
+        continue;
+      }
+      const next = neighbors[top.iter];
+      top.iter += 1;
+      const nextColor = color.get(next);
+      if (nextColor === GRAY) {
+        const cycleStart = path.indexOf(next);
+        return [...path.slice(cycleStart), next];
+      }
+      if (nextColor === WHITE) {
+        color.set(next, GRAY);
+        path.push(next);
+        stack.push({ node: next, iter: 0 });
+      }
+    }
+  }
+  return null;
+}
 
 export type ConfiguredPipeline = z.infer<typeof ConfiguredPipelineSchema>;
 
@@ -87,10 +225,7 @@ export const PipelinesConfigSchema = z.record(z.string().min(1), ConfiguredPipel
 export type PipelinesConfig = z.infer<typeof PipelinesConfigSchema>;
 
 /** Convert a parsed YAML pipeline entry into a runtime Pipeline (branded id). */
-export function configuredPipelineToRuntime(
-  key: string,
-  configured: ConfiguredPipeline,
-): Pipeline {
+export function configuredPipelineToRuntime(key: string, configured: ConfiguredPipeline): Pipeline {
   const stages = configured.stages.map((stage): Stage => {
     const executor: StageExecutor =
       stage.executor.kind === "agent"
@@ -108,6 +243,15 @@ export function configuredPipelineToRuntime(
             ...(stage.executor.cwd !== undefined ? { cwd: stage.executor.cwd } : {}),
           };
 
+    const routes: StageRoutes | undefined = stage.routes
+      ? {
+          when: {
+            kind: stage.routes.when.kind,
+            stages: [...stage.routes.when.stages],
+          } as StageRoutePredicate,
+        }
+      : undefined;
+
     return {
       name: stage.name,
       trigger: { on: [...stage.trigger.on] },
@@ -118,6 +262,8 @@ export function configuredPipelineToRuntime(
       ...(stage.timeoutMs !== undefined ? { timeoutMs: stage.timeoutMs } : {}),
       ...(stage.retries !== undefined ? { retries: stage.retries } : {}),
       ...(stage.maxLoopRounds !== undefined ? { maxLoopRounds: stage.maxLoopRounds } : {}),
+      ...(stage.dependsOn !== undefined ? { dependsOn: [...stage.dependsOn] } : {}),
+      ...(routes ? { routes } : {}),
     };
   });
 

--- a/packages/core/src/pipeline/config-schema.ts
+++ b/packages/core/src/pipeline/config-schema.ts
@@ -65,9 +65,9 @@ const StageBudgetSchema = z.object({
 });
 
 const StageRoutePredicateSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("allSucceeded"), stages: z.array(z.string().min(1)) }),
-  z.object({ kind: z.literal("anySucceeded"), stages: z.array(z.string().min(1)) }),
-  z.object({ kind: z.literal("anyFailed"), stages: z.array(z.string().min(1)) }),
+  z.object({ kind: z.literal("allSucceeded"), stages: z.array(z.string().min(1)).min(1) }),
+  z.object({ kind: z.literal("anySucceeded"), stages: z.array(z.string().min(1)).min(1) }),
+  z.object({ kind: z.literal("anyFailed"), stages: z.array(z.string().min(1)).min(1) }),
 ]);
 
 const StageRoutesSchema = z.object({
@@ -92,10 +92,15 @@ const StageSchema = z.object({
  * Pipeline config without its branded id — id is derived from the YAML map key.
  * `name` defaults to that same key when omitted.
  *
- * Cross-stage validations (unknown `dependsOn`/`routes` references and
- * `dependsOn` cycles) run via `superRefine` so they surface alongside the
- * normal Zod errors at config load — operators see one consolidated failure
- * instead of a runtime crash later.
+ * Cross-stage validations (unknown `dependsOn`/`routes` references, self-refs,
+ * and cycles in the combined `dependsOn`+`routes` graph) run via `superRefine`
+ * so they surface alongside the normal Zod errors at config load — operators
+ * see one consolidated failure instead of a runtime deadlock later.
+ *
+ * Cycle detection treats both `dependsOn` and `routes.when.stages` as graph
+ * edges because the runtime scheduler waits for both before evaluating a
+ * stage (`arePreconditionsTerminal` in dag.ts). A routes-only cycle would
+ * otherwise leave every stage in the cycle stuck `pending` forever.
  */
 export const ConfiguredPipelineSchema = z
   .object({
@@ -150,34 +155,57 @@ export const ConfiguredPipelineSchema = z
               message: `Stage "${stage.name}" routes references unknown stage "${ref}".`,
             });
           }
+          if (ref === stage.name) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["stages", i, "routes", "when", "stages"],
+              message: `Stage "${stage.name}" cannot route to itself.`,
+            });
+          }
         }
       }
     }
 
-    // Cycle detection on the dependsOn graph (Tarjan's SCC).
-    // Returns the first cycle found, in the order the stages appear so the
-    // error message reads naturally (e.g. "a → b → c → a").
-    const cycle = findFirstDependencyCycle(pipeline.stages);
+    // Cycle detection over the combined dependsOn + routes-refs graph.
+    // Iterative DFS; returns the first cycle found in declaration order so
+    // the error reads naturally (e.g. "a → b → c → a"). Trivial self-loops
+    // (`[X, X]`) are excluded — the explicit self-ref checks above already
+    // report those with clearer messages.
+    const cycle = findFirstStageCycle(pipeline.stages);
     if (cycle) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["stages"],
-        message: `Pipeline has a dependsOn cycle: ${cycle.join(" → ")}.`,
+        message: `Pipeline has a stage dependency cycle: ${cycle.join(" → ")}.`,
       });
     }
   });
 
 /**
- * Find the first dependsOn cycle and return it as `[stage, ..., stage]` (first
- * and last names equal). Iterative DFS — pure, allocation-bounded, suitable
- * for running inside Zod refinements at config load.
+ * Find the first cycle in the combined `dependsOn` + `routes.when.stages`
+ * graph and return it as `[stage, ..., stage]` (first and last names equal).
+ * Trivial self-loops (`[X, X]`) are excluded so the explicit self-reference
+ * checks own that error message; multi-node cycles are reported here.
+ *
+ * Iterative DFS — pure, allocation-bounded, suitable for running inside Zod
+ * refinements at config load. Both edge types contribute because the runtime
+ * scheduler waits for either kind of reference before evaluating a stage, so
+ * a cycle in either graph deadlocks the run.
  */
-function findFirstDependencyCycle(
-  stages: Array<{ name: string; dependsOn?: string[] }>,
+function findFirstStageCycle(
+  stages: Array<{
+    name: string;
+    dependsOn?: string[];
+    routes?: { when: { stages: string[] } };
+  }>,
 ): string[] | null {
   const adjacency = new Map<string, string[]>();
   for (const stage of stages) {
-    adjacency.set(stage.name, [...(stage.dependsOn ?? [])]);
+    const edges = new Set<string>([
+      ...(stage.dependsOn ?? []),
+      ...(stage.routes?.when.stages ?? []),
+    ]);
+    adjacency.set(stage.name, [...edges]);
   }
   const WHITE = 0;
   const GRAY = 1;
@@ -206,6 +234,9 @@ function findFirstDependencyCycle(
       const nextColor = color.get(next);
       if (nextColor === GRAY) {
         const cycleStart = path.indexOf(next);
+        // Skip trivial self-loops; the explicit self-reference checks above
+        // already produced a clearer error for those.
+        if (cycleStart === path.length - 1) continue;
         return [...path.slice(cycleStart), next];
       }
       if (nextColor === WHITE) {

--- a/packages/core/src/pipeline/dag.ts
+++ b/packages/core/src/pipeline/dag.ts
@@ -1,0 +1,180 @@
+/**
+ * DAG-aware scheduling for the pipeline reducer.
+ *
+ * Pure: every function takes timestamps as parameters; no clock reads, no I/O.
+ * Split out from reducer-helpers.ts so the reducer can stay focused on
+ * event-shape transitions while the dependency / routing logic lives here.
+ *
+ * Ordering invariants (what callers can rely on):
+ *  - Skips cascade in a single pass: skipping a stage may make a downstream
+ *    stage's routes evaluate to false, which marks it skipped, which may
+ *    cascade further. `scheduleAfterChange` runs the cascade to fixpoint
+ *    before emitting any START_STAGE effects.
+ *  - Stage declaration order is preserved as priority for slotting: when more
+ *    stages are eligible than `maxConcurrentStages` allows, earlier-declared
+ *    stages win the available slots. This keeps linear pipelines (no
+ *    `dependsOn`) behaviorally identical to v0.
+ */
+
+import type { PipelineEffect } from "./events.js";
+import { iso, patchRun } from "./reducer-helpers.js";
+import {
+  type RunState,
+  type Stage,
+  type StageRoutePredicate,
+  type StageState,
+  isTerminalStageStatus,
+} from "./types.js";
+
+export interface ScheduleResult {
+  /** Run with any newly-skipped stages applied. May equal the input run. */
+  run: RunState;
+  /** START_STAGE effects for stages eligible to run, capped by concurrency. */
+  startEffects: PipelineEffect[];
+  /** Stage names that transitioned `pending → skipped` during this call. */
+  newlySkipped: string[];
+  /** True iff every stage is in a terminal status. */
+  allTerminal: boolean;
+}
+
+/**
+ * After a state change (TRIGGER_FIRED, STAGE_COMPLETED, RUN_RESUMED), figure
+ * out which pending stages should be skipped (routes predicate failed) and
+ * which are eligible to start. Cascade skips run to fixpoint before emitting
+ * any START_STAGE effects, so downstream stages whose dependencies were just
+ * skipped get marked skipped in the same reducer step.
+ */
+export function scheduleAfterChange(run: RunState, now: number): ScheduleResult {
+  const skipResult = applyEligibleSkips(run, now);
+  const current = skipResult.run;
+
+  const max = current.pipelineConfigSnapshot.maxConcurrentStages ?? 1;
+  const inflight = Object.values(current.stages).filter((s) => s.status === "running").length;
+  const slots = Math.max(0, max - inflight);
+
+  const startEffects: PipelineEffect[] = [];
+  if (slots > 0) {
+    for (const stageDef of current.pipelineConfigSnapshot.stages) {
+      if (startEffects.length >= slots) break;
+      const state = current.stages[stageDef.name];
+      if (state.status !== "pending") continue;
+      if (!areDepsSatisfiedForStart(stageDef, current.stages)) continue;
+      if (!evaluateRoutes(stageDef, current.stages)) continue;
+      startEffects.push({
+        type: "START_STAGE",
+        runId: current.runId,
+        stageRunId: state.stageRunId,
+        stage: stageDef,
+      });
+    }
+  }
+
+  const allTerminal = Object.values(current.stages).every((s) => isTerminalStageStatus(s.status));
+  return { run: current, startEffects, newlySkipped: skipResult.newlySkipped, allTerminal };
+}
+
+/**
+ * Walk the pipeline and mark as `skipped` every pending stage whose:
+ *  - preconditions (`dependsOn` ∪ `routes` refs) are all in a terminal
+ *    state — only then is the activation decision deterministic, AND
+ *  - `routes` predicate evaluates to `false` (or — when `routes` is unset —
+ *    any `dependsOn` reached a non-`succeeded` terminal state).
+ *
+ * Iterates to fixpoint so cascade skips land in one reducer step.
+ *
+ * Note: `routes` may reference stages outside `dependsOn` (e.g. a parallel
+ * branch the user wants to react to without forcing serialization). The
+ * scheduler waits for those references to be terminal too before deciding.
+ */
+function applyEligibleSkips(run: RunState, now: number): { run: RunState; newlySkipped: string[] } {
+  let current = run;
+  const newlySkipped: string[] = [];
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const stageDef of current.pipelineConfigSnapshot.stages) {
+      const state = current.stages[stageDef.name];
+      if (state.status !== "pending") continue;
+      if (!arePreconditionsTerminal(stageDef, current.stages)) continue;
+
+      const shouldSkip = stageDef.routes
+        ? !evaluatePredicate(stageDef.routes.when, current.stages)
+        : !areAllDepsSucceeded(stageDef, current.stages);
+
+      if (shouldSkip) {
+        const skippedStage: StageState = {
+          ...state,
+          status: "skipped",
+          completedAt: iso(now),
+        };
+        current = patchRun(current, { [stageDef.name]: skippedStage }, now);
+        newlySkipped.push(stageDef.name);
+        changed = true;
+      }
+    }
+  }
+  return { run: current, newlySkipped };
+}
+
+function arePreconditionsTerminal(stage: Stage, stages: Record<string, StageState>): boolean {
+  if (!areDepsTerminal(stage, stages)) return false;
+  if (stage.routes) {
+    for (const ref of stage.routes.when.stages) {
+      const refState = stages[ref];
+      if (!refState || !isTerminalStageStatus(refState.status)) return false;
+    }
+  }
+  return true;
+}
+
+function areDepsTerminal(stage: Stage, stages: Record<string, StageState>): boolean {
+  const deps = stage.dependsOn ?? [];
+  for (const dep of deps) {
+    const depState = stages[dep];
+    if (!depState || !isTerminalStageStatus(depState.status)) return false;
+  }
+  return true;
+}
+
+function areAllDepsSucceeded(stage: Stage, stages: Record<string, StageState>): boolean {
+  const deps = stage.dependsOn ?? [];
+  for (const dep of deps) {
+    const depState = stages[dep];
+    if (!depState || depState.status !== "succeeded") return false;
+  }
+  return true;
+}
+
+/**
+ * Eligible-to-start: every `dependsOn` must be `succeeded` (default) so the
+ * scheduler doesn't optimistically start a stage whose upstream skipped or
+ * failed. Routes are evaluated separately by `evaluateRoutes`.
+ */
+function areDepsSatisfiedForStart(stage: Stage, stages: Record<string, StageState>): boolean {
+  return areAllDepsSucceeded(stage, stages);
+}
+
+function evaluateRoutes(stage: Stage, stages: Record<string, StageState>): boolean {
+  if (!stage.routes) return true;
+  return evaluatePredicate(stage.routes.when, stages);
+}
+
+/**
+ * Pure predicate evaluator over the runtime stage states. Stages referenced
+ * here are guaranteed by config validation to exist in the pipeline; missing
+ * entries are treated as non-terminal (i.e. `false` for everything except
+ * `anyFailed` short-circuits) so an unevaluable predicate never green-lights.
+ */
+function evaluatePredicate(
+  predicate: StageRoutePredicate,
+  stages: Record<string, StageState>,
+): boolean {
+  switch (predicate.kind) {
+    case "allSucceeded":
+      return predicate.stages.every((name) => stages[name]?.status === "succeeded");
+    case "anySucceeded":
+      return predicate.stages.some((name) => stages[name]?.status === "succeeded");
+    case "anyFailed":
+      return predicate.stages.some((name) => stages[name]?.status === "failed");
+  }
+}

--- a/packages/core/src/pipeline/dag.ts
+++ b/packages/core/src/pipeline/dag.ts
@@ -178,3 +178,75 @@ function evaluatePredicate(
       return predicate.stages.some((name) => stages[name]?.status === "failed");
   }
 }
+
+/**
+ * Find the first cycle in the combined `dependsOn` + `routes.when.stages`
+ * graph and return it as `[stage, ..., stage]` (first and last names equal).
+ * Trivial self-loops (`[X, X]`) are excluded so the explicit self-reference
+ * checks own that error message; multi-node cycles are reported here.
+ *
+ * Iterative DFS — pure, allocation-bounded. Both edge types contribute
+ * because the runtime scheduler waits for either kind of reference before
+ * evaluating a stage, so a cycle in either graph deadlocks the run. Used by
+ * Zod (`config-schema.ts`) at config load and by the engine
+ * (`validatePipelineDag`) as defense-in-depth for programmatic pipelines.
+ *
+ * The structural input type accepts both Zod-inferred shapes and runtime
+ * `Stage` objects so a single implementation serves both call sites.
+ */
+export function findFirstStageCycle(
+  stages: ReadonlyArray<{
+    name: string;
+    dependsOn?: string[];
+    routes?: { when: { stages: string[] } };
+  }>,
+): string[] | null {
+  const adjacency = new Map<string, string[]>();
+  for (const stage of stages) {
+    const edges = new Set<string>([
+      ...(stage.dependsOn ?? []),
+      ...(stage.routes?.when.stages ?? []),
+    ]);
+    adjacency.set(stage.name, [...edges]);
+  }
+  const WHITE = 0;
+  const GRAY = 1;
+  const BLACK = 2;
+  const color = new Map<string, number>();
+  for (const stage of stages) color.set(stage.name, WHITE);
+
+  for (const stage of stages) {
+    if (color.get(stage.name) !== WHITE) continue;
+    const stack: Array<{ node: string; iter: number }> = [{ node: stage.name, iter: 0 }];
+    const path: string[] = [];
+    color.set(stage.name, GRAY);
+    path.push(stage.name);
+
+    while (stack.length > 0) {
+      const top = stack[stack.length - 1];
+      const neighbors = adjacency.get(top.node) ?? [];
+      if (top.iter >= neighbors.length) {
+        color.set(top.node, BLACK);
+        stack.pop();
+        path.pop();
+        continue;
+      }
+      const next = neighbors[top.iter];
+      top.iter += 1;
+      const nextColor = color.get(next);
+      if (nextColor === GRAY) {
+        const cycleStart = path.indexOf(next);
+        // Skip trivial self-loops; explicit self-reference checks emit a
+        // clearer error for those.
+        if (cycleStart === path.length - 1) continue;
+        return [...path.slice(cycleStart), next];
+      }
+      if (nextColor === WHITE) {
+        color.set(next, GRAY);
+        path.push(next);
+        stack.push({ node: next, iter: 0 });
+      }
+    }
+  }
+  return null;
+}

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -45,7 +45,7 @@ import {
   type StageRunId,
   type StageTriggerEvent,
 } from "./types.js";
-import { validatePipelineAgentModes } from "./validation.js";
+import { validatePipelineAgentModes, validatePipelineDag } from "./validation.js";
 import {
   type AgentStageExecutor,
   type RunningAgentStage,
@@ -284,6 +284,7 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
 
   async function startRun(input: StartRunInput): Promise<RunId> {
     validatePipelineAgentModes(input.pipeline, registry);
+    validatePipelineDag(input.pipeline);
 
     const runId = asRunId(`run-${randomUUID()}`);
     const stageRunIds: Record<string, StageRunId> = {};

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -291,10 +291,13 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   }
 
   async function startRun(input: StartRunInput): Promise<RunId> {
-    // Pipeline validation lives in `dispatch` so any TRIGGER_FIRED entering
-    // the engine is checked the same way; we run validation here too only
-    // to surface errors before the runId/stageRunId allocations below
-    // (which would otherwise leak into runMetadata if dispatch threw).
+    // Validate exactly once. Calling `dispatch` here would re-validate
+    // inside the lock, opening a window where the registry could mutate
+    // between the two synchronous checks — if the second throws, the
+    // `runMetadata.set` below would have already populated an orphan entry
+    // with no matching run. Instead we validate up front and skip
+    // `dispatch`'s validation by going through `withLock(dispatchInline)`
+    // directly.
     validatePipelineAgentModes(input.pipeline, registry);
     validatePipelineDag(input.pipeline);
 
@@ -312,16 +315,18 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
       issueId: input.issueId,
     });
 
-    await dispatch({
-      type: "TRIGGER_FIRED",
-      now: now(),
-      trigger: input.trigger ?? "manual",
-      sessionId: input.sessionId,
-      pipeline: input.pipeline,
-      headSha: input.headSha,
-      runId,
-      stageRunIds,
-    });
+    await withLock(() =>
+      dispatchInline({
+        type: "TRIGGER_FIRED",
+        now: now(),
+        trigger: input.trigger ?? "manual",
+        sessionId: input.sessionId,
+        pipeline: input.pipeline,
+        headSha: input.headSha,
+        runId,
+        stageRunIds,
+      }),
+    );
 
     return runId;
   }

--- a/packages/core/src/pipeline/engine.ts
+++ b/packages/core/src/pipeline/engine.ts
@@ -135,6 +135,14 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   }
 
   async function dispatch(event: PipelineEvent): Promise<void> {
+    // Defense-in-depth: any TRIGGER_FIRED that enters the engine — whether
+    // via `startRun`, a test, or a future config-watcher injection — gets
+    // the same validation `startRun` applies. Validates synchronously
+    // before taking the lock so the error surfaces before any state moves.
+    if (event.type === "TRIGGER_FIRED") {
+      validatePipelineAgentModes(event.pipeline, registry);
+      validatePipelineDag(event.pipeline);
+    }
     return withLock(() => dispatchInline(event));
   }
 
@@ -283,6 +291,10 @@ export function createPipelineEngine(deps: PipelineEngineDeps): PipelineEngine {
   }
 
   async function startRun(input: StartRunInput): Promise<RunId> {
+    // Pipeline validation lives in `dispatch` so any TRIGGER_FIRED entering
+    // the engine is checked the same way; we run validation here too only
+    // to surface errors before the runId/stageRunId allocations below
+    // (which would otherwise leak into runMetadata if dispatch threw).
     validatePipelineAgentModes(input.pipeline, registry);
     validatePipelineDag(input.pipeline);
 

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -23,9 +23,10 @@ export {
   PipelineConfigError,
   getSupportedTaskModes,
   validatePipelineAgentModes,
+  validatePipelineDag,
 } from "./validation.js";
 
-export { scheduleAfterChange, type ScheduleResult } from "./dag.js";
+export { findFirstStageCycle, scheduleAfterChange, type ScheduleResult } from "./dag.js";
 
 export { buildStagePrompt, type StagePromptInput } from "./stage-prompt.js";
 

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -25,6 +25,8 @@ export {
   validatePipelineAgentModes,
 } from "./validation.js";
 
+export { scheduleAfterChange, type ScheduleResult } from "./dag.js";
+
 export { buildStagePrompt, type StagePromptInput } from "./stage-prompt.js";
 
 export {

--- a/packages/core/src/pipeline/reducer-helpers.ts
+++ b/packages/core/src/pipeline/reducer-helpers.ts
@@ -88,25 +88,6 @@ export function materializeArtifact(
   } as Artifact;
 }
 
-export function startableStageEffects(run: RunState): PipelineEffect[] {
-  const max = run.pipelineConfigSnapshot.maxConcurrentStages ?? 1;
-  const inflight = Object.values(run.stages).filter((s) => s.status === "running").length;
-  const remaining = Math.max(0, max - inflight);
-  if (remaining === 0) return [];
-
-  const pending = run.pipelineConfigSnapshot.stages
-    .map((stage) => ({ stage, state: run.stages[stage.name] }))
-    .filter(({ state }) => state.status === "pending")
-    .slice(0, remaining);
-
-  return pending.map(({ stage, state }) => ({
-    type: "START_STAGE" as const,
-    runId: run.runId,
-    stageRunId: state.stageRunId,
-    stage,
-  }));
-}
-
 export function invalidTransition(state: EngineState, message: string): ReducerResult {
   return {
     state,

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -36,6 +36,7 @@ import {
   type StageState,
   type StageTriggerEvent,
   type Verdict,
+  isTerminalLoopState,
   loopKey,
 } from "./types.js";
 
@@ -353,6 +354,17 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   const run = state.runs[runId];
   if (!run) return invalidTransition(state, `RUN_RESUMED for unknown runId=${runId}`);
 
+  // Resume only applies to runs that have stopped advancing. The CLI rejects
+  // non-terminal runs at the service layer; this guard catches direct
+  // dispatch (tests, future config-watcher) so the reducer never re-arms a
+  // run the engine still considers active.
+  if (!isTerminalLoopState(run.loopState)) {
+    return invalidTransition(
+      state,
+      `RUN_RESUMED requires a terminal loop state; got ${run.loopState} for ${runId}`,
+    );
+  }
+
   // Refuse to resume when another run already owns the loop key. Without
   // this guard, resuming an old stalled run after a fresh trigger has
   // claimed the loop would silently dispossess the active run of its loop
@@ -367,11 +379,12 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
     );
   }
 
-  // `failed` stages need a fresh stageRunId + attempt bump (a real retry).
-  // `outdated` stages were running at terminate time (terminateRunFromState
-  // marked `running → outdated`); their work was cancelled, so they also
-  // need a fresh stageRunId and attempt bump to re-run cleanly. The CLI
-  // service is expected to allocate stageRunIds for both kinds.
+  // `failed` stages are real retries — bump attempt and consume the
+  // `stage.retries` budget. `outdated` stages were running when an external
+  // event (NEW_SHA_DETECTED, CONFIG_CHANGED, parallel-sibling failure)
+  // forced `terminateRunFromState` to cancel them; that's not a stage
+  // failure, so reviving them must NOT consume the retry cap. They keep
+  // their attempt counter and just get a fresh stageRunId for the next run.
   const failedStageNames = Object.entries(run.stages)
     .filter(([, s]) => s.status === "failed")
     .map(([name]) => name);
@@ -383,25 +396,22 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
     return { state, effects: [] };
   }
 
-  // Cap the attempt bump by the configured retries (when set). The reducer
-  // ignores resumes that would exceed retries — operators can still re-cancel
-  // and re-trigger if they want a fresh run.
   const stageRetriesByName = new Map<string, number | undefined>();
   for (const stage of run.pipelineConfigSnapshot.stages) {
     stageRetriesByName.set(stage.name, stage.retries);
   }
 
   const stageDelta: Record<string, StageState> = {};
-  const retriedStageNames = [...failedStageNames, ...outdatedStageNames];
-  for (const name of retriedStageNames) {
+
+  // Real retries: bump attempt, check the retries cap.
+  for (const name of failedStageNames) {
     const fresh = stageRunIds[name];
     if (!fresh) {
       return invalidTransition(
         state,
-        `RUN_RESUMED missing stageRunId for ${run.stages[name].status} stage "${name}"`,
+        `RUN_RESUMED missing stageRunId for failed stage "${name}"`,
       );
     }
-
     const prior = run.stages[name];
     const cap = stageRetriesByName.get(name);
     if (cap !== undefined && prior.attempt >= cap + 1) {
@@ -410,11 +420,28 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
         `RUN_RESUMED would exceed stage.retries=${cap} for "${name}" (attempt=${prior.attempt})`,
       );
     }
-
     stageDelta[name] = {
       stageRunId: fresh,
       status: "pending",
       attempt: prior.attempt + 1,
+      artifacts: [],
+    };
+  }
+
+  // External cancellations: don't bump attempt, don't check cap.
+  for (const name of outdatedStageNames) {
+    const fresh = stageRunIds[name];
+    if (!fresh) {
+      return invalidTransition(
+        state,
+        `RUN_RESUMED missing stageRunId for outdated stage "${name}"`,
+      );
+    }
+    const prior = run.stages[name];
+    stageDelta[name] = {
+      stageRunId: fresh,
+      status: "pending",
+      attempt: prior.attempt,
       artifacts: [],
     };
   }
@@ -476,7 +503,7 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
         data: {
           runId,
           pipelineName: run.pipelineName,
-          stageNames: retriedStageNames,
+          stageNames: [...failedStageNames, ...outdatedStageNames],
         },
       },
     },

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -393,6 +393,26 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
     };
   }
 
+  // Also revive any stages that `terminateRunFromState` cascade-skipped when
+  // the run failed — they never got an execution attempt, so they keep their
+  // existing stageRunId and attempt counter. Without this, a failure in a
+  // DAG would permanently lose every downstream branch on resume because
+  // `scheduleAfterChange` only considers `pending` stages.
+  //
+  // `scheduleAfterChange` runs after this delta is applied, so any stage
+  // whose `routes` predicate is genuinely unsatisfied gets re-skipped — we
+  // don't accidentally revive predicate-driven skips.
+  for (const [name, prior] of Object.entries(run.stages)) {
+    if (prior.status !== "skipped") continue;
+    if (stageDelta[name]) continue;
+    stageDelta[name] = {
+      stageRunId: prior.stageRunId,
+      status: "pending",
+      attempt: prior.attempt,
+      artifacts: prior.artifacts,
+    };
+  }
+
   const updatedRun: RunState = {
     ...run,
     stages: { ...run.stages, ...stageDelta },

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -12,6 +12,7 @@
  * reducer-helpers.ts.
  */
 
+import { scheduleAfterChange } from "./dag.js";
 import type { PipelineEffect, PipelineEvent, ReducerResult } from "./events.js";
 import {
   deriveLoopStateFromRun,
@@ -20,7 +21,6 @@ import {
   materializeArtifact,
   patchRun,
   replaceRun,
-  startableStageEffects,
   terminateRun,
   terminateRunFromState,
 } from "./reducer-helpers.js";
@@ -36,7 +36,6 @@ import {
   type StageState,
   type StageTriggerEvent,
   type Verdict,
-  isTerminalStageStatus,
   loopKey,
 } from "./types.js";
 
@@ -92,7 +91,7 @@ function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): Reduc
   const isContinuation = trigger === "pr.updated" || trigger === "manual";
   const loopRounds = isContinuation ? priorRound + 1 : Math.max(priorRound, 1);
 
-  const runState: RunState = {
+  const initialRunState: RunState = {
     runId,
     pipelineId: pipeline.id,
     pipelineName: pipeline.name,
@@ -105,6 +104,36 @@ function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): Reduc
     createdAt: iso(now),
     updatedAt: iso(now),
   };
+
+  // Run the DAG scheduler once at trigger time so that:
+  //  - stages whose `routes` reference *no upstream* (vacuous predicates) get
+  //    a single skip decision instead of sitting pending forever, and
+  //  - parallel-startable stages emit START_STAGE in one shot rather than
+  //    waiting for the next reducer step.
+  const sched = scheduleAfterChange(initialRunState, now);
+  const runState = sched.run;
+
+  // Cascade-skipping into a fully-terminal pipeline at trigger time is
+  // possible only with degenerate predicates (e.g. `anyFailed: []`). When it
+  // happens, terminate the run cleanly instead of leaving an orphaned record.
+  if (sched.allTerminal) {
+    const stateWithRun: EngineState = {
+      ...state,
+      runs: { ...state.runs, [runId]: runState },
+      currentRunByLoop: { ...state.currentRunByLoop, [key]: runId },
+    };
+    const preceding: PipelineEffect[] = [
+      {
+        type: "EMIT_OBSERVATION",
+        event: {
+          name: "pipeline.run.created",
+          data: { runId, pipelineName: pipeline.name, sessionId, trigger, headSha, loopRounds },
+        },
+      },
+      ...skipObservations(runState.runId, sched.newlySkipped, runState),
+    ];
+    return terminateRunFromState(stateWithRun, runState, "completed", now, "done", preceding);
+  }
 
   const nextState: EngineState = {
     ...state,
@@ -119,7 +148,7 @@ function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): Reduc
       runId,
       loopState: deriveLoopStateFromRun(runState, now),
     },
-    ...startableStageEffects(runState),
+    ...sched.startEffects,
     {
       type: "EMIT_OBSERVATION",
       event: {
@@ -134,9 +163,30 @@ function reduceTriggerFired(state: EngineState, event: TriggerFiredEvent): Reduc
         },
       },
     },
+    ...skipObservations(runState.runId, sched.newlySkipped, runState),
   ];
 
   return { state: nextState, effects };
+}
+
+/**
+ * Build "pipeline.stage.terminated" observations for stages that just got
+ * skipped via the DAG scheduler. Mirrors the shape emitted by
+ * `finalizeStageCompletion` so consumers don't need a per-source schema.
+ */
+function skipObservations(runId: RunId, skippedNames: string[], run: RunState): PipelineEffect[] {
+  return skippedNames.map((stageName) => ({
+    type: "EMIT_OBSERVATION" as const,
+    event: {
+      name: "pipeline.stage.terminated",
+      data: {
+        runId,
+        stageName,
+        status: "skipped" as const,
+        artifactCount: run.stages[stageName]?.artifacts.length ?? 0,
+      },
+    },
+  }));
 }
 
 interface StageStartedEvent {
@@ -323,10 +373,7 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   for (const name of failedStageNames) {
     const fresh = stageRunIds[name];
     if (!fresh) {
-      return invalidTransition(
-        state,
-        `RUN_RESUMED missing stageRunId for failed stage "${name}"`,
-      );
+      return invalidTransition(state, `RUN_RESUMED missing stageRunId for failed stage "${name}"`);
     }
 
     const prior = run.stages[name];
@@ -354,21 +401,29 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   };
   delete (updatedRun as { terminationReason?: RunTerminationReason }).terminationReason;
 
+  // After re-arming failed stages, run the DAG scheduler so re-pending stages
+  // start in dependsOn order rather than declaration order. Resumes never
+  // terminate the run on their own (we just transitioned back to `running`),
+  // so we ignore `sched.allTerminal`.
+  const sched = scheduleAfterChange(updatedRun, now);
+  const finalRun = sched.run;
+
   const key = loopKey(run.sessionId, run.pipelineName);
   const nextState: EngineState = {
     ...state,
-    runs: { ...state.runs, [runId]: updatedRun },
+    runs: { ...state.runs, [runId]: finalRun },
     currentRunByLoop: { ...state.currentRunByLoop, [key]: runId },
   };
 
   const effects: PipelineEffect[] = [
-    { type: "PERSIST_RUN", runState: updatedRun },
+    { type: "PERSIST_RUN", runState: finalRun },
     {
       type: "PERSIST_LOOP_STATE",
       runId,
-      loopState: deriveLoopStateFromRun(updatedRun, now),
+      loopState: deriveLoopStateFromRun(finalRun, now),
     },
-    ...startableStageEffects(updatedRun),
+    ...sched.startEffects,
+    ...skipObservations(runId, sched.newlySkipped, finalRun),
     {
       type: "EMIT_OBSERVATION",
       event: {
@@ -431,11 +486,6 @@ function finalizeStageCompletion(
 ): ReducerResult {
   const updatedRun = patchRun(run, { [stageName]: updatedStage }, now);
 
-  const allTerminal = run.pipelineConfigSnapshot.stages.every((s) => {
-    const candidate = s.name === stageName ? updatedStage : updatedRun.stages[s.name];
-    return isTerminalStageStatus(candidate.status);
-  });
-
   const effects: PipelineEffect[] = [];
 
   if (newArtifacts.length > 0) {
@@ -461,6 +511,10 @@ function finalizeStageCompletion(
     },
   });
 
+  // Stage failure terminates the run as `stalled` (existing v0 behavior).
+  // Mid-flight or pending stages get cleaned up by terminateRunFromState
+  // (running → outdated, pending → skipped) so we don't leak inflight work
+  // onto the parallel branches that may still be running.
   if (outcome === "failure") {
     return terminateRunFromState(
       replaceRun(state, updatedRun),
@@ -472,10 +526,17 @@ function finalizeStageCompletion(
     );
   }
 
-  if (allTerminal) {
+  // Success path: the DAG scheduler may cascade-skip downstream stages whose
+  // routes are now unsatisfied, and may immediately schedule the next batch
+  // of parallel-eligible stages. Cascade-driven terminality is checked AFTER
+  // the cascade — only this can carry the run to `done` in one reducer step.
+  const sched = scheduleAfterChange(updatedRun, now);
+  effects.push(...skipObservations(run.runId, sched.newlySkipped, sched.run));
+
+  if (sched.allTerminal) {
     return terminateRunFromState(
-      replaceRun(state, updatedRun),
-      updatedRun,
+      replaceRun(state, sched.run),
+      sched.run,
       "completed",
       now,
       "done",
@@ -483,8 +544,8 @@ function finalizeStageCompletion(
     );
   }
 
-  effects.unshift({ type: "PERSIST_RUN", runState: updatedRun });
-  effects.push(...startableStageEffects(updatedRun));
+  effects.unshift({ type: "PERSIST_RUN", runState: sched.run });
+  effects.push(...sched.startEffects);
 
-  return { state: replaceRun(state, updatedRun), effects };
+  return { state: replaceRun(state, sched.run), effects };
 }

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -353,10 +353,32 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   const run = state.runs[runId];
   if (!run) return invalidTransition(state, `RUN_RESUMED for unknown runId=${runId}`);
 
+  // Refuse to resume when another run already owns the loop key. Without
+  // this guard, resuming an old stalled run after a fresh trigger has
+  // claimed the loop would silently dispossess the active run of its loop
+  // pointer — NEW_SHA_DETECTED, CONFIG_CHANGED, and the triggerRun guard
+  // would then track the wrong run.
+  const key = loopKey(run.sessionId, run.pipelineName);
+  const activeRunId = state.currentRunByLoop[key];
+  if (activeRunId !== undefined && activeRunId !== runId) {
+    return invalidTransition(
+      state,
+      `RUN_RESUMED for ${runId} but loop "${key}" is already owned by active run ${activeRunId}; cancel that run before resuming the older one`,
+    );
+  }
+
+  // `failed` stages need a fresh stageRunId + attempt bump (a real retry).
+  // `outdated` stages were running at terminate time (terminateRunFromState
+  // marked `running → outdated`); their work was cancelled, so they also
+  // need a fresh stageRunId and attempt bump to re-run cleanly. The CLI
+  // service is expected to allocate stageRunIds for both kinds.
   const failedStageNames = Object.entries(run.stages)
     .filter(([, s]) => s.status === "failed")
     .map(([name]) => name);
-  if (failedStageNames.length === 0) {
+  const outdatedStageNames = Object.entries(run.stages)
+    .filter(([, s]) => s.status === "outdated")
+    .map(([name]) => name);
+  if (failedStageNames.length === 0 && outdatedStageNames.length === 0) {
     // Nothing to resume. Keep the state unchanged so the caller can no-op too.
     return { state, effects: [] };
   }
@@ -370,10 +392,14 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   }
 
   const stageDelta: Record<string, StageState> = {};
-  for (const name of failedStageNames) {
+  const retriedStageNames = [...failedStageNames, ...outdatedStageNames];
+  for (const name of retriedStageNames) {
     const fresh = stageRunIds[name];
     if (!fresh) {
-      return invalidTransition(state, `RUN_RESUMED missing stageRunId for failed stage "${name}"`);
+      return invalidTransition(
+        state,
+        `RUN_RESUMED missing stageRunId for ${run.stages[name].status} stage "${name}"`,
+      );
     }
 
     const prior = run.stages[name];
@@ -421,14 +447,13 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
   };
   delete (updatedRun as { terminationReason?: RunTerminationReason }).terminationReason;
 
-  // After re-arming failed stages, run the DAG scheduler so re-pending stages
-  // start in dependsOn order rather than declaration order. Resumes never
-  // terminate the run on their own (we just transitioned back to `running`),
-  // so we ignore `sched.allTerminal`.
+  // After re-arming failed/outdated stages, run the DAG scheduler so
+  // re-pending stages start in dependsOn order rather than declaration
+  // order. Resumes never terminate the run on their own (we just
+  // transitioned back to `running`), so we ignore `sched.allTerminal`.
   const sched = scheduleAfterChange(updatedRun, now);
   const finalRun = sched.run;
 
-  const key = loopKey(run.sessionId, run.pipelineName);
   const nextState: EngineState = {
     ...state,
     runs: { ...state.runs, [runId]: finalRun },
@@ -451,7 +476,7 @@ function reduceRunResumed(state: EngineState, event: RunResumedEvent): ReducerRe
         data: {
           runId,
           pipelineName: run.pipelineName,
-          stageNames: failedStageNames,
+          stageNames: retriedStageNames,
         },
       },
     },

--- a/packages/core/src/pipeline/reducer.ts
+++ b/packages/core/src/pipeline/reducer.ts
@@ -221,7 +221,17 @@ function reduceStageStarted(state: EngineState, event: StageStartedEvent): Reduc
         type: "EMIT_OBSERVATION",
         event: {
           name: "pipeline.stage.started",
-          data: { runId, stageName, attempt: stage.attempt },
+          // `stageRunId` rotates on every retry/revival, so it's the only
+          // field that uniquely identifies *this* execution. `attempt` is
+          // not enough now that outdated revival keeps the counter
+          // unchanged — two `stage.started` events for the same
+          // (runId, stageName) can otherwise share the same attempt.
+          data: {
+            runId,
+            stageName,
+            stageRunId: stage.stageRunId,
+            attempt: stage.attempt,
+          },
         },
       },
     ],

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -86,6 +86,24 @@ export interface StageBudget {
   maxDurationMs?: number;
 }
 
+/**
+ * Hardcoded predicate forms for v1.1. The typed predicate DSL (and richer
+ * `exitPredicates`) lands in v1.3 — this union is intentionally minimal so the
+ * scheduler can ship without committing to a DSL surface yet.
+ *
+ * All forms reference stage names within the same pipeline. Validation at
+ * config load rejects unknown names; the scheduler trusts the input here.
+ */
+export type StageRoutePredicate =
+  | { kind: "allSucceeded"; stages: string[] }
+  | { kind: "anySucceeded"; stages: string[] }
+  | { kind: "anyFailed"; stages: string[] };
+
+export interface StageRoutes {
+  /** Evaluated once every referenced upstream stage reaches a terminal state. */
+  when: StageRoutePredicate;
+}
+
 export interface Stage {
   name: string;
   trigger: StageTrigger;
@@ -98,6 +116,19 @@ export interface Stage {
   retries?: number;
   /** Per-stage loop cap (locked decision: not pipeline-global). */
   maxLoopRounds?: number;
+  /**
+   * Stage names this stage waits for before it can be evaluated. Default `[]`.
+   * The named stages must reach a terminal status before the scheduler
+   * considers this stage. Unknown names and cycles are rejected at config load.
+   */
+  dependsOn?: string[];
+  /**
+   * Conditional activation predicate. When set and the predicate evaluates to
+   * `false` (after every referenced upstream stage is terminal), this stage is
+   * marked `skipped` instead of being started. When unset, the default is
+   * "all `dependsOn` stages must have succeeded".
+   */
+  routes?: StageRoutes;
 }
 
 export interface Pipeline {
@@ -166,13 +197,7 @@ export const PIPELINE_FINDINGS_FILENAME = "pipeline-findings.jsonl";
 // Each tier composes upward: a stage exit may cause a run exit, which may cause a
 // loop exit. The reducer is the single point that performs these escalations.
 
-export type StageStatus =
-  | "pending"
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "skipped"
-  | "outdated";
+export type StageStatus = "pending" | "running" | "succeeded" | "failed" | "skipped" | "outdated";
 
 export const TERMINAL_STAGE_STATUSES: readonly StageStatus[] = [
   "succeeded",
@@ -191,12 +216,7 @@ export type RunTerminationReason =
   | "outdated"
   | "worker_dead";
 
-export type LoopStateName =
-  | "running"
-  | "awaiting_context"
-  | "done"
-  | "stalled"
-  | "terminated";
+export type LoopStateName = "running" | "awaiting_context" | "done" | "stalled" | "terminated";
 
 export const TERMINAL_LOOP_STATES: readonly LoopStateName[] = [
   "done",

--- a/packages/core/src/pipeline/types.ts
+++ b/packages/core/src/pipeline/types.ts
@@ -93,6 +93,16 @@ export interface StageBudget {
  *
  * All forms reference stage names within the same pipeline. Validation at
  * config load rejects unknown names; the scheduler trusts the input here.
+ *
+ * **Known limitation in v1.1: `anyFailed` is reachable only via cascade-skip,
+ * not for "run-on-failure" recovery branches.** The reducer terminates the
+ * run as `stalled` immediately on any STAGE_FAILED, so a downstream stage
+ * with `routes.when.kind === "anyFailed"` whose predicate would evaluate
+ * `true` never gets a chance to run — `terminateRunFromState` marks it
+ * `skipped` first. Operators can still use `anyFailed` to express "skip
+ * this stage if any upstream failed" semantics in conjunction with other
+ * predicates, but rollback/cleanup-on-failure stages aren't supported until
+ * failure-tolerant scheduling lands in v1.2/v1.3.
  */
 export type StageRoutePredicate =
   | { kind: "allSucceeded"; stages: string[] }

--- a/packages/core/src/pipeline/validation.ts
+++ b/packages/core/src/pipeline/validation.ts
@@ -1,16 +1,20 @@
 /**
  * Pipeline configuration validation.
  *
- * Runs at config load (not at runtime). Today the only check is the
- * `supportedTaskModes` contract on agent stages: if a stage routes
- * `executor.kind === "agent"` with `mode = "review"`, the named agent plugin
- * must advertise `"review"` in its manifest's `supportedTaskModes`.
+ * Two checks today:
+ *  - `validatePipelineAgentModes` — every agent stage routes to a registered
+ *    plugin whose manifest advertises the requested `task.mode`.
+ *  - `validatePipelineDag` — the dependsOn + routes-refs graph is acyclic.
+ *    Zod already enforces this at config load via `superRefine`; the runtime
+ *    check guards programmatic Pipelines that bypass Zod (e.g. callers that
+ *    construct a `Pipeline` directly and hand it to `engine.startRun`).
  *
  * Failures throw PipelineConfigError with a message that names the offending
- * stage, agent, and mode — the engine never sees a misconfigured pipeline.
+ * stage and pipeline — the engine never advances a misconfigured pipeline.
  */
 
 import type { PluginManifest, PluginRegistry } from "../types.js";
+import { findFirstStageCycle } from "./dag.js";
 import type { Pipeline, TaskMode } from "./types.js";
 
 export class PipelineConfigError extends Error {
@@ -61,5 +65,26 @@ export function validatePipelineAgentModes(pipeline: Pipeline, registry: PluginR
           .join(", ")}].`,
       );
     }
+  }
+}
+
+/**
+ * Reject a runtime `Pipeline` whose `dependsOn` + `routes.when.stages` graph
+ * contains a cycle. Zod already enforces this at config load, but programmatic
+ * callers (tests, future engine consumers, in-process pipeline construction)
+ * skip Zod and would otherwise deadlock the run silently — every cycle member
+ * would stay `pending` forever because `arePreconditionsTerminal` is false
+ * for every node in the cycle.
+ *
+ * Throws `PipelineConfigError` on the first cycle found. Self-loops are not
+ * surfaced here; the schema-level explicit self-reference checks own that
+ * error path.
+ */
+export function validatePipelineDag(pipeline: Pipeline): void {
+  const cycle = findFirstStageCycle(pipeline.stages);
+  if (cycle) {
+    throw new PipelineConfigError(
+      `Pipeline "${pipeline.name}" has a stage dependency cycle: ${cycle.join(" → ")}.`,
+    );
   }
 }


### PR DESCRIPTION
Closes #1630.

Sub-task of #1349. Depends on v0.3 (already merged into `pipelines`).

## Summary

Turns the pipeline engine into a real DAG. Stages declare dependencies, run in parallel up to a configurable cap, and can carry conditional activation predicates that mark them `skipped` when upstream outcomes don't satisfy the route.

- **`Stage.dependsOn: string[]`** — explicit dependency declarations. Default `[]`.
- **`Stage.routes.when`** — typed predicate (minimal hardcoded union: `allSucceeded` / `anySucceeded` / `anyFailed`). The richer predicate DSL is intentionally deferred to v1.3.
- **Cycle detection at config load** — `ConfiguredPipelineSchema.superRefine` rejects bad configs with a clear error naming the cycle (e.g. `a → b → c → a`). Unknown `dependsOn` / `routes` references, self-dependencies, and duplicate stage names fail there too.
- **Parallel scheduling** — `Pipeline.maxConcurrentStages` still defaults to **1** per the v1.1 spec. When raised, independent stages run concurrently; declaration order is preserved as slot priority so linear pipelines stay byte-identical to v0 behavior.
- **Cascade skips run to fixpoint inside one reducer step** — skipping a stage may make a downstream stage's routes evaluate to false, which marks it skipped, which may cascade further. Each transition emits a `pipeline.stage.terminated` observation matching the existing schema.
- **Multi-pipeline support** was already wired in v0.3 (`pipelines:` is a record, `--pipeline <name>` flag works). New tests verify cross-pipeline config validation.

## Implementation notes

- New file `packages/core/src/pipeline/dag.ts` holds the DAG scheduler. `reducer.ts` stays focused on event-shape transitions.
- `startableStageEffects` is removed from `reducer-helpers.ts` — `scheduleAfterChange` supersedes it (returns updated run + start effects + newly-skipped stages + allTerminal flag).
- The reducer integrates `scheduleAfterChange` at three sites: `reduceTriggerFired`, `finalizeStageCompletion` (success path), and `reduceRunResumed`. Failure semantics (run terminates as `stalled`) are preserved.
- `routes` predicates are evaluated only after every referenced upstream stage is terminal; routes refs that aren't in `dependsOn` are still gated correctly so a stage doesn't optimistically start before its predicate is decidable.

## Acceptance criteria mapping

- [x] Cycle detection rejects bad configs at load with a clear error naming the cycle
- [x] Two independent stages run concurrently when `maxConcurrentStages >= 2`
- [x] A stage with unmet `dependsOn` does not start
- [x] A stage with an unsatisfied `routes` predicate is skipped (and marked as such in the run record)
- [x] Vitest coverage on scheduler — 19 new tests in `pipeline-dag.test.ts`
- [x] PR opened against `pipelines`

## Out of scope (per issue)

- New executors (v1.2)
- Predicate DSL / `exitPredicates` (v1.3)
- Workspace classes (v1.3)

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-core test` — 1,152 tests pass (1,133 baseline + 19 new DAG tests)
- [x] `pnpm --filter @aoagents/ao-cli typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-cli test` — 644 tests pass
- [x] Prettier check on all modified files passes