### PR TITLE
chore: add .editorconfig with standard settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` to the repository root with standard editor settings

## Settings applied

- `indent_style = space`
- `indent_size = 2`
- `end_of_line = lf`
- `charset = utf-8`
- `trim_trailing_whitespace = true`
- `insert_final_newline = true`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)