### PR TITLE
fix(core): disambiguate tmux session names by project path

### DIFF
--- a/.changeset/fix-tmux-cross-config-collision.md
+++ b/.changeset/fix-tmux-cross-config-collision.md
@@ -1,0 +1,7 @@
+---
+"@aoagents/ao-core": patch
+---
+
+fix(core): disambiguate tmux session names by project path to avoid cross-config collisions (#1705)
+
+Two `agent-orchestrator.yaml` checkouts on the same machine that share a `sessionPrefix` (e.g. two clones of the same repo) previously collided when both tried to call `tmux new-session -d -s {prefix}-{num}`, since tmux session names are global per user. The persisted `sessionId` and metadata still use the bare `{prefix}-{num}` form; only the tmux name now carries a 6-hex hash of the project path (e.g. `c13a01-int-1`).

--- a/.changeset/fix-tmux-cross-config-collision.md
+++ b/.changeset/fix-tmux-cross-config-collision.md
@@ -4,4 +4,4 @@
 
 fix(core): disambiguate tmux session names by project path to avoid cross-config collisions (#1705)
 
-Two `agent-orchestrator.yaml` checkouts on the same machine that share a `sessionPrefix` (e.g. two clones of the same repo) previously collided when both tried to call `tmux new-session -d -s {prefix}-{num}`, since tmux session names are global per user. The persisted `sessionId` and metadata still use the bare `{prefix}-{num}` form; only the tmux name now carries a 6-hex hash of the project path (e.g. `c13a01-int-1`).
+Two `agent-orchestrator.yaml` checkouts on the same machine that share a `sessionPrefix` (e.g. two clones of the same repo) previously collided when both tried to call `tmux new-session -d -s {prefix}-{num}`, since tmux session names are global per user. The persisted `sessionId` and metadata still use the bare `{prefix}-{num}` form; only the tmux name now carries an 8-hex hash of the project path (e.g. `c13a01d4-int-1`). `parseTmuxName` accepts both the new 8-hex form and the legacy pre-v0.4.0 12-hex `{storageKey}-{prefix}-{num}` form for back-compat.

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   generateProjectId,
   generateSessionName,
+  generateOrchestratorTmuxName,
   generateSessionPrefix,
   generateTmuxName,
   getArchiveDir,
@@ -39,19 +40,38 @@ describe("paths", () => {
     expect(generateSessionName("ao", 7)).toBe("ao-7");
   });
 
-  it("uses the storage key as the tmux hash segment", () => {
-    const tmuxName = generateTmuxName(storageKey, "ao", 3);
-    expect(tmuxName).toBe("aaaaaaaaaaaa-ao-3");
+  it("derives a stable 6-hex hash from the project path for tmux names", () => {
+    const tmuxName = generateTmuxName("/tmp/repo-a", "ao", 3);
+    expect(tmuxName).toMatch(/^[a-f0-9]{6}-ao-3$/);
+    // Same path → same hash (stable across calls)
+    expect(generateTmuxName("/tmp/repo-a", "ao", 3)).toBe(tmuxName);
     expect(parseTmuxName(tmuxName)).toEqual({
-      hash: storageKey,
+      hash: tmuxName.slice(0, 6),
       prefix: "ao",
       num: 3,
     });
   });
 
-  it("keeps parseTmuxName strict about the 12-hex storage key", () => {
+  it("produces different tmux names for two checkouts sharing a sessionPrefix", () => {
+    // Regression test for #1705: two checkouts with the same sessionPrefix
+    // must not collide on tmux session names (tmux names are global per user).
+    const a = generateTmuxName("/tmp/repo-a", "int", 1);
+    const b = generateTmuxName("/tmp/repo-b", "int", 1);
+    expect(a).not.toBe(b);
+  });
+
+  it("disambiguates orchestrator tmux names by project path", () => {
+    const a = generateOrchestratorTmuxName("/tmp/repo-a", "int");
+    const b = generateOrchestratorTmuxName("/tmp/repo-b", "int");
+    expect(a).toMatch(/^[a-f0-9]{6}-int-orchestrator$/);
+    expect(b).toMatch(/^[a-f0-9]{6}-int-orchestrator$/);
+    expect(a).not.toBe(b);
+  });
+
+  it("keeps parseTmuxName strict about the 6-hex hash prefix", () => {
     expect(parseTmuxName("not-a-key-ao-1")).toBeNull();
     expect(parseTmuxName("abc-ao-1")).toBeNull();
+    expect(parseTmuxName("aaaaaaaaaaaa-ao-1")).toBeNull(); // legacy 12-hex no longer matches
   });
 });
 

--- a/packages/core/src/__tests__/paths.test.ts
+++ b/packages/core/src/__tests__/paths.test.ts
@@ -40,13 +40,13 @@ describe("paths", () => {
     expect(generateSessionName("ao", 7)).toBe("ao-7");
   });
 
-  it("derives a stable 6-hex hash from the project path for tmux names", () => {
+  it("derives a stable 8-hex hash from the project path for tmux names", () => {
     const tmuxName = generateTmuxName("/tmp/repo-a", "ao", 3);
-    expect(tmuxName).toMatch(/^[a-f0-9]{6}-ao-3$/);
+    expect(tmuxName).toMatch(/^[a-f0-9]{8}-ao-3$/);
     // Same path → same hash (stable across calls)
     expect(generateTmuxName("/tmp/repo-a", "ao", 3)).toBe(tmuxName);
     expect(parseTmuxName(tmuxName)).toEqual({
-      hash: tmuxName.slice(0, 6),
+      hash: tmuxName.slice(0, 8),
       prefix: "ao",
       num: 3,
     });
@@ -63,15 +63,31 @@ describe("paths", () => {
   it("disambiguates orchestrator tmux names by project path", () => {
     const a = generateOrchestratorTmuxName("/tmp/repo-a", "int");
     const b = generateOrchestratorTmuxName("/tmp/repo-b", "int");
-    expect(a).toMatch(/^[a-f0-9]{6}-int-orchestrator$/);
-    expect(b).toMatch(/^[a-f0-9]{6}-int-orchestrator$/);
+    expect(a).toMatch(/^[a-f0-9]{8}-int-orchestrator$/);
+    expect(b).toMatch(/^[a-f0-9]{8}-int-orchestrator$/);
     expect(a).not.toBe(b);
   });
 
-  it("keeps parseTmuxName strict about the 6-hex hash prefix", () => {
+  it("parseTmuxName accepts both current 8-hex and legacy 12-hex forms", () => {
+    expect(parseTmuxName("c13a01d4-ao-1")).toEqual({
+      hash: "c13a01d4",
+      prefix: "ao",
+      num: 1,
+    });
+    // Legacy pre-v0.4.0 storageKey-prefixed names still parse (back-compat
+    // for external consumers that persisted the old form).
+    expect(parseTmuxName("aaaaaaaaaaaa-ao-1")).toEqual({
+      hash: "aaaaaaaaaaaa",
+      prefix: "ao",
+      num: 1,
+    });
+  });
+
+  it("parseTmuxName rejects non-hex or wrong-width hash segments", () => {
     expect(parseTmuxName("not-a-key-ao-1")).toBeNull();
     expect(parseTmuxName("abc-ao-1")).toBeNull();
-    expect(parseTmuxName("aaaaaaaaaaaa-ao-1")).toBeNull(); // legacy 12-hex no longer matches
+    expect(parseTmuxName("c13a01-ao-1")).toBeNull(); // 6-hex no longer matches
+    expect(parseTmuxName("c13a01d4ff-ao-1")).toBeNull(); // 10-hex doesn't match either
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -267,6 +267,7 @@ export {
   getOriginFilePath,
   generateSessionName,
   generateTmuxName,
+  generateOrchestratorTmuxName,
   requireStorageKey,
   parseTmuxName,
   expandHome,

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -221,8 +221,8 @@ export function generateSessionName(prefix: string, num: number): string {
  * `sessionId` and persisted metadata stay bare ({prefix}-{num}); only the
  * tmux name carries the discriminator.
  *
- * Format: {6-hex-hash}-{prefix}-{num}
- * Example: "c13a01-int-1"
+ * Format: {8-hex-hash}-{prefix}-{num}
+ * Example: "c13a01d4-int-1"
  */
 export function generateTmuxName(projectPath: string, prefix: string, num: number): string {
   return `${hashProjectPath(projectPath)}-${prefix}-${num}`;
@@ -243,19 +243,23 @@ function hashProjectPath(projectPath: string): string {
   } catch {
     resolved = resolve(projectPath);
   }
-  return createHash("sha256").update(resolved).digest("hex").slice(0, 6);
+  return createHash("sha256").update(resolved).digest("hex").slice(0, 8);
 }
 
 /**
- * Parse a tmux session name produced by {@link generateTmuxName}.
- * Format: {6-hex-hash}-{prefix}-{num}
+ * Parse a tmux session name produced by {@link generateTmuxName} (current
+ * 8-hex form) or by the pre-v0.4.0 `{storageKey}-{prefix}-{num}` form
+ * (12-hex). Both widths are accepted so external consumers that persisted
+ * names under the old format keep parsing.
+ *
+ * Format: {8-hex-hash | 12-hex-hash}-{prefix}-{num}
  */
 export function parseTmuxName(tmuxName: string): {
   hash: string;
   prefix: string;
   num: number;
 } | null {
-  const match = tmuxName.match(/^([a-f0-9]{6})-([a-zA-Z0-9_-]+)-(\d+)$/);
+  const match = tmuxName.match(/^([a-f0-9]{8}|[a-f0-9]{12})-([a-zA-Z0-9_-]+)-(\d+)$/);
   if (!match) return null;
 
   return {

--- a/packages/core/src/paths.ts
+++ b/packages/core/src/paths.ts
@@ -212,31 +212,50 @@ export function generateSessionName(prefix: string, num: number): string {
 }
 
 /**
- * @deprecated Session prefixes are globally unique — hash prefix is no longer needed.
- * Use generateSessionName(prefix, num) instead (same output as the new tmux name).
+ * Generate a tmux session name discriminated by a hash of the project path.
  *
- * Generate tmux session name (legacy format with hash).
- * Format: {storageKey}-{prefix}-{num}
- * Example: "a3b4c5d6e7f8-int-1"
+ * tmux session names are global per user, but `sessionPrefix` is only unique
+ * within a single AO config. Two checkouts on the same machine that share a
+ * `sessionPrefix` (e.g. two clones of the same repo) would otherwise collide
+ * when both try to call `tmux new-session -d -s {prefix}-{num}`. The
+ * `sessionId` and persisted metadata stay bare ({prefix}-{num}); only the
+ * tmux name carries the discriminator.
+ *
+ * Format: {6-hex-hash}-{prefix}-{num}
+ * Example: "c13a01-int-1"
  */
-export function generateTmuxName(
-  storageKey: string | undefined,
-  prefix: string,
-  num: number,
-): string {
-  return `${requireStorageKey(storageKey)}-${prefix}-${num}`;
+export function generateTmuxName(projectPath: string, prefix: string, num: number): string {
+  return `${hashProjectPath(projectPath)}-${prefix}-${num}`;
 }
 
 /**
- * @deprecated Use parseTmuxNameV2 instead.
- * Parse a legacy tmux session name (with hash prefix).
+ * Same as {@link generateTmuxName} for the orchestrator session, whose
+ * sessionId has the fixed `{prefix}-orchestrator` form.
+ */
+export function generateOrchestratorTmuxName(projectPath: string, prefix: string): string {
+  return `${hashProjectPath(projectPath)}-${prefix}-orchestrator`;
+}
+
+function hashProjectPath(projectPath: string): string {
+  let resolved: string;
+  try {
+    resolved = realpathSync(projectPath);
+  } catch {
+    resolved = resolve(projectPath);
+  }
+  return createHash("sha256").update(resolved).digest("hex").slice(0, 6);
+}
+
+/**
+ * Parse a tmux session name produced by {@link generateTmuxName}.
+ * Format: {6-hex-hash}-{prefix}-{num}
  */
 export function parseTmuxName(tmuxName: string): {
   hash: string;
   prefix: string;
   num: number;
 } | null {
-  const match = tmuxName.match(/^([a-f0-9]{12})-([a-zA-Z0-9_-]+)-(\d+)$/);
+  const match = tmuxName.match(/^([a-f0-9]{6})-([a-zA-Z0-9_-]+)-(\d+)$/);
   if (!match) return null;
 
   return {

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -73,7 +73,8 @@ import {
   getProjectSessionsDir,
   getProjectWorktreesDir,
   getProjectDir,
-  generateSessionName,
+  generateTmuxName,
+  generateOrchestratorTmuxName,
 } from "./paths.js";
 import { asValidOpenCodeSessionId } from "./opencode-session-id.js";
 import {
@@ -824,7 +825,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     for (let attempts = 0; attempts < 10_000; attempts++) {
       const sessionId = `${project.sessionPrefix}-${num}`;
       const tmuxName = project.path
-        ? generateSessionName(project.sessionPrefix, num)
+        ? generateTmuxName(project.path, project.sessionPrefix, num)
         : undefined;
 
       if (!usedNumbers.has(num) && reserveSessionId(sessionsDir, sessionId)) {
@@ -853,7 +854,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     return {
       sessionId,
-      tmuxName: config.configPath ? sessionId : undefined,
+      tmuxName:
+        config.configPath && project.path
+          ? generateOrchestratorTmuxName(project.path, project.sessionPrefix)
+          : undefined,
     };
   }
 


### PR DESCRIPTION
## Summary

- tmux session names are global per user, but `sessionPrefix` is only unique within a single AO config. Two checkouts on the same machine sharing a `sessionPrefix` (e.g. two clones of the same repo) collide when both call `tmux new-session -d -s {prefix}-{num}` — the second spawn fails with a confusing "duplicate session" error.
- Wire a 6-hex hash of the project path into the tmux name only:
  - `sessionId` / metadata: `int-1` (unchanged)
  - tmux name: `c13a01-int-1` (was `int-1`)
- Internal lookups key off `sessionId` / metadata, so this is a clean decouple. Existing running sessions keep their persisted `tmuxName` and continue to work; new spawns get the discriminated form.

Closes #1705. Full RCA in #1691.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` (1113 passing)
- [x] New regression tests: two project paths sharing a `sessionPrefix` produce distinct tmux names for both worker and orchestrator
- [ ] Manual repro: clone the same repo twice, `ao spawn` from each — both succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)