### PR TITLE
fix(lifecycle): prevent session stuck in working when getPRState fails after cache miss

### DIFF
--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1241,6 +1241,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               errorMessage: err instanceof Error ? err.message : String(err),
             },
           });
+
+          // Don't fall through to default-to-working. Commit current PR state
+          // so the session doesn't regress from a known PR status to bare
+          // "working" while we wait for the next batch cycle to succeed.
+          return commit({
+            status: deriveLegacyStatus(lifecycle),
+            evidence: activityEvidence,
+            detecting: { attempts: 0 },
+          });
         }
       } catch (error) {
         observer?.recordOperation?.({


### PR DESCRIPTION
## Summary

Fixes [#1803](https://github.com/ComposioHQ/agent-orchestrator/issues/1803)

When a PR is merged externally, the AO dashboard can stay stuck showing **PR open / working** indefinitely. There are two failure modes:

1. **Stale enrichment cache** — if the batch GraphQL call fails, `prEnrichmentCache` retains stale `state: "open"` data
2. **Silent fallthrough on cache miss** — when the cache misses and the fallback `scm.getPRState()` throws, the catch block records an AE event but **falls through without committing a decision**, defaulting back to `working`

## Fix

After recording the AE event in the inner `getPRState` catch block (line 1227), commit the current lifecycle state via `deriveLegacyStatus()` instead of falling through. This prevents regression from a known PR status to bare `working` while waiting for the next batch enrichment cycle.

**One-line change:** Added a `return commit(...)` after the AE event recording in the catch block.

## Test Plan

- [ ] Start `ao` with an agent that has an open PR
- [ ] Merge the PR externally (GitHub UI)
- [ ] Simulate batch enrichment failure (disconnect network temporarily)
- [ ] Verify session does **not** regress to bare `working` — it should stay at current status
- [ ] Verify session transitions to `merged` once batch enrichment succeeds on next poll
- [ ] Existing tests: `resolvePREnrichmentDecision` and `getPRState` fallback tests should pass unchanged