### PR TITLE
fix(web): remove stale GitHub rate-limit banner

### DIFF
--- a/packages/web/src/components/BottomSheet.tsx
+++ b/packages/web/src/components/BottomSheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import { getAttentionLevel, isPRRateLimited, isPRUnenriched, type DashboardSession } from "@/lib/types";
+import { getAttentionLevel, isPRUnenriched, type DashboardSession } from "@/lib/types";
 import { getSessionTitle } from "@/lib/format";
 import { projectSessionPath } from "@/lib/routes";
 
@@ -24,12 +24,10 @@ function formatTagLabel(value: string): string {
 }
 
 function isTag(
-  value:
-    | {
-        label: string;
-        tone: "accent" | "neutral" | "mono";
-      }
-    | null,
+  value: {
+    label: string;
+    tone: "accent" | "neutral" | "mono";
+  } | null,
 ): value is { label: string; tone: "accent" | "neutral" | "mono" } {
   return value !== null;
 }
@@ -76,7 +74,7 @@ export function BottomSheet({
     if (!sheetRef.current) return;
 
     const focusable = sheetRef.current.querySelectorAll<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
     );
     if (focusable.length === 0) return;
 
@@ -122,13 +120,13 @@ export function BottomSheet({
 
   const title = getSessionTitle(session);
   const attention = getAttentionLevel(session);
-  const summary =
-    session.summary && !session.summaryIsFallback ? session.summary : null;
+  const summary = session.summary && !session.summaryIsFallback ? session.summary : null;
   const hasLiveTerminateAction =
     attention !== "done" && attention !== "merge" && session.status !== "terminated";
   const pr = session.pr;
-  const showLivePrData = Boolean(pr && !isPRRateLimited(pr) && !isPRUnenriched(pr));
-  const showTerminalStatePills = attention === "done" || session.status === "terminated" || session.activity === "exited";
+  const showLivePrData = Boolean(pr && !isPRUnenriched(pr));
+  const showTerminalStatePills =
+    attention === "done" || session.status === "terminated" || session.activity === "exited";
   const tags = [
     { label: formatTagLabel(attention), tone: "accent" as const },
     { label: formatTagLabel(session.status), tone: "neutral" as const },
@@ -141,11 +139,7 @@ export function BottomSheet({
   return (
     <>
       {/* Backdrop */}
-      <div
-        className="bottom-sheet-backdrop"
-        onClick={onCancel}
-        aria-hidden="true"
-      />
+      <div className="bottom-sheet-backdrop" onClick={onCancel} aria-hidden="true" />
 
       {/* Sheet */}
       <div
@@ -191,7 +185,9 @@ export function BottomSheet({
               <div className="bottom-sheet__preview-content">
                 <div className="bottom-sheet__preview-header">
                   <span className="bottom-sheet__preview-id">{session.id}</span>
-                  <span className="bottom-sheet__preview-time">{getRelativeTime(session.lastActivityAt)}</span>
+                  <span className="bottom-sheet__preview-time">
+                    {getRelativeTime(session.lastActivityAt)}
+                  </span>
                 </div>
                 <h2 id="bottom-sheet-title" className="bottom-sheet__title">
                   {title}
@@ -207,8 +203,7 @@ export function BottomSheet({
                   {pr ? <span className="bottom-sheet__preview-pr">#{pr.number}</span> : null}
                   {showLivePrData && pr ? (
                     <span className="bottom-sheet__preview-diff">
-                      <span className="bottom-sheet__preview-diff-add">+{pr.additions}</span>
-                      {" "}
+                      <span className="bottom-sheet__preview-diff-add">+{pr.additions}</span>{" "}
                       <span className="bottom-sheet__preview-diff-del">-{pr.deletions}</span>
                     </span>
                   ) : null}
@@ -228,7 +223,7 @@ export function BottomSheet({
                         ? "approved"
                         : pr.reviewDecision === "changes_requested"
                           ? "changes requested"
-                        : "needs review"}
+                          : "needs review"}
                     </span>
                     {showTerminalStatePills ? (
                       <span className="bottom-sheet__tag bottom-sheet__tag--accent">

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -11,7 +11,6 @@ import {
   type DashboardOrchestratorLink,
   type DashboardAttentionZoneMode,
   getAttentionLevel,
-  isPRRateLimited,
 } from "@/lib/types";
 import { AttentionZone } from "./AttentionZone";
 import { DynamicFavicon, countNeedingAttention } from "./DynamicFavicon";
@@ -173,9 +172,11 @@ function DashboardInner({
     return sessions.filter((s) => s.projectId === projectId);
   }, [sessions, projectId]);
   const connectionStatus: "connected" | "reconnecting" | "disconnected" =
-    mux?.status === "disconnected" ? "disconnected"
-    : mux?.status === "connected" ? "connected"
-    : "reconnecting";
+    mux?.status === "disconnected"
+      ? "disconnected"
+      : mux?.status === "connected"
+        ? "connected"
+        : "reconnecting";
   const recoveredFromLoadError = Boolean(dashboardLoadError) && liveSessionsResolved;
   const ssrLoadError = recoveredFromLoadError ? undefined : dashboardLoadError;
   // Live WS error takes precedence; fall back to SSR load error when live data hasn't resolved it.
@@ -185,7 +186,6 @@ function DashboardInner({
   const routerRef = useRef(router);
   routerRef.current = router;
   const activeSessionId = searchParams.get("session") ?? undefined;
-  const [rateLimitDismissed, setRateLimitDismissed] = useState(false);
   const [activeOrchestrators, setActiveOrchestrators] =
     useState<DashboardOrchestratorLink[]>(orchestratorLinks);
   const [spawningProjectIds, setSpawningProjectIds] = useState<string[]>([]);
@@ -457,9 +457,7 @@ function DashboardInner({
       <span className="font-semibold text-[var(--color-status-error)]">
         Orchestrator failed to load
       </span>
-      <span className="break-words text-[var(--color-text-secondary)]">
-        {visibleLoadError}
-      </span>
+      <span className="break-words text-[var(--color-text-secondary)]">{visibleLoadError}</span>
       <span className="text-[var(--color-text-secondary)]">
         Confirm <span className="font-mono text-[10px]">agent-orchestrator.yaml</span> exists and is
         valid, then run <span className="font-mono text-[10px]">ao doctor</span> for diagnostics.
@@ -467,10 +465,6 @@ function DashboardInner({
     </div>
   ) : null;
 
-  const anyRateLimited = useMemo(
-    () => sessions.some((session) => session.pr && isPRRateLimited(session.pr)),
-    [sessions],
-  );
   const normalizedProjectName = projectName?.trim().toLowerCase();
   const headerProjectLabel =
     normalizedProjectName === "agent orchestrator"
@@ -624,40 +618,6 @@ function DashboardInner({
 
               <div className="dashboard-main__body">
                 {loadErrorBanner}
-                {anyRateLimited && !rateLimitDismissed && (
-                  <div className="dashboard-alert mb-4 flex items-center gap-2.5 border border-[color-mix(in_srgb,var(--color-status-attention)_25%,transparent)] bg-[var(--color-tint-yellow)] px-3.5 py-2.5 text-[11px] text-[var(--color-status-attention)]">
-                    <svg
-                      className="h-3.5 w-3.5 shrink-0"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle cx="12" cy="12" r="10" />
-                      <path d="M12 8v4M12 16h.01" />
-                    </svg>
-                    <span className="flex-1">
-                      GitHub API rate limited — PR data (CI status, review state, sizes) may be
-                      stale. Will retry automatically on next refresh.
-                    </span>
-                    <button
-                      onClick={() => setRateLimitDismissed(true)}
-                      className="ml-1 shrink-0 opacity-60 hover:opacity-100"
-                      aria-label="Dismiss"
-                    >
-                      <svg
-                        className="h-3.5 w-3.5"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        viewBox="0 0 24 24"
-                      >
-                        <path d="M18 6 6 18M6 6l12 12" />
-                      </svg>
-                    </button>
-                  </div>
-                )}
-
                 {allProjectsView && (
                   <ProjectOverviewGrid
                     overviews={projectOverviews}

--- a/packages/web/src/components/PRStatus.tsx
+++ b/packages/web/src/components/PRStatus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { type DashboardPR, isPRRateLimited, isPRUnenriched } from "@/lib/types";
+import { type DashboardPR, isPRUnenriched } from "@/lib/types";
 import { CIBadge } from "./CIBadge";
 
 export function getSizeLabel(additions: number, deletions: number): string {
@@ -14,7 +14,6 @@ interface PRStatusProps {
 
 export function PRStatus({ pr }: PRStatusProps) {
   const sizeLabel = getSizeLabel(pr.additions, pr.deletions);
-  const rateLimited = isPRRateLimited(pr);
   const unenriched = isPRUnenriched(pr);
 
   return (
@@ -30,14 +29,14 @@ export function PRStatus({ pr }: PRStatusProps) {
         #{pr.number}
       </a>
 
-      {/* Size — shimmer when unenriched, hide when rate limited */}
-      {!rateLimited && (unenriched ? (
+      {/* Size — shimmer when unenriched */}
+      {unenriched ? (
         <span className="inline-block h-[14px] w-16 animate-pulse rounded-full bg-[var(--color-bg-subtle)]" />
       ) : (
         <span className="inline-flex items-center rounded-full bg-[rgba(125,133,144,0.08)] px-2 py-0.5 text-[10px] font-semibold text-[var(--color-text-muted)]">
           +{pr.additions} -{pr.deletions} {sizeLabel}
         </span>
-      ))}
+      )}
 
       {/* Merged badge */}
       {pr.state === "merged" && (
@@ -54,14 +53,16 @@ export function PRStatus({ pr }: PRStatusProps) {
       )}
 
       {/* CI status — shimmer when unenriched */}
-      {pr.state === "open" && !pr.isDraft && !rateLimited && (unenriched ? (
-        <span className="inline-block h-[14px] w-14 animate-pulse rounded-full bg-[var(--color-bg-subtle)]" />
-      ) : (
-        <CIBadge status={pr.ciStatus} checks={pr.ciChecks} />
-      ))}
+      {pr.state === "open" &&
+        !pr.isDraft &&
+        (unenriched ? (
+          <span className="inline-block h-[14px] w-14 animate-pulse rounded-full bg-[var(--color-bg-subtle)]" />
+        ) : (
+          <CIBadge status={pr.ciStatus} checks={pr.ciChecks} />
+        ))}
 
       {/* Review decision (only for open PRs with real data) */}
-      {pr.state === "open" && pr.reviewDecision === "approved" && !rateLimited && !unenriched && (
+      {pr.state === "open" && pr.reviewDecision === "approved" && !unenriched && (
         <span className="inline-flex items-center rounded-full bg-[rgba(63,185,80,0.1)] px-2 py-0.5 text-[10px] font-semibold text-[var(--color-accent-green)]">
           approved
         </span>
@@ -77,9 +78,8 @@ interface PRTableRowProps {
 
 export function PRTableRow({ pr, muted = false }: PRTableRowProps) {
   const sizeLabel = getSizeLabel(pr.additions, pr.deletions);
-  const rateLimited = isPRRateLimited(pr);
   const unenriched = isPRUnenriched(pr);
-  const hideData = rateLimited || unenriched;
+  const hideData = unenriched;
 
   const reviewLabel = hideData
     ? "—"
@@ -87,13 +87,13 @@ export function PRTableRow({ pr, muted = false }: PRTableRowProps) {
       ? "merged"
       : pr.state === "closed"
         ? "closed"
-    : pr.isDraft
-      ? "draft"
-      : pr.reviewDecision === "approved"
-        ? "approved"
-        : pr.reviewDecision === "changes_requested"
-          ? "changes requested"
-          : "needs review";
+        : pr.isDraft
+          ? "draft"
+          : pr.reviewDecision === "approved"
+            ? "approved"
+            : pr.reviewDecision === "changes_requested"
+              ? "changes requested"
+              : "needs review";
 
   const reviewClass = hideData
     ? "text-[var(--color-text-tertiary)]"
@@ -105,10 +105,14 @@ export function PRTableRow({ pr, muted = false }: PRTableRowProps) {
           ? "text-[var(--color-accent-red)]"
           : "text-[var(--color-accent-yellow)]";
 
-  const shimmer = <span className="inline-block h-3 w-12 animate-pulse rounded bg-[var(--color-bg-subtle)]" />;
+  const shimmer = (
+    <span className="inline-block h-3 w-12 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+  );
 
   return (
-    <tr className={`border-b border-[var(--color-border-subtle)] transition-colors hover:bg-[var(--color-bg-subtle)]${muted ? " opacity-60 hover:opacity-100" : ""}`}>
+    <tr
+      className={`border-b border-[var(--color-border-subtle)] transition-colors hover:bg-[var(--color-bg-subtle)]${muted ? " opacity-60 hover:opacity-100" : ""}`}
+    >
       <td className="px-3 py-2.5 text-sm">
         <a href={pr.url} target="_blank" rel="noopener noreferrer" className="hover:underline">
           #{pr.number}
@@ -120,8 +124,8 @@ export function PRTableRow({ pr, muted = false }: PRTableRowProps) {
         </a>
       </td>
       <td className="px-3 py-2.5 text-sm">
-        {unenriched ? shimmer : rateLimited ? (
-          <span className="text-[var(--color-text-tertiary)]">—</span>
+        {unenriched ? (
+          shimmer
         ) : (
           <>
             <span className="text-[var(--color-accent-green)]">+{pr.additions}</span>{" "}
@@ -131,11 +135,7 @@ export function PRTableRow({ pr, muted = false }: PRTableRowProps) {
         )}
       </td>
       <td className="px-3 py-2.5">
-        {unenriched ? shimmer : rateLimited ? (
-          <span className="text-[var(--color-text-tertiary)]">—</span>
-        ) : (
-          <CIBadge status={pr.ciStatus} checks={pr.ciChecks} compact />
-        )}
+        {unenriched ? shimmer : <CIBadge status={pr.ciStatus} checks={pr.ciChecks} compact />}
       </td>
       <td className={`px-3 py-2.5 text-xs font-semibold ${reviewClass}`}>
         {unenriched ? shimmer : reviewLabel}
@@ -168,9 +168,8 @@ function getReviewColor(pr: DashboardPR): string {
 }
 
 export function PRCard({ pr, muted = false }: PRTableRowProps) {
-  const rateLimited = isPRRateLimited(pr);
   const unenriched = isPRUnenriched(pr);
-  const hideData = rateLimited || unenriched;
+  const hideData = unenriched;
 
   const ciLabel = hideData
     ? "—"
@@ -194,7 +193,9 @@ export function PRCard({ pr, muted = false }: PRTableRowProps) {
               ? "changes"
               : "needs review";
 
-  const shimmer = <span className="inline-block h-3 w-10 animate-pulse rounded bg-[var(--color-bg-subtle)]" />;
+  const shimmer = (
+    <span className="inline-block h-3 w-10 animate-pulse rounded bg-[var(--color-bg-subtle)]" />
+  );
   const diffLabel = hideData ? null : `+${pr.additions} -${pr.deletions}`;
   const lineTone =
     pr.state === "merged"
@@ -219,7 +220,9 @@ export function PRCard({ pr, muted = false }: PRTableRowProps) {
         <span className="mobile-pr-card__title">{pr.title}</span>
       </div>
       <div className={`mobile-pr-card__meta ${lineTone}`}>
-        {unenriched ? shimmer : (
+        {unenriched ? (
+          shimmer
+        ) : (
           <span className="mobile-pr-card__metric-value">
             <span
               className="mobile-pr-card__ci-dot"
@@ -228,12 +231,13 @@ export function PRCard({ pr, muted = false }: PRTableRowProps) {
             <span style={{ color: hideData ? undefined : getCiTextColor(pr) }}>{ciLabel}</span>
           </span>
         )}
-        <span className="mobile-pr-card__review" style={{ color: hideData ? undefined : getReviewColor(pr) }}>
+        <span
+          className="mobile-pr-card__review"
+          style={{ color: hideData ? undefined : getReviewColor(pr) }}
+        >
           {unenriched ? shimmer : reviewLabel}
         </span>
-        <span className="mobile-pr-card__diff">
-          {hideData ? shimmer : diffLabel}
-        </span>
+        <span className="mobile-pr-card__diff">{hideData ? shimmer : diffLabel}</span>
       </div>
     </a>
   );

--- a/packages/web/src/components/SessionCard.tsx
+++ b/packages/web/src/components/SessionCard.tsx
@@ -4,7 +4,6 @@ import { memo, useState, useEffect, useRef } from "react";
 import {
   type DashboardSession,
   getAttentionLevel,
-  isPRRateLimited,
   isPRUnenriched,
   CI_STATUS,
   getSessionTruthLabel,
@@ -208,19 +207,16 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
     }
   };
 
-  const rateLimited = pr ? isPRRateLimited(pr) : false;
   const prUnenriched = pr ? isPRUnenriched(pr) : false;
   const alerts = getAlerts(session);
-  const isReadyToMerge = !rateLimited && pr?.mergeability.mergeable && pr.state === "open";
+  const isReadyToMerge = pr?.mergeability.mergeable && pr.state === "open";
   const isTerminal = isDashboardSessionTerminal(session);
   const isRestorable = isDashboardSessionRestorable(session);
 
   const title = getSessionTitle(session);
   const footerStatus = getFooterStatusLabel(session, level, Boolean(isReadyToMerge));
   const visiblePassingChecks =
-    !rateLimited && pr && !prUnenriched
-      ? pr.ciChecks.filter((check) => check.status === "passed").slice(0, 3)
-      : [];
+    pr && !prUnenriched ? pr.ciChecks.filter((check) => check.status === "passed").slice(0, 3) : [];
   const isDone = isDashboardSessionDone(session) || level === "done";
   const truthLine = session.lifecycle
     ? [
@@ -340,7 +336,6 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
             </a>
           )}
           {pr &&
-            !rateLimited &&
             (prUnenriched ? (
               <span className="inline-block h-[14px] w-16 animate-pulse rounded-full bg-[var(--color-bg-subtle)]" />
             ) : (
@@ -583,7 +578,6 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
             </a>
           )}
           {pr &&
-            !rateLimited &&
             (prUnenriched ? (
               <span className="inline-block h-[14px] w-16 animate-pulse rounded-full bg-[var(--color-bg-subtle)]" />
             ) : (
@@ -629,24 +623,6 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
           </div>
         )}
 
-        {rateLimited && pr?.state === "open" && (
-          <div className="px-[10px] pb-[5px]">
-            <span className="inline-flex items-center gap-1 text-[10px] text-[var(--color-text-muted)]">
-              <svg
-                className="h-3 w-3 text-[var(--color-text-tertiary)]"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-              >
-                <circle cx="12" cy="12" r="10" />
-                <path d="M12 8v4M12 16h.01" />
-              </svg>
-              PR data rate limited
-            </span>
-          </div>
-        )}
-
         {visiblePassingChecks.length > 0 && (
           <div className="card__ci">
             {visiblePassingChecks.map((check) => {
@@ -686,7 +662,7 @@ function SessionCardView({ session, onSend, onKill, onMerge, onRestore }: Sessio
           </div>
         )}
 
-        {!rateLimited && alerts.length > 0 && (
+        {alerts.length > 0 && (
           <div className="card__alerts flex flex-col">
             {alerts.slice(0, 3).map((alert) => (
               <div key={alert.key} className={cn("alert-row", `alert-row--${alert.type}`)}>
@@ -928,7 +904,6 @@ interface Alert {
 function getAlerts(session: DashboardSession): Alert[] {
   const pr = session.pr;
   if (!pr || pr.state !== "open") return [];
-  if (isPRRateLimited(pr)) return [];
   if (isPRUnenriched(pr)) return [];
 
   const meta = session.metadata;

--- a/packages/web/src/components/SessionDetailPRCard.tsx
+++ b/packages/web/src/components/SessionDetailPRCard.tsx
@@ -3,12 +3,7 @@
 import { useEffect, useRef, useState } from "react";
 import { CI_STATUS } from "@aoagents/ao-core/types";
 import { cn } from "@/lib/cn";
-import {
-  isPRMergeReady,
-  isPRRateLimited,
-  isPRUnenriched,
-  type DashboardPR,
-} from "@/lib/types";
+import { isPRMergeReady, isPRUnenriched, type DashboardPR } from "@/lib/types";
 import { buildGitHubCompareUrl } from "@/lib/github-links";
 import { PRCommentThread } from "./PRCommentThread";
 
@@ -31,7 +26,7 @@ export interface BlockerChip {
 }
 
 export function hasMergeConflicts(pr: DashboardPR): boolean {
-  const mergeabilityReliable = !isPRUnenriched(pr) && !isPRRateLimited(pr);
+  const mergeabilityReliable = !isPRUnenriched(pr);
   return mergeabilityReliable && pr.state !== "merged" && !pr.mergeability.noConflicts;
 }
 
@@ -62,7 +57,8 @@ export function buildBlockerChips(
     chips.push({
       icon: "✗",
       variant: "fail",
-      text: failCount > 0 ? `${failCount} check${failCount !== 1 ? "s" : ""} failing` : "CI failing",
+      text:
+        failCount > 0 ? `${failCount} check${failCount !== 1 ? "s" : ""} failing` : "CI failing",
       notified: ciNotified,
     });
   } else if (pr.ciStatus === CI_STATUS.PENDING) {
@@ -115,11 +111,7 @@ export function SessionDetailPRCard({
     };
   }, []);
 
-  const handleAskAgentToFix = async (comment: {
-    url: string;
-    path: string;
-    body: string;
-  }) => {
+  const handleAskAgentToFix = async (comment: { url: string; path: string; body: string }) => {
     setSentComments((prev) => {
       const next = new Set(prev);
       next.delete(comment.url);

--- a/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
+++ b/packages/web/src/components/__tests__/Dashboard.mobile.test.tsx
@@ -153,34 +153,6 @@ describe("Dashboard unified layout (mobile viewport)", () => {
     expect(screen.getByText("feat/dashboard-polish")).toBeInTheDocument();
   });
 
-  it("shows and dismisses the rate limit banner", () => {
-    render(
-      <Dashboard
-        initialSessions={[
-          makeSession({
-            id: "review-2",
-            status: "reviewing",
-            activity: "idle",
-            pr: makePR({
-              number: 208,
-              mergeability: {
-                mergeable: false,
-                ciPassing: false,
-                approved: false,
-                noConflicts: true,
-                blockers: ["API rate limited or unavailable"],
-              },
-            }),
-          }),
-        ]}
-      />,
-    );
-
-    expect(screen.getByText(/GitHub API rate limited/i)).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
-    expect(screen.queryByText(/GitHub API rate limited/i)).not.toBeInTheDocument();
-  });
-
   it("opens the done bar and restores completed sessions", async () => {
     vi.setSystemTime(new Date("2026-04-11T11:07:00.000Z"));
 

--- a/packages/web/src/components/__tests__/SessionDetail.mergeConflictActions.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetail.mergeConflictActions.test.tsx
@@ -106,7 +106,7 @@ describe("SessionDetail merge conflict actions", () => {
               ciPassing: true,
               approved: true,
               noConflicts: false,
-              blockers: ["API rate limited or unavailable"],
+              blockers: [],
             },
           }),
         })}
@@ -115,7 +115,11 @@ describe("SessionDetail merge conflict actions", () => {
     );
 
     fireEvent.click(screen.getByRole("link", { name: "PR #100" }));
-    expect(screen.queryByRole("link", { name: /Compare with base branch/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Copy head branch name/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: /Compare with base branch/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Copy head branch name/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/session-detail-utils.ts
+++ b/packages/web/src/components/session-detail-utils.ts
@@ -1,4 +1,4 @@
-import { isPRRateLimited, isPRUnenriched, type DashboardPR } from "@/lib/types";
+import { isPRUnenriched, type DashboardPR } from "@/lib/types";
 
 export const sessionActivityMeta: Record<string, { label: string; color: string }> = {
   active: { label: "Active", color: "var(--color-status-working)" },
@@ -24,14 +24,14 @@ export function formatTimeCompact(isoDate: string | null): string {
 }
 
 export function getCiShortLabel(pr: DashboardPR): string {
-  if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "CI";
+  if (isPRUnenriched(pr)) return "CI";
   if (pr.ciStatus === "passing") return "CI passing";
   if (pr.ciStatus === "failing") return "CI failed";
   return "CI pending";
 }
 
 export function getReviewShortLabel(pr: DashboardPR): string {
-  if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "";
+  if (isPRUnenriched(pr)) return "";
   if (pr.reviewDecision === "approved") return "approved";
   if (pr.reviewDecision === "changes_requested") return "changes";
   return "review";
@@ -104,7 +104,7 @@ export function mobileStatusPillClass(activityLabel: string): string {
 }
 
 export function ciToneClass(pr: DashboardPR): string {
-  if (isPRRateLimited(pr) || isPRUnenriched(pr)) return "session-detail-ci-tone--neutral";
+  if (isPRUnenriched(pr)) return "session-detail-ci-tone--neutral";
   if (pr.ciStatus === "passing") return "session-detail-ci-tone--pass";
   if (pr.ciStatus === "failing") return "session-detail-ci-tone--fail";
   return "session-detail-ci-tone--pending";

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -246,15 +246,6 @@ export interface DashboardOrchestratorLink {
   projectName: string;
 }
 
-/**
- * Returns true when this PR's enrichment data couldn't be fetched due to
- * API rate limiting. When true, CI status / review decision / mergeability
- * may be stale defaults — don't make decisions based on them.
- */
-export function isPRRateLimited(pr: DashboardPR): boolean {
-  return pr.mergeability.blockers.includes("API rate limited or unavailable");
-}
-
 /** Returns true when a PR has not yet been enriched with live SCM data.
  *  Only returns true for explicit `false` — undefined (legacy data) is treated as enriched. */
 export function isPRUnenriched(pr: DashboardPR): boolean {
@@ -509,7 +500,7 @@ function getDetailedAttentionLevel(session: DashboardSession): AttentionLevel {
   ) {
     return "review";
   }
-  if (session.pr && !isPRRateLimited(session.pr) && !isPRUnenriched(session.pr)) {
+  if (session.pr && !isPRUnenriched(session.pr)) {
     const pr = session.pr;
     if (pr.ciStatus === CI_STATUS.FAILING) return "review";
     if (pr.reviewDecision === "changes_requested") return "review";
@@ -524,7 +515,7 @@ function getDetailedAttentionLevel(session: DashboardSession): AttentionLevel {
   ) {
     return "pending";
   }
-  if (session.pr && !isPRRateLimited(session.pr) && !isPRUnenriched(session.pr)) {
+  if (session.pr && !isPRUnenriched(session.pr)) {
     const pr = session.pr;
     if (!pr.isDraft && pr.unresolvedThreads > 0) return "pending";
     if (!pr.isDraft && (pr.reviewDecision === "pending" || pr.reviewDecision === "none")) {


### PR DESCRIPTION
## Summary
- Remove the dead PR rate-limit blocker detector and dashboard banner.
- Stop hiding PR metadata based on the legacy "API rate limited or unavailable" blocker string; keep `enriched === false` as the unavailable-data guard.
- Remove stale rate-limit fixture coverage from web tests.

Closes #1686.

## Validation
- `pnpm install`
- `pnpm build` (fails in this session because exported `NODE_ENV=development` makes Next prerender /404 with the known `<Html>` error)
- `NODE_ENV=production pnpm build` (passes; existing warnings for optional `@composio/core` in tracker-linear and one non-null assertion in terminal code)
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm test`
- `NODE_ENV=test pnpm --filter @aoagents/ao-web test` (changed component tests pass; full web suite still has unrelated existing failures in `api-routes.test.ts` PR enrichment expectations and `sessions/[id]/page.test.tsx` missing `TestErrorBoundary`)
