### PR TITLE
feat(core): add per-project env block to ProjectConfig

### DIFF
--- a/.changeset/per-project-env.md
+++ b/.changeset/per-project-env.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-core": minor
+---
+
+Add optional per-project `env` block to `ProjectConfig` that forwards string-to-string env vars into worker session runtimes (e.g. pin `GH_TOKEN` per project). AO-internal vars (`AO_SESSION`, `AO_PROJECT_ID`, etc.) always take precedence.

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -79,6 +79,12 @@ projects:
     #     deliveryHeader: x-github-delivery
     #     maxBodyBytes: 1048576
 
+    # Per-project environment variables forwarded into worker session runtimes.
+    # Useful for scoping per-project tokens (e.g. pinning gh auth via GH_TOKEN).
+    # AO-internal vars (AO_SESSION, AO_PROJECT_ID, etc.) always take precedence.
+    # env:
+    #   GH_TOKEN: ghp_xxx
+
     # Files to symlink into workspaces
     # symlinks: [.env, .claude]
 

--- a/packages/core/src/__tests__/config-validation.test.ts
+++ b/packages/core/src/__tests__/config-validation.test.ts
@@ -447,6 +447,45 @@ describe("Config Schema Validation", () => {
     expect(validated.projects.proj1.sessionPrefix).toBe("test"); // "test" is 4 chars, used as-is
   });
 
+  it("accepts a string-to-string env map at the project level", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          env: {
+            GH_TOKEN: "ghp_xxx",
+            CUSTOM_FLAG: "1",
+          },
+        },
+      },
+    };
+
+    const validated = validateConfig(config);
+    expect(validated.projects.proj1.env).toEqual({
+      GH_TOKEN: "ghp_xxx",
+      CUSTOM_FLAG: "1",
+    });
+  });
+
+  it("rejects non-string values in project env map", () => {
+    const config = {
+      projects: {
+        proj1: {
+          path: "/repos/test",
+          repo: "org/test",
+          defaultBranch: "main",
+          env: {
+            GH_TOKEN: 123,
+          },
+        },
+      },
+    };
+
+    expect(() => validateConfig(config)).toThrow();
+  });
+
   it("accepts orchestratorModel in agentConfig", () => {
     const config = {
       projects: {

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -103,6 +103,62 @@ describe("spawn", () => {
     }
   });
 
+  it("forwards project.env into spawned agent runtime env", async () => {
+    const projectConfig = config.projects["my-app"];
+    if (!projectConfig) throw new Error("test setup: my-app missing");
+    const configWithEnv: OrchestratorConfig = {
+      ...config,
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...projectConfig,
+          env: {
+            GH_TOKEN: "ghp_project_scoped",
+            CUSTOM_VAR: "hello",
+          },
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithEnv, registry: mockRegistry });
+    await sm.spawn({ projectId: "my-app" });
+
+    expect(mockRuntime.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        environment: expect.objectContaining({
+          GH_TOKEN: "ghp_project_scoped",
+          CUSTOM_VAR: "hello",
+        }),
+      }),
+    );
+  });
+
+  it("AO_* internals override project.env values with the same key", async () => {
+    const projectConfig = config.projects["my-app"];
+    if (!projectConfig) throw new Error("test setup: my-app missing");
+    const configWithEnv: OrchestratorConfig = {
+      ...config,
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...projectConfig,
+          env: {
+            AO_SESSION: "should-not-win",
+            AO_PROJECT_ID: "should-not-win",
+          },
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithEnv, registry: mockRegistry });
+    await sm.spawn({ projectId: "my-app" });
+
+    const call = (mockRuntime.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(call?.environment?.AO_SESSION).not.toBe("should-not-win");
+    expect(call?.environment?.AO_SESSION).toBe("app-1");
+    expect(call?.environment?.AO_PROJECT_ID).toBe("my-app");
+  });
+
   it("uses issue ID to derive branch name", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -159,6 +159,33 @@ describe("spawn", () => {
     expect(call?.environment?.AO_PROJECT_ID).toBe("my-app");
   });
 
+  it("PATH and GH_PATH override project.env values with the same key", async () => {
+    const projectConfig = config.projects["my-app"];
+    if (!projectConfig) throw new Error("test setup: my-app missing");
+    const configWithEnv: OrchestratorConfig = {
+      ...config,
+      projects: {
+        ...config.projects,
+        "my-app": {
+          ...projectConfig,
+          env: {
+            PATH: "/should/not/win",
+            GH_PATH: "/should/not/win",
+          },
+        },
+      },
+    };
+
+    const sm = createSessionManager({ config: configWithEnv, registry: mockRegistry });
+    await sm.spawn({ projectId: "my-app" });
+
+    const call = (mockRuntime.create as ReturnType<typeof vi.fn>).mock.calls[0]?.[0];
+    expect(call?.environment?.PATH).not.toBe("/should/not/win");
+    expect(call?.environment?.PATH).toContain(".ao/bin");
+    expect(call?.environment?.GH_PATH).not.toBe("/should/not/win");
+    expect(call?.environment?.GH_PATH).toBe("/usr/local/bin/gh");
+  });
+
   it("uses issue ID to derive branch name", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -249,6 +249,7 @@ const ProjectConfigSchema = z.object({
   runtime: z.string().optional(),
   agent: z.string().optional(),
   workspace: z.string().optional(),
+  env: z.record(z.string(), z.string()).optional(),
   tracker: TrackerConfigSchema.optional(),
   scm: SCMConfigSchema.optional(),
   symlinks: z.array(z.string()).optional(),

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1304,6 +1304,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ...(process.env["AO_AGENT_GH_TRACE"] && {
             AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
           }),
+          ...(project.env ?? {}),
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
           AO_SESSION_NAME: sessionId, // User-facing session name
@@ -1675,6 +1676,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
           ...(process.env["AO_AGENT_GH_TRACE"] && {
             AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
           }),
+          ...(project.env ?? {}),
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir,
           AO_SESSION_NAME: sessionId,
@@ -2940,6 +2942,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         ...(process.env["AO_AGENT_GH_TRACE"] && {
           AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
         }),
+        ...(project.env ?? {}),
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1299,12 +1299,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         environment: {
           ...environment,
           ...(opencodeConfigFile ? { OPENCODE_CONFIG: opencodeConfigFile } : {}),
+          ...(project.env ?? {}),
           PATH: buildAgentPath(environment["PATH"] ?? process.env["PATH"]),
           GH_PATH: PREFERRED_GH_PATH,
           ...(process.env["AO_AGENT_GH_TRACE"] && {
             AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
           }),
-          ...(project.env ?? {}),
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir, // Pass sessions directory (not root dataDir)
           AO_SESSION_NAME: sessionId, // User-facing session name
@@ -1671,12 +1671,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         launchCommand,
         environment: {
           ...environment,
+          ...(project.env ?? {}),
           PATH: buildAgentPath(environment["PATH"] ?? process.env["PATH"]),
           GH_PATH: PREFERRED_GH_PATH,
           ...(process.env["AO_AGENT_GH_TRACE"] && {
             AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
           }),
-          ...(project.env ?? {}),
           AO_SESSION: sessionId,
           AO_DATA_DIR: sessionsDir,
           AO_SESSION_NAME: sessionId,
@@ -2937,12 +2937,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       environment: {
         ...environment,
         ...(opencodeConfigPath ? { OPENCODE_CONFIG: opencodeConfigPath } : {}),
+        ...(project.env ?? {}),
         PATH: buildAgentPath(environment["PATH"] ?? process.env["PATH"]),
         GH_PATH: PREFERRED_GH_PATH,
         ...(process.env["AO_AGENT_GH_TRACE"] && {
           AO_AGENT_GH_TRACE: process.env["AO_AGENT_GH_TRACE"],
         }),
-        ...(project.env ?? {}),
         AO_SESSION: sessionId,
         AO_DATA_DIR: sessionsDir,
         AO_SESSION_NAME: sessionId,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1504,6 +1504,9 @@ export interface ProjectConfig {
   /** Override default workspace */
   workspace?: string;
 
+  /** Environment variables forwarded into worker session runtimes (AO_* internals always win) */
+  env?: Record<string, string>;
+
   /** Issue tracker configuration */
   tracker?: TrackerConfig;
 


### PR DESCRIPTION
## Summary
- Adds optional `env: Record<string, string>` field to `ProjectConfig` schema and type, forwarding env vars into worker session runtimes (e.g. pin `GH_TOKEN` per project).
- Wires `project.env` into the three `runtime.create` environment maps in `session-manager.ts` (worker spawn, orchestrator spawn, restore). AO-internal vars (`AO_SESSION`, `AO_PROJECT_ID`, etc.) always win — `project.env` is spread before the AO_* keys.
- Updates `agent-orchestrator.yaml.example` with a commented example and adds a changeset.

## Test plan
- [x] `pnpm typecheck` clean
- [x] New unit test: `ProjectConfigSchema` parses `env` as string-to-string map and rejects non-string values
- [x] New session-manager test: `project.env` values appear in the runtime environment map
- [x] New session-manager test: AO_* internals override `project.env` values with the same key (`AO_SESSION` set in `project.env` does NOT win)
- [x] All existing core tests pass (modulo a pre-existing native-binding failure in `events-fts-integration.test.ts` unrelated to this change)

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)