### PR TITLE
fix(runtime-tmux): disable tmux status bar + dead code cleanup

### DIFF
--- a/packages/core/src/__tests__/tmux.test.ts
+++ b/packages/core/src/__tests__/tmux.test.ts
@@ -4,7 +4,6 @@ import {
   isTmuxAvailable,
   listSessions,
   hasSession,
-  newSession,
   sendKeys,
   capturePane,
   killSession,
@@ -115,68 +114,6 @@ describe("hasSession", () => {
   it("returns false when session does not exist", async () => {
     mockTmuxError("session not found");
     expect(await hasSession("app-99")).toBe(false);
-  });
-});
-
-describe("newSession", () => {
-  it("creates a basic session", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({ name: "test-1", cwd: "/tmp/workspace" });
-
-    expect(mockExecFile).toHaveBeenCalledWith(
-      "tmux",
-      ["new-session", "-d", "-s", "test-1", "-c", "/tmp/workspace"],
-      expect.any(Object),
-      expect.any(Function),
-    );
-  });
-
-  it("includes environment variables", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({
-      name: "test-2",
-      cwd: "/tmp",
-      environment: { AO_SESSION: "test-2", SOME_VAR: "value" },
-    });
-
-    const args = mockExecFile.mock.calls[0][1] as string[];
-    expect(args).toContain("-e");
-    expect(args).toContain("AO_SESSION=test-2");
-    expect(args).toContain("SOME_VAR=value");
-  });
-
-  it("includes window size", async () => {
-    mockTmuxSuccess("");
-
-    await newSession({ name: "test-3", cwd: "/tmp", width: 200, height: 50 });
-
-    const args = mockExecFile.mock.calls[0][1] as string[];
-    expect(args).toContain("-x");
-    expect(args).toContain("200");
-    expect(args).toContain("-y");
-    expect(args).toContain("50");
-  });
-
-  it("sends initial command after creation", async () => {
-    // Calls: new-session, set-option status off, send-keys Escape, send-keys text, send-keys Enter
-    mockTmuxSequence([{ stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }, { stdout: "" }]);
-
-    await newSession({ name: "test-4", cwd: "/tmp", command: "echo hello" });
-
-    expect(mockExecFile).toHaveBeenCalledTimes(5);
-    // Call 0: new-session
-    // Call 1: set-option status off (hide status bar)
-    const statusArgs = mockExecFile.mock.calls[1][1] as string[];
-    expect(statusArgs).toEqual(["set-option", "-t", "test-4", "status", "off"]);
-    // Call 2: send-keys Escape (clear partial input)
-    const escapeArgs = mockExecFile.mock.calls[2][1] as string[];
-    expect(escapeArgs).toEqual(["send-keys", "-t", "test-4", "Escape"]);
-    // Call 3: send-keys text
-    const textArgs = mockExecFile.mock.calls[3][1] as string[];
-    expect(textArgs).toContain("send-keys");
-    expect(textArgs).toContain("echo hello");
   });
 });
 

--- a/packages/core/src/gh-trace.ts
+++ b/packages/core/src/gh-trace.ts
@@ -60,7 +60,7 @@ export interface GhTraceContext {
   cwd?: string;
 }
 
-export interface GhTraceResult {
+interface GhTraceResult {
   ok: boolean;
   stdout: string;
   stderr: string;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,7 +110,6 @@ export {
   isTmuxAvailable,
   listSessions as listTmuxSessions,
   hasSession as hasTmuxSession,
-  newSession as newTmuxSession,
   sendKeys as tmuxSendKeys,
   capturePane as tmuxCapturePane,
   killSession as killTmuxSession,

--- a/packages/core/src/tmux.ts
+++ b/packages/core/src/tmux.ts
@@ -75,50 +75,6 @@ export async function hasSession(sessionName: string): Promise<boolean> {
   }
 }
 
-export interface NewSessionOptions {
-  /** Session name */
-  name: string;
-  /** Working directory */
-  cwd: string;
-  /** Initial command to run */
-  command?: string;
-  /** Environment variables to set */
-  environment?: Record<string, string>;
-  /** Window width/height */
-  width?: number;
-  height?: number;
-}
-
-/** Create a new tmux session (detached). */
-export async function newSession(opts: NewSessionOptions): Promise<void> {
-  const args = ["new-session", "-d", "-s", opts.name, "-c", opts.cwd];
-
-  // Add environment variables
-  if (opts.environment) {
-    for (const [key, value] of Object.entries(opts.environment)) {
-      args.push("-e", `${key}=${value}`);
-    }
-  }
-
-  // Window size
-  if (opts.width) {
-    args.push("-x", String(opts.width));
-  }
-  if (opts.height) {
-    args.push("-y", String(opts.height));
-  }
-
-  await tmux(...args);
-
-  // Hide the tmux status bar — sessions are embedded in web terminal
-  await tmux("set-option", "-t", opts.name, "status", "off");
-
-  // Send the initial command if provided
-  if (opts.command) {
-    await sendKeys(opts.name, opts.command);
-  }
-}
-
 /**
  * Send keys (text + Enter) to a tmux session.
  * For long/multiline messages, uses load-buffer + paste-buffer with

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -83,7 +83,8 @@ describe("runtime.create()", () => {
   it("calls new-session with correct args", async () => {
     const runtime = create();
 
-    // 1: new-session, 2: send-keys (launch command)
+    // 1: new-session, 2: set-option status off, 3: send-keys (launch command)
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 
@@ -106,9 +107,34 @@ describe("runtime.create()", () => {
     );
   });
 
+  it("disables the tmux status bar immediately after new-session", async () => {
+    const runtime = create();
+
+    // 1: new-session, 2: set-option status off, 3: send-keys
+    mockTmuxSuccess();
+    mockTmuxSuccess();
+    mockTmuxSuccess();
+
+    await runtime.create({
+      sessionId: "status-bar-off",
+      workspacePath: "/tmp/ws",
+      launchCommand: "echo hi",
+      environment: {},
+    });
+
+    // Second call must be set-option ... status off, scoped to the session
+    expect(mockExecFileCustom).toHaveBeenNthCalledWith(
+      2,
+      "tmux",
+      ["set-option", "-t", "status-bar-off", "status", "off"],
+      expectedTmuxOptions,
+    );
+  });
+
   it("includes -e KEY=VALUE flags for environment variables", async () => {
     const runtime = create();
 
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 
@@ -132,6 +158,7 @@ describe("runtime.create()", () => {
 
     mockTmuxSuccess();
     mockTmuxSuccess();
+    mockTmuxSuccess();
 
     await runtime.create({
       sessionId: "launch-test",
@@ -140,7 +167,7 @@ describe("runtime.create()", () => {
       environment: {},
     });
 
-    // Second call: send-keys with the launch command
+    // Third call: send-keys with the launch command (after new-session and set-option)
     expect(mockExecFileCustom).toHaveBeenCalledWith(
       "tmux",
       ["send-keys", "-t", "launch-test", "claude --session abc", "Enter"],
@@ -152,6 +179,8 @@ describe("runtime.create()", () => {
     const runtime = create();
     const longCommand = "x".repeat(250);
 
+    // 1: new-session, 2: set-option, 3: send-keys -l, 4: send-keys Enter
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
@@ -170,7 +199,7 @@ describe("runtime.create()", () => {
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      2,
+      3,
       "tmux",
       [
         "send-keys",
@@ -183,7 +212,7 @@ describe("runtime.create()", () => {
     );
 
     expect(mockExecFileCustom).toHaveBeenNthCalledWith(
-      3,
+      4,
       "tmux",
       ["send-keys", "-t", "launch-long", "Enter"],
       expectedTmuxOptions,
@@ -195,9 +224,11 @@ describe("runtime.create()", () => {
 
     // 1: new-session succeeds
     mockTmuxSuccess();
-    // 2: send-keys fails
+    // 2: set-option succeeds
+    mockTmuxSuccess();
+    // 3: send-keys fails
     mockTmuxError("send-keys failed");
-    // 3: kill-session (cleanup attempt)
+    // 4: kill-session (cleanup attempt)
     mockTmuxSuccess();
 
     await expect(
@@ -248,6 +279,7 @@ describe("runtime.create()", () => {
 
     mockTmuxSuccess();
     mockTmuxSuccess();
+    mockTmuxSuccess();
 
     const handle = await runtime.create({
       sessionId: "valid-session_123",
@@ -262,6 +294,7 @@ describe("runtime.create()", () => {
   it("handles no environment (undefined)", async () => {
     const runtime = create();
 
+    mockTmuxSuccess();
     mockTmuxSuccess();
     mockTmuxSuccess();
 

--- a/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
+++ b/packages/plugins/runtime-tmux/src/__tests__/index.test.ts
@@ -238,12 +238,39 @@ describe("runtime.create()", () => {
         launchCommand: "bad-command",
         environment: {},
       }),
-    ).rejects.toThrow('Failed to send launch command to session "fail-session"');
+    ).rejects.toThrow('Failed to configure or launch session "fail-session"');
 
     // Verify kill-session was called for cleanup
     expect(mockExecFileCustom).toHaveBeenCalledWith(
       "tmux",
       ["kill-session", "-t", "fail-session"],
+      expectedTmuxOptions,
+    );
+  });
+
+  it("cleans up session if set-option fails", async () => {
+    const runtime = create();
+
+    // 1: new-session succeeds
+    mockTmuxSuccess();
+    // 2: set-option fails (e.g. tmux command timeout on a slow host)
+    mockTmuxError("set-option timed out");
+    // 3: kill-session (cleanup attempt)
+    mockTmuxSuccess();
+
+    await expect(
+      runtime.create({
+        sessionId: "setopt-fail",
+        workspacePath: "/tmp/ws",
+        launchCommand: "echo hi",
+        environment: {},
+      }),
+    ).rejects.toThrow('Failed to configure or launch session "setopt-fail"');
+
+    // kill-session must run so we don't leave an orphaned tmux session
+    expect(mockExecFileCustom).toHaveBeenCalledWith(
+      "tmux",
+      ["kill-session", "-t", "setopt-fail"],
       expectedTmuxOptions,
     );
   });

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -66,6 +66,11 @@ export function create(): Runtime {
       // Create tmux session in detached mode
       await tmux("new-session", "-d", "-s", sessionName, "-c", config.workspacePath, ...envArgs);
 
+      // Hide the tmux status bar — sessions are embedded in the web terminal,
+      // and the green bar at the bottom is visual noise (and racy with the
+      // web layer's own set-option call, which only fires on WebSocket connect).
+      await tmux("set-option", "-t", sessionName, "status", "off");
+
       // Re-export PATH inside the launch script. macOS zsh runs path_helper
       // during shell startup which resets PATH, wiping entries set via tmux -e.
       // Including the export in the script file (not send-keys) avoids terminal

--- a/packages/plugins/runtime-tmux/src/index.ts
+++ b/packages/plugins/runtime-tmux/src/index.ts
@@ -66,11 +66,6 @@ export function create(): Runtime {
       // Create tmux session in detached mode
       await tmux("new-session", "-d", "-s", sessionName, "-c", config.workspacePath, ...envArgs);
 
-      // Hide the tmux status bar — sessions are embedded in the web terminal,
-      // and the green bar at the bottom is visual noise (and racy with the
-      // web layer's own set-option call, which only fires on WebSocket connect).
-      await tmux("set-option", "-t", sessionName, "status", "off");
-
       // Re-export PATH inside the launch script. macOS zsh runs path_helper
       // during shell startup which resets PATH, wiping entries set via tmux -e.
       // Including the export in the script file (not send-keys) avoids terminal
@@ -83,10 +78,16 @@ export function create(): Runtime {
         launchCommand = `export PATH=$(printf '%s' ${JSON.stringify(pathValue)})\n${launchCommand}`;
       }
 
-      // Send the launch command — clean up the session if this fails.
-      // Use a temp script for long commands so the pane shows a short
+      // Configure the session and send the launch command — kill the session
+      // if any of these fail so we don't leave an orphaned tmux process.
+      // Use a temp script for long launch commands so the pane shows a short
       // invocation instead of a pasted wall of shell.
       try {
+        // Hide the tmux status bar — sessions are embedded in the web terminal,
+        // and the green bar at the bottom is visual noise (and racy with the
+        // web layer's own set-option call, which only fires on WebSocket connect).
+        await tmux("set-option", "-t", sessionName, "status", "off");
+
         if (launchCommand.length > 200) {
           const invocation = writeLaunchScript(launchCommand);
           await tmux("send-keys", "-t", sessionName, "-l", invocation);
@@ -102,7 +103,7 @@ export function create(): Runtime {
           // Best-effort cleanup
         }
         const msg = err instanceof Error ? err.message : String(err);
-        throw new Error(`Failed to send launch command to session "${sessionName}": ${msg}`, {
+        throw new Error(`Failed to configure or launch session "${sessionName}": ${msg}`, {
           cause: err,
         });
       }


### PR DESCRIPTION
## Summary

- **Fix #1709**: hide the tmux status bar at session creation in the actual spawn path (`runtime-tmux` plugin), not in dead code.
- **Cleanup**: remove the unused `newSession` helper from `core/src/tmux.ts` (the home of the prior #1683 fix), and demote one stray exported type that has no in-repo consumers.

## Why #1683 didn't fix #1682

#1683 added `set-option ... status off` to `core/src/tmux.ts::newSession()`. But that helper has **zero callers** anywhere in the workspace — worker sessions are spawned by the `runtime-tmux` plugin, which was never modified. So the green status bar was still visible at session creation; the only thing actually disabling it was the web layer's own `set-option` call on WebSocket connect (with a flash window before that).

Verification:

```console
$ grep -rn "newTmuxSession\|newSession\b" --include='*.ts' packages/ \
    | grep -v 'dist/\|__tests__\|newSessionState\|newSessionReason'
packages/core/src/tmux.ts:93:export async function newSession(opts: NewSessionOptions): Promise<void> {
packages/core/src/index.ts:113:  newSession as newTmuxSession,
```

Only the definition and the (unused) re-export. No actual callers.

## Changes

### Commit 1 — `fix(runtime-tmux): disable tmux status bar at session creation (closes #1709)`

In `packages/plugins/runtime-tmux/src/index.ts`, immediately after `tmux new-session`:

```ts
await tmux("set-option", "-t", sessionName, "status", "off");
```

Plus a dedicated test (`disables the tmux status bar immediately after new-session`) and updates to existing tests' mock-call counts to account for the extra tmux call.

### Commit 2 — `chore(core): remove unused newSession helper`

Deletes:

| Symbol | File | Evidence |
|---|---|---|
| `newSession` (function) | `packages/core/src/tmux.ts` | grep above — no callers |
| `NewSessionOptions` (interface) | `packages/core/src/tmux.ts` | only used by the function being deleted |
| `newSession as newTmuxSession` (re-export) | `packages/core/src/index.ts` | grep above — no callers |
| `describe("newSession", ...)` block (4 tests) | `packages/core/src/__tests__/tmux.test.ts` | tests for deleted function |

The other tmux command wrappers (`isTmuxAvailable`, `tmuxSendKeys`, `tmuxCapturePane`, `killTmuxSession`, `getTmuxPaneTTY`, etc.) are kept — they're plugin-author-facing public API even if not consumed in-repo.

### Commit 3 — `chore(core): demote unused GhTraceResult export to internal`

`GhTraceResult` was `export interface` in `core/src/gh-trace.ts` but never re-exported from `core/src/index.ts` and never imported anywhere in the workspace. Its only consumer is `writeTraceEntry()` inside the same file. Demoted to a private interface.

```console
$ grep -rn "GhTraceResult" --include='*.ts' packages/ | grep -v dist/
packages/core/src/gh-trace.ts:63:interface GhTraceResult {
packages/core/src/gh-trace.ts:284:  result: GhTraceResult,
```

## Candidates not removed (left for human triage)

- **`AGENT_REPORT_CLOCK_SKEW_TOLERANCE_MS`** (`core/src/agent-report.ts:119`) — exported but only referenced by `agent-report.test.ts` and as a default-parameter value within the same file. Borderline: the test legitimately uses it to verify boundary behavior, and unexporting would force the test to hardcode `60_000`. Keeping.
- **`_testUtils`** (`core/src/gh-trace.ts:399`) — test-only export, by intent. Keeping.

The dead-code sweep was deliberately bounded; no other unambiguously dead exports surfaced in `packages/core/src/` or `packages/plugins/*/src/` that aren't plausibly part of the plugin-author-facing public API.

## Test plan

- [x] `pnpm typecheck` — all 21 packages green
- [x] `pnpm --filter @aoagents/ao-plugin-runtime-tmux test` — 29 passed
- [x] `pnpm --filter @aoagents/ao-core test` — 1101 passed (the 6 failing tests are pre-existing `better-sqlite3` native-binding failures on main, unrelated to this change; verified by stashing my changes and re-running)
- [ ] Manual: `ao spawn --prompt "hello"` then open the session in the web terminal — green status bar should be absent from the moment the session is created (cannot exercise from inside this worktree session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)