### PR TITLE
fix(core): disable tmux status bar at session creation

### DIFF
--- a/packages/core/src/__tests__/tmux.test.ts
+++ b/packages/core/src/__tests__/tmux.test.ts
@@ -160,18 +160,21 @@ describe("newSession", () => {
   });
 
   it("sends initial command after creation", async () => {
-    // Calls: new-session, send-keys Escape, send-keys text, send-keys Enter
-    mockTmuxSequence([{ stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }]);
+    // Calls: new-session, set-option status off, send-keys Escape, send-keys text, send-keys Enter
+    mockTmuxSequence([{ stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }]);
 
     await newSession({ name: "test-4", cwd: "/tmp", command: "echo hello" });
 
-    expect(mockExecFile).toHaveBeenCalledTimes(4);
+    expect(mockExecFile).toHaveBeenCalledTimes(5);
     // Call 0: new-session
-    // Call 1: send-keys Escape (clear partial input)
-    const escapeArgs = mockExecFile.mock.calls[1][1] as string[];
+    // Call 1: set-option status off (hide status bar)
+    const statusArgs = mockExecFile.mock.calls[1][1] as string[];
+    expect(statusArgs).toEqual(["set-option", "-t", "test-4", "status", "off"]);
+    // Call 2: send-keys Escape (clear partial input)
+    const escapeArgs = mockExecFile.mock.calls[2][1] as string[];
     expect(escapeArgs).toEqual(["send-keys", "-t", "test-4", "Escape"]);
-    // Call 2: send-keys text
-    const textArgs = mockExecFile.mock.calls[2][1] as string[];
+    // Call 3: send-keys text
+    const textArgs = mockExecFile.mock.calls[3][1] as string[];
     expect(textArgs).toContain("send-keys");
     expect(textArgs).toContain("echo hello");
   });

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -110,6 +110,9 @@ export async function newSession(opts: NewSessionOptions): Promise<void> {
 
   await tmux(...args);
 
+  // Hide the tmux status bar — sessions are embedded in web terminal
+  await tmux("set-option", "-t", opts.name, "status", "off");
+
   // Send the initial command if provided
   if (opts.command) {
     await sendKeys(opts.name, opts.command);


### PR DESCRIPTION
## Problem

The tmux green status bar is visible at the bottom of web terminals in agent sessions.

## Root Cause

`packages/core/src/tmux.ts::newSession()` does not set `status off` when creating tmux sessions. The global tmux config has `status on`.

The web layer (`mux-websocket.ts`) does run `set-option status off`, but only when a WebSocket client connects. Between session spawn and first web connection, the green bar is visible.

## Fix

Add `set-option status off` immediately after `tmux new-session` in `newSession()`. This ensures the bar is hidden from birth.

## Testing

- Verified global tmux config has `status on` (`tmux show-option -g status`)
- Verified per-session override works (`tmux set-option -t <session> status off`)
- Existing tmux unit tests cover `newSession()` args — no args changed, just an additional call

Fixes #1682