### PR TITLE
fix(lifecycle): re-verify CI/conflict state before dispatching alerts

### DIFF
--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -3007,7 +3007,16 @@ describe("reactions", () => {
     };
 
     const batchMock = mockBatchEnrichment({ hasConflicts: true });
+    const getMergeabilityMock = vi.fn().mockResolvedValue({
+      mergeable: false,
+      ciPassing: true,
+      approved: false,
+      noConflicts: false,
+      blockers: ["Merge conflicts"],
+    });
     const mockSCM = createMockSCM({
+      // Dispatch-time re-verification (issue #1122) — track conflict state.
+      getMergeability: getMergeabilityMock,
       enrichSessionsPRBatch: batchMock,
     });
 
@@ -3038,6 +3047,13 @@ describe("reactions", () => {
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ hasConflicts: false }),
     );
+    getMergeabilityMock.mockResolvedValue({
+      mergeable: true,
+      ciPassing: true,
+      approved: false,
+      noConflicts: true,
+      blockers: [],
+    });
     await lm.check("app-1");
     const metadata = readMetadataRaw(env.sessionsDir, "app-1");
     expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
@@ -3046,6 +3062,13 @@ describe("reactions", () => {
     vi.mocked(mockSCM.enrichSessionsPRBatch!).mockImplementation(
       mockBatchEnrichment({ hasConflicts: true }),
     );
+    getMergeabilityMock.mockResolvedValue({
+      mergeable: false,
+      ciPassing: true,
+      approved: false,
+      noConflicts: false,
+      blockers: ["Merge conflicts"],
+    });
     vi.mocked(notifier.notify).mockClear();
     await lm.check("app-1");
 
@@ -3415,6 +3438,15 @@ describe("reactions", () => {
 
     const batchMock = mockBatchEnrichment({ hasConflicts: true });
     const mockSCM = createMockSCM({
+      // Dispatch-time re-verification (issue #1122) calls getMergeability;
+      // for this test we want conflicts to actually be confirmed.
+      getMergeability: vi.fn().mockResolvedValue({
+        mergeable: false,
+        ciPassing: true,
+        approved: false,
+        noConflicts: false,
+        blockers: ["Merge conflicts"],
+      }),
       enrichSessionsPRBatch: batchMock,
     });
 
@@ -3615,7 +3647,12 @@ describe("rate limiting optimizations", () => {
     return makePR({ owner: "org", repo: "my-app" });
   }
 
-  it("skips getMergeability() when batch enrichment has hasConflicts data", async () => {
+  it("re-verifies via getMergeability() before dispatching merge conflict alert", async () => {
+    // Conflict-condition detection comes from batch enrichment (hasConflicts),
+    // but right before dispatching the alert we re-fetch via getMergeability()
+    // so that a stale batch snapshot doesn't fire a false alarm telling the
+    // worker to rebase + force-push when the branch is actually clean
+    // (issue #1122).
     config.reactions = {
       "merge-conflicts": {
         auto: true,
@@ -3625,7 +3662,13 @@ describe("rate limiting optimizations", () => {
     };
 
     const pr = makeMatchingPR();
-    const getMergeabilityMock = vi.fn();
+    const getMergeabilityMock = vi.fn().mockResolvedValue({
+      mergeable: false,
+      ciPassing: true,
+      approved: false,
+      noConflicts: false,
+      blockers: ["Merge conflicts"],
+    });
     const mockSCM = createMockSCM({
       getMergeability: getMergeabilityMock,
       getCISummary: vi.fn().mockResolvedValue("passing"),
@@ -3660,10 +3703,75 @@ describe("rate limiting optimizations", () => {
     await vi.advanceTimersByTimeAsync(0);
     lm.stop();
 
-    // getMergeability() should NOT be called — batch enrichment has the data
-    expect(getMergeabilityMock).not.toHaveBeenCalled();
-    // Conflict notification should have been sent
+    // getMergeability() IS called now — for dispatch-time re-verification
+    expect(getMergeabilityMock).toHaveBeenCalled();
+    // Verification confirmed conflicts, so the notification fires as expected
     expect(mockSessionManager.send).toHaveBeenCalledWith("s-1", "Resolve conflicts.");
+  });
+
+  it("suppresses merge conflict alert when fresh getMergeability() shows no conflicts", async () => {
+    // Stale batch snapshot says hasConflicts=true, but the worker has already
+    // rebased and a fresh getMergeability() reports noConflicts. The orchestrator
+    // must NOT fire the alert (issue #1122) — telling the worker to
+    // rebase + force-push when the branch is clean is a real wrong-action risk.
+    config.reactions = {
+      "merge-conflicts": {
+        auto: true,
+        action: "send-to-agent",
+        message: "Resolve conflicts.",
+      },
+    };
+
+    const pr = makeMatchingPR();
+    const getMergeabilityMock = vi.fn().mockResolvedValue({
+      mergeable: true,
+      ciPassing: true,
+      approved: false,
+      noConflicts: true,
+      blockers: [],
+    });
+    const mockSCM = createMockSCM({
+      getMergeability: getMergeabilityMock,
+      getCISummary: vi.fn().mockResolvedValue("passing"),
+      enrichSessionsPRBatch: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            `${pr.owner}/${pr.repo}#${pr.number}`,
+            {
+              state: "open" as const,
+              ciStatus: "passing" as const,
+              reviewDecision: "none" as const,
+              mergeable: false,
+              hasConflicts: true,
+              headSha: "deadbeefcafef00d",
+            },
+          ],
+        ]),
+      ),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const session = makeSession({ id: "s-1", status: "pr_open", pr, workspacePath: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    lm.stop();
+
+    expect(getMergeabilityMock).toHaveBeenCalled();
+    expect(mockSessionManager.send).not.toHaveBeenCalled();
+
+    // Dedup flag must remain unset — the condition isn't actually present, so
+    // a real recurrence on a later poll should still dispatch fresh.
+    const metadata = readMetadataRaw(env.sessionsDir, "s-1");
+    expect(metadata?.["lastMergeConflictDispatched"]).toBeFalsy();
   });
 
   it("skips getCIChecks() when batch enrichment has ciChecks data", async () => {
@@ -3735,6 +3843,158 @@ describe("rate limiting optimizations", () => {
     expect(detailMessage).not.toContain("test");
 
     lm.stop();
+  });
+
+  it("suppresses CI failure alert when fresh getCIChecks() shows no failures", async () => {
+    // Stale batch snapshot says CI is failing (e.g. transient bun CDN error),
+    // but a rerun has already cleared it. Without dispatch-time re-verification
+    // the worker gets a "fix failing CI" alert pointing at green CI — the exact
+    // false-alarm pattern issue #1122 calls out.
+    //
+    // Setup: session is already in ci_failed (so the transition path doesn't
+    // fire — we exercise the standalone maybeDispatchCIFailureDetails path on a
+    // subsequent poll, which is where the staleness window matters most).
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        message: "CI failing.",
+        retries: 3,
+        escalateAfter: 3,
+      },
+    };
+
+    const pr = makeMatchingPR();
+    const freshCIChecks = [
+      { name: "lint", status: "passed" as const, conclusion: "SUCCESS" },
+      { name: "test", status: "passed" as const, conclusion: "SUCCESS" },
+    ];
+    const getCIChecksMock = vi.fn().mockResolvedValue(freshCIChecks);
+    const mockSCM = createMockSCM({
+      getCIChecks: getCIChecksMock,
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      enrichSessionsPRBatch: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            `${pr.owner}/${pr.repo}#${pr.number}`,
+            {
+              state: "open" as const,
+              ciStatus: "failing" as const,
+              reviewDecision: "none" as const,
+              mergeable: false,
+              hasConflicts: false,
+              headSha: "abc1234def5678",
+              ciChecks: [
+                {
+                  name: "lint",
+                  status: "failed" as const,
+                  conclusion: "FAILURE",
+                  url: "https://example.com/lint",
+                },
+              ],
+            },
+          ],
+        ]),
+      ),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    // Start with ci_failed so the transition path is bypassed and we exercise
+    // the dispatch-time re-verification on a steady-state poll.
+    const session = makeSession({ id: "s-3", status: "ci_failed", pr, workspacePath: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    lm.stop();
+
+    // Re-verification must have called getCIChecks
+    expect(getCIChecksMock).toHaveBeenCalled();
+    // The stale alert must NOT be dispatched
+    const detailedSends = vi
+      .mocked(mockSessionManager.send)
+      .mock.calls.filter((c) => typeof c[1] === "string" && (c[1] as string).includes("lint"));
+    expect(detailedSends).toEqual([]);
+  });
+
+  it("annotates CI failure message with verified SHA from batch enrichment", async () => {
+    // The dispatched alert includes the head SHA the batch saw, so workers
+    // can compare against their local HEAD to detect the rare case where
+    // the verification call also returned stale data.
+    config.reactions = {
+      "ci-failed": {
+        auto: true,
+        action: "send-to-agent",
+        retries: 3,
+        escalateAfter: 3,
+      },
+    };
+
+    const pr = makeMatchingPR();
+    const mockSCM = createMockSCM({
+      getCIChecks: vi.fn().mockResolvedValue([
+        {
+          name: "lint",
+          status: "failed" as const,
+          conclusion: "FAILURE",
+          url: "https://example.com/lint",
+        },
+      ]),
+      getCISummary: vi.fn().mockResolvedValue("failing"),
+      enrichSessionsPRBatch: vi.fn().mockResolvedValue(
+        new Map([
+          [
+            `${pr.owner}/${pr.repo}#${pr.number}`,
+            {
+              state: "open" as const,
+              ciStatus: "failing" as const,
+              reviewDecision: "none" as const,
+              mergeable: false,
+              hasConflicts: false,
+              headSha: "abc1234def5678",
+              ciChecks: [
+                {
+                  name: "lint",
+                  status: "failed" as const,
+                  conclusion: "FAILURE",
+                  url: "https://example.com/lint",
+                },
+              ],
+            },
+          ],
+        ]),
+      ),
+    });
+
+    const registry = createMockRegistry({
+      runtime: plugins.runtime,
+      agent: plugins.agent,
+      scm: mockSCM,
+    });
+
+    const session = makeSession({ id: "s-4", status: "pr_open", pr, workspacePath: null });
+    vi.mocked(mockSessionManager.list).mockResolvedValue([session]);
+    vi.mocked(mockSessionManager.send).mockResolvedValue(undefined);
+
+    const lm = createLifecycleManager({ config, registry, sessionManager: mockSessionManager });
+    lm.start(60_000);
+    await vi.advanceTimersByTimeAsync(0);
+    lm.stop();
+
+    const sentMessages = vi
+      .mocked(mockSessionManager.send)
+      .mock.calls.map((c) => c[1] as string);
+    const message = sentMessages.find((m) => m.includes("lint"));
+    expect(message).toBeDefined();
+    // First 7 chars of the SHA appear in the verified-at suffix
+    expect(message).toContain("abc1234");
   });
 
   it("throttles review backlog API calls to at most once per 2 minutes", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -1884,11 +1884,29 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
   }
 
   /**
+   * Format the verified-at-SHA anchor included with dispatched alerts.
+   *
+   * Workers compare the anchor against their current HEAD (e.g. `git rev-parse
+   * HEAD`) to detect rare cases where verification slipped through stale —
+   * the alert may have been computed against an older commit than the one
+   * currently on the PR. Returns "" when no SHA is available so the rest of
+   * the message degrades gracefully.
+   */
+  function formatVerifiedShaSuffix(headSha?: string): string {
+    if (!headSha) return "";
+    const short = headSha.slice(0, 7);
+    return ` (verified at SHA ${short}; if your current HEAD is past ${short}, verify before acting — the condition may already be resolved)`;
+  }
+
+  /**
    * Format CI check failures into a human-readable message for the agent.
    * Includes check names, statuses, and links for debugging.
    */
-  function formatCIFailureMessage(failedChecks: CICheck[]): string {
-    const lines = ["CI checks are failing on your PR. Here are the failed checks:", ""];
+  function formatCIFailureMessage(failedChecks: CICheck[], headSha?: string): string {
+    const lines = [
+      `CI checks are failing on your PR${formatVerifiedShaSuffix(headSha)}. Here are the failed checks:`,
+      "",
+    ];
     for (const check of failedChecks) {
       const status = check.conclusion ?? check.status;
       const link = check.url ? ` — ${check.url}` : "";
@@ -1945,11 +1963,14 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const cachedEnrichment = prEnrichmentCache.get(prKey);
 
     let checks: CICheck[];
+    let dataSource: "batch" | "fresh";
     if (cachedEnrichment?.ciChecks !== undefined) {
       checks = cachedEnrichment.ciChecks;
+      dataSource = "batch";
     } else {
       try {
         checks = await scm.getCIChecks(session.pr);
+        dataSource = "fresh";
       } catch {
         // Failed to fetch checks — skip this cycle
         return;
@@ -1994,6 +2015,58 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     // Skip if we already dispatched this exact failure set
     if (ciFingerprint === lastCIDispatchHash) return;
 
+    // Re-verify against fresh SCM state before dispatching.
+    //
+    // Why: batch enrichment runs once per poll cycle and the cached snapshot can
+    // describe a prior commit's CI state — e.g. a transient infra failure that
+    // has already been rerun-fixed, or a real failure that the worker has
+    // already pushed a fix for. Dispatching the queued alert against that stale
+    // snapshot tells the worker to "fix failing CI" when CI is actually green,
+    // which is a real noise/wrong-action risk (issue #1122).
+    //
+    // The fresh fetch hits gh's per-instance 5s cache, which is populated by
+    // getCIChecks() itself — NOT by the batch GraphQL path — so even within the
+    // same poll cycle this surfaces the current truth (unless we already
+    // fell back to a fresh fetch above, in which case the same cache entry
+    // is returned at ~zero cost).
+    let verifiedChecks = failedChecks;
+    if (dataSource === "batch") {
+      try {
+        const freshChecks = await scm.getCIChecks(session.pr);
+        const freshFailed = freshChecks.filter(
+          (c) => c.status === "failed" || c.conclusion?.toUpperCase() === "FAILURE",
+        );
+        if (freshFailed.length === 0) {
+          // CI has cleared since the batch snapshot — suppress the stale alert.
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "lifecycle.ci_failure_dispatch.suppressed_stale",
+            outcome: "success",
+            correlationId: createCorrelationId("ci-stale-suppress"),
+            projectId: session.projectId,
+            sessionId: session.id,
+            data: {
+              prNumber: session.pr.number,
+              cachedFailedChecks: failedChecks.map((c) => c.name),
+              cachedHeadSha: cachedEnrichment?.headSha,
+            },
+            level: "info",
+          });
+          // Record this fingerprint as dispatched so we don't re-evaluate it
+          // every poll for a snapshot we've confirmed is stale.
+          updateSessionMetadata(session, {
+            lastCIFailureDispatchHash: ciFingerprint,
+            lastCIFailureDispatchAt: new Date().toISOString(),
+          });
+          return;
+        }
+        verifiedChecks = freshFailed;
+      } catch {
+        // Fail open: verification call failed, dispatch with cached data
+        // rather than swallow a potentially real failure.
+      }
+    }
+
     // Dispatch CI failure details directly via sessionManager.send() rather than
     // executeReaction() to avoid consuming the ci-failed reaction's retry budget.
     // The transition reaction owns escalation; this is a follow-up info delivery.
@@ -2003,7 +2076,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       reactionConfig.action &&
       (reactionConfig.auto !== false || reactionConfig.action === "notify")
     ) {
-      const detailedMessage = formatCIFailureMessage(failedChecks);
+      const detailedMessage = formatCIFailureMessage(verifiedChecks, cachedEnrichment?.headSha);
 
       try {
         if (reactionConfig.action === "send-to-agent") {
@@ -2015,7 +2088,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
             sessionId: session.id,
             projectId: session.projectId,
             message: detailedMessage,
-            data: { failedChecks: failedChecks.map((c) => c.name), context, schemaVersion: 2 },
+            data: {
+              failedChecks: verifiedChecks.map((c) => c.name),
+              context,
+              schemaVersion: 2,
+              ...(cachedEnrichment?.headSha ? { headSha: cachedEnrichment.headSha } : {}),
+            },
           });
           await notifyHuman(event, reactionConfig.priority ?? "warning");
         }
@@ -2088,6 +2166,47 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
       // Already dispatched for current conflict state — skip
       if (lastDispatched === "true") return;
 
+      // Re-verify against fresh SCM state before dispatching.
+      //
+      // Why: batch enrichment runs once per poll cycle and GitHub computes
+      // `mergeable` asynchronously — the snapshot can carry a transient
+      // CONFLICTING that has since flipped back to MERGEABLE, or the worker
+      // may have already rebased. Dispatching the queued alert tells the
+      // worker to rebase + force-push when the branch is actually clean,
+      // which is a destructive wrong-action risk (issue #1122).
+      //
+      // getMergeability() runs a fresh `gh pr view --json mergeable,...`;
+      // it is NOT populated by the batch GraphQL path, so this returns the
+      // current truth even within the same poll cycle.
+      try {
+        const fresh = await scm.getMergeability(session.pr);
+        if (fresh.noConflicts) {
+          // Conflicts have cleared since the batch snapshot — suppress.
+          observer.recordOperation({
+            metric: "lifecycle_poll",
+            operation: "lifecycle.merge_conflict_dispatch.suppressed_stale",
+            outcome: "success",
+            correlationId: createCorrelationId("conflict-stale-suppress"),
+            projectId: session.projectId,
+            sessionId: session.id,
+            data: {
+              prNumber: session.pr.number,
+              cachedHeadSha: cachedData.headSha,
+              freshBlockers: fresh.blockers,
+            },
+            level: "info",
+          });
+          // Don't set lastMergeConflictDispatched=true — conflicts aren't
+          // actually present, so a real recurrence on a later cycle should
+          // still dispatch fresh. The expensive next-cycle re-fetch is
+          // gated by the cached snapshot continuing to claim conflicts.
+          return;
+        }
+      } catch {
+        // Fail open: verification call failed, dispatch with cached data
+        // rather than swallow a potentially real conflict.
+      }
+
       const reactionConfig = getReactionConfigForSession(session, conflictReactionKey);
       if (
         reactionConfig &&
@@ -2105,7 +2224,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           if (reactionConfig.action === "send-to-agent" && !reactionConfig.message) {
             const baseBranch = session.pr.baseBranch ?? "the default branch";
             const behindNote = cachedData.isBehind ? ` is behind ${baseBranch} and` : "";
-            enrichedConfig.message = `Your PR branch${behindNote} has merge conflicts with ${baseBranch}. Rebase your branch on ${baseBranch}, resolve the conflicts, and push. You should not need to call gh for merge status unless you need additional context — this information is current.`;
+            const shaSuffix = formatVerifiedShaSuffix(cachedData.headSha);
+            enrichedConfig.message = `Your PR branch${behindNote} has merge conflicts with ${baseBranch}${shaSuffix}. Rebase your branch on ${baseBranch}, resolve the conflicts, and push. You should not need to call gh for merge status unless you need additional context — this information is current.`;
           }
 
           const result = await executeReaction(session, conflictReactionKey, enrichedConfig);
@@ -2443,7 +2563,7 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
               if (failedChecks.length > 0) {
                 reactionConfig = {
                   ...reactionConfig,
-                  message: formatCIFailureMessage(failedChecks),
+                  message: formatCIFailureMessage(failedChecks, cachedData.headSha),
                 };
               }
             }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -894,6 +894,12 @@ export interface PREnrichmentData {
   isBehind?: boolean;
   /** List of blockers preventing merge */
   blockers?: string[];
+  /**
+   * Head SHA the enrichment was computed against. Lifecycle reactions use this
+   * to anchor dispatched alerts ("verified at SHA X") so workers can detect
+   * staleness if a later commit has already resolved the alert condition.
+   */
+  headSha?: string;
 }
 
 /**
@@ -1091,6 +1097,12 @@ export interface PREnrichmentData {
   blockers?: string[];
   /** Individual CI check results (populated from batch enrichment when available) */
   ciChecks?: CICheck[];
+  /**
+   * Head SHA the enrichment was computed against. Lifecycle reactions use this
+   * to anchor dispatched alerts ("verified at SHA X") so workers can detect
+   * staleness if a later commit has already resolved the alert condition.
+   */
+  headSha?: string;
 }
 
 /**

--- a/packages/plugins/scm-github/src/graphql-batch.ts
+++ b/packages/plugins/scm-github/src/graphql-batch.ts
@@ -1024,6 +1024,7 @@ function extractPREnrichment(
     isBehind,
     blockers,
     ...(ciChecks !== undefined ? { ciChecks } : {}),
+    ...(headSha ? { headSha } : {}),
   };
 
   return { data, headSha };


### PR DESCRIPTION
## Summary

Fixes #1122. Lifecycle reactions were firing 'CI is failing' and 'merge conflicts' alerts against the cached batch-enrichment snapshot, telling workers to take destructive actions (rebase + force-push, 'fix the failing CI') on PRs whose conditions had already been resolved.

- Added dispatch-time re-verification: before firing a CI-failure or merge-conflict alert, call `getCIChecks()` / `getMergeability()` and skip when the condition has cleared. These methods aren't populated by the batch GraphQL path, so they return fresh truth even within the same poll cycle. Verification failures fail open — a flaky API call never swallows a real failure.
- Added `headSha` to `PREnrichmentData`, populated by `extractPREnrichment`, and threaded it into the dispatched message as a 'verified at SHA X' anchor so workers can detect rare staleness slip-throughs and the orchestrator's log has a falsifiable record.
- Updated 2 existing merge-conflict tests to mock `getMergeability` for the new re-verification path; added 3 new tests covering CI suppression, conflict suppression, and SHA annotation.

## Test plan

- [x] `pnpm --filter @aoagents/ao-core typecheck`
- [x] `pnpm --filter @aoagents/ao-core test` (1200 passed)
- [x] `pnpm --filter @aoagents/ao-plugin-scm-github typecheck`
- [x] `pnpm --filter @aoagents/ao-plugin-scm-github test` (169 passed)
- [x] `pnpm typecheck` (all packages clean)
- [x] `pnpm lint` (0 errors)
- [ ] Manual verification: spawn an agent, push a CI-failing commit, fix it before the next poll cycle, confirm no stale 'CI failing' alert fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)