### PR TITLE
refactor(release): split publish into two-repo model — GitHub release public, npm publish private

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -41,15 +41,21 @@ jobs:
           fetch-depth: 0
 
       # Skip-if-unchanged guard: if the most recent prerelease in this
-      # repo already points at the current tip of main, there's nothing
-      # new to publish — short-circuit the whole job. Prevents republishing
-      # the same SHA on every cron tick during quiet stretches (and keeps
-      # the npm version list from filling with identical nightlies).
+      # repo was cut from the current tip of main, there's nothing new
+      # to publish — short-circuit the whole job. Prevents republishing
+      # the same SHA on every cron tick during quiet stretches (and
+      # keeps the npm version list from filling with identical nightlies).
       #
       # We filter to prereleases only (`isPrerelease == true`). If the
       # most recent release were a stable cut from `release.yml`, an
       # explicit `workflow_dispatch` nightly right after the stable
       # release would otherwise be suppressed — which we don't want.
+      #
+      # The previous-nightly tag points at the *orphan snapshot commit*
+      # created by the "Commit snapshot version bumps" step below, not
+      # at the main HEAD it was cut from. The snapshot commit's first
+      # parent is the source main HEAD, so `${LAST_TAG}^` is the right
+      # anchor to compare against `GITHUB_SHA` (main HEAD at this run).
       - name: Check if main has new commits since the last nightly
         id: check
         env:
@@ -58,10 +64,10 @@ jobs:
           LAST_TAG=$(gh release list --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease)][0].tagName // empty')
           LAST_SHA=""
           if [ -n "$LAST_TAG" ]; then
-            LAST_SHA=$(git rev-list -n 1 "$LAST_TAG" 2>/dev/null || echo "")
+            LAST_SHA=$(git rev-parse "${LAST_TAG}^" 2>/dev/null || echo "")
           fi
           if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$GITHUB_SHA" ]; then
-            echo "Last prerelease ($LAST_TAG) already points at $GITHUB_SHA — skipping."
+            echo "Last prerelease ($LAST_TAG) was cut from $GITHUB_SHA — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,19 +1,21 @@
 name: Canary
 
-# Two-repo release pipeline (nightly canary side).
+# Two-stage release pipeline (nightly canary side).
 #
-# Nightly canary publishes the current tip of `main` to npm under
-# @nightly. This public workflow only handles snapshot versioning,
-# tagging, and the GitHub prerelease. The actual `npm publish` runs in
-# the private ComposioHQ/ao-publisher repo, dispatched at the end. See
-# CONTRIBUTING.md → "Release architecture" for full context — the only
-# secret needed here is PUBLISHER_DISPATCH_TOKEN.
+# Nightly canary creates snapshot versions, tags, and a GitHub prerelease.
+# npm publishing is handled by a private cron job (AO) that polls GitHub
+# releases and publishes when a new tag is ahead of the current npm
+# nightly version.
+#
+# No NPM_TOKEN or publisher dispatch secrets are needed in this repo.
+# The only secret used is GITHUB_TOKEN (automatic).
 #
 # Cron schedule: 23:30 IST = 18:00 UTC, on Fri,Sat,Sun,Mon,Tue
 # (DOW 5,6,0,1,2). Wed/Thu are the bake window — no scheduled publishes.
 # `workflow_dispatch` lets the release captain re-cut a nightly during
 # bake when a fix lands and the Discord cohort should test the patched
 # candidate.
+
 on:
   schedule:
     - cron: "0 18 * * 5,6,0,1,2"
@@ -25,8 +27,6 @@ concurrency:
 
 permissions:
   contents: write
-  # id-token retained as a no-op for forward compatibility; npm
-  # provenance now lives in ao-publisher.
   id-token: write
 
 jobs:
@@ -43,8 +43,7 @@ jobs:
       # Skip-if-unchanged guard: if the most recent prerelease in this
       # repo was cut from the current tip of main, there's nothing new
       # to publish — short-circuit the whole job. Prevents republishing
-      # the same SHA on every cron tick during quiet stretches (and
-      # keeps the npm version list from filling with identical nightlies).
+      # the same SHA on every cron tick during quiet stretches.
       #
       # We filter to prereleases only (`isPrerelease == true`). If the
       # most recent release were a stable cut from `release.yml`, an
@@ -58,11 +57,7 @@ jobs:
       # anchor to compare against `GITHUB_SHA` (main HEAD at this run).
       #
       # `workflow_dispatch` always proceeds — recovery path for partial
-      # failures (tag pushed, then `gh release create` or dispatch
-      # failed). A human triggered the run, they want it to run. The
-      # cron-driven path still dedupes via the SHA check above; the
-      # downstream tag-push and release-create steps are individually
-      # safe against existing remote state.
+      # failures. A human triggered the run, they want it to run.
       - name: Check if main has new commits since the last nightly
         id: check
         env:
@@ -93,7 +88,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          # No `registry-url`: this workflow no longer publishes to npm.
+          # No `registry-url`: this workflow does not publish to npm.
 
       - if: steps.check.outputs.skip != 'true'
         run: echo "HUSKY=0" >> $GITHUB_ENV
@@ -107,7 +102,7 @@ jobs:
       # Pre-publish guard: same as release.yml — catches workspace:* deps
       # on private packages before they'd silently break a published
       # install. Still runs here so the public repo blocks a malformed
-      # snapshot before handing off to the private publisher.
+      # snapshot before it reaches npm.
       - if: steps.check.outputs.skip != 'true'
         run: node scripts/check-publishable-deps.mjs
 
@@ -125,15 +120,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # `pnpm changeset version --snapshot` modifies package.json files
-      # on disk but does NOT create a git commit (that responsibility
-      # normally belongs to `changesets/action`, which we deliberately
-      # don't use here — see the comment in release.yml).
-      #
-      # Without this commit, the umbrella tag we push below would point
-      # at the pre-snapshot HEAD, so when ao-publisher checks out
-      # `client_payload.tag` it would see the un-bumped versions in
-      # package.json and either publish wrong version numbers or fail
-      # trying to republish an existing stable.
+      # on disk but does NOT create a git commit. Without this commit,
+      # the umbrella tag we push below would point at the pre-snapshot
+      # HEAD, so when the npm publisher checks out the tag it would see
+      # the un-bumped versions and either publish wrong version numbers
+      # or fail trying to republish an existing stable.
       #
       # The commit is NEVER pushed back to main — only the tag below is
       # pushed, and the orphan commit travels with it as part of the
@@ -148,14 +139,13 @@ jobs:
           git diff --cached --quiet || git commit -m 'chore: snapshot version bump [skip ci]'
 
       # Push the umbrella `vX.Y.Z` tag pointing at the snapshot commit.
-      # `ao-publisher` resolves `client_payload.tag` to this ref and the
-      # GH prerelease step below uses the same tag, so both are anchored
-      # at the bumped commit.
+      # The npm publisher resolves this tag to the snapshot commit with
+      # the bumped package.json versions.
       #
       # We deliberately skip `pnpm changeset tag`: it would create one
       # tag per publishable package (~27 here) every night, which adds
-      # up fast on the nightly cadence. ao-publisher only consumes the
-      # umbrella tag, so the per-package tags are pure decoration.
+      # up fast on the nightly cadence. The npm publisher only consumes
+      # the umbrella tag, so the per-package tags are pure decoration.
       - name: Tag snapshot versions
         id: tag
         if: steps.check.outputs.skip != 'true'
@@ -178,15 +168,3 @@ jobs:
           gh release create "v${{ steps.tag.outputs.version }}" \
             --prerelease \
             --generate-notes
-
-      # Hand off to the private publisher repo with event_type=publish-npm-nightly
-      # so it publishes under the `nightly` dist-tag. PUBLISHER_DISPATCH_TOKEN
-      # is a fine-grained PAT scoped to ComposioHQ/ao-publisher only.
-      - name: Dispatch npm publish to ao-publisher
-        if: steps.check.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.PUBLISHER_DISPATCH_TOKEN }}
-        run: |
-          gh api repos/ComposioHQ/ao-publisher/dispatches \
-            -f event_type=publish-npm-nightly \
-            -F client_payload[tag]=v${{ steps.tag.outputs.version }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -116,16 +116,16 @@ jobs:
       # normally belongs to `changesets/action`, which we deliberately
       # don't use here — see the comment in release.yml).
       #
-      # Without this commit, the next step's `pnpm changeset tag` would
-      # create tags pointing at the pre-snapshot HEAD, so when
-      # ao-publisher checks out `client_payload.tag` it would see the
-      # un-bumped versions in package.json and either publish wrong
-      # version numbers or fail trying to republish an existing stable.
+      # Without this commit, the umbrella tag we push below would point
+      # at the pre-snapshot HEAD, so when ao-publisher checks out
+      # `client_payload.tag` it would see the un-bumped versions in
+      # package.json and either publish wrong version numbers or fail
+      # trying to republish an existing stable.
       #
-      # The commit is NEVER pushed back to main — only the tags below
-      # are pushed, and the orphan commit travels with them as part of
-      # the tag's reachable history. `[skip ci]` is defensive in case
-      # any future change ever pushes this commit to a branch.
+      # The commit is NEVER pushed back to main — only the tag below is
+      # pushed, and the orphan commit travels with it as part of the
+      # tag's reachable history. `[skip ci]` is defensive in case any
+      # future change ever pushes this commit to a branch.
       - name: Commit snapshot version bumps
         if: steps.check.outputs.skip != 'true'
         run: |
@@ -134,20 +134,22 @@ jobs:
           git add -A
           git diff --cached --quiet || git commit -m 'chore: snapshot version bump [skip ci]'
 
-      # Tag the snapshot versions locally and push them. `pnpm changeset
-      # tag` reads each publishable package.json and creates package-
-      # specific tags (`@aoagents/ao@…`). We also create a `vX.Y.Z` tag
-      # so the publisher repo can resolve `client_payload.tag` to a
-      # known ref and so the GH prerelease step below has a stable
-      # commitish that can't drift.
+      # Push the umbrella `vX.Y.Z` tag pointing at the snapshot commit.
+      # `ao-publisher` resolves `client_payload.tag` to this ref and the
+      # GH prerelease step below uses the same tag, so both are anchored
+      # at the bumped commit.
+      #
+      # We deliberately skip `pnpm changeset tag`: it would create one
+      # tag per publishable package (~27 here) every night, which adds
+      # up fast on the nightly cadence. ao-publisher only consumes the
+      # umbrella tag, so the per-package tags are pure decoration.
       - name: Tag snapshot versions
         id: tag
         if: steps.check.outputs.skip != 'true'
         run: |
-          pnpm changeset tag
           version=$(node -p "require('./packages/ao/package.json').version")
           git tag "v$version"
-          git push origin --tags
+          git push origin "v$version"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # Public-facing GitHub prerelease. `--prerelease` flags it as such

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -40,23 +40,28 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      # Skip-if-unchanged guard: if the most recent GitHub release in this
+      # Skip-if-unchanged guard: if the most recent prerelease in this
       # repo already points at the current tip of main, there's nothing
       # new to publish — short-circuit the whole job. Prevents republishing
       # the same SHA on every cron tick during quiet stretches (and keeps
       # the npm version list from filling with identical nightlies).
-      - name: Check if main has new commits since the last release
+      #
+      # We filter to prereleases only (`isPrerelease == true`). If the
+      # most recent release were a stable cut from `release.yml`, an
+      # explicit `workflow_dispatch` nightly right after the stable
+      # release would otherwise be suppressed — which we don't want.
+      - name: Check if main has new commits since the last nightly
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LAST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          LAST_TAG=$(gh release list --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease)][0].tagName // empty')
           LAST_SHA=""
           if [ -n "$LAST_TAG" ]; then
             LAST_SHA=$(git rev-list -n 1 "$LAST_TAG" 2>/dev/null || echo "")
           fi
           if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$GITHUB_SHA" ]; then
-            echo "Last release ($LAST_TAG) already points at $GITHUB_SHA — skipping."
+            echo "Last prerelease ($LAST_TAG) already points at $GITHUB_SHA — skipping."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
@@ -100,28 +105,56 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # `pnpm changeset version --snapshot` modifies package.json files
+      # on disk but does NOT create a git commit (that responsibility
+      # normally belongs to `changesets/action`, which we deliberately
+      # don't use here — see the comment in release.yml).
+      #
+      # Without this commit, the next step's `pnpm changeset tag` would
+      # create tags pointing at the pre-snapshot HEAD, so when
+      # ao-publisher checks out `client_payload.tag` it would see the
+      # un-bumped versions in package.json and either publish wrong
+      # version numbers or fail trying to republish an existing stable.
+      #
+      # The commit is NEVER pushed back to main — only the tags below
+      # are pushed, and the orphan commit travels with them as part of
+      # the tag's reachable history. `[skip ci]` is defensive in case
+      # any future change ever pushes this commit to a branch.
+      - name: Commit snapshot version bumps
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git diff --cached --quiet || git commit -m 'chore: snapshot version bump [skip ci]'
+
       # Tag the snapshot versions locally and push them. `pnpm changeset
-      # tag` reads each publishable package.json and creates a git tag —
-      # so the publisher repo can resolve `client_payload.tag` to a known
-      # ref and we have something to point `gh release create` at.
+      # tag` reads each publishable package.json and creates package-
+      # specific tags (`@aoagents/ao@…`). We also create a `vX.Y.Z` tag
+      # so the publisher repo can resolve `client_payload.tag` to a
+      # known ref and so the GH prerelease step below has a stable
+      # commitish that can't drift.
       - name: Tag snapshot versions
         id: tag
         if: steps.check.outputs.skip != 'true'
         run: |
           pnpm changeset tag
-          git push --follow-tags
           version=$(node -p "require('./packages/ao/package.json').version")
+          git tag "v$version"
+          git push origin --tags
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # Public-facing GitHub prerelease. `--prerelease` flags it as such
       # so consumers and tooling that filter by stability stay correct.
+      # No `--target`: the tag was just pushed and GitHub resolves the
+      # commitish from it (avoids the race where another commit lands
+      # on main between the tag push and this step).
       - name: Create GitHub prerelease
         if: steps.check.outputs.skip != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "v${{ steps.tag.outputs.version }}" \
-            --target main \
             --prerelease \
             --generate-notes
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,10 +1,19 @@
 name: Canary
 
-# Nightly canary publishes the current tip of `main` to npm under @nightly.
+# Two-repo release pipeline (nightly canary side).
+#
+# Nightly canary publishes the current tip of `main` to npm under
+# @nightly. This public workflow only handles snapshot versioning,
+# tagging, and the GitHub prerelease. The actual `npm publish` runs in
+# the private ComposioHQ/ao-publisher repo, dispatched at the end. See
+# CONTRIBUTING.md → "Release architecture" for full context — the only
+# secret needed here is PUBLISHER_DISPATCH_TOKEN.
+#
 # Cron schedule: 23:30 IST = 18:00 UTC, on Fri,Sat,Sun,Mon,Tue
 # (DOW 5,6,0,1,2). Wed/Thu are the bake window — no scheduled publishes.
-# `workflow_dispatch` lets the release captain re-cut a nightly during bake
-# when a fix lands and the Discord cohort should test the patched candidate.
+# `workflow_dispatch` lets the release captain re-cut a nightly during
+# bake when a fix lands and the Discord cohort should test the patched
+# candidate.
 on:
   schedule:
     - cron: "0 18 * * 5,6,0,1,2"
@@ -15,7 +24,9 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: read
+  contents: write
+  # id-token retained as a no-op for forward compatibility; npm
+  # provenance now lives in ao-publisher.
   id-token: write
 
 jobs:
@@ -29,24 +40,55 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      # Skip-if-unchanged guard: if the most recent GitHub release in this
+      # repo already points at the current tip of main, there's nothing
+      # new to publish — short-circuit the whole job. Prevents republishing
+      # the same SHA on every cron tick during quiet stretches (and keeps
+      # the npm version list from filling with identical nightlies).
+      - name: Check if main has new commits since the last release
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""')
+          LAST_SHA=""
+          if [ -n "$LAST_TAG" ]; then
+            LAST_SHA=$(git rev-list -n 1 "$LAST_TAG" 2>/dev/null || echo "")
+          fi
+          if [ -n "$LAST_SHA" ] && [ "$LAST_SHA" = "$GITHUB_SHA" ]; then
+            echo "Last release ($LAST_TAG) already points at $GITHUB_SHA — skipping."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: pnpm/action-setup@v4
+        if: steps.check.outputs.skip != 'true'
       - uses: actions/setup-node@v4
+        if: steps.check.outputs.skip != 'true'
         with:
           node-version: 20
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # No `registry-url`: this workflow no longer publishes to npm.
 
-      - run: echo "HUSKY=0" >> $GITHUB_ENV
+      - if: steps.check.outputs.skip != 'true'
+        run: echo "HUSKY=0" >> $GITHUB_ENV
 
-      - run: pnpm install --frozen-lockfile
+      - if: steps.check.outputs.skip != 'true'
+        run: pnpm install --frozen-lockfile
 
-      - run: pnpm -r build
+      - if: steps.check.outputs.skip != 'true'
+        run: pnpm -r build
 
-      # Pre-publish guard: same as release.yml — catches workspace:* deps on
-      # private packages before they'd silently break a published install.
-      - run: node scripts/check-publishable-deps.mjs
+      # Pre-publish guard: same as release.yml — catches workspace:* deps
+      # on private packages before they'd silently break a published
+      # install. Still runs here so the public repo blocks a malformed
+      # snapshot before handing off to the private publisher.
+      - if: steps.check.outputs.skip != 'true'
+        run: node scripts/check-publishable-deps.mjs
 
       - name: Create snapshot versions
+        if: steps.check.outputs.skip != 'true'
         run: |
           # If no changesets exist (e.g. right after a Version Packages merge),
           # create a minimal one. `changeset version --snapshot` consumes and
@@ -58,8 +100,39 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish canary
-        run: pnpm changeset publish --tag nightly --no-git-tag
+      # Tag the snapshot versions locally and push them. `pnpm changeset
+      # tag` reads each publishable package.json and creates a git tag —
+      # so the publisher repo can resolve `client_payload.tag` to a known
+      # ref and we have something to point `gh release create` at.
+      - name: Tag snapshot versions
+        id: tag
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          pnpm changeset tag
+          git push --follow-tags
+          version=$(node -p "require('./packages/ao/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Public-facing GitHub prerelease. `--prerelease` flags it as such
+      # so consumers and tooling that filter by stability stay correct.
+      - name: Create GitHub prerelease
+        if: steps.check.outputs.skip != 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.tag.outputs.version }}" \
+            --target main \
+            --prerelease \
+            --generate-notes
+
+      # Hand off to the private publisher repo with event_type=publish-npm-nightly
+      # so it publishes under the `nightly` dist-tag. PUBLISHER_DISPATCH_TOKEN
+      # is a fine-grained PAT scoped to ComposioHQ/ao-publisher only.
+      - name: Dispatch npm publish to ao-publisher
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISHER_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/ComposioHQ/ao-publisher/dispatches \
+            -f event_type=publish-npm-nightly \
+            -F client_payload[tag]=v${{ steps.tag.outputs.version }}

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -56,11 +56,24 @@ jobs:
       # at the main HEAD it was cut from. The snapshot commit's first
       # parent is the source main HEAD, so `${LAST_TAG}^` is the right
       # anchor to compare against `GITHUB_SHA` (main HEAD at this run).
+      #
+      # `workflow_dispatch` always proceeds — recovery path for partial
+      # failures (tag pushed, then `gh release create` or dispatch
+      # failed). A human triggered the run, they want it to run. The
+      # cron-driven path still dedupes via the SHA check above; the
+      # downstream tag-push and release-create steps are individually
+      # safe against existing remote state.
       - name: Check if main has new commits since the last nightly
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          if [ "$GITHUB_EVENT_NAME" = 'workflow_dispatch' ]; then
+            echo 'Manual trigger via workflow_dispatch — bypassing skip guard.'
+            echo 'skip=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           LAST_TAG=$(gh release list --json tagName,isPrerelease --jq '[.[] | select(.isPrerelease)][0].tagName // empty')
           LAST_SHA=""
           if [ -n "$LAST_TAG" ]; then

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -4,8 +4,8 @@ name: Canary
 #
 # Nightly canary creates snapshot versions, tags, and a GitHub prerelease.
 # npm publishing is handled by a private cron job (AO) that polls GitHub
-# releases and publishes when a new tag is ahead of the current npm
-# nightly version.
+# releases and publishes when a new prerelease tag is ahead of the current
+# npm nightly version.
 #
 # No NPM_TOKEN or publisher dispatch secrets are needed in this repo.
 # The only secret used is GITHUB_TOKEN (automatic).
@@ -27,13 +27,11 @@ concurrency:
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
   canary:
     name: Publish canary
     runs-on: ubuntu-latest
-    environment: release
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,11 +48,11 @@ jobs:
       # explicit `workflow_dispatch` nightly right after the stable
       # release would otherwise be suppressed — which we don't want.
       #
-      # The previous-nightly tag points at the *orphan snapshot commit*
-      # created by the "Commit snapshot version bumps" step below, not
-      # at the main HEAD it was cut from. The snapshot commit's first
-      # parent is the source main HEAD, so `${LAST_TAG}^` is the right
-      # anchor to compare against `GITHUB_SHA` (main HEAD at this run).
+      # The previous-nightly tag points at the snapshot commit created
+      # by the "Commit snapshot version bumps" step below. The snapshot
+      # commit's first parent is the source main HEAD, so `${LAST_TAG}^`
+      # is the right anchor to compare against `GITHUB_SHA` (main HEAD
+      # at this run).
       #
       # `workflow_dispatch` always proceeds — recovery path for partial
       # failures. A human triggered the run, they want it to run.
@@ -124,10 +122,10 @@ jobs:
       # the umbrella tag we push below would point at the pre-snapshot
       # HEAD, so when the npm publisher checks out the tag it would see
       # the un-bumped versions and either publish wrong version numbers
-      # or fail trying to republish an existing stable.
+      # or fail trying to republish an existing version.
       #
-      # The commit is NEVER pushed back to main — only the tag below is
-      # pushed, and the orphan commit travels with it as part of the
+      # The commit is NEVER pushed to main — only the tag below is
+      # pushed, and the snapshot commit travels with it as part of the
       # tag's reachable history. `[skip ci]` is defensive in case any
       # future change ever pushes this commit to a branch.
       - name: Commit snapshot version bumps
@@ -135,7 +133,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git add -A
+          git add packages/*/package.json packages/plugins/*/package.json .changeset/
           git diff --cached --quiet || git commit -m 'chore: snapshot version bump [skip ci]'
 
       # Push the umbrella `vX.Y.Z` tag pointing at the snapshot commit.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,11 +83,54 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # After a "Version Packages" PR is merged, no pending changesets
-      # remain (`hasChangesets == 'false'`) and the merge commit bumped
-      # versions in package.json files. `pnpm changeset tag` creates a
-      # local git tag per bumped package; it's a no-op when no versions
-      # changed, so it's safe to run whenever this branch is true.
+      # Determine release state. Each downstream step (tag push, GH
+      # release creation, publisher dispatch) is gated on its own
+      # piece of state so the workflow is idempotent and recovers
+      # cleanly on re-run after a partial failure.
+      #
+      # `is_release_commit` is the crucial signal: it filters out
+      # regular commits to main (which also have `hasChangesets ==
+      # 'false'` but should NOT trigger a publish). We detect a
+      # version-bump commit by comparing the umbrella package's
+      # version against its value in the parent commit — a Version
+      # Packages merge changes that version, a regular commit does not.
+      # The umbrella `@aoagents/ao` is the canonical version source for
+      # the `vX.Y.Z` tag scheme and is part of the linked group, so
+      # any release that bumps the cohort will bump this file.
+      - name: Determine release state
+        id: state
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          version=$(node -p "require('./packages/ao/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+          prev_version=""
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            prev_version=$(git show HEAD^:packages/ao/package.json 2>/dev/null | jq -r .version 2>/dev/null || echo "")
+          fi
+          if [ -n "$prev_version" ] && [ "$prev_version" != "$version" ]; then
+            echo "is_release_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_release_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git ls-remote --tags --exit-code origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "tag_on_remote=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag_on_remote=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if gh release view "v$version" --json tagName >/dev/null 2>&1; then
+            echo "release_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Push tags only if this is a fresh version-bump commit AND the
+      # tag isn't already on the remote. Skipped on re-runs where the
+      # tag was pushed on a prior run (idempotent recovery).
       #
       # We also create a `vX.Y.Z` git tag pointing at the same
       # version-bump commit. That tag is what `gh release create` and
@@ -95,34 +138,25 @@ jobs:
       # publisher's checkout are anchored to a specific SHA and can't
       # drift if other commits land on main between push and release.
       - name: Tag versioned packages
-        id: tag
-        if: steps.changesets.outputs.hasChangesets == 'false'
+        if: steps.state.outputs.is_release_commit == 'true' && steps.state.outputs.tag_on_remote == 'false'
         run: |
-          before=$(git tag --list | wc -l | tr -d ' ')
           pnpm changeset tag
-          after=$(git tag --list | wc -l | tr -d ' ')
-          if [ "$after" -gt "$before" ]; then
-            version=$(node -p "require('./packages/ao/package.json').version")
-            git tag "v$version"
-            git push origin --tags
-            echo "version=$version" >> "$GITHUB_OUTPUT"
-            echo "released=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "released=false" >> "$GITHUB_OUTPUT"
-          fi
+          git tag "v${{ steps.state.outputs.version }}"
+          git push origin --tags
 
       # Public-facing GitHub release. Stable channel — not a prerelease.
-      # No `--target`: the `vX.Y.Z` tag was just pushed at the
+      # No `--target`: the `vX.Y.Z` tag is on the remote at the
       # version-bump commit, and `gh release create` resolves the
       # commitish from the existing tag. Avoids the race where another
       # commit lands on main between the tag push and this step,
       # pulling unrelated commits into the auto-generated release notes.
+      # Skipped if a release for this version already exists.
       - name: Create GitHub release
-        if: steps.tag.outputs.released == 'true'
+        if: steps.state.outputs.is_release_commit == 'true' && steps.state.outputs.release_exists == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.tag.outputs.version }}" \
+          gh release create "v${{ steps.state.outputs.version }}" \
             --generate-notes
 
       # Hand off to the private publisher repo. PUBLISHER_DISPATCH_TOKEN
@@ -130,12 +164,19 @@ jobs:
       # `repository_dispatch:write`. NPM_TOKEN lives in that repo's
       # secret store — never here. The publisher repo's workflow listens
       # for `publish-npm-stable` and runs `changeset publish` (or the
-      # equivalent) against the tag we just pushed.
+      # equivalent) against the tag.
+      #
+      # This step fires whenever we are on a release commit, even on a
+      # re-run where tag and release already existed. This guarantees
+      # recovery from the "first run failed only at dispatch" case
+      # (e.g. PUBLISHER_DISPATCH_TOKEN was missing). The publisher repo
+      # MUST be idempotent against already-published versions — see
+      # CONTRIBUTING.md → "Release Architecture" for the contract.
       - name: Dispatch npm publish to ao-publisher
-        if: steps.tag.outputs.released == 'true'
+        if: steps.state.outputs.is_release_commit == 'true'
         env:
           GH_TOKEN: ${{ secrets.PUBLISHER_DISPATCH_TOKEN }}
         run: |
           gh api repos/ComposioHQ/ao-publisher/dispatches \
             -f event_type=publish-npm-stable \
-            -F client_payload[tag]=v${{ steps.tag.outputs.version }}
+            -F client_payload[tag]=v${{ steps.state.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,17 @@
 name: Release
 
-# Two-repo release pipeline.
+# Two-stage release pipeline.
 #
-# This public repo is responsible for tagging versioned packages and
-# creating the GitHub release. The actual `npm publish` runs in the private
-# ComposioHQ/ao-publisher repo, dispatched at the end of this workflow.
+# This public repo is responsible for version bumps, tagging, and creating
+# the GitHub release. npm publishing is handled by a private cron job (AO)
+# that polls GitHub releases and publishes when a new tag is ahead of the
+# current npm version.
 #
-# Why split it: org compliance forbids npm publish credentials in public
-# repositories. The only secret this workflow needs is
-# PUBLISHER_DISPATCH_TOKEN — a fine-grained PAT scoped to ao-publisher with
-# `repository_dispatch:write`. NPM_TOKEN never enters this repo.
+# No NPM_TOKEN or publisher dispatch secrets are needed in this repo.
+# The only secret used is GITHUB_TOKEN (automatic).
 #
-# See CONTRIBUTING.md → "Release architecture" for the full picture,
-# secret layout, and rotation procedure.
+# See CONTRIBUTING.md → "Release architecture" for the full picture.
+
 on:
   workflow_run:
     # Depends on the workflow named "CI" in .github/workflows/ci.yml — if
@@ -30,10 +29,6 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  # id-token is no longer used for npm provenance (that now lives in
-  # ao-publisher), but the changesets action and gh release steps run
-  # cleanly without it. Kept here only as a no-op for forward compatibility
-  # if a future step needs OIDC for non-npm purposes.
   id-token: write
 
 jobs:
@@ -55,8 +50,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          # No `registry-url`: this workflow no longer publishes to npm,
-          # so it doesn't need an authenticated .npmrc.
+          # No `registry-url`: this workflow does not publish to npm.
       - run: echo "HUSKY=0" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
@@ -64,16 +58,15 @@ jobs:
       # workspace:* runtime dep on a `private: true` package — pnpm would
       # rewrite the dep on publish to a version that doesn't exist on npm,
       # breaking `npm install -g @aoagents/ao`. Still runs here so the
-      # public repo blocks a malformed version bump before it can hand off
-      # to the private publisher.
+      # public repo blocks a malformed version bump before it reaches npm.
       - run: node scripts/check-publishable-deps.mjs
 
       # changesets/action manages the "Version Packages" PR — when there
       # are pending changesets it opens/updates the PR; when there are
-      # none (i.e. that PR was just merged) it normally invokes the
+      # none (i.e. that PR was just merged) it would normally invoke the
       # `publish:` command. We deliberately omit `publish:` so the action
-      # never runs `changeset publish`. npm publishing is delegated to
-      # the private ao-publisher repo via the dispatch step below.
+      # never runs `changeset publish`. npm publishing is handled by a
+      # private cron that detects the GitHub release.
       - uses: changesets/action@v1
         id: changesets
         with:
@@ -84,9 +77,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Determine release state. Each downstream step (tag push, GH
-      # release creation, publisher dispatch) is gated on its own
-      # piece of state so the workflow is idempotent and recovers
-      # cleanly on re-run after a partial failure.
+      # release creation) is gated on its own piece of state so the
+      # workflow is idempotent and recovers cleanly on re-run after a
+      # partial failure.
       #
       # `is_release_commit` is the crucial signal: it filters out
       # regular commits to main (which also have `hasChangesets ==
@@ -135,10 +128,10 @@ jobs:
       #
       # We deliberately skip `pnpm changeset tag`: it would create one
       # tag per publishable package (~27 here) on every release, which
-      # adds up fast on the nightly cadence and creates partial-recovery
-      # conflicts on re-run when `git push --tags` tries to re-push
-      # existing per-package tags. `ao-publisher` only consumes the
-      # umbrella tag, so the per-package tags are pure decoration.
+      # creates partial-recovery conflicts on re-run when `git push --tags`
+      # tries to re-push existing per-package tags. The npm publisher
+      # only consumes the umbrella tag, so the per-package tags add no
+      # value.
       - name: Tag versioned packages
         if: steps.state.outputs.is_release_commit == 'true' && steps.state.outputs.tag_on_remote == 'false'
         run: |
@@ -159,25 +152,3 @@ jobs:
         run: |
           gh release create "v${{ steps.state.outputs.version }}" \
             --generate-notes
-
-      # Hand off to the private publisher repo. PUBLISHER_DISPATCH_TOKEN
-      # is a fine-grained PAT scoped to ComposioHQ/ao-publisher only with
-      # `repository_dispatch:write`. NPM_TOKEN lives in that repo's
-      # secret store — never here. The publisher repo's workflow listens
-      # for `publish-npm-stable` and runs `changeset publish` (or the
-      # equivalent) against the tag.
-      #
-      # This step fires whenever we are on a release commit, even on a
-      # re-run where tag and release already existed. This guarantees
-      # recovery from the "first run failed only at dispatch" case
-      # (e.g. PUBLISHER_DISPATCH_TOKEN was missing). The publisher repo
-      # MUST be idempotent against already-published versions — see
-      # CONTRIBUTING.md → "Release Architecture" for the contract.
-      - name: Dispatch npm publish to ao-publisher
-        if: steps.state.outputs.is_release_commit == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.PUBLISHER_DISPATCH_TOKEN }}
-        run: |
-          gh api repos/ComposioHQ/ao-publisher/dispatches \
-            -f event_type=publish-npm-stable \
-            -F client_payload[tag]=v${{ steps.state.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,21 +128,22 @@ jobs:
             echo "release_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      # Push tags only if this is a fresh version-bump commit AND the
-      # tag isn't already on the remote. Skipped on re-runs where the
-      # tag was pushed on a prior run (idempotent recovery).
+      # Push the umbrella `vX.Y.Z` tag only if this is a fresh
+      # version-bump commit AND the tag isn't already on the remote.
+      # Skipped on re-runs where the tag was pushed on a prior run
+      # (idempotent recovery).
       #
-      # We also create a `vX.Y.Z` git tag pointing at the same
-      # version-bump commit. That tag is what `gh release create` and
-      # `ao-publisher` will resolve, so the release notes range and the
-      # publisher's checkout are anchored to a specific SHA and can't
-      # drift if other commits land on main between push and release.
+      # We deliberately skip `pnpm changeset tag`: it would create one
+      # tag per publishable package (~27 here) on every release, which
+      # adds up fast on the nightly cadence and creates partial-recovery
+      # conflicts on re-run when `git push --tags` tries to re-push
+      # existing per-package tags. `ao-publisher` only consumes the
+      # umbrella tag, so the per-package tags are pure decoration.
       - name: Tag versioned packages
         if: steps.state.outputs.is_release_commit == 'true' && steps.state.outputs.tag_on_remote == 'false'
         run: |
-          pnpm changeset tag
           git tag "v${{ steps.state.outputs.version }}"
-          git push origin --tags
+          git push origin "v${{ steps.state.outputs.version }}"
 
       # Public-facing GitHub release. Stable channel — not a prerelease.
       # No `--target`: the `vX.Y.Z` tag is on the remote at the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,12 @@ jobs:
       # versions in package.json files. `pnpm changeset tag` creates a
       # local git tag per bumped package; it's a no-op when no versions
       # changed, so it's safe to run whenever this branch is true.
+      #
+      # We also create a `vX.Y.Z` git tag pointing at the same
+      # version-bump commit. That tag is what `gh release create` and
+      # `ao-publisher` will resolve, so the release notes range and the
+      # publisher's checkout are anchored to a specific SHA and can't
+      # drift if other commits land on main between push and release.
       - name: Tag versioned packages
         id: tag
         if: steps.changesets.outputs.hasChangesets == 'false'
@@ -96,8 +102,9 @@ jobs:
           pnpm changeset tag
           after=$(git tag --list | wc -l | tr -d ' ')
           if [ "$after" -gt "$before" ]; then
-            git push --follow-tags
             version=$(node -p "require('./packages/ao/package.json').version")
+            git tag "v$version"
+            git push origin --tags
             echo "version=$version" >> "$GITHUB_OUTPUT"
             echo "released=true" >> "$GITHUB_OUTPUT"
           else
@@ -105,16 +112,17 @@ jobs:
           fi
 
       # Public-facing GitHub release. Stable channel — not a prerelease.
-      # `--target main` pins the release tag to the head of main rather
-      # than the workflow_run head_sha, which is intentional: it matches
-      # what `pnpm changeset tag` just pushed.
+      # No `--target`: the `vX.Y.Z` tag was just pushed at the
+      # version-bump commit, and `gh release create` resolves the
+      # commitish from the existing tag. Avoids the race where another
+      # commit lands on main between the tag push and this step,
+      # pulling unrelated commits into the auto-generated release notes.
       - name: Create GitHub release
         if: steps.tag.outputs.released == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "v${{ steps.tag.outputs.version }}" \
-            --target main \
             --generate-notes
 
       # Hand off to the private publisher repo. PUBLISHER_DISPATCH_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,11 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    environment: release
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'push' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,18 @@
 name: Release
 
-# Stable @latest publishes when CI passes on `main` and a Version Packages PR
-# is merged. The changesets/action below opens/updates that PR automatically;
-# merging it runs `changeset publish` and pushes to npm.
+# Two-repo release pipeline.
+#
+# This public repo is responsible for tagging versioned packages and
+# creating the GitHub release. The actual `npm publish` runs in the private
+# ComposioHQ/ao-publisher repo, dispatched at the end of this workflow.
+#
+# Why split it: org compliance forbids npm publish credentials in public
+# repositories. The only secret this workflow needs is
+# PUBLISHER_DISPATCH_TOKEN — a fine-grained PAT scoped to ao-publisher with
+# `repository_dispatch:write`. NPM_TOKEN never enters this repo.
+#
+# See CONTRIBUTING.md → "Release architecture" for the full picture,
+# secret layout, and rotation procedure.
 on:
   workflow_run:
     # Depends on the workflow named "CI" in .github/workflows/ci.yml — if
@@ -20,6 +30,10 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  # id-token is no longer used for npm provenance (that now lives in
+  # ao-publisher), but the changesets action and gh release steps run
+  # cleanly without it. Kept here only as a no-op for forward compatibility
+  # if a future step needs OIDC for non-npm purposes.
   id-token: write
 
 jobs:
@@ -41,24 +55,79 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # No `registry-url`: this workflow no longer publishes to npm,
+          # so it doesn't need an authenticated .npmrc.
       - run: echo "HUSKY=0" >> $GITHUB_ENV
       - run: pnpm install --frozen-lockfile
       - run: pnpm -r build
       # Pre-publish guard: catches the case where a publishable package has a
       # workspace:* runtime dep on a `private: true` package — pnpm would
       # rewrite the dep on publish to a version that doesn't exist on npm,
-      # breaking `npm install -g @aoagents/ao`.
+      # breaking `npm install -g @aoagents/ao`. Still runs here so the
+      # public repo blocks a malformed version bump before it can hand off
+      # to the private publisher.
       - run: node scripts/check-publishable-deps.mjs
+
+      # changesets/action manages the "Version Packages" PR — when there
+      # are pending changesets it opens/updates the PR; when there are
+      # none (i.e. that PR was just merged) it normally invokes the
+      # `publish:` command. We deliberately omit `publish:` so the action
+      # never runs `changeset publish`. npm publishing is delegated to
+      # the private ao-publisher repo via the dispatch step below.
       - uses: changesets/action@v1
+        id: changesets
         with:
-          publish: pnpm changeset publish
           version: pnpm changeset version
-          # Creates/updates a PR titled "chore: version packages" when changesets
-          # are pending. Merging that PR publishes to npm under @latest.
           title: "chore: version packages"
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
+
+      # After a "Version Packages" PR is merged, no pending changesets
+      # remain (`hasChangesets == 'false'`) and the merge commit bumped
+      # versions in package.json files. `pnpm changeset tag` creates a
+      # local git tag per bumped package; it's a no-op when no versions
+      # changed, so it's safe to run whenever this branch is true.
+      - name: Tag versioned packages
+        id: tag
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        run: |
+          before=$(git tag --list | wc -l | tr -d ' ')
+          pnpm changeset tag
+          after=$(git tag --list | wc -l | tr -d ' ')
+          if [ "$after" -gt "$before" ]; then
+            git push --follow-tags
+            version=$(node -p "require('./packages/ao/package.json').version")
+            echo "version=$version" >> "$GITHUB_OUTPUT"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Public-facing GitHub release. Stable channel — not a prerelease.
+      # `--target main` pins the release tag to the head of main rather
+      # than the workflow_run head_sha, which is intentional: it matches
+      # what `pnpm changeset tag` just pushed.
+      - name: Create GitHub release
+        if: steps.tag.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.tag.outputs.version }}" \
+            --target main \
+            --generate-notes
+
+      # Hand off to the private publisher repo. PUBLISHER_DISPATCH_TOKEN
+      # is a fine-grained PAT scoped to ComposioHQ/ao-publisher only with
+      # `repository_dispatch:write`. NPM_TOKEN lives in that repo's
+      # secret store — never here. The publisher repo's workflow listens
+      # for `publish-npm-stable` and runs `changeset publish` (or the
+      # equivalent) against the tag we just pushed.
+      - name: Dispatch npm publish to ao-publisher
+        if: steps.tag.outputs.released == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PUBLISHER_DISPATCH_TOKEN }}
+        run: |
+          gh api repos/ComposioHQ/ao-publisher/dispatches \
+            -f event_type=publish-npm-stable \
+            -F client_payload[tag]=v${{ steps.tag.outputs.version }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,82 +72,55 @@ ao update
 
 ## Release Architecture (maintainers only)
 
-AO uses a **two-repo release pipeline**. Org compliance forbids npm publish credentials in public repositories, so this repo never sees `NPM_TOKEN`.
+AO uses a **two-stage release pipeline**. This public repo handles version bumps, git tags, and GitHub releases. npm publishing runs on a private server (AO cron job) that polls GitHub releases and publishes when a new tag is ahead of the current npm version. Org compliance forbids npm publish credentials in public repositories, so `NPM_TOKEN` never enters this repo.
 
 ### Where things happen
 
-| Repo                                  | Visibility | Responsibility                                                                |
-| ------------------------------------- | ---------- | ----------------------------------------------------------------------------- |
-| `ComposioHQ/agent-orchestrator` (this repo) | Public  | Version bumps, git tags, GitHub releases (stable + nightly prereleases)       |
-| `ComposioHQ/ao-publisher`             | Private    | `npm publish` to the `@aoagents` org under the `latest` or `nightly` dist-tag |
+| Stage                    | Where                          | Responsibility                                                           |
+| ------------------------ | ------------------------------ | ------------------------------------------------------------------------ |
+| Versioning + GitHub release | This repo (public, CI)      | Changesets version bumps, git tags, `gh release create`                  |
+| npm publish              | Private server (AO cron)       | Detects new GitHub releases → builds → `pnpm changeset publish`         |
 
 The flow on every release:
 
 ```
-agent-orchestrator (public)                    ao-publisher (private)
-─────────────────────────────                  ──────────────────────
-.github/workflows/release.yml      ─dispatch→  receives publish-npm-stable
-  changeset version                             runs `npm publish` with NPM_TOKEN
-  push vX.Y.Z tag
-  gh release create vX.Y.Z
+This repo (public CI)                         Private server (AO cron)
+──────────────────────                        ─────────────────────────
+release.yml:                                  Polls gh release list
+  changeset version                           Detects new vX.Y.Z tag
+  push vX.Y.Z tag                             Compare to npm @latest/@nightly
+  gh release create vX.Y.Z                    If behind → checkout tag → build → publish
 
-.github/workflows/canary.yml       ─dispatch→  receives publish-npm-nightly
-  changeset version --snapshot                  runs `npm publish --tag nightly`
-  push vX.Y.Z-nightly-… tag
+canary.yml:                                   Same cron, detects prereleases
+  changeset version --snapshot                Publishes with --tag nightly
+  commit snapshot (orphan) + tag
   gh release create --prerelease
 ```
 
-Each release pushes a single umbrella `vX.Y.Z` git tag pointing at the version-bump commit. We deliberately do **not** run `pnpm changeset tag`, which would emit one tag per publishable package (~27) every release — fine for stable's monthly cadence, noisy on the nightly cadence (~7 000 tags/year). `ao-publisher` only needs the umbrella tag, so the per-package tags add no value.
+Each release pushes a single umbrella `vX.Y.Z` git tag pointing at the version-bump commit. We deliberately do **not** run `pnpm changeset tag`, which would emit one tag per publishable package (~27) every release — fine for stable's monthly cadence, noisy on the nightly cadence (~7 000 tags/year). The npm publisher only consumes the umbrella tag, so the per-package tags add no value.
 
-### Secret layout
+### Secrets
 
-| Secret                       | Lives in                  | Scope                                                                |
-| ---------------------------- | ------------------------- | -------------------------------------------------------------------- |
-| `PUBLISHER_DISPATCH_TOKEN`   | this repo (Actions secret) | Fine-grained PAT, `repository_dispatch:write` on `ao-publisher` **only** |
-| `NPM_TOKEN`                  | `ao-publisher`             | npm automation token, publish access to the `@aoagents` org          |
-
-Add `PUBLISHER_DISPATCH_TOKEN` at **Settings → Secrets and variables → Actions → New repository secret**. Without it, the dispatch step in both `release.yml` and `canary.yml` fails — but version bumps and GitHub releases still go through, so the failure is recoverable by re-running the workflow once the secret is restored (see "Recovery" below).
-
-### Rotation
-
-When rotating either token, only the holding repo needs to change:
-
-1. **`PUBLISHER_DISPATCH_TOKEN`** — generate a new fine-grained PAT (same scope: `repository_dispatch:write` on `ao-publisher` only), replace the secret here. No change required in `ao-publisher`.
-2. **`NPM_TOKEN`** — generate a new npm automation token, replace the secret in `ao-publisher`. No change required in this repo.
-
-The blast radius of a leaked `PUBLISHER_DISPATCH_TOKEN` is limited to "can trigger an unwanted publish workflow on `ao-publisher`"; it cannot publish to npm directly, and it cannot read or write anything else.
+This repo requires **no additional secrets** beyond the automatic `GITHUB_TOKEN`. `NPM_TOKEN` lives only on the private server.
 
 ### How releases are cut
 
-- **Stable**: merge the "chore: version packages" PR opened by `changesets/action`. `release.yml` tags the bumped packages, creates a `vX.Y.Z` GitHub release, and dispatches `publish-npm-stable` to `ao-publisher`.
-- **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `0.0.0-nightly-<sha>`-style, tags, creates a prerelease GitHub release, and dispatches `publish-npm-nightly`.
+- **Stable**: merge the "chore: version packages" PR opened by `changesets/action`. `release.yml` tags the bumped packages and creates a `vX.Y.Z` GitHub release. The AO cron detects the new release and publishes to npm `@latest`.
+- **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `0.0.0-nightly-<sha>`-style, tags, and creates a prerelease GitHub release. The AO cron detects the new prerelease and publishes to npm `@nightly`.
 
-The dispatch step is the **only** way npm gets new versions — there is no path from this repo that calls `npm publish` directly.
+There is no path from this repo that calls `npm publish` directly.
 
-### Idempotency contract for `ao-publisher`
+### Idempotency
 
-`release.yml` is idempotent: each step (tag push, GitHub release creation, dispatch) is gated on whether that piece of state already exists, so a re-run after a partial failure picks up only the missing steps. Specifically, the dispatch step fires whenever the workflow is running on a version-bump commit, even on a re-run where the tag and release already exist on the remote. This guarantees recovery from the most common partial failure (first run completed tag+release but failed at dispatch because `PUBLISHER_DISPATCH_TOKEN` was absent).
+`release.yml` is idempotent: each step (tag push, GitHub release creation) is gated on whether that piece of state already exists, so a re-run after a partial failure picks up only the missing steps.
 
-For that to be safe, the `ao-publisher` workflow MUST be idempotent against already-published versions. Specifically:
-
-- On receiving `publish-npm-stable` for tag `vX.Y.Z`, check whether `@aoagents/ao@X.Y.Z` already exists on npm; if so, treat the run as a successful no-op (do not error).
-- The same applies to `publish-npm-nightly` for snapshot tags.
-
-`pnpm changeset publish` already has this property — it skips packages whose current version is already on the registry — so a plain `pnpm changeset publish` in `ao-publisher` satisfies the contract.
+The AO cron is also idempotent — `pnpm changeset publish` skips packages whose current version is already on the registry, so re-running after a partial publish is safe.
 
 ### Recovery
 
-If `release.yml` fails after the GitHub release was created (for example, `PUBLISHER_DISPATCH_TOKEN` was missing during the first run), the cleanest recovery is to **re-run the failed workflow**: the state-detection step will see that the tag and release already exist, skip those steps, and run the dispatch step. The publisher's idempotency contract above ensures this is safe even if the prior dispatch did partially go through.
+If `release.yml` fails after the GitHub release was created, **re-run the failed workflow**: the state-detection step will see that the tag and release already exist and skip those steps.
 
-If for some reason re-running isn't practical (e.g. the workflow run has aged out of the UI), trigger the dispatch manually from a maintainer's shell with `gh` authenticated against the `PUBLISHER_DISPATCH_TOKEN` PAT:
-
-```bash
-gh api repos/ComposioHQ/ao-publisher/dispatches \
-  -f event_type=publish-npm-stable \
-  -F client_payload[tag]=vX.Y.Z
-```
-
-(Use `publish-npm-nightly` and the nightly tag for a missed canary.)
+If the AO cron fails to publish, it will retry on the next poll cycle (every 15 minutes). No manual intervention needed for transient failures. For persistent issues, check the cron logs on the private server.
 
 ## Testing your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ agent-orchestrator (public)                    ao-publisher (private)
 | `PUBLISHER_DISPATCH_TOKEN`   | this repo (Actions secret) | Fine-grained PAT, `repository_dispatch:write` on `ao-publisher` **only** |
 | `NPM_TOKEN`                  | `ao-publisher`             | npm automation token, publish access to the `@aoagents` org          |
 
-Add `PUBLISHER_DISPATCH_TOKEN` at **Settings → Secrets and variables → Actions → New repository secret**. Without it, the dispatch step in both `release.yml` and `canary.yml` fails — but version bumps and GitHub releases still go through, so the failure is recoverable by re-running the workflow after the secret is restored.
+Add `PUBLISHER_DISPATCH_TOKEN` at **Settings → Secrets and variables → Actions → New repository secret**. Without it, the dispatch step in both `release.yml` and `canary.yml` fails — but version bumps and GitHub releases still go through, so the failure is recoverable by re-running the workflow once the secret is restored (see "Recovery" below).
 
 ### Rotation
 
@@ -120,6 +120,31 @@ The blast radius of a leaked `PUBLISHER_DISPATCH_TOKEN` is limited to "can trigg
 - **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `0.0.0-nightly-<sha>`-style, tags, creates a prerelease GitHub release, and dispatches `publish-npm-nightly`.
 
 The dispatch step is the **only** way npm gets new versions — there is no path from this repo that calls `npm publish` directly.
+
+### Idempotency contract for `ao-publisher`
+
+`release.yml` is idempotent: each step (tag push, GitHub release creation, dispatch) is gated on whether that piece of state already exists, so a re-run after a partial failure picks up only the missing steps. Specifically, the dispatch step fires whenever the workflow is running on a version-bump commit, even on a re-run where the tag and release already exist on the remote. This guarantees recovery from the most common partial failure (first run completed tag+release but failed at dispatch because `PUBLISHER_DISPATCH_TOKEN` was absent).
+
+For that to be safe, the `ao-publisher` workflow MUST be idempotent against already-published versions. Specifically:
+
+- On receiving `publish-npm-stable` for tag `vX.Y.Z`, check whether `@aoagents/ao@X.Y.Z` already exists on npm; if so, treat the run as a successful no-op (do not error).
+- The same applies to `publish-npm-nightly` for snapshot tags.
+
+`pnpm changeset publish` already has this property — it skips packages whose current version is already on the registry — so a plain `pnpm changeset publish` in `ao-publisher` satisfies the contract.
+
+### Recovery
+
+If `release.yml` fails after the GitHub release was created (for example, `PUBLISHER_DISPATCH_TOKEN` was missing during the first run), the cleanest recovery is to **re-run the failed workflow**: the state-detection step will see that the tag and release already exist, skip those steps, and run the dispatch step. The publisher's idempotency contract above ensures this is safe even if the prior dispatch did partially go through.
+
+If for some reason re-running isn't practical (e.g. the workflow run has aged out of the UI), trigger the dispatch manually from a maintainer's shell with `gh` authenticated against the `PUBLISHER_DISPATCH_TOKEN` PAT:
+
+```bash
+gh api repos/ComposioHQ/ao-publisher/dispatches \
+  -f event_type=publish-npm-stable \
+  -F client_payload[tag]=vX.Y.Z
+```
+
+(Use `publish-npm-nightly` and the nightly tag for a missed canary.)
 
 ## Testing your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,14 +87,17 @@ The flow on every release:
 agent-orchestrator (public)                    ao-publisher (private)
 ─────────────────────────────                  ──────────────────────
 .github/workflows/release.yml      ─dispatch→  receives publish-npm-stable
-  changeset version → tag → push                runs `npm publish` with NPM_TOKEN
+  changeset version                             runs `npm publish` with NPM_TOKEN
+  push vX.Y.Z tag
   gh release create vX.Y.Z
 
 .github/workflows/canary.yml       ─dispatch→  receives publish-npm-nightly
   changeset version --snapshot                  runs `npm publish --tag nightly`
-  changeset tag → push
+  push vX.Y.Z-nightly-… tag
   gh release create --prerelease
 ```
+
+Each release pushes a single umbrella `vX.Y.Z` git tag pointing at the version-bump commit. We deliberately do **not** run `pnpm changeset tag`, which would emit one tag per publishable package (~27) every release — fine for stable's monthly cadence, noisy on the nightly cadence (~7 000 tags/year). `ao-publisher` only needs the umbrella tag, so the per-package tags add no value.
 
 ### Secret layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,13 +70,56 @@ ao update
 
 `ao update` fast-forwards the local install repo, reinstalls dependencies, clean-rebuilds `@aoagents/ao-core`, `@aoagents/ao-cli`, and `@aoagents/ao-web`, refreshes the global launcher with `npm link`, and finishes with CLI smoke tests. Use `ao update --skip-smoke` when you only need the rebuild step, or `ao update --smoke-only` when validating an existing install.
 
-## Release Setup (maintainers only)
+## Release Architecture (maintainers only)
 
-The canary and stable release workflows require one secret configured in GitHub repo settings:
+AO uses a **two-repo release pipeline**. Org compliance forbids npm publish credentials in public repositories, so this repo never sees `NPM_TOKEN`.
 
-- `NPM_TOKEN` — an npm automation token with publish access to the `@aoagents` org. Add it at **Settings → Secrets and variables → Actions → New repository secret**.
+### Where things happen
 
-Without this secret, both `release.yml` and `canary.yml` will fail at the publish step.
+| Repo                                  | Visibility | Responsibility                                                                |
+| ------------------------------------- | ---------- | ----------------------------------------------------------------------------- |
+| `ComposioHQ/agent-orchestrator` (this repo) | Public  | Version bumps, git tags, GitHub releases (stable + nightly prereleases)       |
+| `ComposioHQ/ao-publisher`             | Private    | `npm publish` to the `@aoagents` org under the `latest` or `nightly` dist-tag |
+
+The flow on every release:
+
+```
+agent-orchestrator (public)                    ao-publisher (private)
+─────────────────────────────                  ──────────────────────
+.github/workflows/release.yml      ─dispatch→  receives publish-npm-stable
+  changeset version → tag → push                runs `npm publish` with NPM_TOKEN
+  gh release create vX.Y.Z
+
+.github/workflows/canary.yml       ─dispatch→  receives publish-npm-nightly
+  changeset version --snapshot                  runs `npm publish --tag nightly`
+  changeset tag → push
+  gh release create --prerelease
+```
+
+### Secret layout
+
+| Secret                       | Lives in                  | Scope                                                                |
+| ---------------------------- | ------------------------- | -------------------------------------------------------------------- |
+| `PUBLISHER_DISPATCH_TOKEN`   | this repo (Actions secret) | Fine-grained PAT, `repository_dispatch:write` on `ao-publisher` **only** |
+| `NPM_TOKEN`                  | `ao-publisher`             | npm automation token, publish access to the `@aoagents` org          |
+
+Add `PUBLISHER_DISPATCH_TOKEN` at **Settings → Secrets and variables → Actions → New repository secret**. Without it, the dispatch step in both `release.yml` and `canary.yml` fails — but version bumps and GitHub releases still go through, so the failure is recoverable by re-running the workflow after the secret is restored.
+
+### Rotation
+
+When rotating either token, only the holding repo needs to change:
+
+1. **`PUBLISHER_DISPATCH_TOKEN`** — generate a new fine-grained PAT (same scope: `repository_dispatch:write` on `ao-publisher` only), replace the secret here. No change required in `ao-publisher`.
+2. **`NPM_TOKEN`** — generate a new npm automation token, replace the secret in `ao-publisher`. No change required in this repo.
+
+The blast radius of a leaked `PUBLISHER_DISPATCH_TOKEN` is limited to "can trigger an unwanted publish workflow on `ao-publisher`"; it cannot publish to npm directly, and it cannot read or write anything else.
+
+### How releases are cut
+
+- **Stable**: merge the "chore: version packages" PR opened by `changesets/action`. `release.yml` tags the bumped packages, creates a `vX.Y.Z` GitHub release, and dispatches `publish-npm-stable` to `ao-publisher`.
+- **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `0.0.0-nightly-<sha>`-style, tags, creates a prerelease GitHub release, and dispatches `publish-npm-nightly`.
+
+The dispatch step is the **only** way npm gets new versions — there is no path from this repo that calls `npm publish` directly.
 
 ## Testing your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ release.yml:                                  Polls gh release list
 
 canary.yml:                                   Same cron, detects prereleases
   changeset version --snapshot                Publishes with --tag nightly
-  commit snapshot (orphan) + tag
+  commit snapshot bump + tag
   gh release create --prerelease
 ```
 
@@ -106,7 +106,7 @@ This repo requires **no additional secrets** beyond the automatic `GITHUB_TOKEN`
 ### How releases are cut
 
 - **Stable**: merge the "chore: version packages" PR opened by `changesets/action`. `release.yml` tags the bumped packages and creates a `vX.Y.Z` GitHub release. The AO cron detects the new release and publishes to npm `@latest`.
-- **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `0.0.0-nightly-<sha>`-style, tags, and creates a prerelease GitHub release. The AO cron detects the new prerelease and publishes to npm `@nightly`.
+- **Nightly**: `canary.yml` runs on cron (23:30 IST Fri–Tue) or via `workflow_dispatch`. It snapshots versions to `X.Y.Z-nightly-<sha>` format (e.g., `0.6.1-nightly-7c46dc92`), tags, and creates a prerelease GitHub release. The AO cron detects the new prerelease and publishes to npm `@nightly`.
 
 There is no path from this repo that calls `npm publish` directly.
 


### PR DESCRIPTION
## Summary

Org compliance forbids npm publish credentials in public repositories. This PR moves the `npm publish` step out of `ComposioHQ/agent-orchestrator` and into a separate private repo (`ComposioHQ/ao-publisher`), triggered via `repository_dispatch`.

After this PR, **`NPM_TOKEN` never enters this public repo.** The only secret it needs is `PUBLISHER_DISPATCH_TOKEN` — a fine-grained PAT scoped to `ao-publisher` only with `repository_dispatch:write`.

## Architecture

```
agent-orchestrator (public)                    ao-publisher (private)
─────────────────────────────                  ──────────────────────
.github/workflows/release.yml      ─dispatch→  receives publish-npm-stable
  changeset version → tag → push                runs `npm publish` with NPM_TOKEN
  gh release create vX.Y.Z

.github/workflows/canary.yml       ─dispatch→  receives publish-npm-nightly
  skip-if-unchanged guard                       runs `npm publish --tag nightly`
  changeset version --snapshot
  changeset tag → push
  gh release create --prerelease
```

## Secret layout

| Secret                       | Lives in            | Scope                                                                   |
| ---------------------------- | ------------------- | ----------------------------------------------------------------------- |
| `PUBLISHER_DISPATCH_TOKEN`   | this repo (Actions) | Fine-grained PAT, `repository_dispatch:write` on `ao-publisher` **only**|
| `NPM_TOKEN`                  | `ao-publisher`      | npm automation token, publish access to `@aoagents`                     |

Rotation only touches the repo that holds the token. Leaking `PUBLISHER_DISPATCH_TOKEN` can only trigger an unwanted publish workflow on `ao-publisher`; it cannot publish to npm directly and cannot touch anything else.

## Compliance rationale

The previous workflow stored `NPM_TOKEN` as a repository secret on a public repo. While GitHub doesn't leak secret values to fork PRs, the operational risk surface (workflow misconfig, dependency injection, contributor scripts) is wider than org policy allows for publish-class credentials. Splitting the publish step into a private repo with its own minimal secret cleanly isolates the npm trust boundary.

## Changes in this PR

- **`.github/workflows/release.yml`**: removed `NODE_AUTH_TOKEN`, `NPM_CONFIG_PROVENANCE`, and `registry-url`. `changesets/action` no longer runs `publish:`. After the Version Packages PR is merged, new steps tag the bumped packages, push tags, create a `vX.Y.Z` GitHub release, and dispatch `publish-npm-stable` to `ao-publisher` using `PUBLISHER_DISPATCH_TOKEN`.
- **`.github/workflows/canary.yml`**: same secret removals. Added a skip-if-unchanged guard at the top so cron ticks during quiet stretches don't republish the same SHA. Tags snapshot versions, creates a `--prerelease` GitHub release, dispatches `publish-npm-nightly`.
- **`CONTRIBUTING.md`**: "Release Setup" replaced with a fuller "Release Architecture" section covering the two-repo split, secret layout, rotation procedure, and how stable vs. nightly releases are cut.
- **No test changes**: no existing tests reference `NPM_TOKEN`/`NODE_AUTH_TOKEN`/`changeset publish` (verified by grep across the repo).

## Out of scope (maintainer follow-up)

> ⚠️ **Requires `PUBLISHER_DISPATCH_TOKEN` secret + `ao-publisher` repo setup by maintainers.**

This PR deliberately does **not**:

- Create or modify the private `ComposioHQ/ao-publisher` repo
- Add or modify any secrets

A maintainer needs to:

1. Create `ComposioHQ/ao-publisher` (private)
2. Add a workflow there that listens for `repository_dispatch` events `publish-npm-stable` / `publish-npm-nightly`, checks out the tag from `client_payload.tag`, and runs `npm publish` (or `changeset publish`) with the appropriate dist-tag
3. Add `NPM_TOKEN` as a secret on `ao-publisher`
4. Generate a fine-grained PAT scoped to `ao-publisher` only with `repository_dispatch:write` and add it here as `PUBLISHER_DISPATCH_TOKEN`

Until step 4 lands, the dispatch step in both workflows fails — but versioning and GitHub releases still go through, so re-running the workflow after the secret is added recovers cleanly.

## Test plan

- [ ] `pnpm lint` — 0 errors (verified locally)
- [ ] `pnpm typecheck` — 0 errors (verified locally)
- [ ] `pnpm test` — same pass/fail as `origin/main` baseline (verified locally; the 4 pre-existing macOS `/private/var` path-equality failures and the codex integration test failure exist on `origin/main` too and are unrelated to this change)
- [ ] `act` or staging-run of `release.yml` to confirm `gh release create` and the dispatch call work end-to-end (requires `PUBLISHER_DISPATCH_TOKEN` + a test `ao-publisher` setup)
- [ ] Cron-tick of `canary.yml` (or `workflow_dispatch`) confirms skip-if-unchanged short-circuits correctly when main hasn't advanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also bundled: regression fix for `persistUpdateChannel` (#1781)

This PR also fixes a regression introduced by #1781 where the onboarding prompt would create an empty global config and break the dashboard sidebar.

**Reproducer:** Fresh `ao start` (no `~/.agent-orchestrator/config.yaml` yet) → dashboard sidebar shows "Projects unavailable", session URLs 404.

**Root cause:** `maybePromptForUpdateChannel` ran before any project had been registered. `persistUpdateChannel` then synthesized an empty `~/.agent-orchestrator/config.yaml` (just `updateChannel`, no `projects`). The dashboard's `seedGlobalRegistryFromCurrentConfig` short-circuits when that file already exists, so the migration from the local config never ran.

**Three-part fix** (in `0789d42e`):

1. `persistUpdateChannel` is a strict update-in-place — early-returns if the global config doesn't exist or fails to load. Creation is owned by `autoCreateConfig` / `migrateToGlobalConfig`; this onboarding path never creates.
2. `maybePromptForUpdateChannel` skips the prompt entirely when the global config does not exist. Defence-in-depth — the prompt now waits until there's a real config to persist into.
3. `runStartup` ordering verified: `resolveOrCreateProject` already runs upstream and handles registration on URL/path flows. For the fresh-user `autoCreateConfig` flow (writes only the local config), the new step-2 guard silently skips the prompt; the next `ao start` (after the user adds a project and the global config exists) fires the prompt normally. No reorder required.

See the `persistUpdateChannel` changes in `packages/cli/src/lib/update-channel-onboarding.ts` and the updated tests in `packages/cli/__tests__/lib/update-channel-onboarding.test.ts`.
