### PR TITLE
fix(lifecycle): preserve terminal PR association across restore + harden detectPR (closes #1724)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -993,6 +993,55 @@ describe("check (single session)", () => {
     expect(meta?.["branch"]).toBe("fix-login");
   });
 
+  it("does not call detectPR when the session's PR is in a terminal merged state", async () => {
+    const workspacePath = join(env.tmpDir, "worker-ws-merged-pr");
+    const gitDir = join(env.tmpDir, "repo", ".git", "worktrees", "app-1-merged-pr");
+    mkdirSync(workspacePath, { recursive: true });
+    mkdirSync(gitDir, { recursive: true });
+    writeFileSync(join(workspacePath, ".git"), `gitdir: ${gitDir}\n`);
+    writeFileSync(join(gitDir, "HEAD"), "ref: refs/heads/main\n");
+
+    const mergedPR = makePR({ branch: "feat/old", url: "https://github.com/org/repo/pull/100" });
+    const mockSCM = createMockSCM({ detectPR: vi.fn().mockResolvedValue(makePR({ number: 643 })) });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    // Simulate the bug condition: session.branch drifted to "main" (default
+    // branch) after a merge, and session.pr was cleared elsewhere — but the
+    // canonical lifecycle still records the merged terminal state.
+    const session = makeSession({
+      status: "merged",
+      branch: "main",
+      workspacePath,
+      pr: null,
+      metadata: { agent: "mock-agent" },
+    });
+    session.lifecycle.pr.state = "merged";
+    session.lifecycle.pr.reason = "merge_observed";
+    session.lifecycle.pr.number = mergedPR.number;
+    session.lifecycle.pr.url = mergedPR.url;
+    session.lifecycle.pr.lastObservedAt = new Date().toISOString();
+
+    const lm = setupCheck("app-1", {
+      session,
+      metaOverrides: {
+        worktree: workspacePath,
+        branch: "main",
+        agent: "mock-agent",
+      },
+      registry,
+    });
+
+    await lm.check("app-1");
+
+    expect(mockSCM.detectPR).not.toHaveBeenCalled();
+    const meta = readMetadataRaw(env.sessionsDir, "app-1");
+    expect(meta?.["pr"] ?? "").not.toContain("/pull/643");
+  });
+
   it("refreshes branch metadata again after a closed PR when the worker switches branches", async () => {
     const workspacePath = join(env.tmpDir, "worker-ws-closed-pr");
     const gitDir = join(env.tmpDir, "repo", ".git", "worktrees", "app-1-closed-pr");

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -1020,7 +1020,7 @@ describe("check (single session)", () => {
       metadata: { agent: "mock-agent" },
     });
     session.lifecycle.pr.state = "merged";
-    session.lifecycle.pr.reason = "merge_observed";
+    session.lifecycle.pr.reason = "merged";
     session.lifecycle.pr.number = mergedPR.number;
     session.lifecycle.pr.url = mergedPR.url;
     session.lifecycle.pr.lastObservedAt = new Date().toISOString();

--- a/packages/core/src/__tests__/session-manager/restore.test.ts
+++ b/packages/core/src/__tests__/session-manager/restore.test.ts
@@ -226,6 +226,36 @@ describe("restore", () => {
     await expect(sm.restore("app-1")).rejects.toThrow(/is merged/);
   });
 
+  it("refuses to restore sessions whose PR is closed (unmerged terminal state)", async () => {
+    const ws = "/tmp/mock-ws/app-1-closed";
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: ws,
+      branch: "feat/abandoned",
+      status: "killed",
+      pr: "https://github.com/acme/repo/pull/99",
+      project: "my-app",
+      runtimeHandle: makeHandle("rt-old"),
+    });
+    // No legacy `status` maps to lifecycle.pr.state="closed", so write the
+    // canonical lifecycle directly to exercise the closed branch of step 3a.
+    updateMetadata(sessionsDir, "app-1", {
+      lifecycle: JSON.stringify({
+        version: 2,
+        session: { state: "terminated", terminatedAt: new Date().toISOString() },
+        pr: {
+          state: "closed",
+          reason: "closed_unmerged",
+          number: 99,
+          url: "https://github.com/acme/repo/pull/99",
+          lastObservedAt: new Date().toISOString(),
+        },
+      }),
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    await expect(sm.restore("app-1")).rejects.toThrow(/is closed/);
+  });
+
   it("throws SessionNotRestorableError for working sessions", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: "/tmp",

--- a/packages/core/src/__tests__/session-manager/restore.test.ts
+++ b/packages/core/src/__tests__/session-manager/restore.test.ts
@@ -197,12 +197,13 @@ describe("restore", () => {
     expect(mockRuntime.create).toHaveBeenCalled();
   });
 
-  it("allows restoring merged sessions", async () => {
+  it("refuses to restore sessions whose PR has merged (would silently re-spawn against the default branch)", async () => {
     const ws = "/tmp/mock-ws/app-1";
     writeMetadata(sessionsDir, "app-1", {
       worktree: ws,
       branch: "main",
       status: "merged",
+      pr: "https://github.com/acme/repo/pull/1723",
       project: "my-app",
       runtimeHandle: makeHandle("rt-old"),
     });
@@ -222,8 +223,7 @@ describe("restore", () => {
     };
 
     const sm = createSessionManager({ config, registry });
-    const restored = await sm.restore("app-1");
-    expect(restored.id).toBe("app-1");
+    await expect(sm.restore("app-1")).rejects.toThrow(/is merged/);
   });
 
   it("throws SessionNotRestorableError for working sessions", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -654,6 +654,18 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (session.metadata["prAutoDetect"] === "off" || session.metadata["prAutoDetect"] === "false") continue;
       if (session.metadata["role"] === "orchestrator" || session.id.endsWith("-orchestrator"))
         continue;
+      // Once a session's PR is merged, do not re-run detectPR. The head
+      // branch is typically deleted on merge and session.branch may have
+      // drifted to the default branch (e.g. agent-side `git checkout main`);
+      // detectPR on the default branch would then match unrelated PRs
+      // (including fork PRs that share the head ref name). The merged PR
+      // association is settled — preserve it.
+      // Note: `closed` (unmerged) intentionally does NOT short-circuit here;
+      // an agent that pivots to a new branch after a closed PR should be
+      // able to rediscover the follow-up PR via detectPR.
+      if (session.lifecycle.pr.state === "merged") {
+        continue;
+      }
       if (
         session.pr &&
         !(session.lifecycle.pr.state === "closed" && session.pr.branch !== session.branch)

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2801,6 +2801,23 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       throw new SessionNotRestorableError(sessionId, reason);
     }
 
+    // 3a. Refuse to silently revive a session whose PR has reached a terminal
+    //     state. The original branch has typically been deleted on merge, so
+    //     `session.branch` may have drifted to the project default branch
+    //     between the kill and the restore. Re-spawning would associate the
+    //     session with whatever PR `detectPR` finds on that branch — including
+    //     unrelated fork PRs (see #1724). If the user wants a fresh session
+    //     in this workspace, they should spawn a new one.
+    const prState = session.lifecycle.pr.state;
+    if (prState === "merged" || prState === "closed") {
+      const prRef = session.lifecycle.pr.url ?? session.pr?.url ?? raw["pr"] ?? "(unknown)";
+      throw new SessionNotRestorableError(
+        sessionId,
+        `PR ${prRef} is ${prState}; the session's work is complete. ` +
+          `Spawn a new session for follow-up work instead of restoring.`,
+      );
+    }
+
     // 4. Validate required plugins (plugins already resolved above for enrichment)
     if (!plugins.runtime) {
       throw new Error(`Runtime plugin '${project.runtime ?? config.defaults.runtime}' not found`);
@@ -2967,16 +2984,8 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     restoredLifecycle.runtime.handle = handle;
     restoredLifecycle.runtime.lastObservedAt = now;
 
-    // Reset terminal PR state so the lifecycle manager doesn't immediately
-    // re-terminate the session. The old PR is done — if the agent creates
-    // a new one, PR auto-detect will pick it up.
-    if (restoredLifecycle.pr.state === "merged" || restoredLifecycle.pr.state === "closed") {
-      restoredLifecycle.pr.state = "none";
-      restoredLifecycle.pr.reason = "cleared_on_restore";
-      restoredLifecycle.pr.number = null;
-      restoredLifecycle.pr.url = null;
-      restoredLifecycle.pr.lastObservedAt = null;
-    }
+    // Terminal PR state (merged/closed) is rejected up-front in step 3a, so
+    // by here the lifecycle.pr is non-terminal and is preserved as-is.
 
     updateMetadata(sessionsDir, sessionId, {
       ...buildLifecycleMetadataPatch(restoredLifecycle),

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -650,10 +650,13 @@ function createGitHubSCM(): SCM {
         }> = JSON.parse(raw);
 
         // Only same-repo PRs auto-associate. Fork PRs (different head owner)
-        // are someone else's work — never the session's.
+        // are someone else's work — never the session's. Strict-by-default:
+        // a missing/null/empty headOwner is rejected so a future gh API
+        // change or deleted-account edge case can't quietly let a fork PR
+        // through.
         const sameRepoPrs = prs.filter((pr) => {
           const headOwner = pr.headRepositoryOwner?.login;
-          return !headOwner || headOwner === owner;
+          return typeof headOwner === "string" && headOwner === owner;
         });
 
         if (sameRepoPrs.length === 0) return null;

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -607,6 +607,12 @@ function createGitHubSCM(): SCM {
 
     async detectPR(session: Session, project: ProjectConfig): Promise<PRInfo | null> {
       if (!session.branch || !project.repo) return null;
+      // Refuse to associate a session with the project's default branch.
+      // `gh pr list --head <branch>` matches PRs across all forks, so when
+      // session.branch === defaultBranch (typically "main") we'd match
+      // unrelated contributors' fork PRs. A worker session should never
+      // legitimately have its head ref be the default branch.
+      if (project.defaultBranch && session.branch === project.defaultBranch) return null;
       parseProjectRepo(project.repo);
       const [owner, repoName] = project.repo.split("/");
       // Positive-only cache: never cache [] (null). A just-created PR must
@@ -624,9 +630,13 @@ function createGitHubSCM(): SCM {
           "--head",
           session.branch,
           "--json",
-          "number,url,title,headRefName,baseRefName,isDraft",
+          "number,url,title,headRefName,baseRefName,isDraft,headRepositoryOwner",
+          // Pull more rows than we need so we can filter out fork-owned PRs
+          // before picking one. `--head` matches by branch name only and
+          // returns PRs from forks where the contributor's branch happens to
+          // share the name (very common when the branch is "main").
           "--limit",
-          "1",
+          "10",
         ]);
 
         const prs: Array<{
@@ -636,11 +646,19 @@ function createGitHubSCM(): SCM {
           headRefName: string;
           baseRefName: string;
           isDraft: boolean;
+          headRepositoryOwner?: { login?: string } | null;
         }> = JSON.parse(raw);
 
-        if (prs.length === 0) return null;
+        // Only same-repo PRs auto-associate. Fork PRs (different head owner)
+        // are someone else's work — never the session's.
+        const sameRepoPrs = prs.filter((pr) => {
+          const headOwner = pr.headRepositoryOwner?.login;
+          return !headOwner || headOwner === owner;
+        });
 
-        const info = prInfoFromView(prs[0], project.repo);
+        if (sameRepoPrs.length === 0) return null;
+
+        const info = prInfoFromView(sameRepoPrs[0], project.repo);
         writePRCache(cacheK, info, PR_CACHE_TTL_MS.detectPR);
         return info;
       } catch {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -400,6 +400,7 @@ describe("scm-github plugin", () => {
           headRefName: "feat/my-feature",
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
 
@@ -459,10 +460,35 @@ describe("scm-github plugin", () => {
           headRefName: "feat/my-feature",
           baseRefName: "main",
           isDraft: true,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       const result = await scm.detectPR(makeSession(), project);
       expect(result?.isDraft).toBe(true);
+    });
+
+    it("rejects PRs with missing/null headRepositoryOwner (strict-by-default)", async () => {
+      mockGh([
+        {
+          number: 50,
+          url: "https://github.com/acme/repo/pull/50",
+          title: "owner missing",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+          headRepositoryOwner: null,
+        },
+        {
+          number: 51,
+          url: "https://github.com/acme/repo/pull/51",
+          title: "owner field absent",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result).toBeNull();
     });
 
     it("returns null when session.branch === project.defaultBranch", async () => {
@@ -1334,6 +1360,7 @@ describe("scm-github plugin", () => {
           headRefName: "feat/my-feature",
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       const a = await scm.detectPR(makeSession(), project);
@@ -1366,6 +1393,7 @@ describe("scm-github plugin", () => {
           headRefName: "feat/my-feature",
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       const after = await scm.detectPR(makeSession(), project);
@@ -1382,6 +1410,7 @@ describe("scm-github plugin", () => {
           headRefName: "feat/a",
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       mockGh([
@@ -1392,6 +1421,7 @@ describe("scm-github plugin", () => {
           headRefName: "feat/b",
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       const a = await scm.detectPR(makeSession({ branch: "feat/a" }), project);
@@ -1410,6 +1440,7 @@ describe("scm-github plugin", () => {
           headRefName: pr.branch,
           baseRefName: "main",
           isDraft: false,
+          headRepositoryOwner: { login: "acme" },
         },
       ]);
       await scm.detectPR(makeSession({ branch: pr.branch }), project);

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -465,6 +465,67 @@ describe("scm-github plugin", () => {
       expect(result?.isDraft).toBe(true);
     });
 
+    it("returns null when session.branch === project.defaultBranch", async () => {
+      const result = await scm.detectPR(
+        makeSession({ branch: "main" }),
+        { ...project, defaultBranch: "main" },
+      );
+      expect(result).toBeNull();
+      // Must short-circuit before any gh call — fork PRs on `--head main`
+      // would otherwise be incorrectly auto-associated.
+      expect(ghMock).not.toHaveBeenCalled();
+    });
+
+    it("filters out fork-owned PRs (different headRepositoryOwner)", async () => {
+      mockGh([
+        {
+          number: 643,
+          url: "https://github.com/acme/repo/pull/643",
+          title: "Fork PR by other contributor",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+          headRepositoryOwner: { login: "MayurVirkar" },
+        },
+        {
+          number: 415,
+          url: "https://github.com/acme/repo/pull/415",
+          title: "Another fork PR",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+          headRepositoryOwner: { login: "zvictor" },
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result).toBeNull();
+    });
+
+    it("picks the same-repo PR when fork and same-repo PRs both match", async () => {
+      mockGh([
+        {
+          number: 643,
+          url: "https://github.com/acme/repo/pull/643",
+          title: "Fork PR",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+          headRepositoryOwner: { login: "fork-owner" },
+        },
+        {
+          number: 42,
+          url: "https://github.com/acme/repo/pull/42",
+          title: "Same-repo PR",
+          headRefName: "feat/my-feature",
+          baseRefName: "main",
+          isDraft: false,
+          headRepositoryOwner: { login: "acme" },
+        },
+      ]);
+      const result = await scm.detectPR(makeSession(), project);
+      expect(result?.number).toBe(42);
+    });
+
     it("resolves PR by reference", async () => {
       mockGh({
         number: 42,


### PR DESCRIPTION
## Summary

Three layered fixes for #1724, where a restored worker session whose PR had merged got silently re-associated with an unrelated fork PR (in the reported repro: `ao-179` (release worker for #1723) ended up polling CI/reviews for fork PR #643 after restore).

Per-commit:

1. **`fix(scm-github): drop fork PRs and default-branch sessions from detectPR`** — `detectPR` now (a) returns `null` when `session.branch === project.defaultBranch`, and (b) requests `headRepositoryOwner` from `gh pr list` and discards PRs whose head owner differs from the repo owner. The `gh pr list --head <branch>` filter previously matched any PR with that head ref name across all forks.
2. **`fix(lifecycle): skip detectPR for sessions whose PR is already merged`** — lifecycle-manager short-circuits `scm.detectPR` when `session.lifecycle.pr.state === "merged"`. Branch drift between poll cycles (agent runs `git checkout main`, branch metadata hook fires, lifecycle observes branch=main) was the trigger that let detectPR run against the default branch and pick up unrelated PRs. Closed (unmerged) PRs intentionally still go through detectPR so the existing follow-up-PR rediscovery flow is preserved.
3. **`fix(session-manager): refuse to restore sessions with merged/closed PRs`** — restore now throws `SessionNotRestorableError` up-front when the session's PR is in a terminal state. Previously restore silently cleared `lifecycle.pr.*` and reset `session.state` to `working`, which combined with branch drift caused the bug. The dead clear-on-restore block has been removed.

## Investigation notes

- Repro metadata at `~/.agent-orchestrator/projects/agent-orchestrator/sessions/ao-179.json` showed: `branch: "main"`, `lifecycle.pr.number: 643`, `lifecycle.pr.state: "open"`, `agentReportedPrUrl: ".../pull/1723"`.
- `lifecycle-manager.ts:657-662` previously guarded detectPR by `session.pr` truthiness; once `repairSessionMetadataOnRead` (session-manager.ts:623-665) cleared `pr` for duplicate-PR-attached sessions, detectPR ran unguarded against `session.branch="main"` and matched fork PRs (`gh pr list --head main` returns #643 by MayurVirkar and #415 by zvictor).
- `scm-github/src/index.ts::detectPR` requested `--head <branch>` without owner filtering — the entry point for the fork-match.
- The exact code path that promoted `branch` from `chore/release-0.6.0` → `"main"` is the agent-side metadata hook (`agent-claude-code/src/index.ts:188-200`) firing on a `git checkout main` invocation post-merge. It is not pinpointed in this PR because the three fixes here neutralize the impact regardless of how the branch drifted.

## Invariants preserved

- **scm-github:** `detectPR` semantics unchanged for non-default branches with same-repo PRs (existing tests still green).
- **lifecycle:** sessions with `pr.state` in `{"open", "none"}` continue to be auto-detected; the existing `closed`-PR + branch-switch follow-up-detection test still passes; orchestrator/auto-detect-off opt-outs continue to take precedence.
- **session-manager:** `isRestorable` semantics unchanged for terminated/done/runtime-lost; only the PR-terminal sub-case now refuses with an explicit reason. Workers with `pr.state` of `"open"`/`"none"` still restore normally.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm --filter @aoagents/ao-core test` — 1102 unit tests pass; 6 unrelated FTS5 failures stem from a missing `better-sqlite3` native binding in the local sandbox (pre-existing, not caused by this PR)
- [x] `pnpm --filter @aoagents/ao-plugin-scm-github test` — 172 tests pass
- [x] New regression tests:
  - `scm-github`: same-repo PR preferred when both fork and same-repo PRs match; fork-only matches return `null`; `branch === defaultBranch` short-circuits without calling `gh`
  - `lifecycle-manager`: merged-PR session does not call `detectPR`
  - `session-manager`: restoring a session with `status: "merged"` rejects with `/is merged/`
- [ ] CI

Closes #1724.