### PR TITLE
fix(core): read legacy key=value session metadata

### DIFF
--- a/packages/core/src/__tests__/metadata.test.ts
+++ b/packages/core/src/__tests__/metadata.test.ts
@@ -150,6 +150,30 @@ describe("writeMetadata + readMetadata", () => {
     const meta = readMetadata(dataDir, "app-6");
     expect(meta?.displayName).toBe("Refactor session manager");
   });
+
+  it("reads legacy key=value metadata from a .json file", () => {
+    writeFileSync(
+      join(dataDir, "ao-orchestrator.json"),
+      [
+        "role=orchestrator",
+        "status=working",
+        "tmuxName=ao-orchestrator",
+        'runtimeHandle={"id":"ao-orchestrator","runtimeName":"tmux","data":{"workspacePath":"/tmp/w"}}',
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const meta = readMetadata(dataDir, "ao-orchestrator");
+    expect(meta).not.toBeNull();
+    expect(meta!.role).toBe("orchestrator");
+    expect(meta!.status).toBe("working");
+    expect(meta!.tmuxName).toBe("ao-orchestrator");
+    expect(meta!.runtimeHandle).toEqual({
+      id: "ao-orchestrator",
+      runtimeName: "tmux",
+      data: { workspacePath: "/tmp/w" },
+    });
+  });
 });
 
 describe("readMetadataRaw", () => {
@@ -184,6 +208,28 @@ describe("readMetadataRaw", () => {
 
     const raw = readMetadataRaw(dataDir, "raw-3");
     expect(raw!["runtimeHandle"]).toBe('{"id":"foo","data":{"key":"val"}}');
+  });
+
+  it("reads legacy key=value metadata from a .json file", () => {
+    writeFileSync(
+      join(dataDir, "ao-orchestrator.json"),
+      [
+        "role=orchestrator",
+        "status=working",
+        "tmuxName=ao-orchestrator",
+        'runtimeHandle={"id":"ao-orchestrator","runtimeName":"tmux","data":{"workspacePath":"/tmp/w"}}',
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const raw = readMetadataRaw(dataDir, "ao-orchestrator");
+    expect(raw).not.toBeNull();
+    expect(raw!["role"]).toBe("orchestrator");
+    expect(raw!["status"]).toBe("working");
+    expect(raw!["tmuxName"]).toBe("ao-orchestrator");
+    expect(raw!["runtimeHandle"]).toBe(
+      '{"id":"ao-orchestrator","runtimeName":"tmux","data":{"workspacePath":"/tmp/w"}}',
+    );
   });
 });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdirSync, readFileSync, existsSync } from "node:fs";
+import { mkdirSync, readFileSync, existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
 import { validateConfig } from "../../config.js";
@@ -1708,6 +1708,33 @@ describe("spawn", () => {
       expect(s1.id).toBe("app-orchestrator");
       expect(s2.id).toBe("app-orchestrator");
       expect(mockWorkspace.create).toHaveBeenCalledTimes(1);
+    });
+
+    it("ensureOrchestrator reuses canonical orchestrator metadata stored as legacy key=value in a .json file", async () => {
+      const runtimeHandle = makeHandle("app-orchestrator");
+      writeFileSync(
+        join(sessionsDir, "app-orchestrator.json"),
+        [
+          "role=orchestrator",
+          "project=my-app",
+          "status=working",
+          "branch=orchestrator/app-orchestrator",
+          `worktree=${join(tmpDir, "legacy-orchestrator")}`,
+          "tmuxName=app-orchestrator",
+          `runtimeHandle=${JSON.stringify(runtimeHandle)}`,
+        ].join("\n"),
+        "utf-8",
+      );
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      const session = await sm.ensureOrchestrator({ projectId: "my-app" });
+
+      expect(session.id).toBe("app-orchestrator");
+      expect(session.status).toBe("working");
+      expect(session.metadata["role"]).toBe("orchestrator");
+      expect(mockWorkspace.create).not.toHaveBeenCalled();
+      expect(mockRuntime.create).not.toHaveBeenCalled();
+      expect(mockRuntime.isAlive).toHaveBeenCalledWith(runtimeHandle);
     });
 
     it("ensureOrchestrator coalesces concurrent creation calls", async () => {

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -35,6 +35,7 @@ import { assertValidSessionIdComponent, SESSION_ID_COMPONENT_PATTERN } from "./u
 import { flattenToStringRecord } from "./utils/metadata-flatten.js";
 import { validateStatus } from "./utils/validation.js";
 import { withFileLockSync } from "./file-lock.js";
+import { parseKeyValueContent } from "./key-value.js";
 
 const JSON_EXTENSION = ".json";
 
@@ -43,14 +44,18 @@ function serializeMetadata(data: Record<string, unknown>): string {
   return JSON.stringify(data, null, 2) + "\n";
 }
 
-/** Parse JSON metadata file content. Returns null on invalid JSON. */
+/** Parse JSON metadata file content, with legacy key=value fallback. */
 function parseMetadataContent(content: string): Record<string, unknown> | null {
   try {
     const parsed = JSON.parse(content);
     if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return null;
     return parsed as Record<string, unknown>;
   } catch {
-    return null;
+    const trimmed = content.trimStart();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) return null;
+
+    const parsed = parseKeyValueContent(content);
+    return Object.keys(parsed).length > 0 ? parsed : null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Parse legacy key=value session metadata when a `.json` metadata file is not JSON.
- Preserve corrupt JSON handling for content that starts like JSON but fails to parse.
- Cover `readMetadata`, `readMetadataRaw`, and `ensureOrchestrator` reuse of legacy canonical orchestrator metadata.

Fixes #1720

## Tests
- `pnpm --filter @aoagents/ao-core test -- metadata`
- `pnpm --filter @aoagents/ao-core test -- session-manager/spawn`
- `pnpm --filter @aoagents/ao-core typecheck`
