### PR TITLE
fix(core): sm.list() no longer writes terminated state to disk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ spawning -> working -> pr_open -> ci_failed / review_pending
                                       +-> mergeable -> merged -> cleanup -> done
 ```
 
-**Stale runtime reconciliation:** `sm.list()` detects dead runtimes (tmux/process gone) during enrichment and persists `runtime_lost` reason to disk. This maps to legacy status `killed`. Without this, sessions with dead runtimes would show stale "active" status indefinitely.
+**Stale runtime reconciliation:** `sm.list()` detects dead runtimes (tmux/process gone) during enrichment and persists `detecting` state with `runtime_lost` reason to disk. The lifecycle manager's `resolveProbeDecision` pipeline is the single authority on terminal decisions — `sm.list()` never writes `terminated` directly (#1735).
 
 ### Data Flow
 
@@ -224,7 +224,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 - Kanban board filters client-side via `projectSessions` memo
 
 ### Key invariants
-- `sm.list()` persists `runtime_lost` lifecycle to disk when enrichment detects dead runtimes — this is the only place stale runtime state gets reconciled
+- `sm.list()` persists `detecting` state (not `terminated`) to disk when enrichment detects dead runtimes — terminal decisions are made only by the lifecycle manager's probe pipeline (#1735)
 - `deriveLegacyStatus()` maps canonical lifecycle to legacy status — new terminal reasons must be added here
 - Tab completions merge local config + global config to show all projects
 

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -219,7 +219,9 @@ describe("list", () => {
     const sm = createSessionManager({ config, registry: registryWithDead });
     const sessions = await sm.list();
 
-    expect(sessions[0].status).toBe("killed");
+    // sm.list() persists "detecting" (not "terminated") so the lifecycle
+    // manager's probe pipeline makes the final terminal decision (#1735).
+    expect(sessions[0].status).toBe("detecting");
     expect(sessions[0].activity).toBe("exited");
   });
 
@@ -335,7 +337,8 @@ describe("list", () => {
 
     expect(sessions).toHaveLength(1);
     expect(sessions[0].runtimeHandle?.id).toBe(expectedTmuxName);
-    expect(sessions[0].status).toBe("killed");
+    // sm.list() persists "detecting" so the lifecycle manager decides (#1735).
+    expect(sessions[0].status).toBe("detecting");
     expect(sessions[0].activity).toBe("exited");
     expect(agentWithSpy.getActivityState).not.toHaveBeenCalled();
   });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1901,10 +1901,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         }
       }
 
-      // Persist lifecycle to disk when enrichment detected a dead runtime.
-      // enrichSessionWithRuntimeState updates the in-memory lifecycle but
-      // doesn't write to disk — without this, the stale "alive" state persists
-      // and the dashboard shows terminated sessions on the active sidebar.
+      // Persist runtime probe result to disk so the lifecycle manager sees it
+      // on next poll. We only persist the runtime signal and detecting state —
+      // the lifecycle manager's resolveProbeDecision pipeline is the single
+      // authority on terminal decisions (terminated/done). See #1735.
       if (
         session.lifecycle &&
         (session.lifecycle.runtime.state === "missing" ||
@@ -1914,10 +1914,9 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       ) {
         try {
           const persisted = buildUpdatedLifecycle(sessionName, raw, (next) => {
-            next.session.state = "terminated";
+            next.session.state = "detecting";
             next.session.reason = "runtime_lost";
-            next.session.terminatedAt = new Date().toISOString();
-            next.session.lastTransitionAt = next.session.terminatedAt;
+            next.session.lastTransitionAt = new Date().toISOString();
             next.runtime.state = session.lifecycle!.runtime.state;
             next.runtime.reason = session.lifecycle!.runtime.reason;
             next.runtime.lastObservedAt = new Date().toISOString();

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1905,12 +1905,20 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       // on next poll. We only persist the runtime signal and detecting state —
       // the lifecycle manager's resolveProbeDecision pipeline is the single
       // authority on terminal decisions (terminated/done). See #1735.
+      // Check the on-disk state (raw) to avoid re-writing when already
+      // detecting — enrichment sets detecting in-memory, but we only need
+      // to persist the transition once to avoid resetting lastTransitionAt.
+      const onDiskLifecycle = parseCanonicalLifecycle(raw, {
+        sessionId: sessionName,
+        status: validateStatus(raw["status"]),
+      });
       if (
         session.lifecycle &&
         (session.lifecycle.runtime.state === "missing" ||
           session.lifecycle.runtime.state === "exited") &&
-        session.lifecycle.session.state !== "terminated" &&
-        session.lifecycle.session.state !== "done"
+        onDiskLifecycle.session.state !== "terminated" &&
+        onDiskLifecycle.session.state !== "done" &&
+        onDiskLifecycle.session.state !== "detecting"
       ) {
         try {
           const persisted = buildUpdatedLifecycle(sessionName, raw, (next) => {

--- a/packages/web/src/app/api/sessions/patches/route.ts
+++ b/packages/web/src/app/api/sessions/patches/route.ts
@@ -16,7 +16,7 @@ export async function GET(request: Request) {
         ? projectFilter
         : undefined;
 
-    const coreSessions = await sessionManager.list(requestedProjectId);
+    const coreSessions = await sessionManager.listCached(requestedProjectId);
     const visibleSessions = filterWorkerSessions(coreSessions, projectFilter, config.projects);
 
     // Convert to dashboard format


### PR DESCRIPTION
## Summary

Fixes #1735

- **`sm.list()` no longer persists `terminated` to disk** — it now writes `detecting` state with `runtime_lost` reason, so the lifecycle manager's `resolveProbeDecision` pipeline remains the single authority on terminal decisions. A single `isAlive()` failure no longer permanently kills a session.
- **`/api/sessions/patches` now calls `listCached()` instead of `list()`** — the dashboard's 3s poll was the most dangerous caller, probing runtimes ~10x more often than the lifecycle manager. The cache TTL (35s) aligns with the lifecycle manager's 30s poll cycle.
- Updated CLAUDE.md invariants to reflect the new behavior.

## What was happening

`sm.list()` detected a dead runtime via `isAlive()` and immediately persisted `session.state = "terminated"` with `reason = "runtime_lost"` to disk. This bypassed the lifecycle manager's carefully designed probe pipeline which evaluates three independent signals (runtime, process, activity) and routes 4/5 outcomes to `detecting` (retry). Only unanimous agreement across all signals produces a terminal decision.

The dashboard's `/api/sessions/patches` endpoint polled every 3s calling `sm.list()` directly — so a single transient `isAlive()` failure would permanently kill the session before the lifecycle manager's 30s poll could run.

## Test plan

- [x] Updated existing tests that expected `killed` status to expect `detecting`
- [x] `pnpm build` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors, pre-existing warnings only)
- [x] `pnpm test` passes (all core + cli tests green; 3 pre-existing web test failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)