### PR TITLE
chore: release 0.5.0

### DIFF
--- a/.changeset/adopt-orphaned-orchestrator-worktrees.md
+++ b/.changeset/adopt-orphaned-orchestrator-worktrees.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-core": patch
+---
+
+Adopt existing managed orchestrator worktrees instead of failing to create a fresh one. Previously, a leftover worktree from a prior run could block `spawnOrchestrator` with a "worktree already exists" error; spawn now detects and reuses the matching managed worktree. Also normalizes CRLF in `parseWorktreeList` (Windows), filters prunable/deleted entries in `findManagedWorkspace`, and applies `GIT_TIMEOUT` to all internal `git()` calls.

--- a/.changeset/adopt-orphaned-orchestrator-worktrees.md
+++ b/.changeset/adopt-orphaned-orchestrator-worktrees.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-core": patch
----
-
-Adopt existing managed orchestrator worktrees instead of failing to create a fresh one. Previously, a leftover worktree from a prior run could block `spawnOrchestrator` with a "worktree already exists" error; spawn now detects and reuses the matching managed worktree. Also normalizes CRLF in `parseWorktreeList` (Windows), filters prunable/deleted entries in `findManagedWorkspace`, and applies `GIT_TIMEOUT` to all internal `git()` calls.

--- a/.changeset/fix-terminal-attach-mux-routing.md
+++ b/.changeset/fix-terminal-attach-mux-routing.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Fix direct terminal attach and keep mux routing project-scoped. Switches `resolveExactTmuxName` from `execFileSync` to a promisified `execFile` so slow tmux calls no longer stall the WebSocket message handler, and propagates async through `TerminalManager.open` / `subscribe` and the pty `onExit` reattach path. Also drops a duplicate `.kanban-board` grid rule in `globals.css`.

--- a/.changeset/fix-terminal-attach-mux-routing.md
+++ b/.changeset/fix-terminal-attach-mux-routing.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-web": patch
----
-
-Fix direct terminal attach and keep mux routing project-scoped. Switches `resolveExactTmuxName` from `execFileSync` to a promisified `execFile` so slow tmux calls no longer stall the WebSocket message handler, and propagates async through `TerminalManager.open` / `subscribe` and the pty `onExit` reattach path. Also drops a duplicate `.kanban-board` grid rule in `globals.css`.

--- a/.changeset/remove-deprecated-ao-init.md
+++ b/.changeset/remove-deprecated-ao-init.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-cli": minor
----
-
-Remove the deprecated `ao init` command. Use `ao start` instead — it auto-creates the config on first run in an unconfigured repo.

--- a/.changeset/sidebar-empty-state.md
+++ b/.changeset/sidebar-empty-state.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-web": patch
----
-
-Render an empty-state in the project sidebar when no projects are configured. Fresh-install users previously saw a blank sidebar with no way to open the Add Project modal; the sidebar now shows a small empty-state with the `+` button wired up.

--- a/.changeset/sidebar-empty-state.md
+++ b/.changeset/sidebar-empty-state.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Render an empty-state in the project sidebar when no projects are configured. Fresh-install users previously saw a blank sidebar with no way to open the Add Project modal; the sidebar now shows a small empty-state with the `+` button wired up.

--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [3a69722]
+  - @aoagents/ao-cli@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,40 @@
 # @aoagents/ao-cli
 
+## 0.5.0
+
+### Minor Changes
+
+- 3a69722: Remove the deprecated `ao init` command. Use `ao start` instead — it auto-creates the config on first run in an unconfigured repo.
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+- Updated dependencies [dd07b6b]
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+  - @aoagents/ao-web@0.5.0
+  - @aoagents/ao-plugin-agent-aider@0.5.0
+  - @aoagents/ao-plugin-agent-claude-code@0.5.0
+  - @aoagents/ao-plugin-agent-codex@0.5.0
+  - @aoagents/ao-plugin-agent-cursor@0.1.3
+  - @aoagents/ao-plugin-agent-kimicode@0.1.2
+  - @aoagents/ao-plugin-agent-opencode@0.5.0
+  - @aoagents/ao-plugin-notifier-composio@0.5.0
+  - @aoagents/ao-plugin-notifier-desktop@0.5.0
+  - @aoagents/ao-plugin-notifier-discord@0.2.8
+  - @aoagents/ao-plugin-notifier-openclaw@0.2.8
+  - @aoagents/ao-plugin-notifier-slack@0.5.0
+  - @aoagents/ao-plugin-notifier-webhook@0.5.0
+  - @aoagents/ao-plugin-runtime-process@0.5.0
+  - @aoagents/ao-plugin-runtime-tmux@0.5.0
+  - @aoagents/ao-plugin-scm-github@0.5.0
+  - @aoagents/ao-plugin-terminal-iterm2@0.5.0
+  - @aoagents/ao-plugin-terminal-web@0.5.0
+  - @aoagents/ao-plugin-tracker-github@0.5.0
+  - @aoagents/ao-plugin-tracker-linear@0.5.0
+  - @aoagents/ao-plugin-workspace-clone@0.5.0
+  - @aoagents/ao-plugin-workspace-worktree@0.5.0
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aoagents/ao-core
 
+## 0.5.0
+
+### Patch Changes
+
+- dd07b6b: Adopt existing managed orchestrator worktrees instead of failing to create a fresh one. Previously, a leftover worktree from a prior run could block `spawnOrchestrator` with a "worktree already exists" error; spawn now detects and reuses the matching managed worktree. Also normalizes CRLF in `parseWorktreeList` (Windows), filters prunable/deleted entries in `findManagedWorkspace`, and applies `GIT_TIMEOUT` to all internal `git()` calls.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-core",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Core library — types, config, session manager, lifecycle manager, event bus",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-aider/CHANGELOG.md
+++ b/packages/plugins/agent-aider/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-aider
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/agent-aider/package.json
+++ b/packages/plugins/agent-aider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-aider",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent plugin: Aider",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/CHANGELOG.md
+++ b/packages/plugins/agent-claude-code/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-claude-code
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-claude-code",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent plugin: Claude Code",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/CHANGELOG.md
+++ b/packages/plugins/agent-codex/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-codex
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-codex",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent plugin: OpenAI Codex CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/package-version.test.ts
+++ b/packages/plugins/agent-codex/src/package-version.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
 describe("package manifest version", () => {
-  it("is bumped to 0.4.0", () => {
+  it("is bumped to 0.5.0", () => {
     const packageJsonUrl = new URL("../package.json", import.meta.url);
     const packageJson = JSON.parse(readFileSync(packageJsonUrl, "utf8")) as { version?: string };
 
-    expect(packageJson.version).toBe("0.4.0");
+    expect(packageJson.version).toBe("0.5.0");
   });
 });

--- a/packages/plugins/agent-cursor/CHANGELOG.md
+++ b/packages/plugins/agent-cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-cursor
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/plugins/agent-cursor/package.json
+++ b/packages/plugins/agent-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-cursor",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Agent plugin: Cursor CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-kimicode/CHANGELOG.md
+++ b/packages/plugins/agent-kimicode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-kimicode
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/packages/plugins/agent-kimicode/package.json
+++ b/packages/plugins/agent-kimicode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-kimicode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Agent plugin: Kimi Code CLI (MoonshotAI)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/CHANGELOG.md
+++ b/packages/plugins/agent-opencode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-opencode
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-opencode",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Agent plugin: OpenCode",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-composio/CHANGELOG.md
+++ b/packages/plugins/notifier-composio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-composio
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-composio/package.json
+++ b/packages/plugins/notifier-composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-composio",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Notifier plugin: Composio unified notifications (Slack, Discord, email)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/CHANGELOG.md
+++ b/packages/plugins/notifier-desktop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-desktop
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-desktop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Notifier plugin: OS desktop notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/CHANGELOG.md
+++ b/packages/plugins/notifier-discord/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-discord
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-discord",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Notifier plugin: Discord webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-openclaw/CHANGELOG.md
+++ b/packages/plugins/notifier-openclaw/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-openclaw
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/plugins/notifier-openclaw/package.json
+++ b/packages/plugins/notifier-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-openclaw",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Notifier plugin: OpenClaw webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-slack/CHANGELOG.md
+++ b/packages/plugins/notifier-slack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-slack
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-slack/package.json
+++ b/packages/plugins/notifier-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-slack",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Notifier plugin: Slack",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-webhook/CHANGELOG.md
+++ b/packages/plugins/notifier-webhook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-webhook
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-webhook/package.json
+++ b/packages/plugins/notifier-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-webhook",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Notifier plugin: generic webhook",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-process/CHANGELOG.md
+++ b/packages/plugins/runtime-process/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-runtime-process
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/runtime-process/package.json
+++ b/packages/plugins/runtime-process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-process",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runtime plugin: child processes",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/CHANGELOG.md
+++ b/packages/plugins/runtime-tmux/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-runtime-tmux
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-tmux",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Runtime plugin: tmux sessions",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/CHANGELOG.md
+++ b/packages/plugins/scm-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-scm-github
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-github",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "SCM plugin: GitHub (PRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-gitlab/CHANGELOG.md
+++ b/packages/plugins/scm-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-scm-gitlab
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/plugins/scm-gitlab/package.json
+++ b/packages/plugins/scm-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-gitlab",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "SCM plugin: GitLab (MRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-iterm2/CHANGELOG.md
+++ b/packages/plugins/terminal-iterm2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-terminal-iterm2
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/terminal-iterm2/package.json
+++ b/packages/plugins/terminal-iterm2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-iterm2",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Terminal plugin: macOS iTerm2",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/CHANGELOG.md
+++ b/packages/plugins/terminal-web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-terminal-web
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Terminal plugin: xterm.js web terminal",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/CHANGELOG.md
+++ b/packages/plugins/tracker-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-tracker-github
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-github",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Tracker plugin: GitHub Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-gitlab/CHANGELOG.md
+++ b/packages/plugins/tracker-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aoagents/ao-plugin-tracker-gitlab
 
+## 0.2.8
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+  - @aoagents/ao-plugin-scm-gitlab@0.2.8
+
 ## 0.2.7
 
 ### Patch Changes

--- a/packages/plugins/tracker-gitlab/package.json
+++ b/packages/plugins/tracker-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-gitlab",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Tracker plugin: GitLab Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-linear/CHANGELOG.md
+++ b/packages/plugins/tracker-linear/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-tracker-linear
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/tracker-linear/package.json
+++ b/packages/plugins/tracker-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-linear",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Tracker plugin: Linear",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-clone/CHANGELOG.md
+++ b/packages/plugins/workspace-clone/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-workspace-clone
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/workspace-clone/package.json
+++ b/packages/plugins/workspace-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-clone",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Workspace plugin: git clone",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/CHANGELOG.md
+++ b/packages/plugins/workspace-worktree/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-workspace-worktree
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-worktree",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Workspace plugin: git worktrees",
   "license": "MIT",
   "type": "module",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @aoagents/ao-web
 
+## 0.5.0
+
+### Patch Changes
+
+- dd07b6b: Fix direct terminal attach and keep mux routing project-scoped. Switches `resolveExactTmuxName` from `execFileSync` to a promisified `execFile` so slow tmux calls no longer stall the WebSocket message handler, and propagates async through `TerminalManager.open` / `subscribe` and the pty `onExit` reattach path. Also drops a duplicate `.kanban-board` grid rule in `globals.css`.
+- dd07b6b: Render an empty-state in the project sidebar when no projects are configured. Fresh-install users previously saw a blank sidebar with no way to open the Add Project modal; the sidebar now shows a small empty-state with the `+` button wired up.
+- Updated dependencies [dd07b6b]
+  - @aoagents/ao-core@0.5.0
+  - @aoagents/ao-plugin-agent-claude-code@0.5.0
+  - @aoagents/ao-plugin-agent-codex@0.5.0
+  - @aoagents/ao-plugin-agent-cursor@0.1.3
+  - @aoagents/ao-plugin-agent-kimicode@0.1.2
+  - @aoagents/ao-plugin-agent-opencode@0.5.0
+  - @aoagents/ao-plugin-runtime-tmux@0.5.0
+  - @aoagents/ao-plugin-scm-github@0.5.0
+  - @aoagents/ao-plugin-tracker-github@0.5.0
+  - @aoagents/ao-plugin-tracker-linear@0.5.0
+  - @aoagents/ao-plugin-workspace-worktree@0.5.0
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Web dashboard for agent-orchestrator",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Releases all linked packages from `0.4.0` → `0.5.0` and ships three fixes plus the `ao init` removal that have landed since the last release.

### Changes

**`@aoagents/ao-core` (patch)** — fix(core): adopt orphaned orchestrator worktrees (#1643)
The critical fix in this release. A leftover managed worktree from a prior run would cause `spawnOrchestrator` to fail with "worktree already exists"; spawn now detects and reuses the matching managed worktree. Also normalizes CRLF in `parseWorktreeList` (Windows), filters prunable/deleted entries in `findManagedWorkspace`, and applies `GIT_TIMEOUT` to all internal `git()` calls.

**`@aoagents/ao-web` (patch)**
- fix(web): direct terminal attach + project-scoped mux routing (#1608) — switches `resolveExactTmuxName` from `execFileSync` to promisified `execFile` so slow tmux calls no longer stall the WS handler; drops a duplicate `.kanban-board` grid rule.
- fix(web): render empty-state in sidebar when no projects configured (#1549) — fresh-install users previously saw a blank sidebar with no way to open the Add Project modal.

**`@aoagents/ao-cli` (minor)** — chore(cli): remove deprecated `ao init` command (#1438)
Use `ao start` instead — it auto-creates the config on first run in an unconfigured repo.

## Test plan

- [ ] `pnpm install && pnpm build` clean on a fresh checkout
- [ ] `pnpm typecheck` passes
- [ ] `pnpm test` passes
- [ ] After merge: `pnpm release` publishes all linked packages at `0.5.0` to npm