### PR TITLE
feat(web): add formatDuration utility to format.ts

### DIFF
--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { humanizeBranch, getSessionTitle } from "../format";
+import { humanizeBranch, getSessionTitle, formatDuration } from "../format";
 import type { DashboardSession } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -38,6 +38,38 @@ function makeSession(overrides?: Partial<DashboardSession>): DashboardSession {
     ...overrides,
   };
 }
+
+// ---------------------------------------------------------------------------
+// formatDuration
+// ---------------------------------------------------------------------------
+
+describe("formatDuration", () => {
+  it("returns '0s' for zero input", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("returns '0s' for negative input", () => {
+    expect(formatDuration(-1000)).toBe("0s");
+  });
+
+  it("shows seconds only for durations under 60s", () => {
+    expect(formatDuration(45000)).toBe("45s");
+    expect(formatDuration(1000)).toBe("1s");
+    expect(formatDuration(59000)).toBe("59s");
+  });
+
+  it("shows minutes and seconds for durations under 1h", () => {
+    expect(formatDuration(90000)).toBe("1m 30s");
+    expect(formatDuration(60000)).toBe("1m 0s");
+    expect(formatDuration(3599000)).toBe("59m 59s");
+  });
+
+  it("shows hours and minutes for durations of 1h or more", () => {
+    expect(formatDuration(3600000)).toBe("1h 0m");
+    expect(formatDuration(7200000)).toBe("2h 0m");
+    expect(formatDuration(5400000)).toBe("1h 30m");
+  });
+});
 
 // ---------------------------------------------------------------------------
 // humanizeBranch

--- a/packages/web/src/lib/__tests__/format.test.ts
+++ b/packages/web/src/lib/__tests__/format.test.ts
@@ -52,6 +52,11 @@ describe("formatDuration", () => {
     expect(formatDuration(-1000)).toBe("0s");
   });
 
+  it("returns '0s' for sub-second positive input", () => {
+    expect(formatDuration(500)).toBe("0s");
+    expect(formatDuration(999)).toBe("0s");
+  });
+
   it("shows seconds only for durations under 60s", () => {
     expect(formatDuration(45000)).toBe("45s");
     expect(formatDuration(1000)).toBe("1s");

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -114,6 +114,17 @@ export function getSessionTitle(session: DashboardSession): string {
   return session.status;
 }
 
+export function formatDuration(ms: number): string {
+  if (ms <= 0) return "0s";
+  const totalSeconds = Math.floor(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  if (hours >= 1) return `${hours}h ${minutes}m`;
+  if (minutes >= 1) return `${minutes}m ${seconds}s`;
+  return `${seconds}s`;
+}
+
 export function formatRelativeTime(input: number): string {
   const elapsedMs = Date.now() - input;
 

--- a/packages/web/src/lib/format.ts
+++ b/packages/web/src/lib/format.ts
@@ -114,6 +114,20 @@ export function getSessionTitle(session: DashboardSession): string {
   return session.status;
 }
 
+/**
+ * Format a duration given in milliseconds as a compact human-readable string.
+ *
+ * - Returns `"0s"` for zero, negative, or sub-second (< 1 000 ms) inputs.
+ * - Returns `"Xs"` for durations under 60 s.
+ * - Returns `"Xm Ys"` for durations between 1 m and 59 m 59 s.
+ * - Returns `"Xh Ym"` for durations of 1 h or more (seconds are dropped).
+ *
+ * @example
+ *   formatDuration(0)         // → "0s"
+ *   formatDuration(45_000)    // → "45s"
+ *   formatDuration(90_000)    // → "1m 30s"
+ *   formatDuration(3_600_000) // → "1h 0m"
+ */
 export function formatDuration(ms: number): string {
   if (ms <= 0) return "0s";
   const totalSeconds = Math.floor(ms / 1000);


### PR DESCRIPTION
## Summary

- Adds `formatDuration(ms: number): string` to `packages/web/src/lib/format.ts`
- Outputs compact human-readable durations: `"45s"`, `"1m 30s"`, `"2h 0m"`
- Returns `"0s"` for zero or negative input
- Appends 9 Vitest test cases to `src/lib/__tests__/format.test.ts` covering all rules and edge cases

## Test plan

- [x] `pnpm --filter @aoagents/ao-web test` — all 36 format tests pass
- [x] `pnpm --filter @aoagents/ao-web typecheck` — no errors

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)