### PR TITLE
ci: drop windows-latest from typecheck matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,8 @@ jobs:
       - run: pnpm lint
 
   typecheck:
-    name: Typecheck (${{ matrix.os }})
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    name: Typecheck
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Summary
- Drop `windows-latest` from the `typecheck` job matrix in `.github/workflows/ci.yml`; keep `ubuntu-latest`.

## Why
- `tsc` is OS-agnostic — Windows and Ubuntu produce the same diagnostics for this codebase. The `windows-latest` typecheck run was a ~5 min duplicate of the Ubuntu pass on every push.
- Real Windows-specific regressions (path handling, child_process, pty-host, PATH separator, etc.) still surface in the `Test (windows-latest)` and `Test Web (windows-latest)` matrices, which are unchanged.

## Test plan
- [x] CI is green on this PR (typecheck runs only on ubuntu-latest; tests still run on both).