### PR TITLE
fix(web): allow Windows add-folder browsing outside home

### DIFF
--- a/packages/web/src/__tests__/filesystem-browse-api.test.ts
+++ b/packages/web/src/__tests__/filesystem-browse-api.test.ts
@@ -49,7 +49,14 @@ describe("/api/filesystem/browse", () => {
     const response = await browseGET(makeRequest("/api/filesystem/browse?path=~"));
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ entries: [] });
+    const body = (await response.json()) as {
+      entries: unknown[];
+      current: { isGitRepo: boolean; hasLocalConfig: boolean };
+      roots: Array<{ label: string; path: string }>;
+    };
+    expect(body.entries).toEqual([]);
+    expect(body.current).toEqual({ isGitRepo: false, hasLocalConfig: false });
+    expect(Array.isArray(body.roots)).toBe(true);
   });
 
   it("returns 400 when the requested path contains ..", async () => {
@@ -61,19 +68,33 @@ describe("/api/filesystem/browse", () => {
     await expect(response.json()).resolves.toEqual({ error: "path outside allowed root" });
   });
 
-  it("returns 400 for an absolute path outside HOME", async () => {
+  it.skipIf(process.platform === "win32")("returns 400 for an absolute path outside HOME", async () => {
     // Pick an absolute path outside HOME that actually exists on the platform —
-    // `/etc` exists on POSIX; on Windows we use `C:\\Windows`. The route's
-    // realpath() resolves first, so a non-existent path returns 404 (not 400)
-    // before the outside-root check fires.
-    const outsidePath =
-      process.platform === "win32" ? encodeURIComponent("C:\\Windows") : "/etc";
+    // `/etc` exists on POSIX. The route's realpath() resolves first, so a
+    // non-existent path returns 404 (not 400) before the outside-root check fires.
+    const outsidePath = "/etc";
     const response = await browseGET(
       makeRequest(`/api/filesystem/browse?path=${outsidePath}`),
     );
 
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({ error: "path outside allowed root" });
+  });
+
+  it.runIf(process.platform === "win32")("allows an absolute path outside HOME on Windows", async () => {
+    const response = await browseGET(
+      makeRequest(`/api/filesystem/browse?path=${encodeURIComponent(outsideDir)}`),
+    );
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      entries: unknown[];
+      current: { isGitRepo: boolean; hasLocalConfig: boolean };
+      roots: Array<{ label: string; path: string }>;
+    };
+    expect(body.entries).toEqual([]);
+    expect(body.current).toEqual({ isGitRepo: false, hasLocalConfig: false });
+    expect(body.roots.some((root) => /^[A-Z]:$/.test(root.label) && root.path.endsWith("\\"))).toBe(true);
   });
 
   // Skipped on Windows: symlinkSync requires admin or Developer Mode on win32
@@ -121,6 +142,8 @@ describe("/api/filesystem/browse", () => {
     };
 
     expect(body).toEqual({
+      current: { isGitRepo: false, hasLocalConfig: false },
+      roots: expect.any(Array),
       entries: [
         {
           name: "notes",

--- a/packages/web/src/__tests__/filesystem-browse-api.test.ts
+++ b/packages/web/src/__tests__/filesystem-browse-api.test.ts
@@ -185,6 +185,18 @@ describe("/api/filesystem/browse", () => {
     expect(body.entries.map((entry) => entry.name)).not.toContain(".env");
   });
 
+  it("detects git repo and local config for subdirectories", async () => {
+    const repo = path.join(homeDir, "repo");
+    mkdirSync(path.join(repo, ".git"), { recursive: true });
+    writeFileSync(path.join(repo, "agent-orchestrator.yaml"), "version: 1\n");
+
+    const response = await browseGET(makeRequest("http://localhost:3000/api/filesystem/browse?path=~"));
+    const body = await response.json();
+    const entry = body.entries.find((e: { name: string }) => e.name === "repo");
+
+    expect(entry).toMatchObject({ isDirectory: true, isGitRepo: true, hasLocalConfig: true });
+  });
+
   it("redirects the legacy browse endpoint to the new route", async () => {
     const response = await legacyBrowseGET(makeRequest("/api/browse-directory?path=~/repo"));
 

--- a/packages/web/src/__tests__/filesystem-browse-api.test.ts
+++ b/packages/web/src/__tests__/filesystem-browse-api.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpdir } from "node:os";
+import { isWindows } from "@aoagents/ao-core";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NextRequest } from "next/server";
 import { GET as browseGET } from "@/app/api/filesystem/browse/route";
@@ -68,7 +69,7 @@ describe("/api/filesystem/browse", () => {
     await expect(response.json()).resolves.toEqual({ error: "path outside allowed root" });
   });
 
-  it.skipIf(process.platform === "win32")("returns 400 for an absolute path outside HOME", async () => {
+  it.skipIf(isWindows())("returns 400 for an absolute path outside HOME", async () => {
     // Pick an absolute path outside HOME that actually exists on the platform —
     // `/etc` exists on POSIX. The route's realpath() resolves first, so a
     // non-existent path returns 404 (not 400) before the outside-root check fires.
@@ -81,7 +82,7 @@ describe("/api/filesystem/browse", () => {
     await expect(response.json()).resolves.toEqual({ error: "path outside allowed root" });
   });
 
-  it.runIf(process.platform === "win32")("allows an absolute path outside HOME on Windows", async () => {
+  it.runIf(isWindows())("allows an absolute path outside HOME on Windows", async () => {
     const response = await browseGET(
       makeRequest(`/api/filesystem/browse?path=${encodeURIComponent(outsideDir)}`),
     );
@@ -99,7 +100,7 @@ describe("/api/filesystem/browse", () => {
 
   // Skipped on Windows: symlinkSync requires admin or Developer Mode on win32
   // and is not portable in CI. The Linux/macOS path covers the symlink check.
-  it.skipIf(process.platform === "win32")("returns 400 for a symlink inside HOME that points outside", async () => {
+  it.skipIf(isWindows())("returns 400 for a symlink inside HOME that points outside", async () => {
     const outsideRepo = path.join(outsideDir, "external-repo");
     mkdirSync(outsideRepo);
     symlinkSync(outsideRepo, path.join(homeDir, "external-link"));

--- a/packages/web/src/app/api/filesystem/browse/route.ts
+++ b/packages/web/src/app/api/filesystem/browse/route.ts
@@ -1,5 +1,6 @@
-import { readdirSync, type Dirent } from "node:fs";
+import { existsSync, readdirSync, type Dirent } from "node:fs";
 import path from "node:path";
+import { isWindows } from "@aoagents/ao-core";
 import { NextResponse, type NextRequest } from "next/server";
 import {
   PathSecurityError,
@@ -14,6 +15,30 @@ interface BrowseEntry {
   isDirectory: boolean;
   isGitRepo: boolean;
   hasLocalConfig: boolean;
+}
+
+interface BrowseCurrentDirectory {
+  isGitRepo: boolean;
+  hasLocalConfig: boolean;
+}
+
+interface BrowseRoot {
+  label: string;
+  path: string;
+}
+
+function getBrowseRoots(): BrowseRoot[] {
+  if (!isWindows()) return [];
+
+  const roots: BrowseRoot[] = [];
+  for (let code = 65; code <= 90; code += 1) {
+    const drive = String.fromCharCode(code);
+    const rootPath = `${drive}:\\`;
+    if (existsSync(rootPath)) {
+      roots.push({ label: `${drive}:`, path: rootPath });
+    }
+  }
+  return roots;
 }
 
 function isGitRepository(entryPath: string): boolean {
@@ -82,7 +107,12 @@ export async function GET(request: NextRequest) {
         return left.name.localeCompare(right.name);
       });
 
-    return NextResponse.json({ entries });
+    const current: BrowseCurrentDirectory = {
+      isGitRepo: isGitRepository(resolved.resolvedPath),
+      hasLocalConfig: hasLocalConfig(resolved.resolvedPath),
+    };
+
+    return NextResponse.json({ entries, current, roots: getBrowseRoots() });
   } catch {
     return NextResponse.json({ error: "Failed to browse directory" }, { status: 500 });
   }

--- a/packages/web/src/app/api/filesystem/browse/route.ts
+++ b/packages/web/src/app/api/filesystem/browse/route.ts
@@ -1,4 +1,5 @@
-import { existsSync, readdirSync, type Dirent } from "node:fs";
+import { existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
 import { isWindows } from "@aoagents/ao-core";
 import { NextResponse, type NextRequest } from "next/server";
@@ -41,36 +42,18 @@ function getBrowseRoots(): BrowseRoot[] {
   return roots;
 }
 
-function isGitRepository(entryPath: string): boolean {
+async function describeDirectory(
+  entryPath: string,
+): Promise<{ isGitRepo: boolean; hasLocalConfig: boolean }> {
   try {
-    return readdirSync(entryPath).includes(".git");
+    const names = new Set(await readdir(entryPath));
+    return {
+      isGitRepo: names.has(".git"),
+      hasLocalConfig: names.has("agent-orchestrator.yaml") || names.has("agent-orchestrator.yml"),
+    };
   } catch {
-    return false;
+    return { isGitRepo: false, hasLocalConfig: false };
   }
-}
-
-function hasLocalConfig(entryPath: string): boolean {
-  try {
-    const names = new Set(readdirSync(entryPath));
-    return names.has("agent-orchestrator.yaml") || names.has("agent-orchestrator.yml");
-  } catch {
-    return false;
-  }
-}
-
-function serializeEntry(rootPath: string, parentPath: string, entry: Dirent): BrowseEntry | null {
-  const entryPath = path.join(parentPath, entry.name);
-  if (shouldHideBrowseEntry(entryPath, rootPath)) {
-    return null;
-  }
-
-  const isDirectory = entry.isDirectory();
-  return {
-    name: entry.name,
-    isDirectory,
-    isGitRepo: isDirectory ? isGitRepository(entryPath) : false,
-    hasLocalConfig: isDirectory ? hasLocalConfig(entryPath) : false,
-  };
 }
 
 export async function GET(request: NextRequest) {
@@ -97,19 +80,42 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const entries = readdirSync(resolved.resolvedPath, { withFileTypes: true })
-      .map((entry) => serializeEntry(resolved.rootPath, resolved.resolvedPath, entry))
-      .filter((entry): entry is BrowseEntry => entry !== null)
-      .sort((left, right) => {
-        if (left.isDirectory !== right.isDirectory) {
-          return left.isDirectory ? -1 : 1;
-        }
-        return left.name.localeCompare(right.name);
-      });
+    const dirents = await readdir(resolved.resolvedPath, { withFileTypes: true });
+    const entries = (
+      await Promise.all(
+        dirents.map(async (entry): Promise<BrowseEntry | null> => {
+          const entryPath = path.join(resolved.resolvedPath, entry.name);
+          if (shouldHideBrowseEntry(entryPath, resolved.rootPath)) {
+            return null;
+          }
 
+          const isDirectory = entry.isDirectory();
+          const meta = isDirectory
+            ? await describeDirectory(entryPath)
+            : { isGitRepo: false, hasLocalConfig: false };
+
+          return {
+            name: entry.name,
+            isDirectory,
+            isGitRepo: meta.isGitRepo,
+            hasLocalConfig: meta.hasLocalConfig,
+          };
+        }),
+      )
+    )
+      .filter((entry): entry is BrowseEntry => entry !== null)
+      .sort((left, right) =>
+        left.isDirectory !== right.isDirectory
+          ? left.isDirectory
+            ? -1
+            : 1
+          : left.name.localeCompare(right.name),
+      );
+
+    const selfMeta = await describeDirectory(resolved.resolvedPath);
     const current: BrowseCurrentDirectory = {
-      isGitRepo: isGitRepository(resolved.resolvedPath),
-      hasLocalConfig: hasLocalConfig(resolved.resolvedPath),
+      isGitRepo: selfMeta.isGitRepo,
+      hasLocalConfig: selfMeta.hasLocalConfig,
     };
 
     return NextResponse.json({ entries, current, roots: getBrowseRoots() });

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4721,9 +4721,33 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   color: var(--color-text-secondary);
 }
 
+.add-project-modal__location:focus {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+  color: var(--color-text-primary);
+}
+
 .add-project-modal__toolbtn {
   width: 28px;
   height: 28px;
+}
+
+.add-project-modal__drive-select {
+  height: 28px;
+  min-width: 76px;
+  border: 1px solid var(--color-border-default);
+  border-radius: 0;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  padding: 0 8px;
+}
+
+.add-project-modal__drive-select:focus {
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
+  color: var(--color-text-primary);
 }
 
 .add-project-modal__toolicon {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4786,6 +4786,30 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   font-family: var(--font-sans);
 }
 
+.add-project-browser__breadcrumb {
+  min-width: 0;
+  margin-top: 6px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.add-project-browser__crumb {
+  min-width: 0;
+  max-width: 180px;
+  height: 24px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-surface);
+  padding: 0 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
 .add-project-browser__current-path {
   margin-top: 4px;
   font-family: var(--font-mono);

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4850,6 +4850,35 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   color: var(--color-text-secondary);
 }
 
+.add-project-browser__row-icon {
+  width: 16px;
+  height: 16px;
+  flex: 0 0 16px;
+  margin-right: 8px;
+  color: var(--color-text-secondary);
+}
+
+.add-project-browser__row-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.add-project-browser__badge {
+  margin-left: auto;
+  flex: 0 0 auto;
+  border: 1px solid var(--color-border-default);
+  border-radius: 999px;
+  padding: 1px 6px;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-secondary);
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1.4;
+  text-transform: uppercase;
+}
+
 .add-project-browser__state {
   padding: 20px;
   display: flex;

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4766,9 +4766,88 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   min-height: 0;
   height: 100%;
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-columns: 176px minmax(0, 1fr);
   background: var(--color-bg-surface);
   overflow: hidden;
+}
+
+.add-project-browser__sidebar {
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  border-right: 1px solid var(--color-border-subtle);
+  background: var(--color-bg-sidebar);
+}
+
+.add-project-browser__sidebar-section {
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.add-project-browser__sidebar-toggle {
+  width: 100%;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 10px;
+  background: transparent;
+  border: 0;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.add-project-browser__sidebar-toggle:hover,
+.add-project-browser__sidebar-toggle:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-bg-surface);
+}
+
+.add-project-browser__sidebar-chevron {
+  color: var(--color-text-tertiary);
+  transition: transform 160ms ease;
+}
+
+.add-project-browser__sidebar-chevron.is-open {
+  transform: rotate(180deg);
+}
+
+.add-project-browser__sidebar-body {
+  display: flex;
+  flex-direction: column;
+  padding: 0 6px 8px;
+}
+
+.add-project-browser__sidebar-item {
+  min-width: 0;
+  min-height: 30px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  border: 0;
+  background: transparent;
+  padding: 0 6px;
+  text-align: left;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--color-text-secondary);
+}
+
+.add-project-browser__sidebar-item:hover,
+.add-project-browser__sidebar-item:focus-visible {
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+}
+
+.add-project-browser__main {
+  min-width: 0;
+  min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
 }
 
 .add-project-browser__current {
@@ -5085,6 +5164,22 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
   .add-project-modal__content {
     display: block;
+  }
+
+  .add-project-browser {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .add-project-browser__sidebar {
+    max-height: 112px;
+    border-right: 0;
+    border-bottom: 1px solid var(--color-border-subtle);
+  }
+
+  .add-project-browser__sidebar-body {
+    max-height: 76px;
+    overflow-y: auto;
   }
 
   .add-project-modal__footer {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4736,7 +4736,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   height: 28px;
   min-width: 76px;
   border: 1px solid var(--color-border-default);
-  border-radius: var(--radius-base);
+  border-radius: 0;
   background: var(--color-bg-elevated);
   color: var(--color-text-secondary);
   font-family: var(--font-mono);
@@ -4751,8 +4751,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .add-project-modal__drive-select:focus {
-  outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+  outline: 1px solid var(--color-accent);
+  outline-offset: -1px;
   color: var(--color-text-primary);
 }
 
@@ -4772,88 +4772,9 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   min-height: 0;
   height: 100%;
   display: grid;
-  grid-template-columns: 176px minmax(0, 1fr);
-  background: var(--color-bg-surface);
-  overflow: hidden;
-}
-
-.add-project-browser__sidebar {
-  min-width: 0;
-  min-height: 0;
-  overflow-y: auto;
-  border-right: 1px solid var(--color-border-subtle);
-  background: var(--color-bg-sidebar);
-}
-
-.add-project-browser__sidebar-section {
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-
-.add-project-browser__sidebar-toggle {
-  width: 100%;
-  min-height: 34px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 0 10px;
-  background: transparent;
-  border: 0;
-  font-family: var(--font-sans);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--color-text-tertiary);
-}
-
-.add-project-browser__sidebar-toggle:hover,
-.add-project-browser__sidebar-toggle:focus-visible {
-  color: var(--color-text-primary);
-  background: var(--color-bg-surface);
-}
-
-.add-project-browser__sidebar-chevron {
-  color: var(--color-text-tertiary);
-  transition: transform 160ms ease;
-}
-
-.add-project-browser__sidebar-chevron.is-open {
-  transform: rotate(180deg);
-}
-
-.add-project-browser__sidebar-body {
-  display: flex;
-  flex-direction: column;
-  padding: 0 6px 8px;
-}
-
-.add-project-browser__sidebar-item {
-  min-width: 0;
-  min-height: 30px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  border: 0;
-  background: transparent;
-  padding: 0 6px;
-  text-align: left;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--color-text-secondary);
-}
-
-.add-project-browser__sidebar-item:hover,
-.add-project-browser__sidebar-item:focus-visible {
-  background: var(--color-bg-surface);
-  color: var(--color-text-primary);
-}
-
-.add-project-browser__main {
-  min-width: 0;
-  min-height: 0;
-  display: grid;
   grid-template-rows: auto minmax(0, 1fr);
+  background: var(--color-bg-surface);
+  overflow: hidden;
 }
 
 .add-project-browser__current {
@@ -4893,14 +4814,6 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   font-family: var(--font-mono);
   font-size: 11px;
   color: var(--color-text-secondary);
-}
-
-.add-project-browser__current-path {
-  margin-top: 4px;
-  font-family: var(--font-mono);
-  font-size: 12px;
-  color: var(--color-text-primary);
-  word-break: break-all;
 }
 
 .add-project-browser__rows {
@@ -4944,15 +4857,54 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 .add-project-browser__row-name {
+  flex: 1;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.add-project-browser__badge {
-  margin-left: auto;
+.add-project-browser__row-tag {
   flex: 0 0 auto;
+  margin-left: 8px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-tertiary);
+}
+
+.add-project-browser__row-chevron {
+  flex: 0 0 auto;
+  margin-left: 8px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--color-text-tertiary);
+  opacity: 0;
+  transition: opacity 120ms ease-out;
+}
+
+.add-project-browser__row:hover .add-project-browser__row-chevron,
+.add-project-browser__row.is-selected .add-project-browser__row-chevron {
+  opacity: 1;
+}
+
+.add-project-browser__row--current {
+  background: var(--color-bg-elevated);
+}
+
+.add-project-browser__empty-row {
+  margin: 0;
+  padding: 12px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--color-text-tertiary);
+}
+
+.add-project-browser__badge {
+  flex: 0 0 auto;
+  margin-left: 8px;
   border: 1px solid var(--color-border-default);
   border-radius: 999px;
   padding: 1px 6px;
@@ -5004,6 +4956,25 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.add-project-modal__formrow {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.add-project-modal__field {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.add-project-modal__field .add-project-modal__selection-path {
+  flex: 1;
 }
 
 .add-project-modal__selection-label {
@@ -5173,20 +5144,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     display: block;
   }
 
-  .add-project-browser {
-    grid-template-columns: 1fr;
-    grid-template-rows: auto minmax(0, 1fr);
-  }
-
-  .add-project-browser__sidebar {
-    max-height: 112px;
-    border-right: 0;
-    border-bottom: 1px solid var(--color-border-subtle);
-  }
-
-  .add-project-browser__sidebar-body {
-    max-height: 76px;
-    overflow-y: auto;
+  .add-project-modal__formrow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
   }
 
   .add-project-modal__footer {

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -4736,17 +4736,23 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   height: 28px;
   min-width: 76px;
   border: 1px solid var(--color-border-default);
-  border-radius: 0;
+  border-radius: var(--radius-base);
   background: var(--color-bg-elevated);
   color: var(--color-text-secondary);
   font-family: var(--font-mono);
   font-size: 12px;
-  padding: 0 8px;
+  line-height: 1;
+  padding: 0 28px 0 8px;
+  cursor: pointer;
+  transition:
+    background 120ms ease-out,
+    color 120ms ease-out,
+    border-color 120ms ease-out;
 }
 
 .add-project-modal__drive-select:focus {
-  outline: 1px solid var(--color-accent);
-  outline-offset: -1px;
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
   color: var(--color-text-primary);
 }
 
@@ -5111,6 +5117,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 
 .add-project-modal__iconbtn:hover:not(:disabled),
 .add-project-modal__toolbtn:hover:not(:disabled),
+.add-project-modal__drive-select:hover:not(:disabled),
 .add-project-modal__ghostbtn:hover:not(:disabled),
 .add-project-browser__crumb:hover,
 .add-project-browser__row:hover {

--- a/packages/web/src/components/AddProjectModal.parts.tsx
+++ b/packages/web/src/components/AddProjectModal.parts.tsx
@@ -1,32 +1,57 @@
 import type { ReactNode } from "react";
 
 const RECENT_PATHS_KEY = "ao:add-project:recent";
+const WINDOWS_DRIVE_ROOT_PATTERN = /^[A-Za-z]:[\\/]?$/;
+const WINDOWS_ABSOLUTE_PATTERN = /^[A-Za-z]:[\\/]/;
+const UNC_ROOT_PATTERN = /^\\\\[^\\]+\\[^\\]+\\?$/;
 
 export function deriveProjectIdFromPath(input: string): string {
-  const segment = input.split("/").filter(Boolean).pop() ?? "project";
+  const segment = input.split(/[\\/]+/).filter(Boolean).pop() ?? "project";
   const normalized = segment.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
   return normalized || "project";
 }
 
 export function deriveProjectNameFromPath(input: string): string {
-  const segment = input.split("/").filter(Boolean).pop() ?? "Project";
+  const segment = input.split(/[\\/]+/).filter(Boolean).pop() ?? "Project";
   return segment.replace(/[-_]+/g, " ").replace(/\s+/g, " ").trim().replace(/\b\w/g, (char) => char.toUpperCase()) || "Project";
 }
 
+function preferredSeparator(input: string): "/" | "\\" {
+  return input.includes("\\") ? "\\" : "/";
+}
+
+function trimBrowsePathEnd(input: string): string {
+  if (WINDOWS_DRIVE_ROOT_PATTERN.test(input) || UNC_ROOT_PATTERN.test(input)) return input;
+  return input.replace(/[\\/]+$/, "");
+}
+
 export function joinBrowsePath(base: string, child: string): string {
-  return base === "~" ? `~/${child}` : `${base.replace(/\/+$/, "")}/${child}`;
+  if (base === "~") return `~/${child}`;
+  const separator = preferredSeparator(base);
+  const normalizedBase = trimBrowsePathEnd(base);
+  if (/[\\/]$/.test(normalizedBase)) return `${normalizedBase}${child}`;
+  return `${normalizedBase}${separator}${child}`;
 }
 
 export function getParentBrowsePath(currentPath: string): string | null {
   if (currentPath === "~") return null;
-  const parts = currentPath.split("/").filter(Boolean);
+  if (WINDOWS_DRIVE_ROOT_PATTERN.test(currentPath) || UNC_ROOT_PATTERN.test(currentPath)) return null;
+  if (WINDOWS_ABSOLUTE_PATTERN.test(currentPath)) {
+    const separator = preferredSeparator(currentPath);
+    const normalizedPath = trimBrowsePathEnd(currentPath);
+    const parts = normalizedPath.split(/[\\/]+/).filter(Boolean);
+    if (parts.length <= 1) return `${parts[0]}${separator}`;
+    if (parts.length === 2) return `${parts[0]}${separator}`;
+    return parts.slice(0, -1).join(separator);
+  }
+  const parts = currentPath.split(/[\\/]+/).filter(Boolean);
   if (parts.length <= 1) return "~";
   return parts[0] === "~" ? `~/${parts.slice(1, -1).join("/")}` : parts.slice(0, -1).join("/");
 }
 
 export function getBreadcrumbs(currentPath: string): Array<{ label: string; path: string }> {
   if (currentPath === "~") return [{ label: "home", path: "~" }];
-  const parts = currentPath.split("/").filter(Boolean);
+  const parts = currentPath.split(/[\\/]+/).filter(Boolean);
   const crumbs: Array<{ label: string; path: string }> = [{ label: "home", path: "~" }];
   let running = "~";
   for (const part of parts.slice(1)) {

--- a/packages/web/src/components/AddProjectModal.parts.tsx
+++ b/packages/web/src/components/AddProjectModal.parts.tsx
@@ -51,6 +51,23 @@ export function getParentBrowsePath(currentPath: string): string | null {
 
 export function getBreadcrumbs(currentPath: string): Array<{ label: string; path: string }> {
   if (currentPath === "~") return [{ label: "home", path: "~" }];
+  if (WINDOWS_DRIVE_ROOT_PATTERN.test(currentPath)) {
+    const separator = preferredSeparator(currentPath);
+    const label = currentPath.slice(0, 2);
+    return [{ label, path: `${label}${separator}` }];
+  }
+  if (WINDOWS_ABSOLUTE_PATTERN.test(currentPath)) {
+    const separator = preferredSeparator(currentPath);
+    const parts = trimBrowsePathEnd(currentPath).split(/[\\/]+/).filter(Boolean);
+    const drive = parts[0] ?? currentPath.slice(0, 2);
+    let running = `${drive}${separator}`;
+    const crumbs: Array<{ label: string; path: string }> = [{ label: drive, path: running }];
+    for (const part of parts.slice(1)) {
+      running = joinBrowsePath(running, part);
+      crumbs.push({ label: part, path: running });
+    }
+    return crumbs;
+  }
   const parts = currentPath.split(/[\\/]+/).filter(Boolean);
   const crumbs: Array<{ label: string; path: string }> = [{ label: "home", path: "~" }];
   let running = "~";

--- a/packages/web/src/components/AddProjectModal.parts.tsx
+++ b/packages/web/src/components/AddProjectModal.parts.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from "react";
 
-const RECENT_PATHS_KEY = "ao:add-project:recent";
 const WINDOWS_DRIVE_ROOT_PATTERN = /^[A-Za-z]:[\\/]?$/;
 const WINDOWS_ABSOLUTE_PATTERN = /^[A-Za-z]:[\\/]/;
 const UNC_ROOT_PATTERN = /^\\\\[^\\]+\\[^\\]+\\?$/;
@@ -78,22 +77,6 @@ export function getBreadcrumbs(currentPath: string): Array<{ label: string; path
   return crumbs;
 }
 
-export function loadRecentPaths(): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const parsed = JSON.parse(window.localStorage.getItem(RECENT_PATHS_KEY) ?? "[]");
-    return Array.isArray(parsed) ? parsed.filter((value): value is string => typeof value === "string") : [];
-  } catch {
-    return [];
-  }
-}
-
-export function saveRecentPath(input: string) {
-  if (typeof window === "undefined") return;
-  const next = [input, ...loadRecentPaths().filter((value) => value !== input)].slice(0, 5);
-  window.localStorage.setItem(RECENT_PATHS_KEY, JSON.stringify(next));
-}
-
 function Glyph({
   children,
   className,
@@ -104,28 +87,6 @@ function Glyph({
   viewBox?: string;
 }) {
   return <svg aria-hidden="true" viewBox={viewBox} className={className}>{children}</svg>;
-}
-
-export function SidebarSection({
-  title,
-  open,
-  onToggle,
-  children,
-}: {
-  title: string;
-  open: boolean;
-  onToggle: () => void;
-  children: ReactNode;
-}) {
-  return (
-    <section className="add-project-browser__sidebar-section">
-      <button type="button" className="add-project-browser__sidebar-toggle" onClick={onToggle}>
-        <span>{title}</span>
-        <span className={`add-project-browser__sidebar-chevron${open ? " is-open" : ""}`}>∨</span>
-      </button>
-      {open ? <div className="add-project-browser__sidebar-body">{children}</div> : null}
-    </section>
-  );
 }
 
 const iconPath = { fill: "none", stroke: "currentColor", strokeWidth: 1.5, strokeLinejoin: "miter" as const };
@@ -153,7 +114,7 @@ export function ArrowUpIcon() {
 }
 
 export function RefreshIcon() {
-  return <Glyph className="add-project-modal__toolicon"><path d="M12 5V2.75H9.75M4.5 11A4.75 4.75 0 0 0 12 5M3.75 11v2.25H6m5.5-8.25A4.75 4.75 0 0 1 4 11" {...compoundStroke} /></Glyph>;
+  return <Glyph className="add-project-modal__toolicon"><path d="M13 8A5 5 0 1 1 8 3M6.3 1.7 8 3 6.3 4.3" {...compoundStroke} /></Glyph>;
 }
 
 export function SortChevronIcon() {

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -22,6 +22,16 @@ interface BrowseEntry {
   modifiedAt?: number;
 }
 
+interface BrowseCurrentDirectory {
+  isGitRepo: boolean;
+  hasLocalConfig: boolean;
+}
+
+interface BrowseRoot {
+  label: string;
+  path: string;
+}
+
 interface CollisionState {
   error: string;
   existingProjectId: string;
@@ -46,6 +56,9 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   const [browseHistory, setBrowseHistory] = useState<string[]>(["~"]);
   const [browseHistoryIndex, setBrowseHistoryIndex] = useState(0);
   const [browseEntries, setBrowseEntries] = useState<BrowseEntry[]>([]);
+  const [currentDirectory, setCurrentDirectory] = useState<BrowseCurrentDirectory | null>(null);
+  const [browseRoots, setBrowseRoots] = useState<BrowseRoot[]>([]);
+  const [locationInput, setLocationInput] = useState("~");
   const [browseLoading, setBrowseLoading] = useState(false);
   const [browseError, setBrowseError] = useState<string | null>(null);
   const [projectIdInput, setProjectIdInput] = useState("");
@@ -55,6 +68,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     path: string,
     options?: { mode?: "push" | "replace"; selectedPath?: string; historyIndex?: number },
   ) => {
+    setLocationInput(path);
     setBrowseLoading(true);
     setBrowseError(null);
     try {
@@ -63,6 +77,8 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
       );
       if (!response) {
         setBrowseEntries([]);
+        setCurrentDirectory(null);
+        setBrowseRoots([]);
         setSelectedBrowsePath(options?.selectedPath ?? path);
         setBrowseError("Failed to browse directories.");
         return;
@@ -73,19 +89,24 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
           | { error?: string; entries?: BrowseEntry[] }
           | null;
         setBrowseEntries([]);
+        setCurrentDirectory(null);
+        setBrowseRoots([]);
         setSelectedBrowsePath(options?.selectedPath ?? path);
         setBrowseError(body?.error ?? "Failed to browse directories.");
         return;
       }
 
       const body = (await response.json().catch(() => null)) as
-        | { error?: string; entries?: BrowseEntry[] }
+        | { error?: string; entries?: BrowseEntry[]; current?: BrowseCurrentDirectory; roots?: BrowseRoot[] }
         | null;
       const mode = options?.mode ?? "push";
       const targetHistoryIndex = options?.historyIndex ?? browseHistoryIndex;
       setBrowsePath(path);
+      setLocationInput(path);
       setSelectedBrowsePath(options?.selectedPath ?? path);
       setBrowseEntries(body?.entries ?? []);
+      setCurrentDirectory(body?.current ?? null);
+      setBrowseRoots(body?.roots ?? []);
       if (mode === "push") {
         setBrowseHistory((current) => {
           const next = current.slice(0, targetHistoryIndex + 1);
@@ -101,6 +122,8 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
         });
       }
     } catch {
+      setCurrentDirectory(null);
+      setBrowseRoots([]);
       setBrowseError("Failed to browse directories.");
     } finally {
       setBrowseLoading(false);
@@ -117,7 +140,10 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     setBrowseHistory([initialPath]);
     setBrowseHistoryIndex(0);
     setBrowsePath(initialPath);
+    setLocationInput(initialPath);
     setSelectedBrowsePath(initialPath);
+    setCurrentDirectory(null);
+    setBrowseRoots([]);
     setProjectIdInput("");
     setProjectNameInput("");
     modalRef.current?.focus();
@@ -129,7 +155,9 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     () => directoryEntries.find((entry) => joinBrowsePath(browsePath, entry.name) === selectedBrowsePath) ?? null,
     [browsePath, directoryEntries, selectedBrowsePath],
   );
+  const selectedCurrentDirectory = selectedBrowsePath === browsePath ? currentDirectory : null;
   const parentPath = getParentBrowsePath(browsePath);
+  const selectedRootPath = browseRoots.find((root) => browsePath.startsWith(root.path))?.path ?? "";
   const canGoBack = browseHistoryIndex > 0;
   const canGoForward = browseHistoryIndex < browseHistory.length - 1;
   const projectIdValue =
@@ -142,7 +170,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     selectedBrowsePath.trim() !== "" &&
     selectedBrowsePath !== "~" &&
     !browseError &&
-    Boolean(selectedEntry?.isGitRepo) &&
+    Boolean(selectedEntry?.isGitRepo || selectedCurrentDirectory?.isGitRepo) &&
     projectIdValue.length > 0 &&
     projectNameValue.length > 0;
   const selectedIndex = directoryEntries.findIndex(
@@ -258,6 +286,10 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     void browse(browseHistory[nextIndex] ?? "~", { mode: "replace", historyIndex: nextIndex });
   };
 
+  const selectedIsKnownNonRepo =
+    Boolean(selectedEntry && !selectedEntry.isGitRepo) ||
+    Boolean(selectedCurrentDirectory && selectedBrowsePath !== "~" && !selectedCurrentDirectory.isGitRepo);
+
   const selectedNotice = collision ? (
     <div className="add-project-modal__notice add-project-modal__notice--warning">
       <p className="add-project-modal__notice-title">{collision.error}</p>
@@ -271,7 +303,7 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     </div>
   ) : inlineError ? (
     <div role="alert" className="add-project-modal__notice add-project-modal__notice--error">{inlineError}</div>
-  ) : selectedEntry && !selectedEntry.isGitRepo ? (
+  ) : selectedIsKnownNonRepo ? (
     <div role="alert" className="add-project-modal__notice add-project-modal__notice--error">
       Selected folder is not a git repository.
     </div>
@@ -292,8 +324,35 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
             <button type="button" onClick={() => navigateHistory(browseHistoryIndex + 1)} disabled={!canGoForward} className="add-project-modal__toolbtn" aria-label="Go forward"><ChevronRightIcon /></button>
             <button type="button" onClick={() => parentPath && void browse(parentPath)} disabled={!parentPath} className="add-project-modal__toolbtn" aria-label="Go up"><ArrowUpIcon /></button>
             <button type="button" onClick={() => void browse(browsePath, { mode: "replace", selectedPath: selectedBrowsePath })} className="add-project-modal__toolbtn" aria-label="Refresh"><RefreshIcon /></button>
+            {browseRoots.length > 0 ? (
+              <select
+                aria-label="Drive"
+                value={selectedRootPath}
+                onChange={(event) => {
+                  const nextPath = event.target.value;
+                  if (nextPath) void browse(nextPath, { selectedPath: nextPath });
+                }}
+                className="add-project-modal__drive-select"
+              >
+                <option value="">Drive</option>
+                {browseRoots.map((root) => (
+                  <option key={root.path} value={root.path}>{root.label}</option>
+                ))}
+              </select>
+            ) : null}
           </div>
-          <div className="add-project-modal__location">{browsePath}</div>
+          <input
+            aria-label="Folder path"
+            value={locationInput}
+            onChange={(event) => setLocationInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key !== "Enter") return;
+              event.preventDefault();
+              const nextPath = locationInput.trim() || "~";
+              void browse(nextPath, { selectedPath: nextPath });
+            }}
+            className="add-project-modal__location"
+          />
         </div>
 
         <div className="add-project-modal__content">

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -1,36 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
-  ArrowUpIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
   deriveProjectIdFromPath,
   deriveProjectNameFromPath,
-  getParentBrowsePath,
   joinBrowsePath,
-  RefreshIcon,
   saveRecentPath,
 } from "@/components/AddProjectModal.parts";
-
-interface BrowseEntry {
-  name: string;
-  isDirectory: boolean;
-  isGitRepo: boolean;
-  hasLocalConfig: boolean;
-  modifiedAt?: number;
-}
-
-interface BrowseCurrentDirectory {
-  isGitRepo: boolean;
-  hasLocalConfig: boolean;
-}
-
-interface BrowseRoot {
-  label: string;
-  path: string;
-}
+import { DirectoryBrowser } from "@/components/DirectoryBrowser";
+import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
 interface CollisionState {
   error: string;
@@ -46,120 +25,41 @@ interface AddProjectModalProps {
 
 export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   const router = useRouter();
+  const browser = useDirectoryBrowser();
   const modalRef = useRef<HTMLDivElement>(null);
   const [submitting, setSubmitting] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [networkError, setNetworkError] = useState<string | null>(null);
   const [collision, setCollision] = useState<CollisionState | null>(null);
-  const [browsePath, setBrowsePath] = useState("~");
-  const [selectedBrowsePath, setSelectedBrowsePath] = useState("~");
-  const [browseHistory, setBrowseHistory] = useState<string[]>(["~"]);
-  const [browseHistoryIndex, setBrowseHistoryIndex] = useState(0);
-  const [browseEntries, setBrowseEntries] = useState<BrowseEntry[]>([]);
-  const [currentDirectory, setCurrentDirectory] = useState<BrowseCurrentDirectory | null>(null);
-  const [browseRoots, setBrowseRoots] = useState<BrowseRoot[]>([]);
-  const [locationInput, setLocationInput] = useState("~");
-  const [browseLoading, setBrowseLoading] = useState(false);
-  const [browseError, setBrowseError] = useState<string | null>(null);
   const [projectIdInput, setProjectIdInput] = useState("");
   const [projectNameInput, setProjectNameInput] = useState("");
 
-  const browse = async (
-    path: string,
-    options?: { mode?: "push" | "replace"; selectedPath?: string; historyIndex?: number },
-  ) => {
-    setLocationInput(path);
-    setBrowseLoading(true);
-    setBrowseError(null);
-    try {
-      const response = await fetch(`/api/filesystem/browse?path=${encodeURIComponent(path)}`).catch(
-        () => null,
-      );
-      if (!response) {
-        setBrowseEntries([]);
-        setCurrentDirectory(null);
-        setBrowseRoots([]);
-        setSelectedBrowsePath(options?.selectedPath ?? path);
-        setBrowseError("Failed to browse directories.");
-        return;
-      }
-
-      if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as
-          | { error?: string; entries?: BrowseEntry[] }
-          | null;
-        setBrowseEntries([]);
-        setCurrentDirectory(null);
-        setBrowseRoots([]);
-        setSelectedBrowsePath(options?.selectedPath ?? path);
-        setBrowseError(body?.error ?? "Failed to browse directories.");
-        return;
-      }
-
-      const body = (await response.json().catch(() => null)) as
-        | { error?: string; entries?: BrowseEntry[]; current?: BrowseCurrentDirectory; roots?: BrowseRoot[] }
-        | null;
-      const mode = options?.mode ?? "push";
-      const targetHistoryIndex = options?.historyIndex ?? browseHistoryIndex;
-      setBrowsePath(path);
-      setLocationInput(path);
-      setSelectedBrowsePath(options?.selectedPath ?? path);
-      setBrowseEntries(body?.entries ?? []);
-      setCurrentDirectory(body?.current ?? null);
-      setBrowseRoots(body?.roots ?? []);
-      if (mode === "push") {
-        setBrowseHistory((current) => {
-          const next = current.slice(0, targetHistoryIndex + 1);
-          if (next[next.length - 1] !== path) next.push(path);
-          setBrowseHistoryIndex(next.length - 1);
-          return next;
-        });
-      } else {
-        setBrowseHistory((current) => {
-          const next = [...current];
-          next[targetHistoryIndex] = path;
-          return next;
-        });
-      }
-    } catch {
-      setCurrentDirectory(null);
-      setBrowseRoots([]);
-      setBrowseError("Failed to browse directories.");
-    } finally {
-      setBrowseLoading(false);
-    }
-  };
+  const {
+    reset,
+    selectedBrowsePath,
+    directoryEntries,
+    currentDirectory,
+    error: browseError,
+    browsePath,
+  } = browser;
 
   useEffect(() => {
     if (!open) return;
-    const initialPath = "~";
+    setSubmitting(false);
     setInlineError(null);
     setNetworkError(null);
     setCollision(null);
-    setBrowseError(null);
-    setBrowseHistory([initialPath]);
-    setBrowseHistoryIndex(0);
-    setBrowsePath(initialPath);
-    setLocationInput(initialPath);
-    setSelectedBrowsePath(initialPath);
-    setCurrentDirectory(null);
-    setBrowseRoots([]);
     setProjectIdInput("");
     setProjectNameInput("");
     modalRef.current?.focus();
-    void browse(initialPath, { mode: "replace", selectedPath: initialPath });
-  }, [open]);
+    reset();
+  }, [open, reset]);
 
-  const directoryEntries = useMemo(() => browseEntries.filter((entry) => entry.isDirectory), [browseEntries]);
   const selectedEntry = useMemo(
     () => directoryEntries.find((entry) => joinBrowsePath(browsePath, entry.name) === selectedBrowsePath) ?? null,
     [browsePath, directoryEntries, selectedBrowsePath],
   );
   const selectedCurrentDirectory = selectedBrowsePath === browsePath ? currentDirectory : null;
-  const parentPath = getParentBrowsePath(browsePath);
-  const selectedRootPath = browseRoots.find((root) => browsePath.startsWith(root.path))?.path ?? "";
-  const canGoBack = browseHistoryIndex > 0;
-  const canGoForward = browseHistoryIndex < browseHistory.length - 1;
   const projectIdValue =
     projectIdInput.trim() ||
     (selectedBrowsePath.trim() && selectedBrowsePath !== "~" ? deriveProjectIdFromPath(selectedBrowsePath) : "");
@@ -173,9 +73,6 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     Boolean(selectedEntry?.isGitRepo || selectedCurrentDirectory?.isGitRepo) &&
     projectIdValue.length > 0 &&
     projectNameValue.length > 0;
-  const selectedIndex = directoryEntries.findIndex(
-    (entry) => joinBrowsePath(browsePath, entry.name) === selectedBrowsePath,
-  );
 
   useEffect(() => {
     if (!selectedBrowsePath || selectedBrowsePath === "~") {
@@ -187,6 +84,60 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
     setProjectIdInput(deriveProjectIdFromPath(selectedBrowsePath));
     setProjectNameInput(deriveProjectNameFromPath(selectedBrowsePath));
   }, [selectedBrowsePath]);
+
+  const submit = useCallback(
+    async (useDefaultProjectId = false) => {
+      setInlineError(null);
+      setNetworkError(null);
+      setCollision(null);
+      setSubmitting(true);
+      const resolvedPath = selectedBrowsePath.trim();
+      const projectId = projectIdValue;
+      const name = projectNameValue;
+      try {
+        const response = await fetch("/api/projects", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ projectId, name, path: resolvedPath, useDefaultProjectId }),
+        });
+        const body = (await response.json().catch(() => null)) as
+          | {
+              error?: string;
+              projectId?: string;
+              existingProjectId?: string;
+              suggestedProjectId?: string;
+              suggestion?: "choose-project-id";
+            }
+          | null;
+        if (response.status === 409 && body?.existingProjectId && body?.suggestedProjectId && body?.suggestion) {
+          setCollision({
+            error: body.error ?? "A project with that ID already exists.",
+            existingProjectId: body.existingProjectId,
+            suggestedProjectId: body.suggestedProjectId,
+            suggestion: body.suggestion,
+          });
+          setProjectIdInput(body.suggestedProjectId);
+          return;
+        }
+        if (!response.ok) {
+          const message = body?.error ?? "Failed to add project.";
+          if (response.status < 500) setInlineError(message);
+          else setNetworkError(message);
+          return;
+        }
+        saveRecentPath(resolvedPath);
+        const nextProjectId = body?.projectId ?? projectId.trim();
+        onClose();
+        router.push(`/projects/${encodeURIComponent(nextProjectId)}`);
+        router.refresh();
+      } catch {
+        setNetworkError("Network error while adding project.");
+      } finally {
+        setSubmitting(false);
+      }
+    },
+    [onClose, projectIdValue, projectNameValue, router, selectedBrowsePath],
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -200,91 +151,13 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
       if ((event.metaKey || event.ctrlKey) && event.key === "Enter" && canSubmit) {
         event.preventDefault();
         void submit();
-        return;
-      }
-      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        if (directoryEntries.length === 0) return;
-        event.preventDefault();
-        const offset = event.key === "ArrowDown" ? 1 : -1;
-        const nextIndex = selectedIndex === -1 ? (offset > 0 ? 0 : directoryEntries.length - 1) : Math.min(Math.max(selectedIndex + offset, 0), directoryEntries.length - 1);
-        const nextEntry = directoryEntries[nextIndex];
-        if (nextEntry) setSelectedBrowsePath(joinBrowsePath(browsePath, nextEntry.name));
-        return;
-      }
-      if (event.key === "Enter") {
-        if (selectedIndex >= 0) {
-          event.preventDefault();
-          void browse(selectedBrowsePath);
-          return;
-        }
-        if (canSubmit) {
-          event.preventDefault();
-          void submit();
-        }
       }
     };
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [browsePath, canSubmit, directoryEntries, onClose, open, selectedBrowsePath, selectedIndex]);
-
-  const submit = async (useDefaultProjectId = false) => {
-    setInlineError(null);
-    setNetworkError(null);
-    setCollision(null);
-    setSubmitting(true);
-    const resolvedPath = selectedBrowsePath.trim();
-    const projectId = projectIdValue;
-    const name = projectNameValue;
-    try {
-      const response = await fetch("/api/projects", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ projectId, name, path: resolvedPath, useDefaultProjectId }),
-      });
-      const body = (await response.json().catch(() => null)) as
-        | {
-            error?: string;
-            projectId?: string;
-            existingProjectId?: string;
-            suggestedProjectId?: string;
-            suggestion?: "choose-project-id";
-          }
-        | null;
-      if (response.status === 409 && body?.existingProjectId && body?.suggestedProjectId && body?.suggestion) {
-        setCollision({
-          error: body.error ?? "A project with that ID already exists.",
-          existingProjectId: body.existingProjectId,
-          suggestedProjectId: body.suggestedProjectId,
-          suggestion: body.suggestion,
-        });
-        setProjectIdInput(body.suggestedProjectId);
-        return;
-      }
-      if (!response.ok) {
-        const message = body?.error ?? "Failed to add project.";
-        if (response.status < 500) setInlineError(message);
-        else setNetworkError(message);
-        return;
-      }
-      saveRecentPath(resolvedPath);
-      const nextProjectId = body?.projectId ?? projectId.trim();
-      onClose();
-      router.push(`/projects/${encodeURIComponent(nextProjectId)}`);
-      router.refresh();
-    } catch {
-      setNetworkError("Network error while adding project.");
-    } finally {
-      setSubmitting(false);
-    }
-  };
+  }, [canSubmit, onClose, open, submit]);
 
   if (!open) return null;
-
-  const navigateHistory = (nextIndex: number) => {
-    if (nextIndex < 0 || nextIndex >= browseHistory.length) return;
-    setBrowseHistoryIndex(nextIndex);
-    void browse(browseHistory[nextIndex] ?? "~", { mode: "replace", historyIndex: nextIndex });
-  };
 
   const selectedIsKnownNonRepo =
     Boolean(selectedEntry && !selectedEntry.isGitRepo) ||
@@ -293,16 +166,33 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
   const selectedNotice = collision ? (
     <div className="add-project-modal__notice add-project-modal__notice--warning">
       <p className="add-project-modal__notice-title">{collision.error}</p>
-      <p className="add-project-modal__notice-copy">Existing project: <code>{collision.existingProjectId}</code></p>
-      <p className="add-project-modal__notice-copy">Suggested project ID: <code>{collision.suggestedProjectId}</code></p>
+      <p className="add-project-modal__notice-copy">
+        Existing project: <code>{collision.existingProjectId}</code>
+      </p>
+      <p className="add-project-modal__notice-copy">
+        Suggested project ID: <code>{collision.suggestedProjectId}</code>
+      </p>
       <div className="add-project-modal__notice-actions">
-        <button type="button" onClick={() => { onClose(); router.push(`/projects/${encodeURIComponent(collision.existingProjectId)}`); }} className="add-project-modal__ghostbtn">Open existing</button>
-        <button type="button" onClick={() => void submit(true)} className="add-project-modal__ghostbtn">Use suggested ID</button>
+        <button
+          type="button"
+          onClick={() => {
+            onClose();
+            router.push(`/projects/${encodeURIComponent(collision.existingProjectId)}`);
+          }}
+          className="add-project-modal__ghostbtn"
+        >
+          Open existing
+        </button>
+        <button type="button" onClick={() => void submit(true)} className="add-project-modal__ghostbtn">
+          Use suggested ID
+        </button>
         <span className="add-project-modal__notice-hint">Edit the Project ID field or accept the suggested suffix.</span>
       </div>
     </div>
   ) : inlineError ? (
-    <div role="alert" className="add-project-modal__notice add-project-modal__notice--error">{inlineError}</div>
+    <div role="alert" className="add-project-modal__notice add-project-modal__notice--error">
+      {inlineError}
+    </div>
   ) : selectedIsKnownNonRepo ? (
     <div role="alert" className="add-project-modal__notice add-project-modal__notice--error">
       Selected folder is not a git repository.
@@ -313,95 +203,31 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
 
   return (
     <div className="add-project-modal-backdrop">
-      <div ref={modalRef} role="dialog" aria-modal="true" aria-label="Add project" className="add-project-modal" tabIndex={-1}>
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Add project"
+        className="add-project-modal"
+        tabIndex={-1}
+      >
         <div className="add-project-modal__titlebar">
           <h2 className="add-project-modal__windowtitle">add project</h2>
-          <button type="button" aria-label="Close" onClick={onClose} className="add-project-modal__iconbtn">×</button>
-        </div>
-        <div className="add-project-modal__toolbar">
-          <div className="add-project-modal__toolbarcluster">
-            <button type="button" onClick={() => navigateHistory(browseHistoryIndex - 1)} disabled={!canGoBack} className="add-project-modal__toolbtn" aria-label="Go back"><ChevronLeftIcon /></button>
-            <button type="button" onClick={() => navigateHistory(browseHistoryIndex + 1)} disabled={!canGoForward} className="add-project-modal__toolbtn" aria-label="Go forward"><ChevronRightIcon /></button>
-            <button type="button" onClick={() => parentPath && void browse(parentPath)} disabled={!parentPath} className="add-project-modal__toolbtn" aria-label="Go up"><ArrowUpIcon /></button>
-            <button type="button" onClick={() => void browse(browsePath, { mode: "replace", selectedPath: selectedBrowsePath })} className="add-project-modal__toolbtn" aria-label="Refresh"><RefreshIcon /></button>
-            {browseRoots.length > 0 ? (
-              <select
-                aria-label="Drive"
-                value={selectedRootPath}
-                onChange={(event) => {
-                  const nextPath = event.target.value;
-                  if (nextPath) void browse(nextPath, { selectedPath: nextPath });
-                }}
-                className="add-project-modal__drive-select"
-              >
-                <option value="">Drive</option>
-                {browseRoots.map((root) => (
-                  <option key={root.path} value={root.path}>{root.label}</option>
-                ))}
-              </select>
-            ) : null}
-          </div>
-          <input
-            aria-label="Folder path"
-            value={locationInput}
-            onChange={(event) => setLocationInput(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key !== "Enter") return;
-              event.preventDefault();
-              const nextPath = locationInput.trim() || "~";
-              void browse(nextPath, { selectedPath: nextPath });
-            }}
-            className="add-project-modal__location"
-          />
+          <button type="button" aria-label="Close" onClick={onClose} className="add-project-modal__iconbtn">
+            ×
+          </button>
         </div>
 
-        <div className="add-project-modal__content">
-          <div className="add-project-browser">
-            <div className="add-project-browser__current">
-              <div className="add-project-browser__current-label">Current folder</div>
-              <div className="add-project-browser__current-path">{browsePath}</div>
-            </div>
-            {browseError ? (
-              <div className="add-project-browser__state add-project-browser__state--error">
-                <p className="add-project-browser__state-title">Directory browser unavailable</p>
-                <p className="add-project-browser__state-copy">{browseError}</p>
-              </div>
-            ) : browseLoading ? (
-              <div className="add-project-browser__state">
-                <p className="add-project-browser__state-title">Loading folders</p>
-                <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
-              </div>
-            ) : directoryEntries.length === 0 ? (
-              <div className="add-project-browser__state">
-                <p className="add-project-browser__state-title">No visible folders here</p>
-                <p className="add-project-browser__state-copy">Try navigating up or picking a different location.</p>
-              </div>
-            ) : (
-              <div className="add-project-browser__rows">
-                {parentPath ? (
-                  <button type="button" onClick={() => void browse(parentPath)} className="add-project-browser__row add-project-browser__row--parent">
-                    ..
-                  </button>
-                ) : null}
-                {directoryEntries.map((entry) => {
-                  const nextPath = joinBrowsePath(browsePath, entry.name);
-                  return (
-                    <button key={nextPath} type="button" onClick={() => setSelectedBrowsePath(nextPath)} onDoubleClick={() => void browse(nextPath)} className={`add-project-browser__row${selectedBrowsePath === nextPath ? " is-selected" : ""}`}>
-                      {entry.name}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
-          </div>
-        </div>
+        <DirectoryBrowser browser={browser} />
 
         <div className="add-project-modal__pathbar add-project-modal__pathbar--selection">
           <span className="add-project-modal__selection-label">Selected</span>
           <span className="add-project-modal__selection-path">{selectedBrowsePath || "No directory selected"}</span>
         </div>
         <div className="add-project-modal__pathbar add-project-modal__pathbar--selection">
-          <label className="add-project-modal__selection-label" htmlFor="project-id-input">Project ID</label>
+          <label className="add-project-modal__selection-label" htmlFor="project-id-input">
+            Project ID
+          </label>
           <input
             id="project-id-input"
             value={projectIdInput}
@@ -410,7 +236,9 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
           />
         </div>
         <div className="add-project-modal__pathbar add-project-modal__pathbar--selection">
-          <label className="add-project-modal__selection-label" htmlFor="project-name-input">Project name</label>
+          <label className="add-project-modal__selection-label" htmlFor="project-name-input">
+            Project name
+          </label>
           <input
             id="project-name-input"
             value={projectNameInput}
@@ -423,8 +251,17 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
         <div className="add-project-modal__footer">
           <div className="add-project-modal__foldercount">{directoryEntries.length} folders</div>
           <div className="add-project-modal__actions">
-            <button type="button" onClick={onClose} className="add-project-modal__ghostbtn">Cancel</button>
-            <button type="button" onClick={() => void submit()} disabled={!canSubmit || submitting} className="add-project-modal__primarybtn">{submitting ? "Adding…" : "Add project"}</button>
+            <button type="button" onClick={onClose} className="add-project-modal__ghostbtn">
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={!canSubmit || submitting}
+              className="add-project-modal__primarybtn"
+            >
+              {submitting ? "Adding…" : "Add project"}
+            </button>
           </div>
         </div>
       </div>

--- a/packages/web/src/components/AddProjectModal.tsx
+++ b/packages/web/src/components/AddProjectModal.tsx
@@ -6,7 +6,6 @@ import {
   deriveProjectIdFromPath,
   deriveProjectNameFromPath,
   joinBrowsePath,
-  saveRecentPath,
 } from "@/components/AddProjectModal.parts";
 import { DirectoryBrowser } from "@/components/DirectoryBrowser";
 import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
@@ -125,7 +124,6 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
           else setNetworkError(message);
           return;
         }
-        saveRecentPath(resolvedPath);
         const nextProjectId = body?.projectId ?? projectId.trim();
         onClose();
         router.push(`/projects/${encodeURIComponent(nextProjectId)}`);
@@ -224,27 +222,29 @@ export function AddProjectModal({ open, onClose }: AddProjectModalProps) {
           <span className="add-project-modal__selection-label">Selected</span>
           <span className="add-project-modal__selection-path">{selectedBrowsePath || "No directory selected"}</span>
         </div>
-        <div className="add-project-modal__pathbar add-project-modal__pathbar--selection">
-          <label className="add-project-modal__selection-label" htmlFor="project-id-input">
-            Project ID
-          </label>
-          <input
-            id="project-id-input"
-            value={projectIdInput}
-            onChange={(event) => setProjectIdInput(event.target.value)}
-            className="add-project-modal__selection-path"
-          />
-        </div>
-        <div className="add-project-modal__pathbar add-project-modal__pathbar--selection">
-          <label className="add-project-modal__selection-label" htmlFor="project-name-input">
-            Project name
-          </label>
-          <input
-            id="project-name-input"
-            value={projectNameInput}
-            onChange={(event) => setProjectNameInput(event.target.value)}
-            className="add-project-modal__selection-path"
-          />
+        <div className="add-project-modal__pathbar add-project-modal__formrow">
+          <div className="add-project-modal__field">
+            <label className="add-project-modal__selection-label" htmlFor="project-id-input">
+              Project ID
+            </label>
+            <input
+              id="project-id-input"
+              value={projectIdInput}
+              onChange={(event) => setProjectIdInput(event.target.value)}
+              className="add-project-modal__selection-path"
+            />
+          </div>
+          <div className="add-project-modal__field">
+            <label className="add-project-modal__selection-label" htmlFor="project-name-input">
+              Project name
+            </label>
+            <input
+              id="project-name-input"
+              value={projectNameInput}
+              onChange={(event) => setProjectNameInput(event.target.value)}
+              className="add-project-modal__selection-path"
+            />
+          </div>
         </div>
         {selectedNotice}
 

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  getBreadcrumbs,
   joinBrowsePath,
   RefreshIcon,
 } from "@/components/AddProjectModal.parts";
@@ -18,6 +19,10 @@ function isTextEditingTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   if (target.isContentEditable) return true;
   return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement;
+}
+
+function isFolderRowTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement && target.classList.contains("add-project-browser__row");
 }
 
 export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
@@ -58,6 +63,7 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
       if (
         event.key === "Enter" &&
         selectedIndex >= 0 &&
+        isFolderRowTarget(event.target) &&
         !event.metaKey &&
         !event.ctrlKey &&
         !event.altKey &&
@@ -143,6 +149,18 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
         <div className="add-project-browser">
           <div className="add-project-browser__current">
             <div className="add-project-browser__current-label">Current folder</div>
+            <div className="add-project-browser__breadcrumb">
+              {getBreadcrumbs(browser.browsePath).map((crumb) => (
+                <button
+                  key={crumb.path}
+                  type="button"
+                  className="add-project-browser__crumb"
+                  onClick={() => void browser.browse(crumb.path)}
+                >
+                  {crumb.label}
+                </button>
+              ))}
+            </div>
             <div className="add-project-browser__current-path">{browser.browsePath}</div>
           </div>
           {browser.error ? (

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -5,6 +5,7 @@ import {
   ArrowUpIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
+  FolderIcon,
   getBreadcrumbs,
   joinBrowsePath,
   RefreshIcon,
@@ -199,7 +200,13 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
                     onDoubleClick={() => void browser.browse(nextPath)}
                     className={`add-project-browser__row${browser.selectedBrowsePath === nextPath ? " is-selected" : ""}`}
                   >
-                    {entry.name}
+                    <FolderIcon className="add-project-browser__row-icon" />
+                    <span className="add-project-browser__row-name">{entry.name}</span>
+                    {entry.isGitRepo ? (
+                      <span className="add-project-browser__badge" aria-hidden="true">
+                        git
+                      </span>
+                    ) : null}
                   </button>
                 );
               })}

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -151,15 +151,20 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
           </button>
           {browser.roots.length > 0 ? (
             <select
-              aria-label="Drive"
-              value={browser.selectedRootPath}
+              aria-label="Location"
+              // When on home, no drive root matches → the bare select shows "Home" as the
+              // current value. On a drive, selectedRootPath is the drive; picking "Home"
+              // (value="~") routes back to ~.
+              value={browser.browsePath === "~" ? "~" : browser.selectedRootPath}
               onChange={(event) => {
                 const nextPath = event.target.value;
-                if (nextPath) void browser.browse(nextPath, { selectedPath: nextPath });
+                if (!nextPath) return;
+                if (nextPath === "~") void browser.browse("~");
+                else void browser.browse(nextPath);
               }}
               className="add-project-modal__drive-select"
             >
-              <option value="">Drive</option>
+              <option value="~">Home</option>
               {browser.roots.map((root) => (
                 <option key={root.path} value={root.path}>
                   {root.label}

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowUpIcon,
   ChevronLeftIcon,
@@ -8,7 +8,9 @@ import {
   FolderIcon,
   getBreadcrumbs,
   joinBrowsePath,
+  loadRecentPaths,
   RefreshIcon,
+  SidebarSection,
 } from "@/components/AddProjectModal.parts";
 import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
@@ -31,6 +33,8 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
   const contentRef = useRef<HTMLDivElement>(null);
   const typeaheadBufferRef = useRef("");
   const typeaheadLastTsRef = useRef(0);
+  const [recentOpen, setRecentOpen] = useState(true);
+  const [recentPaths] = useState(() => loadRecentPaths());
   const selectedIndex = useMemo(
     () =>
       browser.directoryEntries.findIndex(
@@ -164,72 +168,88 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
         />
       </div>
 
-      <div ref={contentRef} className="add-project-modal__content">
+      <div className="add-project-modal__content">
         <div className="add-project-browser">
-          <div className="add-project-browser__current">
-            <div className="add-project-browser__current-label">Current folder</div>
-            <div className="add-project-browser__breadcrumb">
-              {getBreadcrumbs(browser.browsePath).map((crumb) => (
+          <aside className="add-project-browser__sidebar">
+            <SidebarSection title="Recent" open={recentOpen} onToggle={() => setRecentOpen((open) => !open)}>
+              {recentPaths.map((path) => (
                 <button
-                  key={crumb.path}
+                  key={path}
                   type="button"
-                  className="add-project-browser__crumb"
-                  onClick={() => void browser.browse(crumb.path)}
+                  className="add-project-browser__sidebar-item"
+                  onClick={() => void browser.browse(path, { selectedPath: path })}
                 >
-                  {crumb.label}
+                  {path}
                 </button>
               ))}
-            </div>
-            <div className="add-project-browser__current-path">{browser.browsePath}</div>
-          </div>
-          {browser.error ? (
-            <div className="add-project-browser__state add-project-browser__state--error">
-              <p className="add-project-browser__state-title">Directory browser unavailable</p>
-              <p className="add-project-browser__state-copy">{browser.error}</p>
-            </div>
-          ) : browser.loading ? (
-            <div className="add-project-browser__state">
-              <p className="add-project-browser__state-title">Loading folders</p>
-              <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
-            </div>
-          ) : browser.directoryEntries.length === 0 ? (
-            <div className="add-project-browser__state">
-              <p className="add-project-browser__state-title">No visible folders here</p>
-              <p className="add-project-browser__state-copy">Try navigating up or picking a different location.</p>
-            </div>
-          ) : (
-            <div className="add-project-browser__rows">
-              {browser.parentPath ? (
-                <button
-                  type="button"
-                  onClick={browser.goUp}
-                  className="add-project-browser__row add-project-browser__row--parent"
-                >
-                  ..
-                </button>
-              ) : null}
-              {browser.directoryEntries.map((entry) => {
-                const nextPath = joinBrowsePath(browser.browsePath, entry.name);
-                return (
+            </SidebarSection>
+          </aside>
+          <div ref={contentRef} className="add-project-browser__main">
+            <div className="add-project-browser__current">
+              <div className="add-project-browser__current-label">Current folder</div>
+              <div className="add-project-browser__breadcrumb">
+                {getBreadcrumbs(browser.browsePath).map((crumb) => (
                   <button
-                    key={nextPath}
+                    key={crumb.path}
                     type="button"
-                    onClick={() => browser.setSelectedBrowsePath(nextPath)}
-                    onDoubleClick={() => void browser.browse(nextPath)}
-                    className={`add-project-browser__row${browser.selectedBrowsePath === nextPath ? " is-selected" : ""}`}
+                    className="add-project-browser__crumb"
+                    onClick={() => void browser.browse(crumb.path)}
                   >
-                    <FolderIcon className="add-project-browser__row-icon" />
-                    <span className="add-project-browser__row-name">{entry.name}</span>
-                    {entry.isGitRepo ? (
-                      <span className="add-project-browser__badge" aria-hidden="true">
-                        git
-                      </span>
-                    ) : null}
+                    {crumb.label}
                   </button>
-                );
-              })}
+                ))}
+              </div>
+              <div className="add-project-browser__current-path">{browser.browsePath}</div>
             </div>
-          )}
+            {browser.error ? (
+              <div className="add-project-browser__state add-project-browser__state--error">
+                <p className="add-project-browser__state-title">Directory browser unavailable</p>
+                <p className="add-project-browser__state-copy">{browser.error}</p>
+              </div>
+            ) : browser.loading ? (
+              <div className="add-project-browser__state">
+                <p className="add-project-browser__state-title">Loading folders</p>
+                <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
+              </div>
+            ) : browser.directoryEntries.length === 0 ? (
+              <div className="add-project-browser__state">
+                <p className="add-project-browser__state-title">No visible folders here</p>
+                <p className="add-project-browser__state-copy">Try navigating up or picking a different location.</p>
+              </div>
+            ) : (
+              <div className="add-project-browser__rows">
+                {browser.parentPath ? (
+                  <button
+                    type="button"
+                    onClick={browser.goUp}
+                    className="add-project-browser__row add-project-browser__row--parent"
+                  >
+                    ..
+                  </button>
+                ) : null}
+                {browser.directoryEntries.map((entry) => {
+                  const nextPath = joinBrowsePath(browser.browsePath, entry.name);
+                  return (
+                    <button
+                      key={nextPath}
+                      type="button"
+                      onClick={() => browser.setSelectedBrowsePath(nextPath)}
+                      onDoubleClick={() => void browser.browse(nextPath)}
+                      className={`add-project-browser__row${browser.selectedBrowsePath === nextPath ? " is-selected" : ""}`}
+                    >
+                      <FolderIcon className="add-project-browser__row-icon" />
+                      <span className="add-project-browser__row-name">{entry.name}</span>
+                      {entry.isGitRepo ? (
+                        <span className="add-project-browser__badge" aria-hidden="true">
+                          git
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </>

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import {
+  ArrowUpIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  joinBrowsePath,
+  RefreshIcon,
+} from "@/components/AddProjectModal.parts";
+import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
+
+interface DirectoryBrowserProps {
+  browser: UseDirectoryBrowser;
+}
+
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  if (target.isContentEditable) return true;
+  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement;
+}
+
+export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
+  const toolbarRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const selectedIndex = useMemo(
+    () =>
+      browser.directoryEntries.findIndex(
+        (entry) => joinBrowsePath(browser.browsePath, entry.name) === browser.selectedBrowsePath,
+      ),
+    [browser.browsePath, browser.directoryEntries, browser.selectedBrowsePath],
+  );
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const target = event.target;
+      const isInsideBrowser =
+        target instanceof Node &&
+        (toolbarRef.current?.contains(target) || contentRef.current?.contains(target));
+      if (!isInsideBrowser) return;
+      if (isTextEditingTarget(event.target)) return;
+
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        if (browser.directoryEntries.length === 0) return;
+        event.preventDefault();
+        const offset = event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex =
+          selectedIndex === -1
+            ? offset > 0
+              ? 0
+              : browser.directoryEntries.length - 1
+            : Math.min(Math.max(selectedIndex + offset, 0), browser.directoryEntries.length - 1);
+        const nextEntry = browser.directoryEntries[nextIndex];
+        if (nextEntry) browser.setSelectedBrowsePath(joinBrowsePath(browser.browsePath, nextEntry.name));
+        return;
+      }
+
+      if (
+        event.key === "Enter" &&
+        selectedIndex >= 0 &&
+        !event.metaKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.shiftKey
+      ) {
+        event.preventDefault();
+        void browser.browse(browser.selectedBrowsePath);
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [browser, selectedIndex]);
+
+  return (
+    <>
+      <div ref={toolbarRef} className="add-project-modal__toolbar">
+        <div className="add-project-modal__toolbarcluster">
+          <button
+            type="button"
+            onClick={browser.goBack}
+            disabled={!browser.canGoBack}
+            className="add-project-modal__toolbtn"
+            aria-label="Go back"
+          >
+            <ChevronLeftIcon />
+          </button>
+          <button
+            type="button"
+            onClick={browser.goForward}
+            disabled={!browser.canGoForward}
+            className="add-project-modal__toolbtn"
+            aria-label="Go forward"
+          >
+            <ChevronRightIcon />
+          </button>
+          <button
+            type="button"
+            onClick={browser.goUp}
+            disabled={!browser.parentPath}
+            className="add-project-modal__toolbtn"
+            aria-label="Go up"
+          >
+            <ArrowUpIcon />
+          </button>
+          <button type="button" onClick={browser.refresh} className="add-project-modal__toolbtn" aria-label="Refresh">
+            <RefreshIcon />
+          </button>
+          {browser.roots.length > 0 ? (
+            <select
+              aria-label="Drive"
+              value={browser.selectedRootPath}
+              onChange={(event) => {
+                const nextPath = event.target.value;
+                if (nextPath) void browser.browse(nextPath, { selectedPath: nextPath });
+              }}
+              className="add-project-modal__drive-select"
+            >
+              <option value="">Drive</option>
+              {browser.roots.map((root) => (
+                <option key={root.path} value={root.path}>
+                  {root.label}
+                </option>
+              ))}
+            </select>
+          ) : null}
+        </div>
+        <input
+          aria-label="Folder path"
+          value={browser.locationInput}
+          onChange={(event) => browser.setLocationInput(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter") return;
+            event.preventDefault();
+            const nextPath = browser.locationInput.trim() || "~";
+            void browser.browse(nextPath, { selectedPath: nextPath });
+          }}
+          className="add-project-modal__location"
+        />
+      </div>
+
+      <div ref={contentRef} className="add-project-modal__content">
+        <div className="add-project-browser">
+          <div className="add-project-browser__current">
+            <div className="add-project-browser__current-label">Current folder</div>
+            <div className="add-project-browser__current-path">{browser.browsePath}</div>
+          </div>
+          {browser.error ? (
+            <div className="add-project-browser__state add-project-browser__state--error">
+              <p className="add-project-browser__state-title">Directory browser unavailable</p>
+              <p className="add-project-browser__state-copy">{browser.error}</p>
+            </div>
+          ) : browser.loading ? (
+            <div className="add-project-browser__state">
+              <p className="add-project-browser__state-title">Loading folders</p>
+              <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
+            </div>
+          ) : browser.directoryEntries.length === 0 ? (
+            <div className="add-project-browser__state">
+              <p className="add-project-browser__state-title">No visible folders here</p>
+              <p className="add-project-browser__state-copy">Try navigating up or picking a different location.</p>
+            </div>
+          ) : (
+            <div className="add-project-browser__rows">
+              {browser.parentPath ? (
+                <button
+                  type="button"
+                  onClick={browser.goUp}
+                  className="add-project-browser__row add-project-browser__row--parent"
+                >
+                  ..
+                </button>
+              ) : null}
+              {browser.directoryEntries.map((entry) => {
+                const nextPath = joinBrowsePath(browser.browsePath, entry.name);
+                return (
+                  <button
+                    key={nextPath}
+                    type="button"
+                    onClick={() => browser.setSelectedBrowsePath(nextPath)}
+                    onDoubleClick={() => void browser.browse(nextPath)}
+                    className={`add-project-browser__row${browser.selectedBrowsePath === nextPath ? " is-selected" : ""}`}
+                  >
+                    {entry.name}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import {
   ArrowUpIcon,
   ChevronLeftIcon,
@@ -8,9 +8,7 @@ import {
   FolderIcon,
   getBreadcrumbs,
   joinBrowsePath,
-  loadRecentPaths,
   RefreshIcon,
-  SidebarSection,
 } from "@/components/AddProjectModal.parts";
 import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
@@ -28,13 +26,17 @@ function isFolderRowTarget(target: EventTarget | null): boolean {
   return target instanceof HTMLElement && target.classList.contains("add-project-browser__row");
 }
 
+// A button/link handles Enter natively (breadcrumbs, toolbar buttons). Enter-to-descend
+// must skip those so it does not double-fire alongside the element's own activation.
+function isActivatableElement(target: EventTarget | null): boolean {
+  return target instanceof HTMLButtonElement || target instanceof HTMLAnchorElement;
+}
+
 export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
   const typeaheadBufferRef = useRef("");
   const typeaheadLastTsRef = useRef(0);
-  const [recentOpen, setRecentOpen] = useState(true);
-  const [recentPaths] = useState(() => loadRecentPaths());
   const selectedIndex = useMemo(
     () =>
       browser.directoryEntries.findIndex(
@@ -46,11 +48,18 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const target = event.target;
-      const isInsideBrowser =
-        target instanceof Node &&
-        (toolbarRef.current?.contains(target) || contentRef.current?.contains(target));
-      if (!isInsideBrowser) return;
-      if (isTextEditingTarget(event.target)) return;
+      if (!(target instanceof Node)) return;
+      if (isTextEditingTarget(target)) return;
+      // In scope when the event comes from inside the browser panes OR from an
+      // ancestor that contains them (the modal dialog focused on open, document.body).
+      // The plain ancestor `.contains` checks fail for that case because the dialog
+      // is an ancestor of the panes, not a descendant.
+      const content = contentRef.current;
+      const inScope =
+        (content?.contains(target) ?? false) ||
+        (toolbarRef.current?.contains(target) ?? false) ||
+        (content !== null && target.contains(content));
+      if (!inScope) return;
 
       if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
         const now = Date.now();
@@ -86,7 +95,7 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
       if (
         event.key === "Enter" &&
         selectedIndex >= 0 &&
-        isFolderRowTarget(event.target) &&
+        (isFolderRowTarget(target) || !isActivatableElement(target)) &&
         !event.metaKey &&
         !event.ctrlKey &&
         !event.altKey &&
@@ -100,6 +109,11 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [browser, selectedIndex]);
+
+  const breadcrumbs = getBreadcrumbs(browser.browsePath);
+  const currentName = breadcrumbs[breadcrumbs.length - 1]?.label ?? browser.browsePath;
+  const showCurrentFolder = browser.browsePath !== "~" && browser.currentDirectory !== null;
+  const currentSelected = browser.selectedBrowsePath === browser.browsePath;
 
   return (
     <>
@@ -169,70 +183,74 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
       </div>
 
       <div className="add-project-modal__content">
-        <div className="add-project-browser">
-          <aside className="add-project-browser__sidebar">
-            <SidebarSection title="Recent" open={recentOpen} onToggle={() => setRecentOpen((open) => !open)}>
-              {recentPaths.map((path) => (
+        <div ref={contentRef} className="add-project-browser">
+          <div className="add-project-browser__current">
+            <div className="add-project-browser__current-label">Current folder</div>
+            <div className="add-project-browser__breadcrumb">
+              {breadcrumbs.map((crumb) => (
                 <button
-                  key={path}
+                  key={crumb.path}
                   type="button"
-                  className="add-project-browser__sidebar-item"
-                  onClick={() => void browser.browse(path, { selectedPath: path })}
+                  className="add-project-browser__crumb"
+                  onClick={() => void browser.browse(crumb.path)}
                 >
-                  {path}
+                  {crumb.label}
                 </button>
               ))}
-            </SidebarSection>
-          </aside>
-          <div ref={contentRef} className="add-project-browser__main">
-            <div className="add-project-browser__current">
-              <div className="add-project-browser__current-label">Current folder</div>
-              <div className="add-project-browser__breadcrumb">
-                {getBreadcrumbs(browser.browsePath).map((crumb) => (
-                  <button
-                    key={crumb.path}
-                    type="button"
-                    className="add-project-browser__crumb"
-                    onClick={() => void browser.browse(crumb.path)}
-                  >
-                    {crumb.label}
-                  </button>
-                ))}
-              </div>
-              <div className="add-project-browser__current-path">{browser.browsePath}</div>
             </div>
-            {browser.error ? (
-              <div className="add-project-browser__state add-project-browser__state--error">
-                <p className="add-project-browser__state-title">Directory browser unavailable</p>
-                <p className="add-project-browser__state-copy">{browser.error}</p>
-              </div>
-            ) : browser.loading ? (
-              <div className="add-project-browser__state">
-                <p className="add-project-browser__state-title">Loading folders</p>
-                <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
-              </div>
-            ) : browser.directoryEntries.length === 0 ? (
-              <div className="add-project-browser__state">
-                <p className="add-project-browser__state-title">No visible folders here</p>
-                <p className="add-project-browser__state-copy">Try navigating up or picking a different location.</p>
-              </div>
-            ) : (
-              <div className="add-project-browser__rows">
-                {browser.parentPath ? (
-                  <button
-                    type="button"
-                    onClick={browser.goUp}
-                    className="add-project-browser__row add-project-browser__row--parent"
-                  >
-                    ..
-                  </button>
-                ) : null}
-                {browser.directoryEntries.map((entry) => {
+          </div>
+          {browser.error ? (
+            <div className="add-project-browser__state add-project-browser__state--error">
+              <p className="add-project-browser__state-title">Directory browser unavailable</p>
+              <p className="add-project-browser__state-copy">{browser.error}</p>
+            </div>
+          ) : browser.loading ? (
+            <div className="add-project-browser__state">
+              <p className="add-project-browser__state-title">Loading folders</p>
+              <p className="add-project-browser__state-copy">Fetching directories for this location.</p>
+            </div>
+          ) : (
+            <div className="add-project-browser__rows">
+              {showCurrentFolder ? (
+                <button
+                  type="button"
+                  aria-label={
+                    browser.currentDirectory?.isGitRepo
+                      ? `${currentName}, current folder, Git repository`
+                      : `${currentName}, current folder`
+                  }
+                  onClick={() => browser.setSelectedBrowsePath(browser.browsePath)}
+                  className={`add-project-browser__row add-project-browser__row--current${currentSelected ? " is-selected" : ""}`}
+                >
+                  <FolderIcon className="add-project-browser__row-icon" />
+                  <span className="add-project-browser__row-name">{currentName}</span>
+                  <span className="add-project-browser__row-tag">this folder</span>
+                  {browser.currentDirectory?.isGitRepo ? (
+                    <span className="add-project-browser__badge" aria-hidden="true">
+                      git
+                    </span>
+                  ) : null}
+                </button>
+              ) : null}
+              {browser.parentPath ? (
+                <button
+                  type="button"
+                  onClick={browser.goUp}
+                  className="add-project-browser__row add-project-browser__row--parent"
+                >
+                  ..
+                </button>
+              ) : null}
+              {browser.directoryEntries.length === 0 ? (
+                <p className="add-project-browser__empty-row">No subfolders in this location.</p>
+              ) : (
+                browser.directoryEntries.map((entry) => {
                   const nextPath = joinBrowsePath(browser.browsePath, entry.name);
                   return (
                     <button
                       key={nextPath}
                       type="button"
+                      aria-label={entry.isGitRepo ? `${entry.name}, Git repository` : entry.name}
                       onClick={() => browser.setSelectedBrowsePath(nextPath)}
                       onDoubleClick={() => void browser.browse(nextPath)}
                       className={`add-project-browser__row${browser.selectedBrowsePath === nextPath ? " is-selected" : ""}`}
@@ -244,12 +262,15 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
                           git
                         </span>
                       ) : null}
+                      <span className="add-project-browser__row-chevron" aria-hidden="true">
+                        <ChevronRightIcon />
+                      </span>
                     </button>
                   );
-                })}
-              </div>
-            )}
-          </div>
+                })
+              )}
+            </div>
+          )}
         </div>
       </div>
     </>

--- a/packages/web/src/components/DirectoryBrowser.tsx
+++ b/packages/web/src/components/DirectoryBrowser.tsx
@@ -29,6 +29,8 @@ function isFolderRowTarget(target: EventTarget | null): boolean {
 export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
   const toolbarRef = useRef<HTMLDivElement>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  const typeaheadBufferRef = useRef("");
+  const typeaheadLastTsRef = useRef(0);
   const selectedIndex = useMemo(
     () =>
       browser.directoryEntries.findIndex(
@@ -45,6 +47,22 @@ export function DirectoryBrowser({ browser }: DirectoryBrowserProps) {
         (toolbarRef.current?.contains(target) || contentRef.current?.contains(target));
       if (!isInsideBrowser) return;
       if (isTextEditingTarget(event.target)) return;
+
+      if (event.key.length === 1 && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        const now = Date.now();
+        if (now - typeaheadLastTsRef.current > 600) typeaheadBufferRef.current = "";
+        typeaheadLastTsRef.current = now;
+        typeaheadBufferRef.current += event.key.toLowerCase();
+
+        const matchedEntry = browser.directoryEntries.find((entry) =>
+          entry.name.toLowerCase().startsWith(typeaheadBufferRef.current),
+        );
+        if (matchedEntry) {
+          event.preventDefault();
+          browser.setSelectedBrowsePath(joinBrowsePath(browser.browsePath, matchedEntry.name));
+        }
+        return;
+      }
 
       if (event.key === "ArrowDown" || event.key === "ArrowUp") {
         if (browser.directoryEntries.length === 0) return;

--- a/packages/web/src/components/__tests__/AddProjectModal.parts.test.ts
+++ b/packages/web/src/components/__tests__/AddProjectModal.parts.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveProjectIdFromPath,
+  deriveProjectNameFromPath,
+  getParentBrowsePath,
+  joinBrowsePath,
+} from "@/components/AddProjectModal.parts";
+
+describe("AddProjectModal path helpers", () => {
+  it("derives project metadata from Windows paths", () => {
+    expect(deriveProjectIdFromPath("D:\\projects\\my-repo")).toBe("my-repo");
+    expect(deriveProjectNameFromPath("D:\\projects\\my-repo")).toBe("My Repo");
+  });
+
+  it("joins and climbs Windows drive paths without falling back to home", () => {
+    expect(joinBrowsePath("D:\\", "projects")).toBe("D:\\projects");
+    expect(joinBrowsePath("D:\\projects", "my-repo")).toBe("D:\\projects\\my-repo");
+    expect(getParentBrowsePath("D:\\projects\\my-repo")).toBe("D:\\projects");
+    expect(getParentBrowsePath("D:\\projects")).toBe("D:\\");
+    expect(getParentBrowsePath("D:\\")).toBeNull();
+  });
+});

--- a/packages/web/src/components/__tests__/AddProjectModal.parts.test.ts
+++ b/packages/web/src/components/__tests__/AddProjectModal.parts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   deriveProjectIdFromPath,
   deriveProjectNameFromPath,
+  getBreadcrumbs,
   getParentBrowsePath,
   joinBrowsePath,
 } from "@/components/AddProjectModal.parts";
@@ -18,5 +19,13 @@ describe("AddProjectModal path helpers", () => {
     expect(getParentBrowsePath("D:\\projects\\my-repo")).toBe("D:\\projects");
     expect(getParentBrowsePath("D:\\projects")).toBe("D:\\");
     expect(getParentBrowsePath("D:\\")).toBeNull();
+  });
+
+  it("builds Windows breadcrumbs from the drive root", () => {
+    expect(getBreadcrumbs("D:\\projects\\my-repo")).toEqual([
+      { label: "D:", path: "D:\\" },
+      { label: "projects", path: "D:\\projects" },
+      { label: "my-repo", path: "D:\\projects\\my-repo" },
+    ]);
   });
 });

--- a/packages/web/src/components/__tests__/AddProjectModal.test.tsx
+++ b/packages/web/src/components/__tests__/AddProjectModal.test.tsx
@@ -49,6 +49,98 @@ describe("AddProjectModal", () => {
     );
   });
 
+  it("lets the user type an absolute path and add the current git directory", async () => {
+    const onClose = vi.fn();
+    const absolutePath = "D:\\projects\\my-repo";
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        entries: [],
+        current: { isGitRepo: false, hasLocalConfig: false },
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        entries: [],
+        current: { isGitRepo: true, hasLocalConfig: false },
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true, projectId: "my-repo" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AddProjectModal open onClose={onClose} />);
+
+    const pathInput = await screen.findByLabelText(/folder path/i);
+    fireEvent.change(pathInput, { target: { value: absolutePath } });
+    fireEvent.keyDown(pathInput, { key: "Enter" });
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/filesystem/browse?path=${encodeURIComponent(absolutePath)}`,
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /^add project$/i }));
+
+    await waitFor(() => expect(mockPush).toHaveBeenCalledWith("/projects/my-repo"));
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      "/api/projects",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          projectId: "my-repo",
+          name: "My Repo",
+          path: absolutePath,
+          useDefaultProjectId: false,
+        }),
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("shows Windows drive roots when the browse API returns them", async () => {
+    const roots = [
+      { label: "C:", path: "C:\\" },
+      { label: "D:", path: "D:\\" },
+    ];
+    const fetchMock = vi.fn();
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        entries: [],
+        current: { isGitRepo: false, hasLocalConfig: false },
+        roots,
+      }),
+    });
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        entries: [{ name: "projects", isDirectory: true, isGitRepo: false, hasLocalConfig: false }],
+        current: { isGitRepo: false, hasLocalConfig: false },
+        roots,
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<AddProjectModal open onClose={vi.fn()} />);
+
+    const driveSelect = await screen.findByLabelText(/drive/i);
+    fireEvent.change(driveSelect, { target: { value: "D:\\" } });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/filesystem/browse?path=${encodeURIComponent("D:\\")}`,
+      ),
+    );
+    await waitFor(() => expect(screen.getAllByText("D:\\").length).toBeGreaterThan(0));
+    expect(await screen.findByRole("button", { name: /projects/i })).toBeInTheDocument();
+  });
+
   it("shows the server browse error and disables submit when browsing fails", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: false,

--- a/packages/web/src/components/__tests__/AddProjectModal.test.tsx
+++ b/packages/web/src/components/__tests__/AddProjectModal.test.tsx
@@ -129,7 +129,7 @@ describe("AddProjectModal", () => {
 
     render(<AddProjectModal open onClose={vi.fn()} />);
 
-    const driveSelect = await screen.findByLabelText(/drive/i);
+    const driveSelect = await screen.findByLabelText(/location/i);
     fireEvent.change(driveSelect, { target: { value: "D:\\" } });
 
     await waitFor(() =>
@@ -137,7 +137,11 @@ describe("AddProjectModal", () => {
         `/api/filesystem/browse?path=${encodeURIComponent("D:\\")}`,
       ),
     );
-    await waitFor(() => expect(screen.getAllByText("D:\\").length).toBeGreaterThan(0));
+    // Drive switch navigates but no longer auto-selects (selection is an explicit user
+    // action — see useDirectoryBrowser). The location input is the canonical "where we are".
+    await waitFor(() =>
+      expect((screen.getByLabelText(/folder path/i) as HTMLInputElement).value).toBe("D:\\"),
+    );
     expect(await screen.findByRole("button", { name: /projects/i })).toBeInTheDocument();
   });
 

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -2,8 +2,7 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { useEffect } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { DirectoryBrowser } from "@/components/DirectoryBrowser";
-import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
-import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
+import { useDirectoryBrowser, type UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
 const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
 

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -281,6 +281,110 @@ describe("DirectoryBrowser", () => {
     expect(browser.reset).not.toHaveBeenCalled();
   });
 
+  it("does not auto-select the descended folder on double-click", async () => {
+    const fetchMock = vi
+      .fn()
+      // initial reset → home
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          entries: [{ name: "workspace", isDirectory: true, isGitRepo: false, hasLocalConfig: false }],
+          roots: [],
+        }),
+      })
+      // descend into workspace (not a git repo)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          entries: [],
+          current: { isGitRepo: false, hasLocalConfig: false },
+          roots: [],
+        }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness />);
+
+    const row = (await screen.findByText("workspace")).closest("button");
+    expect(row).not.toBeNull();
+    fireEvent.doubleClick(row!);
+
+    // After descending, the current-folder row exists but must NOT be selected — the
+    // user navigated, they didn't pick. Otherwise the modal flashes a red
+    // "not a git repository" warning for every non-repo folder they pass through.
+    await waitFor(() => {
+      const current = screen.queryByRole("button", { name: "workspace, current folder" });
+      expect(current).not.toBeNull();
+      expect(current?.className).not.toContain("is-selected");
+    });
+  });
+
+  it("offers Home in the location dropdown and browses back to ~ when picked", () => {
+    const browser = {
+      browsePath: "C:\\Users",
+      selectedBrowsePath: "",
+      setSelectedBrowsePath: vi.fn(),
+      directoryEntries: [],
+      currentDirectory: null,
+      roots: [
+        { label: "C:", path: "C:\\" },
+        { label: "D:", path: "D:\\" },
+      ],
+      selectedRootPath: "C:\\",
+      locationInput: "C:\\Users",
+      setLocationInput: vi.fn(),
+      loading: false,
+      error: null,
+      parentPath: "C:\\",
+      canGoBack: true,
+      canGoForward: false,
+      browse: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      goUp: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    } satisfies UseDirectoryBrowser;
+
+    render(<DirectoryBrowser browser={browser} />);
+
+    const select = screen.getByLabelText("Location") as HTMLSelectElement;
+    // Home is the first option so it acts as the route back to ~ from any drive.
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(["~", "C:\\", "D:\\"]);
+    fireEvent.change(select, { target: { value: "~" } });
+
+    expect(browser.browse).toHaveBeenCalledWith("~");
+  });
+
+  it("shows Home as the selected location when browsePath is ~", () => {
+    const browser = {
+      browsePath: "~",
+      selectedBrowsePath: "",
+      setSelectedBrowsePath: vi.fn(),
+      directoryEntries: [],
+      currentDirectory: null,
+      roots: [{ label: "C:", path: "C:\\" }],
+      selectedRootPath: "",
+      locationInput: "~",
+      setLocationInput: vi.fn(),
+      loading: false,
+      error: null,
+      parentPath: null,
+      canGoBack: false,
+      canGoForward: false,
+      browse: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      goUp: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    } satisfies UseDirectoryBrowser;
+
+    render(<DirectoryBrowser browser={browser} />);
+
+    expect((screen.getByLabelText("Location") as HTMLSelectElement).value).toBe("~");
+  });
+
   it("handles keyboard navigation when focus is on an ancestor container", async () => {
     vi.stubGlobal(
       "fetch",

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -38,6 +38,32 @@ describe("DirectoryBrowser", () => {
     await waitFor(() => expect(row.closest("button")?.className).toContain("is-selected"));
   });
 
+  it("shows a git badge only for git-repo folders", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          entries: [
+            { name: "repo", isDirectory: true, isGitRepo: true, hasLocalConfig: false },
+            { name: "plain", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+          ],
+          roots: [],
+        }),
+      }),
+    );
+
+    render(<Harness />);
+
+    const repoRow = await screen.findByRole("button", { name: "repo" });
+    const plainRow = await screen.findByRole("button", { name: "plain" });
+
+    expect(repoRow.querySelector(".add-project-browser__row-icon")).not.toBeNull();
+    expect(plainRow.querySelector(".add-project-browser__row-icon")).not.toBeNull();
+    expect(repoRow.querySelector(".add-project-browser__badge")).not.toBeNull();
+    expect(plainRow.querySelector(".add-project-browser__badge")).toBeNull();
+  });
+
   it("renders breadcrumb segments and navigates on crumb click", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -38,6 +38,58 @@ describe("DirectoryBrowser", () => {
     await waitFor(() => expect(row.closest("button")?.className).toContain("is-selected"));
   });
 
+  it("renders breadcrumb segments and navigates on crumb click", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ entries: [], roots: [] }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness />);
+
+    await waitFor(() => expect(screen.getByText("home")).toBeInTheDocument());
+    fetchMock.mockClear();
+    fireEvent.click(screen.getByText("home"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith("/api/filesystem/browse?path=~"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets focused breadcrumb Enter activate the crumb instead of descending into the selected folder", () => {
+    const browser = {
+      browsePath: "~/workspace",
+      selectedBrowsePath: "~/workspace/alpha",
+      setSelectedBrowsePath: vi.fn(),
+      directoryEntries: [{ name: "alpha", isDirectory: true, isGitRepo: false, hasLocalConfig: false }],
+      currentDirectory: null,
+      roots: [],
+      selectedRootPath: "",
+      locationInput: "~/workspace",
+      setLocationInput: vi.fn(),
+      loading: false,
+      error: null,
+      parentPath: "~",
+      canGoBack: false,
+      canGoForward: false,
+      browse: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      goUp: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    } satisfies UseDirectoryBrowser;
+
+    render(<DirectoryBrowser browser={browser} />);
+
+    const homeCrumb = screen.getByRole("button", { name: "home" });
+    homeCrumb.focus();
+    fireEvent.keyDown(homeCrumb, { key: "Enter" });
+    fireEvent.click(homeCrumb);
+
+    expect(browser.browse).toHaveBeenCalledWith("~");
+    expect(browser.browse).not.toHaveBeenCalledWith("~/workspace/alpha");
+  });
+
   it("selects a folder with ArrowDown and descends with Enter", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -5,6 +5,8 @@ import { DirectoryBrowser } from "@/components/DirectoryBrowser";
 import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
+const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+
 function Harness() {
   const browser = useDirectoryBrowser();
   useEffect(() => {
@@ -16,6 +18,7 @@ function Harness() {
 describe("DirectoryBrowser", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
+    if (localStorageDescriptor) Object.defineProperty(window, "localStorage", localStorageDescriptor);
   });
 
   it("renders folders from the browse API and selects on click", async () => {
@@ -168,6 +171,80 @@ describe("DirectoryBrowser", () => {
     fireEvent.keyDown(row!, { key: "b" });
 
     await waitFor(() => expect(row?.className).toContain("is-selected"));
+  });
+
+  it("lists recent folders and navigates on click", async () => {
+    const store = new Map<string, string>([["ao:add-project:recent", JSON.stringify(["~/projects/old"])]]);
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => store.set(k, v),
+        removeItem: (k: string) => store.delete(k),
+        clear: () => store.clear(),
+        get length() {
+          return store.size;
+        },
+        key: (i: number) => [...store.keys()][i] ?? null,
+      },
+      writable: true,
+      configurable: true,
+    });
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ entries: [], roots: [] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness />);
+
+    fireEvent.click(await screen.findByText("~/projects/old"));
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/filesystem/browse?path=~%2Fprojects%2Fold"),
+    );
+    await waitFor(() => expect(screen.getAllByText("~/projects/old")).toHaveLength(2));
+  });
+
+  it("selects the recent folder path when navigating from the sidebar", async () => {
+    const store = new Map<string, string>([["ao:add-project:recent", JSON.stringify(["~/projects/old"])]]);
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: (k: string) => store.get(k) ?? null,
+        setItem: (k: string, v: string) => store.set(k, v),
+        removeItem: (k: string) => store.delete(k),
+        clear: () => store.clear(),
+        get length() {
+          return store.size;
+        },
+        key: (i: number) => [...store.keys()][i] ?? null,
+      },
+      writable: true,
+      configurable: true,
+    });
+    const browser = {
+      browsePath: "~",
+      selectedBrowsePath: "~",
+      setSelectedBrowsePath: vi.fn(),
+      directoryEntries: [],
+      currentDirectory: null,
+      roots: [],
+      selectedRootPath: "",
+      locationInput: "~",
+      setLocationInput: vi.fn(),
+      loading: false,
+      error: null,
+      parentPath: null,
+      canGoBack: false,
+      canGoForward: false,
+      browse: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      goUp: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    } satisfies UseDirectoryBrowser;
+
+    render(<DirectoryBrowser browser={browser} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "~/projects/old" }));
+
+    expect(browser.browse).toHaveBeenCalledWith("~/projects/old", { selectedPath: "~/projects/old" });
   });
 
   it("does not descend on modified Enter when a folder is selected", async () => {

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -144,6 +144,32 @@ describe("DirectoryBrowser", () => {
     );
   });
 
+  it("jumps selection to a folder by typeahead", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          entries: [
+            { name: "apple", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+            { name: "banana", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+            { name: "cherry", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+          ],
+          roots: [],
+        }),
+      }),
+    );
+
+    render(<Harness />);
+
+    const row = (await screen.findByText("banana")).closest("button");
+    expect(row).not.toBeNull();
+    row!.focus();
+    fireEvent.keyDown(row!, { key: "b" });
+
+    await waitFor(() => expect(row?.className).toContain("is-selected"));
+  });
+
   it("does not descend on modified Enter when a folder is selected", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -4,8 +4,6 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { DirectoryBrowser } from "@/components/DirectoryBrowser";
 import { useDirectoryBrowser, type UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
 
-const localStorageDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
-
 function Harness() {
   const browser = useDirectoryBrowser();
   useEffect(() => {
@@ -17,7 +15,6 @@ function Harness() {
 describe("DirectoryBrowser", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
-    if (localStorageDescriptor) Object.defineProperty(window, "localStorage", localStorageDescriptor);
   });
 
   it("renders folders from the browse API and selects on click", async () => {
@@ -57,7 +54,7 @@ describe("DirectoryBrowser", () => {
 
     render(<Harness />);
 
-    const repoRow = await screen.findByRole("button", { name: "repo" });
+    const repoRow = await screen.findByRole("button", { name: "repo, Git repository" });
     const plainRow = await screen.findByRole("button", { name: "plain" });
 
     expect(repoRow.querySelector(".add-project-browser__row-icon")).not.toBeNull();
@@ -172,63 +169,20 @@ describe("DirectoryBrowser", () => {
     await waitFor(() => expect(row?.className).toContain("is-selected"));
   });
 
-  it("lists recent folders and navigates on click", async () => {
-    const store = new Map<string, string>([["ao:add-project:recent", JSON.stringify(["~/projects/old"])]]);
-    Object.defineProperty(window, "localStorage", {
-      value: {
-        getItem: (k: string) => store.get(k) ?? null,
-        setItem: (k: string, v: string) => store.set(k, v),
-        removeItem: (k: string) => store.delete(k),
-        clear: () => store.clear(),
-        get length() {
-          return store.size;
-        },
-        key: (i: number) => [...store.keys()][i] ?? null,
-      },
-      writable: true,
-      configurable: true,
-    });
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ entries: [], roots: [] }) });
-    vi.stubGlobal("fetch", fetchMock);
-
-    render(<Harness />);
-
-    fireEvent.click(await screen.findByText("~/projects/old"));
-    await waitFor(() =>
-      expect(fetchMock).toHaveBeenCalledWith("/api/filesystem/browse?path=~%2Fprojects%2Fold"),
-    );
-    await waitFor(() => expect(screen.getAllByText("~/projects/old")).toHaveLength(2));
-  });
-
-  it("selects the recent folder path when navigating from the sidebar", async () => {
-    const store = new Map<string, string>([["ao:add-project:recent", JSON.stringify(["~/projects/old"])]]);
-    Object.defineProperty(window, "localStorage", {
-      value: {
-        getItem: (k: string) => store.get(k) ?? null,
-        setItem: (k: string, v: string) => store.set(k, v),
-        removeItem: (k: string) => store.delete(k),
-        clear: () => store.clear(),
-        get length() {
-          return store.size;
-        },
-        key: (i: number) => [...store.keys()][i] ?? null,
-      },
-      writable: true,
-      configurable: true,
-    });
+  it("renders a selectable, git-aware current-folder row", () => {
     const browser = {
-      browsePath: "~",
-      selectedBrowsePath: "~",
+      browsePath: "~/workspace/app",
+      selectedBrowsePath: "~/workspace/app/sub",
       setSelectedBrowsePath: vi.fn(),
-      directoryEntries: [],
-      currentDirectory: null,
+      directoryEntries: [{ name: "sub", isDirectory: true, isGitRepo: false, hasLocalConfig: false }],
+      currentDirectory: { isGitRepo: true, hasLocalConfig: false },
       roots: [],
       selectedRootPath: "",
-      locationInput: "~",
+      locationInput: "~/workspace/app",
       setLocationInput: vi.fn(),
       loading: false,
       error: null,
-      parentPath: null,
+      parentPath: "~/workspace",
       canGoBack: false,
       canGoForward: false,
       browse: vi.fn(),
@@ -241,9 +195,10 @@ describe("DirectoryBrowser", () => {
 
     render(<DirectoryBrowser browser={browser} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "~/projects/old" }));
+    const currentRow = screen.getByRole("button", { name: "app, current folder, Git repository" });
+    fireEvent.click(currentRow);
 
-    expect(browser.browse).toHaveBeenCalledWith("~/projects/old", { selectedPath: "~/projects/old" });
+    expect(browser.setSelectedBrowsePath).toHaveBeenCalledWith("~/workspace/app");
   });
 
   it("does not descend on modified Enter when a folder is selected", async () => {
@@ -324,5 +279,36 @@ describe("DirectoryBrowser", () => {
     render(<DirectoryBrowser browser={browser} />);
 
     expect(browser.reset).not.toHaveBeenCalled();
+  });
+
+  it("handles keyboard navigation when focus is on an ancestor container", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          entries: [
+            { name: "alpha", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+            { name: "beta", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+          ],
+          roots: [],
+        }),
+      }),
+    );
+
+    render(
+      <div data-testid="dialog">
+        <Harness />
+      </div>,
+    );
+
+    const alpha = (await screen.findByText("alpha")).closest("button");
+    expect(alpha).not.toBeNull();
+
+    // The dialog wrapper is an ancestor of the browser panes — the state focus
+    // lands on when the modal opens. Keyboard nav must still respond.
+    fireEvent.keyDown(screen.getByTestId("dialog"), { key: "ArrowDown" });
+
+    await waitFor(() => expect(alpha?.className).toContain("is-selected"));
   });
 });

--- a/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/packages/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -1,0 +1,148 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DirectoryBrowser } from "@/components/DirectoryBrowser";
+import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
+import type { UseDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
+
+function Harness() {
+  const browser = useDirectoryBrowser();
+  useEffect(() => {
+    browser.reset();
+  }, [browser.reset]);
+  return <DirectoryBrowser browser={browser} />;
+}
+
+describe("DirectoryBrowser", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders folders from the browse API and selects on click", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          entries: [{ name: "my-repo", isDirectory: true, isGitRepo: true, hasLocalConfig: false }],
+          roots: [],
+        }),
+      }),
+    );
+
+    render(<Harness />);
+
+    const row = await screen.findByText("my-repo");
+    fireEvent.click(row);
+
+    await waitFor(() => expect(row.closest("button")?.className).toContain("is-selected"));
+  });
+
+  it("selects a folder with ArrowDown and descends with Enter", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        entries: [
+          { name: "alpha", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+          { name: "beta", isDirectory: true, isGitRepo: false, hasLocalConfig: false },
+        ],
+        roots: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness />);
+
+    const row = (await screen.findByText("alpha")).closest("button");
+    expect(row).not.toBeNull();
+
+    fireEvent.keyDown(row!, { key: "ArrowDown" });
+    await waitFor(() => expect(row?.className).toContain("is-selected"));
+
+    fireEvent.keyDown(row!, { key: "Enter" });
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith("/api/filesystem/browse?path=~%2Falpha"),
+    );
+  });
+
+  it("does not descend on modified Enter when a folder is selected", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        entries: [{ name: "my-repo", isDirectory: true, isGitRepo: true, hasLocalConfig: false }],
+        roots: [],
+      }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Harness />);
+
+    const row = (await screen.findByText("my-repo")).closest("button");
+    expect(row).not.toBeNull();
+    fireEvent.click(row!);
+    await waitFor(() => expect(row?.className).toContain("is-selected"));
+
+    fireEvent.keyDown(row!, { key: "Enter", ctrlKey: true });
+    fireEvent.keyDown(row!, { key: "Enter", metaKey: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores keyboard events from outside the browser", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          entries: [{ name: "my-repo", isDirectory: true, isGitRepo: true, hasLocalConfig: false }],
+          roots: [],
+        }),
+      }),
+    );
+
+    render(
+      <>
+        <button type="button">Outside</button>
+        <Harness />
+      </>,
+    );
+
+    const outside = await screen.findByText("Outside");
+    const row = await screen.findByText("my-repo");
+    outside.focus();
+
+    fireEvent.keyDown(outside, { key: "ArrowDown" });
+
+    expect(row.closest("button")?.className).not.toContain("is-selected");
+  });
+
+  it("does not reset the browser on mount", () => {
+    const browser = {
+      browsePath: "~",
+      selectedBrowsePath: "~",
+      setSelectedBrowsePath: vi.fn(),
+      directoryEntries: [],
+      currentDirectory: null,
+      roots: [],
+      selectedRootPath: "",
+      locationInput: "~",
+      setLocationInput: vi.fn(),
+      loading: false,
+      error: null,
+      parentPath: null,
+      canGoBack: false,
+      canGoForward: false,
+      browse: vi.fn(),
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      goUp: vi.fn(),
+      refresh: vi.fn(),
+      reset: vi.fn(),
+    } satisfies UseDirectoryBrowser;
+
+    render(<DirectoryBrowser browser={browser} />);
+
+    expect(browser.reset).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/__tests__/useDirectoryBrowser.test.ts
+++ b/packages/web/src/hooks/__tests__/useDirectoryBrowser.test.ts
@@ -74,7 +74,9 @@ describe("useDirectoryBrowser", () => {
 
     expect(result.current.browsePath).toBe("~");
     expect(result.current.locationInput).toBe("~");
-    expect(result.current.selectedBrowsePath).toBe("~");
+    // History-replay navigation no longer carries a selection — selecting is an explicit
+    // user action (click a row, type a path) so descend/back/forward leave selection clear.
+    expect(result.current.selectedBrowsePath).toBe("");
     expect(result.current.canGoForward).toBe(true);
     act(() => result.current.goForward());
     await waitFor(() => expect(result.current.browsePath).toBe("~/a"));

--- a/packages/web/src/hooks/__tests__/useDirectoryBrowser.test.ts
+++ b/packages/web/src/hooks/__tests__/useDirectoryBrowser.test.ts
@@ -1,0 +1,82 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useDirectoryBrowser } from "@/hooks/useDirectoryBrowser";
+
+function mockBrowse(entries: unknown[]) {
+  return vi.fn().mockResolvedValue({ ok: true, json: async () => ({ entries, roots: [] }) });
+}
+
+function deferredResponse() {
+  let resolve!: (value: { ok: true; json: () => Promise<{ entries: never[]; roots: never[] }> }) => void;
+  const promise = new Promise<{ ok: true; json: () => Promise<{ entries: never[]; roots: never[] }> }>((res) => {
+    resolve = res;
+  });
+  return {
+    promise,
+    resolve: () => resolve({ ok: true, json: async () => ({ entries: [], roots: [] }) }),
+  };
+}
+
+describe("useDirectoryBrowser", () => {
+  it("loads the initial path on reset and tracks history", async () => {
+    vi.stubGlobal("fetch", mockBrowse([{ name: "a", isDirectory: true, isGitRepo: false, hasLocalConfig: false }]));
+    const { result } = renderHook(() => useDirectoryBrowser());
+    act(() => result.current.reset());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.browsePath).toBe("~");
+    expect(result.current.canGoBack).toBe(false);
+
+    await act(async () => {
+      await result.current.browse("~/a");
+    });
+    expect(result.current.browsePath).toBe("~/a");
+    expect(result.current.canGoBack).toBe(true);
+
+    act(() => result.current.goBack());
+    await waitFor(() => expect(result.current.browsePath).toBe("~"));
+  });
+
+  it("surfaces a browse error when the API fails", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false, json: async () => ({ error: "path is restricted" }) }));
+    const { result } = renderHook(() => useDirectoryBrowser());
+    await act(async () => {
+      await result.current.browse("~/secret");
+    });
+    expect(result.current.error).toBe("path is restricted");
+  });
+
+  it("ignores stale pending replace responses after newer navigation", async () => {
+    const pendingRefresh = deferredResponse();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ entries: [], roots: [] }) })
+      .mockReturnValueOnce(pendingRefresh.promise)
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ entries: [], roots: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ entries: [], roots: [] }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useDirectoryBrowser());
+
+    await act(async () => {
+      await result.current.browse("~/a");
+    });
+    expect(result.current.browsePath).toBe("~/a");
+    expect(result.current.canGoBack).toBe(true);
+
+    act(() => result.current.refresh());
+    act(() => result.current.goBack());
+    await waitFor(() => expect(result.current.browsePath).toBe("~"));
+
+    await act(async () => {
+      pendingRefresh.resolve();
+      await pendingRefresh.promise;
+    });
+
+    expect(result.current.browsePath).toBe("~");
+    expect(result.current.locationInput).toBe("~");
+    expect(result.current.selectedBrowsePath).toBe("~");
+    expect(result.current.canGoForward).toBe(true);
+    act(() => result.current.goForward());
+    await waitFor(() => expect(result.current.browsePath).toBe("~/a"));
+  });
+});

--- a/packages/web/src/hooks/useDirectoryBrowser.ts
+++ b/packages/web/src/hooks/useDirectoryBrowser.ts
@@ -82,7 +82,10 @@ export function useDirectoryBrowser(): UseDirectoryBrowser {
     setBrowseEntries([]);
     setCurrentDirectory(null);
     setRoots([]);
-    setSelectedBrowsePath(selectedPath ?? path);
+    // Navigating to `path` (descend, breadcrumb, drive switch) must not auto-select it —
+    // a selection should only ever come from explicit user intent. Callers that DO want
+    // to seed a selection (refresh, reset, typed-path Enter) pass `selectedPath` explicitly.
+    setSelectedBrowsePath(selectedPath ?? "");
   }, []);
 
   const browse = useCallback(
@@ -116,7 +119,7 @@ export function useDirectoryBrowser(): UseDirectoryBrowser {
         const mode = options?.mode ?? "push";
         setBrowsePath(path);
         setLocationInput(path);
-        setSelectedBrowsePath(options?.selectedPath ?? path);
+        setSelectedBrowsePath(options?.selectedPath ?? "");
         setBrowseEntries(body?.entries ?? []);
         setCurrentDirectory(body?.current ?? null);
         setRoots(body?.roots ?? []);

--- a/packages/web/src/hooks/useDirectoryBrowser.ts
+++ b/packages/web/src/hooks/useDirectoryBrowser.ts
@@ -1,0 +1,212 @@
+"use client";
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import { getParentBrowsePath } from "@/components/AddProjectModal.parts";
+
+export interface BrowseEntry {
+  name: string;
+  isDirectory: boolean;
+  isGitRepo: boolean;
+  hasLocalConfig: boolean;
+  modifiedAt?: number;
+}
+
+export interface BrowseCurrentDirectory {
+  isGitRepo: boolean;
+  hasLocalConfig: boolean;
+}
+
+export interface BrowseRoot {
+  label: string;
+  path: string;
+}
+
+export interface UseDirectoryBrowser {
+  browsePath: string;
+  selectedBrowsePath: string;
+  setSelectedBrowsePath: (path: string) => void;
+  directoryEntries: BrowseEntry[];
+  currentDirectory: BrowseCurrentDirectory | null;
+  roots: BrowseRoot[];
+  selectedRootPath: string;
+  locationInput: string;
+  setLocationInput: (value: string) => void;
+  loading: boolean;
+  error: string | null;
+  parentPath: string | null;
+  canGoBack: boolean;
+  canGoForward: boolean;
+  browse: (
+    path: string,
+    options?: { mode?: "push" | "replace"; selectedPath?: string; historyIndex?: number },
+  ) => Promise<void>;
+  goBack: () => void;
+  goForward: () => void;
+  goUp: () => void;
+  refresh: () => void;
+  reset: () => void;
+}
+
+interface BrowseResponseBody {
+  error?: string;
+  entries?: BrowseEntry[];
+  current?: BrowseCurrentDirectory;
+  roots?: BrowseRoot[];
+}
+
+const INITIAL_PATH = "~";
+
+export function useDirectoryBrowser(): UseDirectoryBrowser {
+  const [browsePath, setBrowsePath] = useState(INITIAL_PATH);
+  const [selectedBrowsePath, setSelectedBrowsePath] = useState(INITIAL_PATH);
+  const [browseHistory, setBrowseHistory] = useState<string[]>([INITIAL_PATH]);
+  const [browseHistoryIndex, setBrowseHistoryIndex] = useState(0);
+  const browseHistoryRef = useRef<string[]>([INITIAL_PATH]);
+  const browseHistoryIndexRef = useRef(0);
+  const browseRequestIdRef = useRef(0);
+  const [browseEntries, setBrowseEntries] = useState<BrowseEntry[]>([]);
+  const [currentDirectory, setCurrentDirectory] = useState<BrowseCurrentDirectory | null>(null);
+  const [roots, setRoots] = useState<BrowseRoot[]>([]);
+  const [locationInput, setLocationInput] = useState(INITIAL_PATH);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const syncHistory = useCallback((nextHistory: string[], nextIndex: number) => {
+    browseHistoryRef.current = nextHistory;
+    browseHistoryIndexRef.current = nextIndex;
+    setBrowseHistory(nextHistory);
+    setBrowseHistoryIndex(nextIndex);
+  }, []);
+
+  const clearBrowseResults = useCallback((path: string, selectedPath?: string) => {
+    setBrowseEntries([]);
+    setCurrentDirectory(null);
+    setRoots([]);
+    setSelectedBrowsePath(selectedPath ?? path);
+  }, []);
+
+  const browse = useCallback(
+    async (
+      path: string,
+      options?: { mode?: "push" | "replace"; selectedPath?: string; historyIndex?: number },
+    ) => {
+      const requestId = browseRequestIdRef.current + 1;
+      browseRequestIdRef.current = requestId;
+      const targetHistoryIndex = options?.historyIndex ?? browseHistoryIndexRef.current;
+      setLocationInput(path);
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(`/api/filesystem/browse?path=${encodeURIComponent(path)}`).catch(() => null);
+        if (requestId !== browseRequestIdRef.current) return;
+        if (!response) {
+          clearBrowseResults(path, options?.selectedPath);
+          setError("Failed to browse directories.");
+          return;
+        }
+
+        const body = (await response.json().catch(() => null)) as BrowseResponseBody | null;
+        if (requestId !== browseRequestIdRef.current) return;
+        if (!response.ok) {
+          clearBrowseResults(path, options?.selectedPath);
+          setError(body?.error ?? "Failed to browse directories.");
+          return;
+        }
+
+        const mode = options?.mode ?? "push";
+        setBrowsePath(path);
+        setLocationInput(path);
+        setSelectedBrowsePath(options?.selectedPath ?? path);
+        setBrowseEntries(body?.entries ?? []);
+        setCurrentDirectory(body?.current ?? null);
+        setRoots(body?.roots ?? []);
+
+        if (mode === "push") {
+          const nextHistory = browseHistoryRef.current.slice(0, targetHistoryIndex + 1);
+          if (nextHistory[nextHistory.length - 1] !== path) nextHistory.push(path);
+          syncHistory(nextHistory, nextHistory.length - 1);
+        } else {
+          const nextHistory = [...browseHistoryRef.current];
+          nextHistory[targetHistoryIndex] = path;
+          syncHistory(nextHistory, targetHistoryIndex);
+        }
+      } catch {
+        if (requestId !== browseRequestIdRef.current) return;
+        clearBrowseResults(path, options?.selectedPath);
+        setError("Failed to browse directories.");
+      } finally {
+        if (requestId === browseRequestIdRef.current) setLoading(false);
+      }
+    },
+    [clearBrowseResults, syncHistory],
+  );
+
+  const navigateHistory = useCallback(
+    (nextIndex: number) => {
+      const history = browseHistoryRef.current;
+      if (nextIndex < 0 || nextIndex >= history.length) return;
+      browseHistoryIndexRef.current = nextIndex;
+      setBrowseHistoryIndex(nextIndex);
+      void browse(history[nextIndex] ?? INITIAL_PATH, { mode: "replace", historyIndex: nextIndex });
+    },
+    [browse],
+  );
+
+  const directoryEntries = useMemo(() => browseEntries.filter((entry) => entry.isDirectory), [browseEntries]);
+  const parentPath = getParentBrowsePath(browsePath);
+  const selectedRootPath = roots.find((root) => browsePath.startsWith(root.path))?.path ?? "";
+  const canGoBack = browseHistoryIndex > 0;
+  const canGoForward = browseHistoryIndex < browseHistory.length - 1;
+
+  const goBack = useCallback(() => {
+    navigateHistory(browseHistoryIndexRef.current - 1);
+  }, [navigateHistory]);
+
+  const goForward = useCallback(() => {
+    navigateHistory(browseHistoryIndexRef.current + 1);
+  }, [navigateHistory]);
+
+  const goUp = useCallback(() => {
+    if (!parentPath) return;
+    void browse(parentPath);
+  }, [browse, parentPath]);
+
+  const refresh = useCallback(() => {
+    void browse(browsePath, { mode: "replace", selectedPath: selectedBrowsePath });
+  }, [browse, browsePath, selectedBrowsePath]);
+
+  const reset = useCallback(() => {
+    setError(null);
+    syncHistory([INITIAL_PATH], 0);
+    setBrowsePath(INITIAL_PATH);
+    setLocationInput(INITIAL_PATH);
+    setSelectedBrowsePath(INITIAL_PATH);
+    setBrowseEntries([]);
+    setCurrentDirectory(null);
+    setRoots([]);
+    void browse(INITIAL_PATH, { mode: "replace", selectedPath: INITIAL_PATH, historyIndex: 0 });
+  }, [browse, syncHistory]);
+
+  return {
+    browsePath,
+    selectedBrowsePath,
+    setSelectedBrowsePath,
+    directoryEntries,
+    currentDirectory,
+    roots,
+    selectedRootPath,
+    locationInput,
+    setLocationInput,
+    loading,
+    error,
+    parentPath,
+    canGoBack,
+    canGoForward,
+    browse,
+    goBack,
+    goForward,
+    goUp,
+    refresh,
+    reset,
+  };
+}

--- a/packages/web/src/lib/path-security.ts
+++ b/packages/web/src/lib/path-security.ts
@@ -1,6 +1,7 @@
 import { lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { isWindows } from "@aoagents/ao-core";
 
 const RESTRICTED_SINGLE_SEGMENTS = new Set([
   ".ssh",
@@ -44,6 +45,10 @@ function containsRestrictedSegments(targetPath: string, rootPath = homeRealPath(
   }
 
   return false;
+}
+
+function shouldConstrainToHome(): boolean {
+  return !isWindows();
 }
 
 function toRequestedAbsolutePath(rawPath: string, rootPath: string): string {
@@ -93,11 +98,12 @@ export function resolveHomeContainedPath(rawPath: string): ResolvedHomePath {
     throw new PathSecurityError("not_found", "path not found");
   }
 
-  if (!isWithinRoot(rootPath, resolvedPath)) {
+  if (shouldConstrainToHome() && !isWithinRoot(rootPath, resolvedPath)) {
     throw new PathSecurityError("outside_root", "path outside allowed root");
   }
 
-  if (containsRestrictedSegments(resolvedPath, rootPath)) {
+  const restrictedRootPath = shouldConstrainToHome() ? rootPath : path.parse(resolvedPath).root;
+  if (containsRestrictedSegments(resolvedPath, restrictedRootPath)) {
     throw new PathSecurityError("restricted", "path is restricted");
   }
 
@@ -127,8 +133,9 @@ export function shouldHideBrowseEntry(entryPath: string, rootPath: string): bool
       return true;
     }
     const resolvedEntryPath = realpathSync(entryPath);
-    if (!isWithinRoot(rootPath, resolvedEntryPath)) return true;
-    return containsRestrictedSegments(resolvedEntryPath, rootPath);
+    if (shouldConstrainToHome() && !isWithinRoot(rootPath, resolvedEntryPath)) return true;
+    const restrictedRootPath = shouldConstrainToHome() ? rootPath : path.parse(resolvedEntryPath).root;
+    return containsRestrictedSegments(resolvedEntryPath, restrictedRootPath);
   } catch {
     return true;
   }


### PR DESCRIPTION
## Summary
- Allow the Add Project file browser to browse Windows absolute paths outside the user home while keeping restricted folders blocked.
- Add current-directory git metadata so typed/pasted paths can be selected directly.
- Add a Windows drive selector for available drive roots and regression tests for typed paths, drive navigation, and platform-specific backend behavior.

## Test plan
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/filesystem-browse-api.test.ts src/components/__tests__/AddProjectModal.test.tsx src/components/__tests__/AddProjectModal.parts.test.ts`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web... build` was attempted but blocked by the dashboard safety guard because AO was running on port 3000.

Closes #1749