### PR TITLE
fix(cli): upgrade @clack/prompts to fix duplicate select options on Windows

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -56,7 +56,7 @@
     "@aoagents/ao-plugin-workspace-clone": "workspace:*",
     "@aoagents/ao-plugin-workspace-worktree": "workspace:*",
     "@aoagents/ao-web": "workspace:*",
-    "@clack/prompts": "^0.9.1",
+    "@clack/prompts": "^1.4.0",
     "chalk": "^5.4.0",
     "commander": "^13.0.0",
     "ora": "^8.1.0",


### PR DESCRIPTION
## Summary

Upgrades `@clack/prompts` from `^0.9.1` to `^1.4.0` to fix a rendering bug where the first-run setup's select prompt shows duplicate entries on arrow key navigation in Windows PowerShell.

**Root cause:** `@clack/core@0.4.1` hardcoded `rowPadding=4` in `SelectPrompt` render, causing `restoreCursor()` to miscalculate frame height on Windows terminals. When the cursor doesn't return to the top of the previous frame, `erase.down()` doesn't clear old content, and new content writes below it — producing ghost duplicates.

Fixed upstream in `@clack/core@1.0.0` ([bombshell-dev/clack#412](https://github.com/bombshell-dev/clack/issues/412)) — `rowPadding` is now calculated dynamically based on actual rendered lines.

## Changes

- `packages/cli/package.json`: `@clack/prompts` `^0.9.1` → `^1.4.0`

## Compatibility

- **ESM-only:** v1.0.0 dropped CJS output. AO CLI is already `"type": "module"` — no impact.
- **API:** `select()`, `confirm()`, `text()`, `isCancel`, `Option<T>` all maintain compatible signatures.
- **No code changes needed** — purely a dependency bump.

## Test

1. On Windows 11 PowerShell: `node packages/ao/bin/ao.js start` → first-run select prompt should render 3 options, and arrow keys should cycle without duplicates
2. On macOS/Linux: verify select prompts still work correctly
3. `pnpm install && pnpm build` should pass

Fixes #1814