### PR TITLE
fix: enable tmux mouse mode on web terminal attach

### DIFF
--- a/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
+++ b/packages/web/server/__tests__/direct-terminal-ws.integration.test.ts
@@ -16,6 +16,7 @@ import { createDirectTerminalServer, type DirectTerminalServer } from "../direct
 
 const TMUX = findTmux();
 const TEST_SESSION = `ao-test-integration-${process.pid}`;
+const TEST_MOUSE_SESSION = `ao-test-mouse-${process.pid}`;
 const TEST_HASH_SESSION = `abcdef123456-ao-test-hash-${process.pid}`;
 const TEST_SPACED_TARGET = `abcdef123456-my project-${process.pid}`;
 
@@ -81,12 +82,41 @@ function waitForMessage(
   });
 }
 
+async function waitForTmuxOption(sessionName: string, option: string): Promise<string> {
+  const deadline = Date.now() + 3000;
+  let lastOutput = "";
+
+  while (Date.now() < deadline) {
+    try {
+      lastOutput = execFileSync(TMUX, ["show-option", "-t", sessionName, option], {
+        timeout: 5000,
+        encoding: "utf8",
+      }).trim();
+      if (lastOutput) {
+        return lastOutput;
+      }
+    } catch {
+      /* keep polling until tmux applies the option or the timeout expires */
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  return lastOutput;
+}
+
 // =============================================================================
 // Lifecycle
 // =============================================================================
 
 beforeAll(() => {
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_SESSION, "-x", "80", "-y", "24"], {
+    timeout: 5000,
+  });
+  execFileSync(TMUX, ["new-session", "-d", "-s", TEST_MOUSE_SESSION, "-x", "80", "-y", "24"], {
+    timeout: 5000,
+  });
+  execFileSync(TMUX, ["set-option", "-t", TEST_MOUSE_SESSION, "mouse", "off"], {
     timeout: 5000,
   });
   execFileSync(TMUX, ["new-session", "-d", "-s", TEST_HASH_SESSION, "-x", "80", "-y", "24"], {
@@ -106,6 +136,11 @@ afterAll(() => {
   terminal.shutdown();
   try {
     execFileSync(TMUX, ["kill-session", "-t", TEST_SESSION], { timeout: 5000 });
+  } catch {
+    /* */
+  }
+  try {
+    execFileSync(TMUX, ["kill-session", "-t", TEST_MOUSE_SESSION], { timeout: 5000 });
   } catch {
     /* */
   }
@@ -201,6 +236,25 @@ describe("mux terminal open", () => {
 
     const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
     expect(msg.id).toBe("test-session");
+
+    ws.close();
+  });
+
+  it("enables tmux mouse mode when opening a terminal over mux", async () => {
+    const ws = await connectMux();
+
+    ws.send(
+      JSON.stringify({
+        ch: "terminal",
+        id: "mouse-session",
+        tmuxName: TEST_MOUSE_SESSION,
+        type: "open",
+      }),
+    );
+
+    const msg = await waitForMessage(ws, (m) => m.ch === "terminal" && m.type === "opened");
+    expect(msg.id).toBe("mouse-session");
+    await expect(waitForTmuxOption(TEST_MOUSE_SESSION, "mouse")).resolves.toBe("mouse on");
 
     ws.close();
   });

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -41,6 +41,12 @@ const { SessionBroadcaster, TerminalManager } = await import("../mux-websocket")
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
+function makeMockProcess(): EventEmitter & { stderr: EventEmitter } {
+  const proc = new EventEmitter() as EventEmitter & { stderr: EventEmitter };
+  proc.stderr = new EventEmitter();
+  return proc;
+}
+
 describe("SessionBroadcaster", () => {
   let broadcaster: SessionBroadcasterType;
 
@@ -262,13 +268,13 @@ describe("SessionBroadcaster", () => {
   });
 });
 
-describe("TerminalManager.open — tmux target args (regression for #1714)", () => {
+describe("TerminalManager.open — tmux set-option handling (regression for #1704)", () => {
   beforeEach(() => {
     mockSpawn.mockReset();
     mockPtySpawn.mockReset();
 
     // spawn() returns an object that emits "error" — we just need .on() to work.
-    mockSpawn.mockImplementation(() => new EventEmitter());
+    mockSpawn.mockImplementation(() => makeMockProcess());
 
     // ptySpawn() returns a minimal IPty-like stub so terminal wiring doesn't crash.
     mockPtySpawn.mockImplementation(() => ({
@@ -309,5 +315,29 @@ describe("TerminalManager.open — tmux target args (regression for #1714)", () 
     expect(mockPtySpawn).toHaveBeenCalledTimes(1);
     const [, args] = mockPtySpawn.mock.calls[0];
     expect(args).toEqual(["attach-session", "-t", "=ao-177"]);
+  });
+
+  it("logs non-zero set-option exits with tmux stderr", () => {
+    const procs: Array<EventEmitter & { stderr: EventEmitter }> = [];
+    mockSpawn.mockImplementation(() => {
+      const proc = makeMockProcess();
+      procs.push(proc);
+      return proc;
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      const mgr = new TerminalManager("/usr/bin/tmux");
+      mgr.open("ao-177");
+
+      procs[0].stderr.emit("data", Buffer.from("no such session: =ao-177\n"));
+      procs[0].emit("exit", 1, null);
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        "[MuxServer] Failed to set mouse mode for ao-177: tmux set-option exit 1: no such session: =ao-177",
+      );
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -230,6 +230,36 @@ export class TerminalManager {
     this.TMUX = tmuxPath ?? findTmux();
   }
 
+  private setTmuxOption(
+    tmuxSessionId: string,
+    option: string,
+    value: string,
+    description: string,
+  ): void {
+    const proc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, option, value]);
+    let stderr = "";
+
+    proc.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+
+    proc.on("error", (err) => {
+      console.error(`[MuxServer] Failed to ${description} for ${tmuxSessionId}:`, err.message);
+    });
+
+    proc.on("exit", (code, signal) => {
+      if (code === 0) {
+        return;
+      }
+
+      const reason = code === null ? `signal ${signal ?? "unknown"}` : `exit ${code}`;
+      const detail = stderr.trim();
+      console.error(
+        `[MuxServer] Failed to ${description} for ${tmuxSessionId}: tmux set-option ${reason}${detail ? `: ${detail}` : ""}`,
+      );
+    });
+  }
+
   private terminalKey(id: string, projectId?: string): string {
     return projectId ? `${projectId}:${id}` : id;
   }
@@ -279,16 +309,10 @@ export class TerminalManager {
     // here. The `=`-prefixed form is built below for attach-session.
 
     // Enable mouse mode
-    const mouseProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "mouse", "on"]);
-    mouseProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to set mouse mode for ${tmuxSessionId}:`, err.message);
-    });
+    this.setTmuxOption(tmuxSessionId, "mouse", "on", "set mouse mode");
 
     // Hide the status bar
-    const statusProc = spawn(this.TMUX, ["set-option", "-t", tmuxSessionId, "status", "off"]);
-    statusProc.on("error", (err) => {
-      console.error(`[MuxServer] Failed to hide status bar for ${tmuxSessionId}:`, err.message);
-    });
+    this.setTmuxOption(tmuxSessionId, "status", "off", "hide status bar");
 
     // Build environment
     const homeDir = process.env.HOME || homedir();


### PR DESCRIPTION
## Summary
- keep tmux `set-option` targets bare while preserving exact-match `attach-session` targets
- log non-zero `set-option` exits with stderr so tmux option failures are visible
- add unit and mux integration coverage that verifies `tmux show-option -t <session> mouse` becomes `mouse on`

Fixes #1704

## Validation
- `pnpm --filter @aoagents/ao-web test -- server/__tests__/mux-websocket.test.ts server/__tests__/direct-terminal-ws.integration.test.ts`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `NODE_ENV=production pnpm build` (passes; plain `pnpm build` failed in this shell because `NODE_ENV=development` is exported)

## Known unrelated test failures observed
- `pnpm test` fails in `packages/cli/__tests__/commands/start.test.ts` on the existing test "ao start <project> while daemon alive but project removed..." timing out after 10s; rerunning that file reproduces the same timeout.
- `pnpm --filter @aoagents/ao-web test` fails in unrelated API/session/debug tests: PR enrichment call count expectations, debug bundle default visibility, and `TestErrorBoundary is not defined` in `src/app/sessions/[id]/page.test.tsx`.
