### PR TITLE
fix(web): disable xterm scrollback to prevent terminal right-side clipping

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -479,6 +479,16 @@ a:hover {
 
 /* ── xterm.js terminal viewport scrollbar — macOS-style auto-hide ──── */
 
+/* Reset body's -0.011em letter-spacing inside the terminal subtree.
+   xterm's DOM renderer measures cell width with the inherited spacing
+   applied, but renders rows with an inline override that effectively
+   cancels it. The mismatch causes glyphs to paint ~0.17px wider than
+   the allocated cell, which accumulates over many cols and clips the
+   rightmost chars under .xterm-rows > div { overflow: hidden }. */
+.xterm {
+  letter-spacing: 0;
+}
+
 .xterm .xterm-viewport {
   overflow-y: overlay !important;
 }

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -336,7 +336,7 @@ export function useXtermTerminal(
     // fontSize intentionally NOT in deps — it's handled by a dedicated effect
     // below that mutates terminal.options.fontSize in place. Adding it here
     // would tear down and recreate the terminal (and WebSocket) on every
-    // stepper click, losing scrollback and flashing content.
+    // stepper click, causing a content flash and WebSocket reconnect.
   }, [
     appearance,
     sessionId,
@@ -392,12 +392,14 @@ export function useXtermTerminal(
     const t = terminalInstance.current;
     if (t) {
       if (t.buffer.active.type === "normal") {
-        // Normal buffer: scrollback exists in xterm, use its API.
+        // Normal buffer: xterm scrollback is disabled (scrollback: 0), so
+        // history lives in tmux. scrollToBottom() is a safe no-op that
+        // re-anchors the viewport to the live tail.
         t.scrollToBottom();
       } else {
-        // Alternate buffer (tmux/vim): xterm has no scrollback to scroll
-        // to. The user is in tmux copy-mode (entered by attachTouchScroll
-        // on swipe). Send 'q' to exit copy-mode and return to live tail.
+        // Alternate buffer (tmux/vim): the user is in tmux copy-mode
+        // (entered by attachTouchScroll on swipe). Send 'q' to exit
+        // copy-mode and return to live tail.
         writeTerminal(sessionId, "q", projectId);
       }
     }

--- a/packages/web/src/components/terminal/useXtermTerminal.ts
+++ b/packages/web/src/components/terminal/useXtermTerminal.ts
@@ -104,7 +104,11 @@ export function useXtermTerminal(
           // Light mode needs an explicit contrast floor because agent UIs often emit
           // dim/faint ANSI sequences that become unreadable on a near-white background.
           minimumContrastRatio: isDark ? 1 : 7,
-          scrollback: 10000,
+          // scrollback disabled — tmux provides scrollback/copy-mode, and leaving
+          // this > 0 makes FitAddon subtract DEFAULT_SCROLL_BAR_WIDTH (14px) from
+          // the available width, causing right-side clipping when the actual
+          // scrollbar is narrower or wider than assumed. Fixes #1677.
+          scrollback: 0,
           allowProposedApi: true,
           fastScrollSensitivity: 3,
           scrollSensitivity: 1,


### PR DESCRIPTION
## Problem

The right side of terminal content is clipped when viewing a session detail page (e.g. `/projects/integrator/sessions/int-orchestrator`). Characters at the rightmost columns are hidden under the scrollbar.

## Root Cause

`FitAddon.proposeDimensions()` hardcodes a **14px scrollbar reservation** (`ViewportConstants.DEFAULT_SCROLL_BAR_WIDTH = 14`) when `scrollback > 0`. The custom CSS sets the actual scrollbar to 5px with `overflow-y: overlay` (deprecated in Chrome 114+). This mismatch causes FitAddon to calculate the wrong number of columns, and the actual scrollbar overlaps the rightmost characters.

## Fix

Set `scrollback: 0` on the xterm Terminal options. tmux already provides scrollback and copy-mode, so xterm's scrollback is redundant. With `scrollback: 0`, FitAddon subtracts 0px and the width calculation matches the actual rendering.

## Testing

- Open any active session in the dashboard
- Verify terminal content fills the full width with no clipping on the right
- Verify tmux copy-mode still works for scrolling (Ctrl+B then [)

Fixes #1677