### PR TITLE
fix(core): clear terminatedAt/completedAt when restoring a session out of terminal state (closes #1831)

### DIFF
--- a/packages/core/src/__tests__/lifecycle-transition.test.ts
+++ b/packages/core/src/__tests__/lifecycle-transition.test.ts
@@ -129,6 +129,29 @@ describe("applyDecisionToLifecycle", () => {
     expect(lifecycle.session.terminatedAt).toBe("2026-04-16T12:00:00.000Z");
   });
 
+  it("clears terminal markers when transitioning into a non-terminal state", () => {
+    lifecycle.session.state = "terminated";
+    lifecycle.session.reason = "runtime_lost";
+    lifecycle.session.completedAt = "2026-04-15T12:00:00.000Z";
+    lifecycle.session.terminatedAt = "2026-04-16T12:00:00.000Z";
+    lifecycle.session.lastTransitionAt = "2026-04-16T12:00:00.000Z";
+
+    const decision: LifecycleDecision = {
+      status: "working",
+      evidence: "restore",
+      detecting: { attempts: 0 },
+      sessionState: "working",
+      sessionReason: "task_in_progress",
+    };
+
+    applyDecisionToLifecycle(lifecycle, decision, nowIso);
+
+    expect(lifecycle.session.state).toBe("working");
+    expect(lifecycle.session.completedAt).toBeNull();
+    expect(lifecycle.session.terminatedAt).toBeNull();
+    expect(lifecycle.session.lastTransitionAt).toBe(nowIso);
+  });
+
   it("applies PR state and reason", () => {
     const decision: LifecycleDecision = {
       status: "pr_open",
@@ -371,6 +394,45 @@ describe("applyLifecycleDecision (integration)", () => {
 
     expect(result.success).toBe(true);
     expect(result.previousStatus).toBe("spawning");
+  });
+
+  it("persists cleared terminal markers when a terminal snapshot transitions to working", () => {
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    lifecycle.session.state = "terminated";
+    lifecycle.session.reason = "runtime_lost";
+    lifecycle.session.completedAt = "2026-04-16T11:00:00.000Z";
+    lifecycle.session.terminatedAt = "2026-04-16T12:00:00.000Z";
+    lifecycle.session.lastTransitionAt = "2026-04-16T12:00:00.000Z";
+
+    writeTestSession("test-5", {
+      status: "killed",
+      lifecycle: JSON.stringify(lifecycle),
+      worktree: "/tmp/test",
+      branch: "main",
+    });
+
+    const result = applyLifecycleDecision({
+      dataDir,
+      sessionId: "test-5",
+      decision: {
+        status: "working",
+        evidence: "restore",
+        detecting: { attempts: 0 },
+        sessionState: "working",
+        sessionReason: "task_in_progress",
+      },
+      source: "restore",
+      now: new Date("2026-04-17T12:00:00.000Z"),
+    });
+
+    expect(result.success).toBe(true);
+
+    const meta = readMetadataRaw(dataDir, "test-5");
+    const persisted = JSON.parse(meta!["lifecycle"]);
+    expect(persisted.session.state).toBe("working");
+    expect(persisted.session.completedAt).toBeNull();
+    expect(persisted.session.terminatedAt).toBeNull();
+    expect(persisted.session.lastTransitionAt).toBe("2026-04-17T12:00:00.000Z");
   });
 });
 

--- a/packages/core/src/__tests__/session-manager/restore.test.ts
+++ b/packages/core/src/__tests__/session-manager/restore.test.ts
@@ -320,7 +320,9 @@ describe("restore", () => {
     expect(lifecycle.session.state).toBe("working");
     expect(lifecycle.session.completedAt).toBeNull();
     expect(lifecycle.session.terminatedAt).toBeNull();
-    expect(lifecycle.session.lastTransitionAt).not.toBe("2025-01-01T00:02:00.000Z");
+    expect(new Date(lifecycle.session.lastTransitionAt).getTime()).toBeGreaterThan(
+      new Date("2025-01-01T00:02:00.000Z").getTime(),
+    );
   });
 
   it("preserves displayName when restoring terminated session", async () => {

--- a/packages/core/src/__tests__/session-manager/restore.test.ts
+++ b/packages/core/src/__tests__/session-manager/restore.test.ts
@@ -7,6 +7,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { createSessionManager } from "../../session-manager.js";
+import { createInitialCanonicalLifecycle } from "../../lifecycle-state.js";
 import { getWorkspaceAgentsMdPath } from "../../opencode-agents-md.js";
 import { getProjectDir } from "../../paths.js";
 import {
@@ -283,8 +284,22 @@ describe("restore", () => {
       createdAt: "2025-01-01T00:00:00.000Z",
       runtimeHandle: makeHandle("rt-old"),
     });
+    const staleLifecycle = createInitialCanonicalLifecycle(
+      "worker",
+      new Date("2025-01-01T00:00:00.000Z"),
+    );
+    staleLifecycle.session.state = "terminated";
+    staleLifecycle.session.reason = "runtime_lost";
+    staleLifecycle.session.completedAt = "2025-01-01T00:01:00.000Z";
+    staleLifecycle.session.terminatedAt = "2025-01-01T00:02:00.000Z";
+    staleLifecycle.session.lastTransitionAt = "2025-01-01T00:02:00.000Z";
+    staleLifecycle.pr.state = "open";
+    staleLifecycle.pr.reason = "in_progress";
+    staleLifecycle.pr.number = 10;
+    staleLifecycle.pr.url = "https://github.com/org/my-app/pull/10";
+    staleLifecycle.pr.lastObservedAt = "2025-01-01T00:00:00.000Z";
     updateMetadata(sessionsDir, "app-1", {
-      lifecycle: JSON.stringify({ session: { state: "terminated", terminatedAt: new Date().toISOString() } }),
+      lifecycle: JSON.stringify(staleLifecycle),
     });
 
     const sm = createSessionManager({ config, registry: mockRegistry });
@@ -300,6 +315,12 @@ describe("restore", () => {
     expect(meta).not.toBeNull();
     expect(meta!["issue"]).toBe("TEST-1");
     expect(meta!["pr"]).toBe("https://github.com/org/my-app/pull/10");
+
+    const lifecycle = JSON.parse(meta!["lifecycle"]);
+    expect(lifecycle.session.state).toBe("working");
+    expect(lifecycle.session.completedAt).toBeNull();
+    expect(lifecycle.session.terminatedAt).toBeNull();
+    expect(lifecycle.session.lastTransitionAt).not.toBe("2025-01-01T00:02:00.000Z");
   });
 
   it("preserves displayName when restoring terminated session", async () => {

--- a/packages/core/src/lifecycle-state.ts
+++ b/packages/core/src/lifecycle-state.ts
@@ -128,6 +128,19 @@ const CanonicalSessionLifecycleSchema = z.object({
 
 type ParsedCanonicalSessionLifecycle = z.infer<typeof CanonicalSessionLifecycleSchema>;
 
+const TERMINAL_CANONICAL_SESSION_STATES: ReadonlySet<CanonicalSessionState> = new Set([
+  "done",
+  "terminated",
+]);
+
+export function clearTerminalMarkersForNonTerminalState(
+  lifecycle: CanonicalSessionLifecycle,
+): void {
+  if (TERMINAL_CANONICAL_SESSION_STATES.has(lifecycle.session.state)) return;
+  lifecycle.session.completedAt = null;
+  lifecycle.session.terminatedAt = null;
+}
+
 function normalizeTimestamp(value: unknown, fallback: string | null = null): string | null {
   if (typeof value !== "string") return fallback;
   const parsed = Date.parse(value);

--- a/packages/core/src/lifecycle-transition.ts
+++ b/packages/core/src/lifecycle-transition.ts
@@ -19,7 +19,11 @@ import type {
   SessionId,
   SessionStatus,
 } from "./types.js";
-import { cloneLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
+import {
+  clearTerminalMarkersForNonTerminalState,
+  cloneLifecycle,
+  deriveLegacyStatus,
+} from "./lifecycle-state.js";
 import { updateMetadata, readMetadataRaw, readCanonicalLifecycle } from "./metadata.js";
 import type { LifecycleDecision } from "./lifecycle-status-decisions.js";
 
@@ -35,18 +39,6 @@ export type TransitionSource =
   | "cleanup" // Session cleanup
   | "claim_pr"; // PR claim
 
-const TERMINAL_SESSION_STATES: ReadonlySet<CanonicalSessionState> = new Set([
-  "done",
-  "terminated",
-]);
-
-function clearTerminalMarkersForNonTerminalState(
-  lifecycle: CanonicalSessionLifecycle,
-): void {
-  if (TERMINAL_SESSION_STATES.has(lifecycle.session.state)) return;
-  lifecycle.session.completedAt = null;
-  lifecycle.session.terminatedAt = null;
-}
 
 /**
  * Result of a lifecycle transition attempt.

--- a/packages/core/src/lifecycle-transition.ts
+++ b/packages/core/src/lifecycle-transition.ts
@@ -35,6 +35,19 @@ export type TransitionSource =
   | "cleanup" // Session cleanup
   | "claim_pr"; // PR claim
 
+const TERMINAL_SESSION_STATES: ReadonlySet<CanonicalSessionState> = new Set([
+  "done",
+  "terminated",
+]);
+
+function clearTerminalMarkersForNonTerminalState(
+  lifecycle: CanonicalSessionLifecycle,
+): void {
+  if (TERMINAL_SESSION_STATES.has(lifecycle.session.state)) return;
+  lifecycle.session.completedAt = null;
+  lifecycle.session.terminatedAt = null;
+}
+
 /**
  * Result of a lifecycle transition attempt.
  */
@@ -106,6 +119,8 @@ export function applyDecisionToLifecycle(
       lifecycle.session.terminatedAt = nowIso;
     }
   }
+
+  clearTerminalMarkersForNonTerminalState(lifecycle);
 }
 
 /**

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -62,6 +62,7 @@ import {
 } from "./metadata.js";
 import {
   buildLifecycleMetadataPatch,
+  clearTerminalMarkersForNonTerminalState,
   cloneLifecycle,
   createInitialCanonicalLifecycle,
   deriveLegacyStatus,
@@ -108,17 +109,6 @@ const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
 const EXEC_SHELL_OPTION =
   process.platform === "win32" ? ({ shell: true, windowsHide: true } as const) : ({} as const);
 
-const TERMINAL_CANONICAL_SESSION_STATES: ReadonlySet<
-  CanonicalSessionLifecycle["session"]["state"]
-> = new Set(["done", "terminated"]);
-
-function clearTerminalMarkersForNonTerminalState(
-  lifecycle: CanonicalSessionLifecycle,
-): void {
-  if (TERMINAL_CANONICAL_SESSION_STATES.has(lifecycle.session.state)) return;
-  lifecycle.session.completedAt = null;
-  lifecycle.session.terminatedAt = null;
-}
 
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -108,6 +108,18 @@ const OPENCODE_INTERACTIVE_DISCOVERY_TIMEOUT_MS = 10_000;
 const EXEC_SHELL_OPTION =
   process.platform === "win32" ? ({ shell: true, windowsHide: true } as const) : ({} as const);
 
+const TERMINAL_CANONICAL_SESSION_STATES: ReadonlySet<
+  CanonicalSessionLifecycle["session"]["state"]
+> = new Set(["done", "terminated"]);
+
+function clearTerminalMarkersForNonTerminalState(
+  lifecycle: CanonicalSessionLifecycle,
+): void {
+  if (TERMINAL_CANONICAL_SESSION_STATES.has(lifecycle.session.state)) return;
+  lifecycle.session.completedAt = null;
+  lifecycle.session.terminatedAt = null;
+}
+
 function errorIncludesSessionNotFound(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const e = err as Error & { stderr?: string; stdout?: string };
@@ -479,6 +491,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       }),
     );
     updater(lifecycle);
+    clearTerminalMarkersForNonTerminalState(lifecycle);
     return lifecycle;
   }
 


### PR DESCRIPTION
Closes #1831

## Summary
- Clear `lifecycle.session.terminatedAt` and `completedAt` whenever lifecycle transition helpers settle on a non-terminal session state.
- Apply the same marker hygiene to session-manager lifecycle rewrites so restore/repair paths cannot persist stale terminal timestamps.
- Add regression coverage for both the direct lifecycle transition and `session-manager.restore()` writing restored metadata.

## Orchestrator restore manifestation
A restored orchestrator could be alive and `state: working / reason: task_in_progress` while still carrying the old terminal timestamp from the false `runtime_lost` transition. Downstream dashboard code then saw `terminatedAt != null` and rendered the active session as exited.

Before:
```json
{
  "session": {
    "state": "working",
    "reason": "task_in_progress",
    "terminatedAt": "2026-05-13T19:13:20.146Z",
    "completedAt": "2026-05-13T19:13:20.146Z",
    "lastTransitionAt": "2026-05-13T19:50:30.914Z"
  }
}
```

After:
```json
{
  "session": {
    "state": "working",
    "reason": "task_in_progress",
    "terminatedAt": null,
    "completedAt": null,
    "lastTransitionAt": "2026-05-13T19:50:30.914Z"
  }
}
```

## Invariants preserved
- Terminal-state idempotence: `done`/`terminated` remain terminal and keep their terminal markers; the new cleanup only runs for non-terminal states.
- No state change without `lastTransitionAt` update: existing transition code still updates `lastTransitionAt` before marker hygiene runs; this change only clears stale marker fields after the new state is known.

## Verification
- `pnpm install`
- `pnpm build` (needed locally so workspace packages expose `dist` for typecheck; completed with pre-existing Next/composio warnings)
- `PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" pnpm --filter @aoagents/ao-core test -- lifecycle-transition.test.ts session-manager/restore.test.ts`
- `PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" pnpm --filter @aoagents/ao-core test`
- `PATH="$HOME/.nvm/versions/node/v20.19.5/bin:$PATH" pnpm typecheck`

Note: local default Node was v25.9.0, which cannot build `better-sqlite3@11.10.0`; I switched to installed Node v20.19.5 for the final test/typecheck runs.
