### PR TITLE
feat(lifecycle): inject failed-job/step + log tail into CI-failure agent messages (closes #1807)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2416,7 +2416,7 @@ describe("reactions", () => {
     const sentMessage = vi.mocked(mockSessionManager.send).mock.calls[0]![1];
     expect(sentMessage).toContain("CI is failing on your PR.");
     expect(sentMessage).toContain("Failed: build → Run pnpm test");
-    expect(sentMessage).toContain("Run: https://github.com/org/repo/actions/runs/123/job/456");
+    expect(sentMessage).toContain("Failure URL: https://github.com/org/repo/actions/runs/123/job/456");
     expect(sentMessage).toContain("Log tail (last 3 lines):");
     expect(sentMessage).toContain("AssertionError: expected true to be false");
     expect(sentMessage).toContain("\u200B```");

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2365,7 +2365,64 @@ describe("reactions", () => {
     expect(sentMessage).toContain("Potential issue detected");
   });
 
-  it("dispatches CI failure details with check names and URLs on subsequent polls", async () => {
+  it("dispatches CI failure summary with failed step and log tail", async () => {
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 3,
+        escalateAfter: 3,
+      },
+    };
+
+    const ciChecks = [
+      {
+        name: "build",
+        status: "failed",
+        url: "https://github.com/org/repo/actions/runs/123/job/456",
+        conclusion: "FAILURE",
+      },
+    ];
+    const mockSCM = createMockSCM({
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      getCIFailureSummary: vi.fn().mockResolvedValue({
+        failedJobs: [
+          {
+            name: "build",
+            failedStep: "Run pnpm test",
+            runUrl: "https://github.com/org/repo/actions/runs/123/job/456",
+            logTail:
+              "AssertionError: expected true to be false\nProcess completed with exit code 1",
+          },
+        ],
+      }),
+      enrichSessionsPRBatch: mockBatchEnrichment({ ciStatus: "failing", ciChecks }),
+    });
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = setupCheck("app-1", {
+      session: makeSession({ status: "pr_open", pr: makePR() }),
+      registry,
+    });
+
+    await lm.check("app-1");
+    expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
+    const sentMessage = vi.mocked(mockSessionManager.send).mock.calls[0]![1];
+    expect(sentMessage).toContain("CI is failing on your PR.");
+    expect(sentMessage).toContain("Failed: build → Run pnpm test");
+    expect(sentMessage).toContain("Run: https://github.com/org/repo/actions/runs/123/job/456");
+    expect(sentMessage).toContain("Log tail (last 2 lines):");
+    expect(sentMessage).toContain("AssertionError: expected true to be false");
+    expect(sentMessage).toContain("Fix the issues and push again.");
+  });
+
+  it("falls back to check names and URLs when SCM lacks getCIFailureSummary", async () => {
     config.reactions = {
       "ci-failed": {
         auto: true,
@@ -2419,6 +2476,7 @@ describe("reactions", () => {
     expect(lm.getStates().get("app-1")).toBe("ci_failed");
     expect(mockSessionManager.send).toHaveBeenCalledTimes(1);
     const sentMessage = vi.mocked(mockSessionManager.send).mock.calls[0]![1];
+    expect(sentMessage).toContain("CI checks are failing on your PR.");
     expect(sentMessage).toContain("lint");
     expect(sentMessage).toContain("typecheck");
     expect(sentMessage).toContain("https://github.com/org/repo/actions/runs/123");

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -2392,7 +2392,7 @@ describe("reactions", () => {
             failedStep: "Run pnpm test",
             runUrl: "https://github.com/org/repo/actions/runs/123/job/456",
             logTail:
-              "AssertionError: expected true to be false\nProcess completed with exit code 1",
+              "AssertionError: expected true to be false\n```\nProcess completed with exit code 1",
           },
         ],
       }),
@@ -2417,9 +2417,11 @@ describe("reactions", () => {
     expect(sentMessage).toContain("CI is failing on your PR.");
     expect(sentMessage).toContain("Failed: build → Run pnpm test");
     expect(sentMessage).toContain("Run: https://github.com/org/repo/actions/runs/123/job/456");
-    expect(sentMessage).toContain("Log tail (last 2 lines):");
+    expect(sentMessage).toContain("Log tail (last 3 lines):");
     expect(sentMessage).toContain("AssertionError: expected true to be false");
+    expect(sentMessage).toContain("\u200B```");
     expect(sentMessage).toContain("Fix the issues and push again.");
+    expect(mockSCM.getCIFailureSummary).toHaveBeenCalledWith(makePR(), ciChecks);
   });
 
   it("falls back to check names and URLs when SCM lacks getCIFailureSummary", async () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -669,8 +669,6 @@ function applyDefaultReactions(config: OrchestratorConfig): OrchestratorConfig {
     "ci-failed": {
       auto: true,
       action: "send-to-agent",
-      message:
-        "CI is failing on your PR. Investigate the failures, fix the issues, and push again.",
       retries: 2,
       escalateAfter: 2,
     },

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1937,7 +1937,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     for (const job of summary.failedJobs) {
       const failed = job.failedStep ? `${job.name} → ${job.failedStep}` : job.name;
       lines.push(`Failed: ${failed}`);
-      lines.push(`Run: ${job.runUrl}`);
+      lines.push(`Failure URL: ${job.runUrl}`);
 
       if (job.logTail) {
         const lineCount = job.logTail.split(/\r?\n/).length;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -39,6 +39,8 @@ import {
   type ProjectConfig as _ProjectConfig,
   type PREnrichmentData,
   type CICheck,
+  type CIFailureSummary,
+  type PRInfo,
   type ReviewComment,
   type ReviewSummary,
   type ProcessProbeResult,
@@ -108,6 +110,12 @@ const PERSISTENT_REACTION_KEYS = new Set(["ci-failed"]);
  *  (including its escalated flag) is cleared, allowing a fresh budget for the
  *  next real CI failure incident. */
 const CI_PASSING_STABLE_THRESHOLD = 2;
+
+type TransitionReaction = {
+  key: string;
+  result: ReactionResult | null;
+  messageEnriched?: boolean;
+};
 
 type WorkspaceBranchProbe =
   | { kind: "branch"; branch: string }
@@ -1644,7 +1652,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     session: Session,
     _oldStatus: SessionStatus,
     newStatus: SessionStatus,
-    transitionReaction?: { key: string; result: ReactionResult | null },
+    transitionReaction?: TransitionReaction,
   ): Promise<void> {
     const project = config.projects[session.projectId];
     if (!project || !session.pr) return;
@@ -1919,11 +1927,32 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return lines.join("\n");
   }
 
-  /**
-   * Format CI check failures into a human-readable message for the agent.
-   * Includes check names, statuses, and links for debugging.
-   */
-  function formatCIFailureMessage(failedChecks: CICheck[]): string {
+  function isFailedCICheck(check: CICheck): boolean {
+    return check.status === "failed" || check.conclusion?.toUpperCase() === "FAILURE";
+  }
+
+  function formatCIFailureSummaryMessage(summary: CIFailureSummary): string {
+    const lines = ["CI is failing on your PR.", ""];
+
+    for (const job of summary.failedJobs) {
+      const failed = job.failedStep ? `${job.name} → ${job.failedStep}` : job.name;
+      lines.push(`Failed: ${failed}`);
+      lines.push(`Run: ${job.runUrl}`);
+
+      if (job.logTail) {
+        const lineCount = job.logTail.split(/\r?\n/).length;
+        const lineLabel = lineCount === 1 ? "line" : "lines";
+        lines.push("", `Log tail (last ${lineCount} ${lineLabel}):`, "```", job.logTail, "```");
+      }
+
+      lines.push("");
+    }
+
+    lines.push("Fix the issues and push again.");
+    return lines.join("\n");
+  }
+
+  function formatCIFailureChecksFallback(failedChecks: CICheck[]): string {
     const lines = ["CI checks are failing on your PR. Here are the failed checks:", ""];
     for (const check of failedChecks) {
       const status = check.conclusion ?? check.status;
@@ -1934,11 +1963,35 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return lines.join("\n");
   }
 
+  /**
+   * Format CI failures into a human-readable message for the agent.
+   * Uses SCM-provided failed job/step/log details when available and falls
+   * back to check names/statuses/links for SCM plugins that do not implement it.
+   */
+  async function formatCIFailureMessage(
+    scm: SCM,
+    pr: PRInfo,
+    failedChecks: CICheck[],
+  ): Promise<string> {
+    if (scm.getCIFailureSummary) {
+      try {
+        const summary = await scm.getCIFailureSummary(pr);
+        if (summary?.failedJobs.length) {
+          return formatCIFailureSummaryMessage(summary);
+        }
+      } catch {
+        // Fall back to check names when summary enrichment fails.
+      }
+    }
+
+    return formatCIFailureChecksFallback(failedChecks);
+  }
+
   async function maybeDispatchCIFailureDetails(
     session: Session,
     _oldStatus: SessionStatus,
     newStatus: SessionStatus,
-    transitionReaction?: { key: string; result: ReactionResult | null },
+    transitionReaction?: TransitionReaction,
   ): Promise<void> {
     const project = config.projects[session.projectId];
     if (!project || !session.pr) return;
@@ -1992,9 +2045,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       }
     }
 
-    const failedChecks = checks.filter(
-      (c) => c.status === "failed" || c.conclusion?.toUpperCase() === "FAILURE",
-    );
+    const failedChecks = checks.filter(isFailedCICheck);
     if (failedChecks.length === 0) return;
 
     const ciFingerprint = makeFingerprint(
@@ -2013,12 +2064,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       });
     }
 
-    // If the transition reaction already sent a ci-failed reaction (now enriched
-    // with detailed check info from the batch cache), record the dispatch hash so
-    // subsequent polls don't re-send the same failure details.
+    // If the transition reaction already delivered an enriched agent message,
+    // or handled a non-agent action, record the dispatch hash so subsequent
+    // polls don't re-send the same failure details.
     if (
       transitionReaction?.key === ciReactionKey &&
-      transitionReaction.result?.success
+      transitionReaction.result?.success &&
+      (transitionReaction.messageEnriched === true ||
+        transitionReaction.result.action !== "send-to-agent")
     ) {
       updateSessionMetadata(session, {
         lastCIFailureDispatchHash: ciFingerprint,
@@ -2039,7 +2092,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       reactionConfig.action &&
       (reactionConfig.auto !== false || reactionConfig.action === "notify")
     ) {
-      const detailedMessage = formatCIFailureMessage(failedChecks);
+      const detailedMessage = await formatCIFailureMessage(scm, session.pr, failedChecks);
 
       try {
         if (reactionConfig.action === "send-to-agent") {
@@ -2335,7 +2388,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     }
     const newStatus = assessment.status;
     const lifecycleChanged = session.metadata["lifecycle"] !== JSON.stringify(session.lifecycle);
-    let transitionReaction: { key: string; result: ReactionResult | null } | undefined;
+    let transitionReaction: TransitionReaction | undefined;
 
     const nextLifecycleEvidence = assessment.evidence;
     const nextDetectingAttempts =
@@ -2473,18 +2526,29 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
         if (reactionKey) {
           let reactionConfig = getReactionConfigForSession(session, reactionKey);
+          let messageEnriched = false;
 
-          // Enrich CI failure message with actual check details from batch cache
-          if (reactionKey === "ci-failed" && session.pr && reactionConfig) {
+          // Enrich CI failure message with failed job/step/log details when
+          // batch check data is already available. If it is not, the
+          // post-transition CI dispatcher below fetches checks and sends the
+          // composed message without altering lifecycle state transitions.
+          if (
+            reactionKey === "ci-failed" &&
+            session.pr &&
+            reactionConfig?.action === "send-to-agent"
+          ) {
             const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
             const cachedData = prEnrichmentCache.get(prKey);
-            if (cachedData?.ciChecks) {
-              const failedChecks = cachedData.ciChecks.filter((c) => c.status === "failed");
+            const project = config.projects[session.projectId];
+            const scm = project?.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
+            if (cachedData?.ciChecks && scm) {
+              const failedChecks = cachedData.ciChecks.filter(isFailedCICheck);
               if (failedChecks.length > 0) {
                 reactionConfig = {
                   ...reactionConfig,
-                  message: formatCIFailureMessage(failedChecks),
+                  message: await formatCIFailureMessage(scm, session.pr, failedChecks),
                 };
+                messageEnriched = true;
               }
             }
           }
@@ -2493,7 +2557,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             // auto: false skips automated agent actions but still allows notifications
             if (reactionConfig.auto !== false || reactionConfig.action === "notify") {
               const reactionResult = await executeReaction(session, reactionKey, reactionConfig);
-              transitionReaction = { key: reactionKey, result: reactionResult };
+              transitionReaction = { key: reactionKey, result: reactionResult, messageEnriched };
               observer.recordOperation({
                 metric: "lifecycle_poll",
                 operation: "lifecycle.transition.reaction",

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1995,6 +1995,31 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     return formatCIFailureChecksFallback(failedChecks);
   }
 
+  async function getFailedCIChecks(
+    scm: SCM,
+    pr: PRInfo,
+    options: { allowFetch: boolean },
+  ): Promise<CICheck[] | null> {
+    const prKey = `${pr.owner}/${pr.repo}#${pr.number}`;
+    const cachedEnrichment = prEnrichmentCache.get(prKey);
+
+    let checks: CICheck[] | undefined = cachedEnrichment?.ciChecks;
+    if (checks === undefined && options.allowFetch) {
+      try {
+        checks = await scm.getCIChecks(pr);
+      } catch {
+        return null;
+      }
+    }
+
+    const failedChecks = checks?.filter(isFailedCICheck) ?? [];
+    return failedChecks.length > 0 ? failedChecks : null;
+  }
+
+  function makeCIFailureFingerprint(failedChecks: CICheck[]): string {
+    return makeFingerprint(failedChecks.map((c) => `${c.name}:${c.status}:${c.conclusion ?? ""}`));
+  }
+
   async function maybeDispatchCIFailureDetails(
     session: Session,
     _oldStatus: SessionStatus,
@@ -2035,30 +2060,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       return;
     }
 
-    // Fetch individual CI checks for failure details.
-    // Use batch enrichment data when available to avoid an extra REST call;
-    // fall back to getCIChecks() when the batch didn't run this cycle.
-    const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-    const cachedEnrichment = prEnrichmentCache.get(prKey);
+    const failedChecks = await getFailedCIChecks(scm, session.pr, { allowFetch: true });
+    if (!failedChecks) return;
 
-    let checks: CICheck[];
-    if (cachedEnrichment?.ciChecks !== undefined) {
-      checks = cachedEnrichment.ciChecks;
-    } else {
-      try {
-        checks = await scm.getCIChecks(session.pr);
-      } catch {
-        // Failed to fetch checks — skip this cycle
-        return;
-      }
-    }
-
-    const failedChecks = checks.filter(isFailedCICheck);
-    if (failedChecks.length === 0) return;
-
-    const ciFingerprint = makeFingerprint(
-      failedChecks.map((c) => `${c.name}:${c.status}:${c.conclusion ?? ""}`),
-    );
+    const ciFingerprint = makeCIFailureFingerprint(failedChecks);
     const lastCIFingerprint = session.metadata["lastCIFailureFingerprint"] ?? "";
     const lastCIDispatchHash = session.metadata["lastCIFailureDispatchHash"] ?? "";
 
@@ -2545,13 +2550,11 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             session.pr &&
             reactionConfig?.action === "send-to-agent"
           ) {
-            const prKey = `${session.pr.owner}/${session.pr.repo}#${session.pr.number}`;
-            const cachedData = prEnrichmentCache.get(prKey);
             const project = config.projects[session.projectId];
             const scm = project?.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
-            if (cachedData?.ciChecks && scm) {
-              const failedChecks = cachedData.ciChecks.filter(isFailedCICheck);
-              if (failedChecks.length > 0) {
+            if (scm) {
+              const failedChecks = await getFailedCIChecks(scm, session.pr, { allowFetch: false });
+              if (failedChecks) {
                 reactionConfig = {
                   ...reactionConfig,
                   message: await formatCIFailureMessage(scm, session.pr, failedChecks),

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1942,7 +1942,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       if (job.logTail) {
         const lineCount = job.logTail.split(/\r?\n/).length;
         const lineLabel = lineCount === 1 ? "line" : "lines";
-        lines.push("", `Log tail (last ${lineCount} ${lineLabel}):`, "```", job.logTail, "```");
+        const escapedTail = escapeMarkdownCodeFenceClosers(job.logTail);
+        lines.push("", `Log tail (last ${lineCount} ${lineLabel}):`, "```", escapedTail, "```");
       }
 
       lines.push("");
@@ -1950,6 +1951,13 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     lines.push("Fix the issues and push again.");
     return lines.join("\n");
+  }
+
+  function escapeMarkdownCodeFenceClosers(logTail: string): string {
+    return logTail
+      .split(/\r?\n/)
+      .map((line) => (line.startsWith("```") ? `\u200B${line}` : line))
+      .join("\n");
   }
 
   function formatCIFailureChecksFallback(failedChecks: CICheck[]): string {
@@ -1975,7 +1983,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   ): Promise<string> {
     if (scm.getCIFailureSummary) {
       try {
-        const summary = await scm.getCIFailureSummary(pr);
+        const summary = await scm.getCIFailureSummary(pr, failedChecks);
         if (summary?.failedJobs.length) {
           return formatCIFailureSummaryMessage(summary);
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -828,6 +828,9 @@ export interface SCM {
   /** Get individual CI check statuses */
   getCIChecks(pr: PRInfo): Promise<CICheck[]>;
 
+  /** Get failed CI jobs/steps with a bounded failed-log tail, if supported. */
+  getCIFailureSummary?(pr: PRInfo): Promise<CIFailureSummary | null>;
+
   /** Get overall CI summary */
   getCISummary(pr: PRInfo): Promise<CIStatus>;
 
@@ -1008,6 +1011,15 @@ export interface CICheck {
   conclusion?: string;
   startedAt?: Date;
   completedAt?: Date;
+}
+
+export interface CIFailureSummary {
+  failedJobs: Array<{
+    name: string;
+    failedStep?: string;
+    runUrl: string;
+    logTail?: string;
+  }>;
 }
 
 export type CIStatus = "pending" | "passing" | "failing" | "none";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -829,7 +829,7 @@ export interface SCM {
   getCIChecks(pr: PRInfo): Promise<CICheck[]>;
 
   /** Get failed CI jobs/steps with a bounded failed-log tail, if supported. */
-  getCIFailureSummary?(pr: PRInfo): Promise<CIFailureSummary | null>;
+  getCIFailureSummary?(pr: PRInfo, failedChecks?: CICheck[]): Promise<CIFailureSummary | null>;
 
   /** Get overall CI summary */
   getCISummary(pr: PRInfo): Promise<CIStatus>;

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -221,6 +221,29 @@ function extractFailedStep(log: string): string | undefined {
   return lastStep;
 }
 
+async function getFailedJobLog(
+  pr: PRInfo,
+  runReference: { runId: string; jobId?: string },
+): Promise<string> {
+  try {
+    return await gh([
+      "run",
+      "view",
+      runReference.runId,
+      "--repo",
+      repoFlag(pr),
+      "--log-failed",
+      ...(runReference.jobId ? ["--job", runReference.jobId] : []),
+    ]);
+  } catch (err) {
+    if (!runReference.jobId) throw err;
+    return gh([
+      "api",
+      `repos/${pr.owner}/${pr.repo}/actions/jobs/${runReference.jobId}/logs`,
+    ]);
+  }
+}
+
 async function getCIChecksFromStatusRollup(pr: PRInfo): Promise<CICheck[]> {
   const raw = await gh([
     "pr",
@@ -886,15 +909,7 @@ function createGitHubSCM(): SCM {
           if (seenRuns.has(seenKey)) continue;
           seenRuns.add(seenKey);
 
-          const log = await gh([
-            "run",
-            "view",
-            runReference.runId,
-            "--repo",
-            repoFlag(pr),
-            "--log-failed",
-            ...(runReference.jobId ? ["--job", runReference.jobId] : []),
-          ]);
+          const log = await getFailedJobLog(pr, runReference);
 
           const failedJob: CIFailureSummary["failedJobs"][number] = {
             name: check.name,

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -212,12 +212,13 @@ function tailLines(text: string, maxLines: number): string | undefined {
 }
 
 function extractFailedStep(log: string): string | undefined {
+  let lastStep: string | undefined;
   for (const line of log.split(/\r?\n/)) {
     const parts = line.split("\t");
     const step = parts.length >= 3 ? parts[1]?.trim() : undefined;
-    if (step) return step;
+    if (step) lastStep = step;
   }
-  return undefined;
+  return lastStep;
 }
 
 async function getCIChecksFromStatusRollup(pr: PRInfo): Promise<CICheck[]> {
@@ -864,10 +865,14 @@ function createGitHubSCM(): SCM {
       });
     },
 
-    async getCIFailureSummary(pr: PRInfo): Promise<CIFailureSummary | null> {
+    async getCIFailureSummary(
+      pr: PRInfo,
+      providedFailedChecks?: CICheck[],
+    ): Promise<CIFailureSummary | null> {
       try {
-        const checks = await this.getCIChecks(pr);
-        const failedChecks = checks.filter(isFailedCheck);
+        const failedChecks = (providedFailedChecks ?? (await this.getCIChecks(pr))).filter(
+          isFailedCheck,
+        );
         if (failedChecks.length === 0) return null;
 
         const failedJobs: CIFailureSummary["failedJobs"] = [];

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -23,6 +23,7 @@ import {
   type PRState,
   type MergeMethod,
   type CICheck,
+  type CIFailureSummary,
   type CIStatus,
   type Review,
   type ReviewDecision,
@@ -59,6 +60,8 @@ const BOT_AUTHORS = new Set([
   "snyk-bot",
   "lgtm-com[bot]",
 ]);
+
+const CI_FAILURE_LOG_TAIL_LINES = 120;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -165,6 +168,56 @@ function mapRawCheckStateToStatus(rawState: string | undefined): CICheck["status
   }
 
   return "skipped";
+}
+
+function isFailedCheck(check: CICheck): boolean {
+  return check.status === "failed" || check.conclusion?.toUpperCase() === "FAILURE";
+}
+
+function isDecimalId(value: string): boolean {
+  return value.length > 0 && [...value].every((char) => char >= "0" && char <= "9");
+}
+
+function extractActionRunReference(
+  check: CICheck,
+): { runId: string; jobId?: string; runUrl: string } | null {
+  if (!check.url) return null;
+  let pathParts: string[];
+  try {
+    pathParts = new URL(check.url).pathname.split("/").filter(Boolean);
+  } catch {
+    return null;
+  }
+
+  const actionsIndex = pathParts.findIndex(
+    (part, index) => part === "actions" && pathParts[index + 1] === "runs",
+  );
+  const runId = actionsIndex >= 0 ? pathParts[actionsIndex + 2] : undefined;
+  if (!runId || !isDecimalId(runId)) return null;
+
+  const jobIndex = pathParts.findIndex((part, index) => index > actionsIndex && part === "job");
+  const jobId = jobIndex >= 0 ? pathParts[jobIndex + 1] : undefined;
+
+  return {
+    runId,
+    ...(jobId && isDecimalId(jobId) ? { jobId } : {}),
+    runUrl: check.url,
+  };
+}
+
+function tailLines(text: string, maxLines: number): string | undefined {
+  const lines = text.split(/\r?\n/);
+  const tail = lines.slice(-maxLines).join("\n").trimEnd();
+  return tail.length > 0 ? tail : undefined;
+}
+
+function extractFailedStep(log: string): string | undefined {
+  for (const line of log.split(/\r?\n/)) {
+    const parts = line.split("\t");
+    const step = parts.length >= 3 ? parts[1]?.trim() : undefined;
+    if (step) return step;
+  }
+  return undefined;
 }
 
 async function getCIChecksFromStatusRollup(pr: PRInfo): Promise<CICheck[]> {
@@ -809,6 +862,50 @@ function createGitHubSCM(): SCM {
           throw new Error("Failed to fetch CI checks", { cause: err });
         }
       });
+    },
+
+    async getCIFailureSummary(pr: PRInfo): Promise<CIFailureSummary | null> {
+      try {
+        const checks = await this.getCIChecks(pr);
+        const failedChecks = checks.filter(isFailedCheck);
+        if (failedChecks.length === 0) return null;
+
+        const failedJobs: CIFailureSummary["failedJobs"] = [];
+        const seenRuns = new Set<string>();
+
+        for (const check of failedChecks) {
+          const runReference = extractActionRunReference(check);
+          if (!runReference) continue;
+
+          const seenKey = `${runReference.runId}:${runReference.jobId ?? ""}`;
+          if (seenRuns.has(seenKey)) continue;
+          seenRuns.add(seenKey);
+
+          const log = await gh([
+            "run",
+            "view",
+            runReference.runId,
+            "--repo",
+            repoFlag(pr),
+            "--log-failed",
+            ...(runReference.jobId ? ["--job", runReference.jobId] : []),
+          ]);
+
+          const failedJob: CIFailureSummary["failedJobs"][number] = {
+            name: check.name,
+            runUrl: runReference.runUrl,
+          };
+          const failedStep = extractFailedStep(log);
+          if (failedStep) failedJob.failedStep = failedStep;
+          const logTail = tailLines(log, CI_FAILURE_LOG_TAIL_LINES);
+          if (logTail) failedJob.logTail = logTail;
+          failedJobs.push(failedJob);
+        }
+
+        return failedJobs.length > 0 ? { failedJobs } : null;
+      } catch {
+        return null;
+      }
     },
 
     async getCISummary(pr: PRInfo): Promise<CIStatus> {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -707,6 +707,34 @@ describe("scm-github plugin", () => {
 
       await expect(scm.getCIFailureSummary?.(pr, checks)).resolves.toBeNull();
     });
+
+    it("falls back to job logs API when gh run view cannot read logs yet", async () => {
+      const checks = [
+        {
+          name: "lint",
+          status: "failed" as const,
+          conclusion: "FAILURE",
+          url: "https://github.com/acme/repo/actions/runs/123/job/456",
+        },
+      ];
+      mockGhError("run 123 is still in progress; logs will be available when it is complete");
+      mockGhRaw("2026-05-14T23:40:42Z ##[error]Lint failed\nunused variable");
+
+      const summary = await scm.getCIFailureSummary?.(pr, checks);
+
+      expect(summary?.failedJobs).toEqual([
+        {
+          name: "lint",
+          runUrl: "https://github.com/acme/repo/actions/runs/123/job/456",
+          logTail: "2026-05-14T23:40:42Z ##[error]Lint failed\nunused variable",
+        },
+      ]);
+      expect(ghMock).toHaveBeenLastCalledWith(
+        expect.stringMatching(/(?:^|[\\/])gh(?:\.(?:exe|cmd|bat))?$/i),
+        ["api", "repos/acme/repo/actions/jobs/456/logs"],
+        expect.any(Object),
+      );
+    });
   });
 
   // ---- getCISummary ------------------------------------------------------

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -647,6 +647,61 @@ describe("scm-github plugin", () => {
     });
   });
 
+  // ---- getCIFailureSummary -----------------------------------------------
+
+  describe("getCIFailureSummary", () => {
+    it("returns failed job step and caps the failed log tail", async () => {
+      mockGh([
+        {
+          name: "build",
+          state: "FAILURE",
+          link: "https://github.com/acme/repo/actions/runs/123/job/456",
+        },
+        {
+          name: "lint",
+          state: "SUCCESS",
+          link: "https://github.com/acme/repo/actions/runs/124/job/457",
+        },
+      ]);
+      const logLines = Array.from(
+        { length: 125 },
+        (_, index) => `build\tRun pnpm test\t2026-05-12T00:00:00Z line ${index + 1}`,
+      );
+      mockGhRaw(logLines.join("\n"));
+
+      const summary = await scm.getCIFailureSummary?.(pr);
+
+      expect(summary?.failedJobs).toHaveLength(1);
+      expect(summary?.failedJobs[0]).toEqual({
+        name: "build",
+        failedStep: "Run pnpm test",
+        runUrl: "https://github.com/acme/repo/actions/runs/123/job/456",
+        logTail: logLines.slice(-120).join("\n"),
+      });
+      expect(summary?.failedJobs[0]?.logTail?.split("\n")).toHaveLength(120);
+      expect(summary?.failedJobs[0]?.logTail?.split("\n")[0]).toContain("line 6");
+      expect(summary?.failedJobs[0]?.logTail).toContain("line 125");
+      expect(ghMock).toHaveBeenLastCalledWith(
+        expect.stringMatching(/(?:^|[\\/])gh(?:\.(?:exe|cmd|bat))?$/i),
+        ["run", "view", "123", "--repo", "acme/repo", "--log-failed", "--job", "456"],
+        expect.any(Object),
+      );
+    });
+
+    it("returns null when failed-log fetch fails", async () => {
+      mockGh([
+        {
+          name: "build",
+          state: "FAILURE",
+          link: "https://github.com/acme/repo/actions/runs/123/job/456",
+        },
+      ]);
+      mockGhError("run view failed");
+
+      await expect(scm.getCIFailureSummary?.(pr)).resolves.toBeNull();
+    });
+  });
+
   // ---- getCISummary ------------------------------------------------------
 
   describe("getCISummary", () => {

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -651,25 +651,30 @@ describe("scm-github plugin", () => {
 
   describe("getCIFailureSummary", () => {
     it("returns failed job step and caps the failed log tail", async () => {
-      mockGh([
+      const checks = [
         {
           name: "build",
-          state: "FAILURE",
-          link: "https://github.com/acme/repo/actions/runs/123/job/456",
+          status: "failed" as const,
+          conclusion: "FAILURE",
+          url: "https://github.com/acme/repo/actions/runs/123/job/456",
         },
         {
           name: "lint",
-          state: "SUCCESS",
-          link: "https://github.com/acme/repo/actions/runs/124/job/457",
+          status: "passed" as const,
+          conclusion: "SUCCESS",
+          url: "https://github.com/acme/repo/actions/runs/124/job/457",
         },
-      ]);
+      ];
       const logLines = Array.from(
         { length: 125 },
-        (_, index) => `build\tRun pnpm test\t2026-05-12T00:00:00Z line ${index + 1}`,
+        (_, index) => {
+          const step = index < 100 ? "Install dependencies" : "Run pnpm test";
+          return `build\t${step}\t2026-05-12T00:00:00Z line ${index + 1}`;
+        },
       );
       mockGhRaw(logLines.join("\n"));
 
-      const summary = await scm.getCIFailureSummary?.(pr);
+      const summary = await scm.getCIFailureSummary?.(pr, checks);
 
       expect(summary?.failedJobs).toHaveLength(1);
       expect(summary?.failedJobs[0]).toEqual({
@@ -686,19 +691,21 @@ describe("scm-github plugin", () => {
         ["run", "view", "123", "--repo", "acme/repo", "--log-failed", "--job", "456"],
         expect.any(Object),
       );
+      expect(ghMock).toHaveBeenCalledTimes(1);
     });
 
     it("returns null when failed-log fetch fails", async () => {
-      mockGh([
+      const checks = [
         {
           name: "build",
-          state: "FAILURE",
-          link: "https://github.com/acme/repo/actions/runs/123/job/456",
+          status: "failed" as const,
+          conclusion: "FAILURE",
+          url: "https://github.com/acme/repo/actions/runs/123/job/456",
         },
-      ]);
+      ];
       mockGhError("run view failed");
 
-      await expect(scm.getCIFailureSummary?.(pr)).resolves.toBeNull();
+      await expect(scm.getCIFailureSummary?.(pr, checks)).resolves.toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary

Per commit:
- `a7338838` — adds the optional SCM `getCIFailureSummary(pr)` contract and shared `CIFailureSummary` type.
- `e0156ab7` — implements GitHub CI failure summaries with `gh run view --log-failed`, exact Actions run/job URL parsing, and a 120-line per-job log tail cap.
- `0c66889c` — wires lifecycle CI-failure messaging to prefer failed job/step/log summaries, falls back for SCM plugins without summaries, removes the generic default `ci-failed` text, and updates tests.

## Lifecycle invariants preserved

- No lifecycle status decisions or state-machine transitions changed.
- `ci-failed` persistent tracker behavior, retry/escalation thresholds, and stable-passing reset semantics remain unchanged.
- The change is limited to `ci-failed` reaction payload composition and duplicate-dispatch hashing.

## Before / after agent-visible message

Before:

```text
CI is failing on your PR. Investigate the failures, fix the issues, and push again.
```

After:

````text
CI is failing on your PR.

Failed: build → Run pnpm test
Run: https://github.com/org/repo/actions/runs/123/job/456

Log tail (last 2 lines):
```
AssertionError: expected true to be false
Process completed with exit code 1
```

Fix the issues and push again.
````

## Verification

Run under Node 20.19.5 (Node 25 failed the optional `better-sqlite3` native build used by core tests):

```bash
PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" corepack pnpm install
PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" corepack pnpm typecheck
PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" corepack pnpm test --filter @aoagents/ao-core --filter @aoagents/ao-plugin-scm-github
```

Closes #1807
Refs #389
