### PR TITLE
feat(notifier-pet): add Unix socket notifier for macOS pet overlay

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,6 +44,7 @@
     "@aoagents/ao-plugin-notifier-desktop": "workspace:*",
     "@aoagents/ao-plugin-notifier-discord": "workspace:*",
     "@aoagents/ao-plugin-notifier-openclaw": "workspace:*",
+    "@aoagents/ao-plugin-notifier-pet": "workspace:*",
     "@aoagents/ao-plugin-notifier-slack": "workspace:*",
     "@aoagents/ao-plugin-notifier-webhook": "workspace:*",
     "@aoagents/ao-plugin-runtime-process": "workspace:*",

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -61,6 +61,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "notifier", name: "desktop", pkg: "@aoagents/ao-plugin-notifier-desktop" },
   { slot: "notifier", name: "discord", pkg: "@aoagents/ao-plugin-notifier-discord" },
   { slot: "notifier", name: "openclaw", pkg: "@aoagents/ao-plugin-notifier-openclaw" },
+  { slot: "notifier", name: "pet", pkg: "@aoagents/ao-plugin-notifier-pet" },
   { slot: "notifier", name: "slack", pkg: "@aoagents/ao-plugin-notifier-slack" },
   { slot: "notifier", name: "webhook", pkg: "@aoagents/ao-plugin-notifier-webhook" },
   // Terminals

--- a/packages/plugins/notifier-pet/package.json
+++ b/packages/plugins/notifier-pet/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@aoagents/ao-plugin-notifier-pet",
+  "version": "0.0.1",
+  "description": "Notifier plugin: Unix socket bridge to the macOS pet overlay app",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/notifier-pet"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/notifier-pet/src/__tests__/index.test.ts
+++ b/packages/plugins/notifier-pet/src/__tests__/index.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createServer, type Server, type Socket } from "node:net";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OrchestratorEvent, NotifyAction } from "@aoagents/ao-core";
+import { create, manifest } from "../index.js";
+
+function makeEvent(overrides: Partial<OrchestratorEvent> = {}): OrchestratorEvent {
+  return {
+    id: "evt-1",
+    type: "session.spawned",
+    priority: "info",
+    sessionId: "app-1",
+    projectId: "my-project",
+    timestamp: new Date("2025-01-01T00:00:00Z"),
+    message: "Session app-1 spawned",
+    data: { foo: "bar" },
+    ...overrides,
+  };
+}
+
+interface RunningServer {
+  server: Server;
+  socketPath: string;
+  received: string[];
+  cleanup: () => Promise<void>;
+}
+
+async function startServer(dir: string, name = "pet.sock"): Promise<RunningServer> {
+  const socketPath = join(dir, name);
+  const received: string[] = [];
+  const sockets = new Set<Socket>();
+
+  const server = createServer((conn) => {
+    sockets.add(conn);
+    let buf = "";
+    conn.on("data", (chunk) => {
+      buf += chunk.toString("utf8");
+    });
+    conn.on("end", () => {
+      if (buf.length > 0) received.push(buf);
+      sockets.delete(conn);
+    });
+    conn.on("close", () => {
+      sockets.delete(conn);
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(socketPath, () => resolve());
+  });
+
+  return {
+    server,
+    socketPath,
+    received,
+    async cleanup() {
+      for (const s of sockets) s.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    },
+  };
+}
+
+async function waitForReceive(server: RunningServer, expected = 1, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (server.received.length < expected) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `Timed out waiting for ${expected} message(s); received ${server.received.length}`,
+      );
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "ao-notifier-pet-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("notifier-pet manifest", () => {
+  it("has correct name and slot", () => {
+    expect(manifest.name).toBe("pet");
+    expect(manifest.slot).toBe("notifier");
+    expect(manifest.description).toMatch(/pet/i);
+    expect(typeof manifest.version).toBe("string");
+  });
+});
+
+describe("notifier-pet create", () => {
+  it("returns a notifier with the expected shape", () => {
+    const notifier = create({ socketPath: join(tmpDir, "pet.sock") });
+    expect(notifier.name).toBe("pet");
+    expect(typeof notifier.notify).toBe("function");
+    expect(typeof notifier.notifyWithActions).toBe("function");
+  });
+
+  it("expands ~ in socketPath default without throwing", () => {
+    expect(() => create()).not.toThrow();
+  });
+});
+
+describe("notifier-pet notify (success path)", () => {
+  it("writes one newline-terminated JSON line to the socket and closes", async () => {
+    const server = await startServer(tmpDir);
+    try {
+      const notifier = create({ socketPath: server.socketPath });
+      await notifier.notify(makeEvent());
+      await waitForReceive(server);
+
+      expect(server.received).toHaveLength(1);
+      const raw = server.received[0]!;
+      expect(raw.endsWith("\n")).toBe(true);
+      const parsed = JSON.parse(raw.trimEnd()) as Record<string, unknown>;
+
+      expect(parsed).toEqual({
+        v: 1,
+        kind: "event",
+        event: {
+          id: "evt-1",
+          type: "session.spawned",
+          priority: "info",
+          sessionId: "app-1",
+          projectId: "my-project",
+          timestamp: "2025-01-01T00:00:00.000Z",
+          message: "Session app-1 spawned",
+          data: { foo: "bar" },
+        },
+      });
+      expect(Object.keys(parsed)).not.toContain("actions");
+    } finally {
+      await server.cleanup();
+    }
+  });
+
+  it("opens a fresh connection for each notify call (no pooling)", async () => {
+    const server = await startServer(tmpDir);
+    try {
+      const notifier = create({ socketPath: server.socketPath });
+      await notifier.notify(makeEvent({ id: "a" }));
+      await notifier.notify(makeEvent({ id: "b" }));
+      await notifier.notify(makeEvent({ id: "c" }));
+      await waitForReceive(server, 3);
+
+      expect(server.received).toHaveLength(3);
+      const ids = server.received.map((r) => (JSON.parse(r.trimEnd()) as { event: { id: string } }).event.id);
+      expect(ids).toEqual(["a", "b", "c"]);
+    } finally {
+      await server.cleanup();
+    }
+  });
+});
+
+describe("notifier-pet notifyWithActions (success path)", () => {
+  it("includes actions array with {label, action} entries", async () => {
+    const server = await startServer(tmpDir);
+    try {
+      const notifier = create({ socketPath: server.socketPath });
+      const actions: NotifyAction[] = [
+        { label: "Open PR", url: "https://github.com/pr/1" },
+        { label: "Kill", callbackEndpoint: "/api/kill" },
+      ];
+      await notifier.notifyWithActions!(makeEvent({ priority: "action" }), actions);
+      await waitForReceive(server);
+
+      const parsed = JSON.parse(server.received[0]!.trimEnd()) as {
+        v: number;
+        kind: string;
+        actions: Array<{ label: string; action: string }>;
+      };
+      expect(parsed.v).toBe(1);
+      expect(parsed.kind).toBe("event");
+      expect(parsed.actions).toEqual([
+        { label: "Open PR", action: "https://github.com/pr/1" },
+        { label: "Kill", action: "/api/kill" },
+      ]);
+    } finally {
+      await server.cleanup();
+    }
+  });
+});
+
+describe("notifier-pet graceful fallback", () => {
+  it("does not throw when the socket file does not exist (ENOENT)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const notifier = create({ socketPath: join(tmpDir, "missing.sock") });
+      await expect(notifier.notify(makeEvent())).resolves.toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]![0]).toMatch(/notifier-pet/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("warns only once per process across many failures", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const notifier = create({ socketPath: join(tmpDir, "missing.sock") });
+      await notifier.notify(makeEvent());
+      await notifier.notify(makeEvent());
+      await notifier.notifyWithActions!(makeEvent(), [{ label: "X", url: "https://x" }]);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("swallows write errors when the server hangs up immediately", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const socketPath = join(tmpDir, "pet.sock");
+    const server = createServer((conn) => {
+      // Drop the connection before the client can write.
+      conn.destroy();
+    });
+    await new Promise<void>((resolve) => server.listen(socketPath, () => resolve()));
+
+    try {
+      const notifier = create({ socketPath });
+      await expect(notifier.notify(makeEvent())).resolves.toBeUndefined();
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      warn.mockRestore();
+    }
+  });
+
+  it("is a no-op when enabled=false (no warning, no throw)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const notifier = create({
+        socketPath: join(tmpDir, "missing.sock"),
+        enabled: false,
+      });
+      await notifier.notify(makeEvent());
+      await notifier.notifyWithActions!(makeEvent(), []);
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/plugins/notifier-pet/src/index.ts
+++ b/packages/plugins/notifier-pet/src/index.ts
@@ -1,0 +1,148 @@
+import { createConnection, type Socket } from "node:net";
+import { homedir } from "node:os";
+import {
+  type PluginModule,
+  type Notifier,
+  type OrchestratorEvent,
+  type NotifyAction,
+} from "@aoagents/ao-core";
+
+export const manifest = {
+  name: "pet",
+  slot: "notifier" as const,
+  description: "Notifier plugin: Unix socket bridge to the macOS pet overlay app",
+  version: "0.1.0",
+};
+
+const WIRE_VERSION = 1 as const;
+
+interface WireAction {
+  label: string;
+  action: string;
+}
+
+interface WireEvent {
+  id: string;
+  type: string;
+  priority: string;
+  sessionId: string;
+  projectId: string;
+  timestamp: string;
+  message: string;
+  data: Record<string, unknown>;
+}
+
+interface WireMessage {
+  v: typeof WIRE_VERSION;
+  kind: "event";
+  event: WireEvent;
+  actions?: WireAction[];
+}
+
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return `${homedir()}/${p.slice(2)}`;
+  return p;
+}
+
+function serializeEvent(event: OrchestratorEvent): WireEvent {
+  return {
+    id: event.id,
+    type: event.type,
+    priority: event.priority,
+    sessionId: event.sessionId,
+    projectId: event.projectId,
+    timestamp: event.timestamp.toISOString(),
+    message: event.message,
+    data: event.data,
+  };
+}
+
+function serializeAction(action: NotifyAction): WireAction {
+  // The pet app's wire contract uses a single `action` string. Prefer the
+  // explicit callback endpoint (server-side trigger) and fall back to the URL
+  // (link-out) so the pet always has something to fire when the user clicks.
+  return {
+    label: action.label,
+    action: action.callbackEndpoint ?? action.url ?? "",
+  };
+}
+
+function sendOnce(socketPath: string, line: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let socket: Socket;
+    try {
+      socket = createConnection(socketPath);
+    } catch (err) {
+      reject(err instanceof Error ? err : new Error(String(err)));
+      return;
+    }
+
+    let settled = false;
+    const finish = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      if (err) reject(err);
+      else resolve();
+    };
+
+    socket.once("error", finish);
+    socket.once("connect", () => {
+      socket.end(line, () => finish());
+    });
+  });
+}
+
+export function create(config?: Record<string, unknown>): Notifier {
+  const enabled = typeof config?.enabled === "boolean" ? config.enabled : true;
+  const rawSocketPath =
+    typeof config?.socketPath === "string" && config.socketPath.length > 0
+      ? config.socketPath
+      : "~/.agent-orchestrator/pet.sock";
+  const socketPath = expandHome(rawSocketPath);
+
+  let warned = false;
+  const warnOnce = (err: unknown) => {
+    if (warned) return;
+    warned = true;
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[notifier-pet] Could not deliver to pet socket at ${socketPath}: ${reason}. ` +
+        `Further failures this process will be silenced.`,
+    );
+  };
+
+  async function deliver(message: WireMessage): Promise<void> {
+    if (!enabled) return;
+    const line = `${JSON.stringify(message)}\n`;
+    try {
+      await sendOnce(socketPath, line);
+    } catch (err) {
+      warnOnce(err);
+    }
+  }
+
+  return {
+    name: "pet",
+
+    async notify(event: OrchestratorEvent): Promise<void> {
+      await deliver({
+        v: WIRE_VERSION,
+        kind: "event",
+        event: serializeEvent(event),
+      });
+    },
+
+    async notifyWithActions(event: OrchestratorEvent, actions: NotifyAction[]): Promise<void> {
+      await deliver({
+        v: WIRE_VERSION,
+        kind: "event",
+        event: serializeEvent(event),
+        actions: actions.map(serializeAction),
+      });
+    },
+  };
+}
+
+export default { manifest, create } satisfies PluginModule<Notifier>;

--- a/packages/plugins/notifier-pet/tsconfig.json
+++ b/packages/plugins/notifier-pet/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@aoagents/ao-plugin-notifier-openclaw':
         specifier: workspace:*
         version: link:../plugins/notifier-openclaw
+      '@aoagents/ao-plugin-notifier-pet':
+        specifier: workspace:*
+        version: link:../plugins/notifier-pet
       '@aoagents/ao-plugin-notifier-slack':
         specifier: workspace:*
         version: link:../plugins/notifier-slack
@@ -412,6 +415,22 @@ importers:
         version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/plugins/notifier-openclaw:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/notifier-pet:
     dependencies:
       '@aoagents/ao-core':
         specifier: workspace:*


### PR DESCRIPTION
## Summary
- Adds `@aoagents/ao-plugin-notifier-pet`, a notifier that bridges orchestrator events to a separate macOS pet overlay app over a local Unix socket.
- Each `notify` / `notifyWithActions` call opens a fresh `node:net` connection, writes one newline-terminated JSON line in the pet wire format (`{v:1, kind:"event", event:{...}, actions?:[{label, action}]}`), and closes — no pooling.
- Best-effort delivery: missing socket / `ECONNREFUSED` / write errors warn exactly once per process and are otherwise swallowed so the orchestrator is never blocked by the overlay being absent.
- Config under `notifiers.pet`: `socketPath` (string, `~`-expanded, defaults to `~/.agent-orchestrator/pet.sock`) and `enabled` (bool, defaults to `true`). Validated in `create()` and closed over.
- Registered in `packages/core/src/plugin-registry.ts` and added to `packages/cli/package.json` workspace deps alongside the other notifier plugins.
- No new external dependencies — built on Node's `node:net` and `node:os` only.

## Wire contract (one JSON line, newline-terminated)
```json
{
  "v": 1,
  "kind": "event",
  "event": {
    "id": "...",
    "type": "...",
    "priority": "urgent|action|warning|info",
    "sessionId": "...",
    "projectId": "...",
    "timestamp": "ISO8601",
    "message": "...",
    "data": {}
  },
  "actions": [{ "label": "...", "action": "..." }]
}
```
`actions` is omitted entirely for plain `notify()`.

## Test plan
- [x] `pnpm --filter @aoagents/ao-plugin-notifier-pet test` — 10/10 passing (manifest, create shape, wire format, multi-call/no-pool, action serialization, ENOENT fallback, warn-once, server-hangup write error, `enabled:false` no-op)
- [x] `pnpm build` — green across all packages
- [x] `pnpm typecheck` — green across all packages
- [x] `pnpm lint` — 0 errors (only the same `no-console` warning the other notifier plugins emit for the once-per-process fallback log)
- [x] `pnpm test` — full sweep green (note: a couple of pre-existing local integration flakes in `agent-codex` / `agent-claude-code` cleared on re-run; CI remains the source of truth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)