### PR TITLE
fix(web): drop = prefix from set-option in mux-websocket (closes #1714)

### DIFF
--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -1,12 +1,48 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { SessionBroadcaster } from "../mux-websocket";
+import { EventEmitter } from "node:events";
+import type { SessionBroadcaster as SessionBroadcasterType } from "../mux-websocket";
+
+// vi.mock factories run before module-level statements. Hoist the mock
+// fns so the factories close over the same instances the tests use.
+const { mockSpawn, mockPtySpawn } = vi.hoisted(() => ({
+  mockSpawn: vi.fn(),
+  mockPtySpawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  const spawnFn = (...args: unknown[]) => mockSpawn(...args);
+  return {
+    ...actual,
+    default: { ...(actual.default as object), spawn: spawnFn },
+    spawn: spawnFn,
+  };
+});
+
+vi.mock("node-pty", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => mockPtySpawn(...args),
+  };
+});
+
+// Mock tmux-utils so resolveTmuxSession returns a deterministic session id
+// and we don't shell out to a real tmux binary.
+vi.mock("../tmux-utils.js", () => ({
+  findTmux: () => "/usr/bin/tmux",
+  validateSessionId: () => true,
+  resolveTmuxSession: () => "ao-177",
+}));
+
+const { SessionBroadcaster, TerminalManager } = await import("../mux-websocket");
 
 // Mock global fetch
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 describe("SessionBroadcaster", () => {
-  let broadcaster: SessionBroadcaster;
+  let broadcaster: SessionBroadcasterType;
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -223,5 +259,55 @@ describe("SessionBroadcaster", () => {
       // Should only have 1 fetch (initial snapshot)
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe("TerminalManager.open — tmux target args (regression for #1714)", () => {
+  beforeEach(() => {
+    mockSpawn.mockReset();
+    mockPtySpawn.mockReset();
+
+    // spawn() returns an object that emits "error" — we just need .on() to work.
+    mockSpawn.mockImplementation(() => new EventEmitter());
+
+    // ptySpawn() returns a minimal IPty-like stub so terminal wiring doesn't crash.
+    mockPtySpawn.mockImplementation(() => ({
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+    }));
+  });
+
+  it("invokes set-option mouse on with the bare session id (no = prefix)", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    const mouseCall = mockSpawn.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1].includes("mouse"),
+    );
+    expect(mouseCall).toBeDefined();
+    expect(mouseCall?.[1]).toEqual(["set-option", "-t", "ao-177", "mouse", "on"]);
+  });
+
+  it("invokes set-option status off with the bare session id (no = prefix)", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    const statusCall = mockSpawn.mock.calls.find(
+      (call) => Array.isArray(call[1]) && call[1].includes("status"),
+    );
+    expect(statusCall).toBeDefined();
+    expect(statusCall?.[1]).toEqual(["set-option", "-t", "ao-177", "status", "off"]);
+  });
+
+  it("still uses the = exact-match prefix for attach-session", () => {
+    const mgr = new TerminalManager("/usr/bin/tmux");
+    mgr.open("ao-177");
+
+    expect(mockPtySpawn).toHaveBeenCalledTimes(1);
+    const [, args] = mockPtySpawn.mock.calls[0];
+    expect(args).toEqual(["attach-session", "-t", "=ao-177"]);
   });
 });

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -274,9 +274,9 @@ export class TerminalManager {
       return tmuxSessionId;
     }
 
-    // tmux 3.4 only honours the `=` exact-match prefix for has-session and
-    // attach-session — set-option silently ignores it, so use the bare id here.
-    const exactTmuxTarget = `=${tmuxSessionId}`;
+    // tmux 3.4 only honours the `=` exact-match prefix on has-session and
+    // attach-session; set-option silently ignores it, so we use the bare id
+    // here. The `=`-prefixed form is built below for attach-session.
 
     // Enable mouse mode
     const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
@@ -307,7 +307,9 @@ export class TerminalManager {
       throw new Error("node-pty not available");
     }
 
-    // Spawn PTY
+    // Spawn PTY — use `=`-prefixed exact-match target so we never attach to
+    // a session whose name happens to be a prefix of the requested id.
+    const exactTmuxTarget = `=${tmuxSessionId}`;
     const pty = ptySpawn(this.TMUX, ["attach-session", "-t", exactTmuxTarget], {
       name: "xterm-256color",
       cols: 80,

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -222,7 +222,7 @@ const REATTACH_RESET_GRACE_MS = 5_000;
  * TerminalManager manages PTY processes independently of WebSocket connections.
  * A single manager instance is shared across all mux connections.
  */
-class TerminalManager {
+export class TerminalManager {
   private terminals = new Map<string, ManagedTerminal>();
   private TMUX: string;
 
@@ -274,16 +274,18 @@ class TerminalManager {
       return tmuxSessionId;
     }
 
-    // Enable mouse mode
+    // tmux 3.4 only honours the `=` exact-match prefix for has-session and
+    // attach-session — set-option silently ignores it, so use the bare id here.
     const exactTmuxTarget = `=${tmuxSessionId}`;
 
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "mouse", "on"]);
+    // Enable mouse mode
+    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
     mouseProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
     });
 
     // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", exactTmuxTarget, "status", "off"]);
+    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
     statusProc.on("error", (err) => {
       console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
     });


### PR DESCRIPTION
## Summary

Fixes scroll-wheel regression in the dashboard tmux terminal (#1714).

In tmux 3.4 the `=` exact-match prefix is only honoured by `has-session` and `attach-session`. For `set-option`, the prefix is silently ignored — so the `mouse on` and `status off` calls in `mux-websocket.ts` never applied. Result: scroll wheel sent arrow keys instead of mouse events ("Scroll wheel is sending arrow keys · use PgUp/PgDn to scroll"), and the tmux status bar remained visible.

The fix is surgical: use the bare `tmuxSessionId` for the two `set-option` calls; keep `=${tmuxSessionId}` for `attach-session` where it is correct.

> Note: #1711 already fixed the green-bar symptom at the runtime-tmux layer (session creation). This PR fixes the underlying tmux-3.4 `=` prefix bug in the web layer, which restores `mouse on` (scroll wheel) and gives belt-and-suspenders coverage for `status off`.

## Causal chain

- #1608 introduced the `=` prefix on all tmux commands in `mux-websocket.ts` — silent failure on `set-option` in tmux 3.4
- #1682 / #1683 / #1711 chased the green status bar through `runtime-tmux` without spotting the web-layer regression
- #1714 identifies the actual root cause; this PR is the surgical fix for the mouse/scroll regression

## Test plan

- [x] `pnpm install`
- [x] `pnpm --filter @aoagents/ao-web typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-web test -- mux-websocket` — 12/12 pass, including 3 new regression tests:
  - `set-option ... mouse on` is invoked with the bare session id (no `=`)
  - `set-option ... status off` is invoked with the bare session id (no `=`)
  - `attach-session` still uses `=${id}`
- [x] Pre-existing unrelated failures in `api-routes.test.ts` and `sessions/[id]/page.test.tsx` confirmed present on main (not caused by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)