### PR TITLE
fix(cli): reload dashboard config after adding project from already-running menu

### DIFF
--- a/.changeset/reload-dashboard-on-add-project.md
+++ b/.changeset/reload-dashboard-on-add-project.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-cli": patch
+---
+
+Fix dashboard 404 after adding a project from the "AO is already running" menu. The CLI now notifies the running daemon to reload its cached config so the new project's page is reachable immediately.

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -1411,6 +1411,14 @@ export function registerStart(program: Command): void {
                     `\n✓ Added "${addedId}" — open the dashboard to start an orchestrator.\n`,
                   ),
                 );
+                const notifyResult = await attachToDaemon(running).notifyProjectChange();
+                if (!notifyResult.ok) {
+                  console.log(
+                    chalk.yellow(
+                      `  ⚠ ${notifyResult.reason}. Refresh the page if the project doesn't show up.`,
+                    ),
+                  );
+                }
                 openUrl(`http://localhost:${running.port}`);
                 unlockStartup();
                 process.exit(0);


### PR DESCRIPTION
## Summary

When `ao start` is run while a daemon is already running and the user selects **"Add <dir>"** from the prompt, the new project is written to the global config but the running dashboard never sees it — visiting `/projects/<new-id>` renders **Page not found**.

The dashboard caches `Services` (with the parsed config) in `globalThis._aoServices` (`packages/web/src/lib/services.ts`), so without an explicit reload it keeps serving the snapshot from when it started. The sibling flow `attachAndSpawnOrchestrator` already handles this via `daemon.notifyProjectChange()` (which POSTs `/api/projects/reload` → `invalidatePortfolioServicesCache`). The "add" menu branch just forgot to do it.

This patch calls `notifyProjectChange()` after `addProjectToConfig` and before `openUrl`, so the new project is reachable on first navigation.

## Repro

1. `ao start` from a registered project — daemon comes up.
2. From a different (unregistered) git repo, `ao start` again.
3. Choose **"Add <dir>"**.
4. CLI prints `✓ Added "<id>"` and opens the dashboard.
5. Navigate to `/projects/<id>` → **Page not found** (before fix).

## Test plan

- [ ] Manual: with a daemon already up, `ao start` in a fresh dir, choose "Add", confirm `/projects/<id>` resolves without restarting `ao`.
- [ ] Existing CLI tests still pass (`pnpm --filter @aoagents/ao-cli typecheck` clean locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)