### PR TITLE
chore: release 0.6.0

### DIFF
--- a/.changeset/per-project-env.md
+++ b/.changeset/per-project-env.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-core": minor
----
-
-Add optional per-project `env` block to `ProjectConfig` that forwards string-to-string env vars into worker session runtimes (e.g. pin `GH_TOKEN` per project). AO-internal vars (`AO_SESSION`, `AO_PROJECT_ID`, etc.) always take precedence.

--- a/.changeset/reload-dashboard-on-add-project.md
+++ b/.changeset/reload-dashboard-on-add-project.md
@@ -1,5 +1,0 @@
----
-"@aoagents/ao-cli": patch
----
-
-Fix dashboard 404 after adding a project from the "AO is already running" menu. The CLI now notifies the running daemon to reload its cached config so the new project's page is reachable immediately.

--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [0f539a3]
+  - @aoagents/ao-cli@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,41 @@
 # @aoagents/ao-cli
 
+## 0.6.0
+
+### Patch Changes
+
+- 0f539a3: Fix dashboard 404 after adding a project from the "AO is already running" menu. The CLI now notifies the running daemon to reload its cached config so the new project's page is reachable immediately.
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+  - @aoagents/ao-web@0.6.0
+  - @aoagents/ao-plugin-runtime-tmux@0.6.0
+  - @aoagents/ao-plugin-agent-aider@0.6.0
+  - @aoagents/ao-plugin-agent-claude-code@0.6.0
+  - @aoagents/ao-plugin-agent-codex@0.6.0
+  - @aoagents/ao-plugin-agent-cursor@0.1.4
+  - @aoagents/ao-plugin-agent-kimicode@0.1.3
+  - @aoagents/ao-plugin-agent-opencode@0.6.0
+  - @aoagents/ao-plugin-notifier-composio@0.6.0
+  - @aoagents/ao-plugin-notifier-desktop@0.6.0
+  - @aoagents/ao-plugin-notifier-discord@0.2.9
+  - @aoagents/ao-plugin-notifier-openclaw@0.2.9
+  - @aoagents/ao-plugin-notifier-slack@0.6.0
+  - @aoagents/ao-plugin-notifier-webhook@0.6.0
+  - @aoagents/ao-plugin-runtime-process@0.6.0
+  - @aoagents/ao-plugin-scm-github@0.6.0
+  - @aoagents/ao-plugin-terminal-iterm2@0.6.0
+  - @aoagents/ao-plugin-terminal-web@0.6.0
+  - @aoagents/ao-plugin-tracker-github@0.6.0
+  - @aoagents/ao-plugin-tracker-linear@0.6.0
+  - @aoagents/ao-plugin-workspace-clone@0.6.0
+  - @aoagents/ao-plugin-workspace-worktree@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @aoagents/ao-core
 
+## 0.6.0
+
+### Minor Changes
+
+- Wire activity events into `lifecycle-manager` failure paths so failures surface as activity entries for downstream consumers (#1620).
+- 40aeb78: Add optional per-project `env` block to `ProjectConfig` that forwards string-to-string env vars into worker session runtimes (e.g. pin `GH_TOKEN` per project). AO-internal vars (`AO_SESSION`, `AO_PROJECT_ID`, etc.) always take precedence.
+
+### Patch Changes
+
+- Disable the tmux status bar in the runtime-tmux plugin and clean up dead code in core (#1711).
+- Disable tmux status bar at session creation (#1683). The change touched dead code; the actual user-visible fix landed in #1711.
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-core",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Core library — types, config, session manager, lifecycle manager, event bus",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-aider/CHANGELOG.md
+++ b/packages/plugins/agent-aider/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-aider
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/agent-aider/package.json
+++ b/packages/plugins/agent-aider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-aider",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent plugin: Aider",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/CHANGELOG.md
+++ b/packages/plugins/agent-claude-code/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-claude-code
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-claude-code",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent plugin: Claude Code",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/CHANGELOG.md
+++ b/packages/plugins/agent-codex/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-codex
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-codex",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent plugin: OpenAI Codex CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/package-version.test.ts
+++ b/packages/plugins/agent-codex/src/package-version.test.ts
@@ -2,10 +2,10 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "node:fs";
 
 describe("package manifest version", () => {
-  it("is bumped to 0.5.0", () => {
+  it("is bumped to 0.6.0", () => {
     const packageJsonUrl = new URL("../package.json", import.meta.url);
     const packageJson = JSON.parse(readFileSync(packageJsonUrl, "utf8")) as { version?: string };
 
-    expect(packageJson.version).toBe("0.5.0");
+    expect(packageJson.version).toBe("0.6.0");
   });
 });

--- a/packages/plugins/agent-cursor/CHANGELOG.md
+++ b/packages/plugins/agent-cursor/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-cursor
 
+## 0.1.4
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.1.3
 
 ### Patch Changes

--- a/packages/plugins/agent-cursor/package.json
+++ b/packages/plugins/agent-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-cursor",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Agent plugin: Cursor CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-kimicode/CHANGELOG.md
+++ b/packages/plugins/agent-kimicode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-kimicode
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/plugins/agent-kimicode/package.json
+++ b/packages/plugins/agent-kimicode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-kimicode",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Agent plugin: Kimi Code CLI (MoonshotAI)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/CHANGELOG.md
+++ b/packages/plugins/agent-opencode/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-agent-opencode
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-opencode",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Agent plugin: OpenCode",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-composio/CHANGELOG.md
+++ b/packages/plugins/notifier-composio/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-composio
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-composio/package.json
+++ b/packages/plugins/notifier-composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-composio",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Notifier plugin: Composio unified notifications (Slack, Discord, email)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/CHANGELOG.md
+++ b/packages/plugins/notifier-desktop/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-desktop
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-desktop",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Notifier plugin: OS desktop notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/CHANGELOG.md
+++ b/packages/plugins/notifier-discord/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-discord
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-discord",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Notifier plugin: Discord webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-openclaw/CHANGELOG.md
+++ b/packages/plugins/notifier-openclaw/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-openclaw
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/packages/plugins/notifier-openclaw/package.json
+++ b/packages/plugins/notifier-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-openclaw",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Notifier plugin: OpenClaw webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-slack/CHANGELOG.md
+++ b/packages/plugins/notifier-slack/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-slack
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-slack/package.json
+++ b/packages/plugins/notifier-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-slack",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Notifier plugin: Slack",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-webhook/CHANGELOG.md
+++ b/packages/plugins/notifier-webhook/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-notifier-webhook
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-webhook/package.json
+++ b/packages/plugins/notifier-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-webhook",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Notifier plugin: generic webhook",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-process/CHANGELOG.md
+++ b/packages/plugins/runtime-process/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-runtime-process
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/runtime-process/package.json
+++ b/packages/plugins/runtime-process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-process",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Runtime plugin: child processes",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/CHANGELOG.md
+++ b/packages/plugins/runtime-tmux/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-runtime-tmux
 
+## 0.6.0
+
+### Patch Changes
+
+- Disable the tmux status bar in the runtime-tmux plugin and clean up dead code in core (#1711).
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-tmux",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Runtime plugin: tmux sessions",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/CHANGELOG.md
+++ b/packages/plugins/scm-github/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-scm-github
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-github",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "SCM plugin: GitHub (PRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-gitlab/CHANGELOG.md
+++ b/packages/plugins/scm-gitlab/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-scm-gitlab
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.2.8
 
 ### Patch Changes

--- a/packages/plugins/scm-gitlab/package.json
+++ b/packages/plugins/scm-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-gitlab",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "SCM plugin: GitLab (MRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-iterm2/CHANGELOG.md
+++ b/packages/plugins/terminal-iterm2/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-terminal-iterm2
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/terminal-iterm2/package.json
+++ b/packages/plugins/terminal-iterm2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-iterm2",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Terminal plugin: macOS iTerm2",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/CHANGELOG.md
+++ b/packages/plugins/terminal-web/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-terminal-web
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Terminal plugin: xterm.js web terminal",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/CHANGELOG.md
+++ b/packages/plugins/tracker-github/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-tracker-github
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-github",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Tracker plugin: GitHub Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-gitlab/CHANGELOG.md
+++ b/packages/plugins/tracker-gitlab/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-tracker-gitlab
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+  - @aoagents/ao-plugin-scm-gitlab@0.2.9
+
 ## 0.2.8
 
 ### Patch Changes

--- a/packages/plugins/tracker-gitlab/package.json
+++ b/packages/plugins/tracker-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-gitlab",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Tracker plugin: GitLab Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-linear/CHANGELOG.md
+++ b/packages/plugins/tracker-linear/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-tracker-linear
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/tracker-linear/package.json
+++ b/packages/plugins/tracker-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-linear",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Tracker plugin: Linear",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-clone/CHANGELOG.md
+++ b/packages/plugins/workspace-clone/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-workspace-clone
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/workspace-clone/package.json
+++ b/packages/plugins/workspace-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-clone",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Workspace plugin: git clone",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/CHANGELOG.md
+++ b/packages/plugins/workspace-worktree/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @aoagents/ao-plugin-workspace-worktree
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-worktree",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Workspace plugin: git worktrees",
   "license": "MIT",
   "type": "module",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @aoagents/ao-web
 
+## 0.6.0
+
+### Patch Changes
+
+- Drop `=` prefix from `set-option` invocation in `mux-websocket` so tmux accepts the option without erroring out (#1715).
+- Bound the PTY re-attach loop with a grace-period counter reset to prevent runaway reconnect attempts (#1640).
+- Disable xterm scrollback to prevent terminal right-side clipping (#1678).
+- Updated dependencies
+- Updated dependencies [40aeb78]
+- Updated dependencies
+- Updated dependencies
+  - @aoagents/ao-core@0.6.0
+  - @aoagents/ao-plugin-runtime-tmux@0.6.0
+  - @aoagents/ao-plugin-agent-claude-code@0.6.0
+  - @aoagents/ao-plugin-agent-codex@0.6.0
+  - @aoagents/ao-plugin-agent-cursor@0.1.4
+  - @aoagents/ao-plugin-agent-kimicode@0.1.3
+  - @aoagents/ao-plugin-agent-opencode@0.6.0
+  - @aoagents/ao-plugin-scm-github@0.6.0
+  - @aoagents/ao-plugin-tracker-github@0.6.0
+  - @aoagents/ao-plugin-tracker-linear@0.6.0
+  - @aoagents/ao-plugin-workspace-worktree@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Web dashboard for agent-orchestrator",
   "type": "module",
   "files": [


### PR DESCRIPTION
## Summary

Release 0.6.0. Bumps core/cli/web/plugins per accumulated changesets.

## Highlights

- **feat(core):** per-project `env` block in `ProjectConfig` (#1679)
- **feat(core):** activity events wired into lifecycle-manager failure paths (#1620)
- **fix(runtime-tmux):** disable tmux status bar + dead code cleanup (#1711)
- **fix(web):** drop `=` prefix from set-option in mux-websocket (#1715)
- **fix(web):** disable xterm scrollback to prevent right-side clipping (#1678)
- **fix(web):** bound PTY re-attach loop (#1640)
- **fix(cli):** reload dashboard config after adding project (#1706)
- **fix(core):** disable tmux status bar at session creation (#1683) — touched dead code; user-visible fix landed in #1711

## Version bumps

Linked packages → **0.6.0**: ao, ao-cli, ao-core, ao-web, plus runtime-tmux, runtime-process, agent-claude-code, agent-codex, agent-aider, agent-opencode, workspace-worktree, workspace-clone, tracker-github, tracker-linear, scm-github, notifier-{desktop,slack,webhook,composio}, terminal-{iterm2,web}.

Off-track plugins bumped via internal-dep update:
- agent-cursor → 0.1.4
- agent-kimicode → 0.1.3
- notifier-discord, notifier-openclaw, scm-gitlab, tracker-gitlab → 0.2.9

## Test plan

- [ ] CI green
- [ ] CHANGELOGs reflect all 8 PRs merged since #1676
- [ ] All packages bumped to 0.6.0 (or appropriate per their track)