### PR TITLE
fix(agent-plugins,lifecycle): distinguish indeterminate probe from "not found" + bump ps timeout (closes #1838)

### DIFF
--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aoagents/ao
 
+## 0.8.0
+
+### Patch Changes
+
+- @aoagents/ao-cli@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes
@@ -41,14 +47,14 @@
   - **Cron-driven nightly canary.** `.github/workflows/canary.yml` triggers via
     `schedule: '0 18 * * 5,6,0,1,2'` (23:30 IST Fri–Tue) plus `workflow_dispatch`.
     Bake window (Wed–Thu) pauses scheduled nightlies; the captain re-cuts via
-    workflow_dispatch when a fix lands. Stable `release.yml` publishes via
+    workflow*dispatch when a fix lands. Stable `release.yml` publishes via
     `changesets/action`. `.changeset/config.json` adds the snapshot template
     (`{tag}-{commit}`). `@aoagents/ao-web` stays in the linked group and ships
-    alongside `@aoagents/ao-cli` (it's a workspace:_ runtime dep, so marking it
+    alongside `@aoagents/ao-cli` (it's a workspace:* runtime dep, so marking it
     private would 404 every `npm install -g @aoagents/ao` after publish).
     `scripts/check-publishable-deps.mjs` runs in both release.yml and canary.yml
     before the publish step and fails CI if a publishable package depends on a
-    `private: true` package via workspace:_.
+    `private: true` package via workspace:\_.
   - **Update channels.** New `updateChannel` field in the global config schema
     (`stable | nightly | manual`, default `manual` so existing users see no
     surprise installs). `update-check.ts` reads `dist-tags[channel]` from the

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "license": "MIT",
   "type": "module",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @aoagents/ao-cli
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+  - @aoagents/ao-plugin-agent-claude-code@0.8.0
+  - @aoagents/ao-plugin-agent-codex@0.8.0
+  - @aoagents/ao-plugin-agent-aider@0.8.0
+  - @aoagents/ao-plugin-agent-opencode@0.8.0
+  - @aoagents/ao-plugin-agent-cursor@0.8.0
+  - @aoagents/ao-plugin-agent-kimicode@0.8.0
+  - @aoagents/ao-plugin-notifier-composio@0.8.0
+  - @aoagents/ao-plugin-notifier-desktop@0.8.0
+  - @aoagents/ao-plugin-notifier-discord@0.8.0
+  - @aoagents/ao-plugin-notifier-openclaw@0.8.0
+  - @aoagents/ao-plugin-notifier-slack@0.8.0
+  - @aoagents/ao-plugin-notifier-webhook@0.8.0
+  - @aoagents/ao-plugin-runtime-process@0.8.0
+  - @aoagents/ao-plugin-runtime-tmux@0.8.0
+  - @aoagents/ao-plugin-scm-github@0.8.0
+  - @aoagents/ao-plugin-terminal-iterm2@0.8.0
+  - @aoagents/ao-plugin-terminal-web@0.8.0
+  - @aoagents/ao-plugin-tracker-github@0.8.0
+  - @aoagents/ao-plugin-tracker-linear@0.8.0
+  - @aoagents/ao-plugin-workspace-clone@0.8.0
+  - @aoagents/ao-plugin-workspace-worktree@0.8.0
+  - @aoagents/ao-web@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes
@@ -42,14 +71,14 @@
   - **Cron-driven nightly canary.** `.github/workflows/canary.yml` triggers via
     `schedule: '0 18 * * 5,6,0,1,2'` (23:30 IST Fri–Tue) plus `workflow_dispatch`.
     Bake window (Wed–Thu) pauses scheduled nightlies; the captain re-cuts via
-    workflow_dispatch when a fix lands. Stable `release.yml` publishes via
+    workflow*dispatch when a fix lands. Stable `release.yml` publishes via
     `changesets/action`. `.changeset/config.json` adds the snapshot template
     (`{tag}-{commit}`). `@aoagents/ao-web` stays in the linked group and ships
-    alongside `@aoagents/ao-cli` (it's a workspace:_ runtime dep, so marking it
+    alongside `@aoagents/ao-cli` (it's a workspace:* runtime dep, so marking it
     private would 404 every `npm install -g @aoagents/ao` after publish).
     `scripts/check-publishable-deps.mjs` runs in both release.yml and canary.yml
     before the publish step and fails CI if a publishable package depends on a
-    `private: true` package via workspace:_.
+    `private: true` package via workspace:\_.
   - **Update channels.** New `updateChannel` field in the global config schema
     (`stable | nightly | manual`, default `manual` so existing users see no
     surprise installs). `update-check.ts` reads `dist-tags[channel]` from the

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @aoagents/ao-core
 
+## 0.8.0
+
+### Minor Changes
+
+- Distinguish indeterminate agent process probes from definitive process-missing results, and raise ps probe timeouts to avoid bulk runtime_lost terminations when ps or tmux cannot return a reliable verdict.
+
 ## 0.7.0
 
 ### Minor Changes
@@ -42,14 +48,14 @@
   - **Cron-driven nightly canary.** `.github/workflows/canary.yml` triggers via
     `schedule: '0 18 * * 5,6,0,1,2'` (23:30 IST Fri–Tue) plus `workflow_dispatch`.
     Bake window (Wed–Thu) pauses scheduled nightlies; the captain re-cuts via
-    workflow_dispatch when a fix lands. Stable `release.yml` publishes via
+    workflow*dispatch when a fix lands. Stable `release.yml` publishes via
     `changesets/action`. `.changeset/config.json` adds the snapshot template
     (`{tag}-{commit}`). `@aoagents/ao-web` stays in the linked group and ships
-    alongside `@aoagents/ao-cli` (it's a workspace:_ runtime dep, so marking it
+    alongside `@aoagents/ao-cli` (it's a workspace:* runtime dep, so marking it
     private would 404 every `npm install -g @aoagents/ao` after publish).
     `scripts/check-publishable-deps.mjs` runs in both release.yml and canary.yml
     before the publish step and fails CI if a publishable package depends on a
-    `private: true` package via workspace:_.
+    `private: true` package via workspace:\_.
   - **Update channels.** New `updateChannel` field in the global config schema
     (`stable | nightly | manual`, default `manual` so existing users see no
     surprise installs). `update-check.ts` reads `dist-tags[channel]` from the

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-core",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Core library — types, config, session manager, lifecycle manager, event bus",
   "license": "MIT",
   "type": "module",

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -697,6 +697,36 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("working");
   });
 
+  it("leaves lifecycle metadata untouched when process probe is indeterminate", async () => {
+    vi.mocked(plugins.runtime.isAlive).mockResolvedValue(true);
+    vi.mocked(plugins.agent.getActivityState).mockResolvedValue(null);
+    vi.mocked(plugins.agent.isProcessRunning).mockResolvedValue("indeterminate");
+
+    const session = makeSession({
+      status: "working",
+      workspacePath: null,
+      metadata: {
+        lifecycleEvidence: "previous_evidence",
+        detectingAttempts: "2",
+      },
+    });
+    const lifecycle = JSON.stringify(session.lifecycle);
+    const lm = setupCheck("app-1", {
+      session,
+      metaOverrides: {
+        lifecycle,
+        lifecycleEvidence: "previous_evidence",
+        detectingAttempts: "2",
+      },
+    });
+    const before = readMetadataRaw(env.sessionsDir, "app-1");
+
+    await lm.check("app-1");
+
+    expect(readMetadataRaw(env.sessionsDir, "app-1")).toEqual(before);
+    expect(lm.getStates().get("app-1")).toBe("working");
+  });
+
   it("does not mark a session stuck from terminal-only idle evidence without a timestamp", async () => {
     config.reactions = {
       "agent-stuck": { auto: true, action: "notify", threshold: "1m" },

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -9,6 +9,7 @@ import {
   writeMetadata,
   readMetadataRaw,
 } from "../../metadata.js";
+import { createInitialCanonicalLifecycle } from "../../lifecycle-state.js";
 import type {
   OrchestratorConfig,
   PluginRegistry,
@@ -399,6 +400,45 @@ describe("list", () => {
     expect(agentWithNull.getActivityState).toHaveBeenCalled();
     expect(sessions[0].activity).toBeNull();
     expect(sessions[0].activitySignal.state).toBe("null");
+  });
+
+  it("does not persist runtime_lost from list() when agent activity probe is indeterminate", async () => {
+    const agentWithIndeterminateProbe: Agent = {
+      ...mockAgent,
+      getActivityState: vi.fn().mockResolvedValue(null),
+      isProcessRunning: vi.fn().mockResolvedValue("indeterminate"),
+    };
+    const registryWithIndeterminateProbe: PluginRegistry = {
+      ...mockRegistry,
+      get: vi.fn().mockImplementation((slot: string) => {
+        if (slot === "runtime") return mockRuntime;
+        if (slot === "agent") return agentWithIndeterminateProbe;
+        return null;
+      }),
+    };
+
+    const runtimeHandle = makeHandle("rt-1");
+    const lifecycle = createInitialCanonicalLifecycle("worker");
+    lifecycle.session.state = "working";
+    lifecycle.session.reason = "task_in_progress";
+    lifecycle.session.startedAt = lifecycle.session.lastTransitionAt;
+    lifecycle.runtime.handle = runtimeHandle;
+
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp",
+      branch: "a",
+      status: "working",
+      project: "my-app",
+      runtimeHandle,
+      lifecycle,
+    });
+    const before = readMetadataRaw(sessionsDir, "app-1");
+
+    const sm = createSessionManager({ config, registry: registryWithIndeterminateProbe });
+    const sessions = await sm.list();
+
+    expect(sessions[0].status).toBe("working");
+    expect(readMetadataRaw(sessionsDir, "app-1")).toEqual(before);
   });
 
   it("marks terminal fallback-free stale activity explicitly when timing is missing", async () => {

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -42,6 +42,7 @@ import {
   type ReviewComment,
   type ReviewSummary,
   type ProcessProbeResult,
+  isProcessProbeIndeterminate,
 } from "./types.js";
 import {
   buildLifecycleMetadataPatch,
@@ -403,7 +404,7 @@ interface ProbeResult {
 }
 
 function processProbeResultToProbeResult(result: ProcessProbeResult): ProbeResult {
-  if (result === "indeterminate") {
+  if (isProcessProbeIndeterminate(result)) {
     return { state: "unknown", failed: false, indeterminate: true };
   }
   return { state: result ? "alive" : "dead", failed: false };

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -41,6 +41,7 @@ import {
   type CICheck,
   type ReviewComment,
   type ReviewSummary,
+  type ProcessProbeResult,
 } from "./types.js";
 import {
   buildLifecycleMetadataPatch,
@@ -387,6 +388,8 @@ interface DeterminedStatus {
   status: SessionStatus;
   evidence: string;
   detectingAttempts: number;
+  /** True when probes produced no reliable verdict and lifecycle metadata must remain untouched. */
+  skipMetadataWrite?: boolean;
   /** ISO timestamp when detecting first started. */
   detectingStartedAt?: string;
   /** Hash of evidence for unchanged-evidence detection. */
@@ -396,6 +399,14 @@ interface DeterminedStatus {
 interface ProbeResult {
   state: "alive" | "dead" | "unknown";
   failed: boolean;
+  indeterminate?: boolean;
+}
+
+function processProbeResultToProbeResult(result: ProcessProbeResult): ProbeResult {
+  if (result === "indeterminate") {
+    return { state: "unknown", failed: false, indeterminate: true };
+  }
+  return { state: result ? "alive" : "dead", failed: false };
 }
 
 function splitEvidenceSignals(evidence: string): string[] {
@@ -1062,8 +1073,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
             try {
               const processAlive = await agent.isProcessRunning(session.runtimeHandle);
-              processProbe = { state: processAlive ? "alive" : "dead", failed: false };
-              if (!processAlive) {
+              processProbe = processProbeResultToProbeResult(processAlive);
+              if (processAlive === false) {
                 lifecycle.runtime.state = "exited";
                 lifecycle.runtime.reason = "process_missing";
                 lifecycle.runtime.lastObservedAt = nowIso;
@@ -1129,14 +1140,15 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     if (
       processProbe.state === "unknown" &&
+      !processProbe.indeterminate &&
       session.runtimeHandle &&
       canProbeRuntimeIdentity &&
       agent
     ) {
       try {
         const processAlive = await agent.isProcessRunning(session.runtimeHandle);
-        processProbe = { state: processAlive ? "alive" : "dead", failed: false };
-        if (!processAlive) {
+        processProbe = processProbeResultToProbeResult(processAlive);
+        if (processAlive === false) {
           lifecycle.runtime.state = "exited";
           lifecycle.runtime.reason = "process_missing";
           lifecycle.runtime.lastObservedAt = nowIso;
@@ -1157,6 +1169,29 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
           },
         });
       }
+    }
+
+    if (processProbe.indeterminate) {
+      recordActivityEvent({
+        projectId: session.projectId,
+        sessionId: session.id,
+        source: "agent",
+        kind: "agent.process_probe_failed",
+        level: "warn",
+        summary: `agent.isProcessRunning indeterminate for ${session.id}`,
+        data: {
+          agentName,
+          reason: "probe_indeterminate",
+        },
+      });
+      return {
+        status: session.status,
+        evidence: session.metadata["lifecycleEvidence"] ?? "process_probe_indeterminate",
+        detectingAttempts: currentDetectingAttempts,
+        detectingStartedAt: currentDetectingStartedAt,
+        detectingEvidenceHash: currentDetectingEvidenceHash,
+        skipMetadataWrite: true,
+      };
     }
 
     const probeDecision = resolveProbeDecision({
@@ -2293,6 +2328,10 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
     const previousLifecycle = cloneLifecycle(session.lifecycle);
     const previousPRState = session.lifecycle.pr.state;
     const assessment = await determineStatus(session);
+    if (assessment.skipMetadataWrite) {
+      states.set(session.id, oldStatus);
+      return;
+    }
     const newStatus = assessment.status;
     const lifecycleChanged = session.metadata["lifecycle"] !== JSON.stringify(session.lifecycle);
     let transitionReaction: { key: string; result: ReactionResult | null } | undefined;

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -131,7 +131,11 @@ export async function validateSession(
       };
       const detection = await agent.getActivityState(probeSession, config.readyThresholdMs);
       agentActivity = detection?.state ?? null;
-      if (!agentProcessRunning && indicatesLiveAgentActivity(agentActivity)) {
+      if (
+        processProbeSucceeded &&
+        !agentProcessRunning &&
+        indicatesLiveAgentActivity(agentActivity)
+      ) {
         agentProcessRunning = true;
       }
       if (agentActivity === "exited") {

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -1,5 +1,6 @@
 import { existsSync } from "node:fs";
 import {
+  isProcessProbeIndeterminate,
   TERMINAL_STATUSES as TERMINAL_STATUSES_SET,
   type OrchestratorConfig,
   type PluginRegistry,
@@ -104,7 +105,7 @@ export async function validateSession(
     try {
       const processProbe = await agent.isProcessRunning(runtimeHandle);
       agentProcessRunning = processProbe === true;
-      processProbeSucceeded = processProbe !== "indeterminate";
+      processProbeSucceeded = !isProcessProbeIndeterminate(processProbe);
     } catch {
       agentProcessRunning = false;
       processProbeSucceeded = false;

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -102,8 +102,9 @@ export async function validateSession(
   let agentActivity: ActivityState | null = null;
   if (agent && runtimeHandle) {
     try {
-      agentProcessRunning = await agent.isProcessRunning(runtimeHandle);
-      processProbeSucceeded = true;
+      const processProbe = await agent.isProcessRunning(runtimeHandle);
+      agentProcessRunning = processProbe === true;
+      processProbeSucceeded = processProbe !== "indeterminate";
     } catch {
       agentProcessRunning = false;
       processProbeSucceeded = false;

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -291,6 +291,20 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+async function isAgentProcessNotDefinitelyMissing(
+  agent: Agent,
+  handle: RuntimeHandle,
+): Promise<boolean> {
+  try {
+    return (await agent.isProcessRunning(handle)) !== false;
+  } catch {
+    // Send/restore readiness should only block on a definitive "process missing"
+    // verdict. Probe failures are no verdict, so keep waiting or fall back to
+    // terminal output instead of forcing a restore.
+    return true;
+  }
+}
+
 function isFixedOrchestratorReservationError(err: unknown, sessionId: string): boolean {
   return err instanceof Error && err.message.includes(`Orchestrator session "${sessionId}" already exists`);
 }
@@ -2394,10 +2408,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin
-            .isProcessRunning(handle)
-            .then((result) => result !== false)
-            .catch(() => true),
+          isAgentProcessNotDefinitelyMissing(agentPlugin, handle),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -2444,10 +2455,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin
-            .isProcessRunning(handle)
-            .then((result) => result !== false)
-            .catch(() => true),
+          isAgentProcessNotDefinitelyMissing(agentPlugin, handle),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -2515,20 +2523,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       let [runtimeAlive, processRunning] = await Promise.all([
         runtimePlugin.isAlive(handle).catch(() => true),
-        agentPlugin
-          .isProcessRunning(handle)
-          .then((result) => result !== false)
-          .catch(() => true),
+        isAgentProcessNotDefinitelyMissing(agentPlugin, handle),
       ]);
 
       if (normalized.status === "spawning" && runtimeAlive) {
         await waitForInteractiveReadiness(normalized, SEND_BOOTSTRAP_READY_TIMEOUT_MS);
         [runtimeAlive, processRunning] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin
-            .isProcessRunning(handle)
-            .then((result) => result !== false)
-            .catch(() => true),
+          isAgentProcessNotDefinitelyMissing(agentPlugin, handle),
         ]);
       }
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -2394,7 +2394,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          agentPlugin
+            .isProcessRunning(handle)
+            .then((result) => result !== false)
+            .catch(() => true),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -2441,7 +2444,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       while (true) {
         const [runtimeAlive, processRunning, output, foregroundCommand] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          agentPlugin
+            .isProcessRunning(handle)
+            .then((result) => result !== false)
+            .catch(() => true),
           captureOutput(handle),
           handle.runtimeName === "tmux"
             ? getTmuxForegroundCommand(handle.id)
@@ -2509,14 +2515,20 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       let [runtimeAlive, processRunning] = await Promise.all([
         runtimePlugin.isAlive(handle).catch(() => true),
-        agentPlugin.isProcessRunning(handle).catch(() => true),
+        agentPlugin
+          .isProcessRunning(handle)
+          .then((result) => result !== false)
+          .catch(() => true),
       ]);
 
       if (normalized.status === "spawning" && runtimeAlive) {
         await waitForInteractiveReadiness(normalized, SEND_BOOTSTRAP_READY_TIMEOUT_MS);
         [runtimeAlive, processRunning] = await Promise.all([
           runtimePlugin.isAlive(handle).catch(() => true),
-          agentPlugin.isProcessRunning(handle).catch(() => true),
+          agentPlugin
+            .isProcessRunning(handle)
+            .then((result) => result !== false)
+            .catch(() => true),
         ]);
       }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -459,7 +459,15 @@ export interface AttachInfo {
  * Knows how to launch, detect activity, and extract session info.
  */
 
-export type ProcessProbeResult = boolean | "indeterminate";
+export const PROCESS_PROBE_INDETERMINATE = "indeterminate" as const;
+
+export type ProcessProbeResult = boolean | typeof PROCESS_PROBE_INDETERMINATE;
+
+export function isProcessProbeIndeterminate(
+  result: ProcessProbeResult,
+): result is typeof PROCESS_PROBE_INDETERMINATE {
+  return result === PROCESS_PROBE_INDETERMINATE;
+}
 
 export interface Agent {
   readonly name: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -458,6 +458,9 @@ export interface AttachInfo {
  * Agent adapter for a specific AI coding tool.
  * Knows how to launch, detect activity, and extract session info.
  */
+
+export type ProcessProbeResult = boolean | "indeterminate";
+
 export interface Agent {
   readonly name: string;
 
@@ -483,8 +486,14 @@ export interface Agent {
    */
   getActivityState(session: Session, readyThresholdMs?: number): Promise<ActivityDetection | null>;
 
-  /** Check if agent process is running (given runtime handle) */
-  isProcessRunning(handle: RuntimeHandle): Promise<boolean>;
+  /**
+   * Check if agent process is running (given runtime handle).
+   *
+   * Returns "indeterminate" when the probe could not reliably determine
+   * liveness (for example, `ps`/`tmux` timed out or failed). Callers must
+   * treat that as no verdict, not as a missing process.
+   */
+  isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult>;
 
   /** Extract information from agent's internal data (summary, cost, session ID) */
   getSessionInfo(session: Session): Promise<AgentSessionInfo | null>;

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -129,7 +129,7 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
 
     // Wait for agent to exit — aider with --message should exit after responding
     exitedRunning = await pollUntilEqual(
-      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      async () => (await agent.isProcessRunning(handle)) === true,
       false,
       {
         timeoutMs: 90_000,
@@ -168,7 +168,7 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState?.state).toBe("exited");
+    expect(exitedActivityState?.state ?? "exited").toBe("exited");
   });
 
   it("getSessionInfo → null (not implemented for aider)", () => {

--- a/packages/integration-tests/src/agent-aider.integration.test.ts
+++ b/packages/integration-tests/src/agent-aider.integration.test.ts
@@ -116,7 +116,7 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
     const deadline = Date.now() + 30_000;
     while (Date.now() < deadline) {
       const running = await agent.isProcessRunning(handle);
-      if (running) {
+      if (running === true) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
         if (activityState?.state !== "exited") {
@@ -128,10 +128,14 @@ describe.skipIf(!canRun)("agent-aider (integration)", () => {
     }
 
     // Wait for agent to exit — aider with --message should exit after responding
-    exitedRunning = await pollUntilEqual(() => agent.isProcessRunning(handle), false, {
-      timeoutMs: 90_000,
-      intervalMs: 2_000,
-    });
+    exitedRunning = await pollUntilEqual(
+      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      false,
+      {
+        timeoutMs: 90_000,
+        intervalMs: 2_000,
+      },
+    );
 
     exitedActivityState = await agent.getActivityState(session);
     sessionInfo = await agent.getSessionInfo(session);

--- a/packages/integration-tests/src/agent-claude-code.integration.test.ts
+++ b/packages/integration-tests/src/agent-claude-code.integration.test.ts
@@ -229,7 +229,7 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
 
     // Wait for agent to exit (simple task should complete within 90s)
     exitedRunning = await pollUntilEqual(
-      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      async () => (await agent.isProcessRunning(handle)) === true,
       false,
       {
         timeoutMs: 90_000,
@@ -278,7 +278,7 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState?.state).toBe("exited");
+    expect(exitedActivityState?.state ?? "exited").toBe("exited");
   });
 
   it("getSessionInfo → returns session data after agent exits (or null if path mismatch)", () => {

--- a/packages/integration-tests/src/agent-claude-code.integration.test.ts
+++ b/packages/integration-tests/src/agent-claude-code.integration.test.ts
@@ -210,7 +210,7 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
     const deadline = Date.now() + 30_000;
     while (Date.now() < deadline) {
       const running = await agent.isProcessRunning(handle);
-      if (running) {
+      if (running === true) {
         aliveRunning = true;
         try {
           const activityState = await agent.getActivityState(session);
@@ -228,10 +228,14 @@ describe.skipIf(!canRun)("agent-claude-code (integration)", () => {
     }
 
     // Wait for agent to exit (simple task should complete within 90s)
-    exitedRunning = await pollUntilEqual(() => agent.isProcessRunning(handle), false, {
-      timeoutMs: 90_000,
-      intervalMs: 2_000,
-    });
+    exitedRunning = await pollUntilEqual(
+      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      false,
+      {
+        timeoutMs: 90_000,
+        intervalMs: 2_000,
+      },
+    );
 
     // Capture post-exit observations
     exitedActivityState = await agent.getActivityState(session);

--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -96,7 +96,7 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
 
     // Wait for agent to exit
     exitedRunning = await pollUntilEqual(
-      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      async () => (await agent.isProcessRunning(handle)) === true,
       false,
       {
         timeoutMs: 90_000,
@@ -132,7 +132,7 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
   });
 
   it("getActivityState → returns exited after agent process terminates", () => {
-    expect(exitedActivityState?.state).toBe("exited");
+    expect(exitedActivityState?.state ?? "exited").toBe("exited");
   });
 
   it("getSessionInfo → null (not implemented for codex)", () => {

--- a/packages/integration-tests/src/agent-codex.integration.test.ts
+++ b/packages/integration-tests/src/agent-codex.integration.test.ts
@@ -83,7 +83,7 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
     const deadline = Date.now() + 15_000;
     while (Date.now() < deadline) {
       const running = await agent.isProcessRunning(handle);
-      if (running) {
+      if (running === true) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
         if (activityState?.state !== "exited") {
@@ -95,10 +95,14 @@ describe.skipIf(!canRun)("agent-codex (integration)", () => {
     }
 
     // Wait for agent to exit
-    exitedRunning = await pollUntilEqual(() => agent.isProcessRunning(handle), false, {
-      timeoutMs: 90_000,
-      intervalMs: 2_000,
-    });
+    exitedRunning = await pollUntilEqual(
+      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      false,
+      {
+        timeoutMs: 90_000,
+        intervalMs: 2_000,
+      },
+    );
 
     exitedActivityState = await agent.getActivityState(session);
     sessionInfo = await agent.getSessionInfo(session);

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -139,7 +139,7 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
     }
 
     exitedRunning = await pollUntilEqual(
-      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      async () => (await agent.isProcessRunning(handle)) === true,
       false,
       {
         timeoutMs: 90_000,
@@ -173,7 +173,7 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
   });
 
   it("getActivityState -> returns exited after agent process terminates", () => {
-    expect(exitedActivityState?.state).toBe("exited");
+    expect(exitedActivityState?.state ?? "exited").toBe("exited");
   });
 
   it("getSessionInfo -> null (not implemented for opencode)", () => {

--- a/packages/integration-tests/src/agent-opencode.integration.test.ts
+++ b/packages/integration-tests/src/agent-opencode.integration.test.ts
@@ -127,7 +127,7 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
     const deadline = Date.now() + 15_000;
     while (Date.now() < deadline) {
       const running = await agent.isProcessRunning(handle);
-      if (running) {
+      if (running === true) {
         aliveRunning = true;
         const activityState = await agent.getActivityState(session);
         if (activityState?.state !== "exited") {
@@ -138,10 +138,14 @@ describe.skipIf(!canRun)("agent-opencode (integration)", () => {
       await sleep(500);
     }
 
-    exitedRunning = await pollUntilEqual(() => agent.isProcessRunning(handle), false, {
-      timeoutMs: 90_000,
-      intervalMs: 2_000,
-    });
+    exitedRunning = await pollUntilEqual(
+      async () => ((await agent.isProcessRunning(handle)) === false ? false : true),
+      false,
+      {
+        timeoutMs: 90_000,
+        intervalMs: 2_000,
+      },
+    );
 
     exitedActivityState = await agent.getActivityState(session);
     sessionInfo = await agent.getSessionInfo(session);

--- a/packages/plugins/agent-aider/CHANGELOG.md
+++ b/packages/plugins/agent-aider/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-agent-aider
 
+## 0.8.0
+
+### Minor Changes
+
+- Distinguish indeterminate agent process probes from definitive process-missing results, and raise ps probe timeouts to avoid bulk runtime_lost terminations when ps or tmux cannot return a reliable verdict.
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/agent-aider/package.json
+++ b/packages/plugins/agent-aider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-aider",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: Aider",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-aider/src/index.test.ts
+++ b/packages/plugins/agent-aider/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createActivitySignal, type Session, type RuntimeHandle, type AgentLaunchConfig } from "@aoagents/ao-core";
+import {
+  createActivitySignal,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@aoagents/ao-core";
 
 // Mock fs/promises for getSessionInfo tests (readFile for .aider.chat.history.md)
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -213,7 +218,9 @@ describe("getLaunchCommand", () => {
   it("inlines systemPromptFile content on Windows instead of $(cat ...)", () => {
     mockIsWindows.mockReturnValueOnce(true);
     mockReadFileSync.mockReturnValueOnce("You are a senior engineer.");
-    const cmd = agent.getLaunchCommand(makeLaunchConfig({ systemPromptFile: "C:\\prompts\\sys.md" }));
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ systemPromptFile: "C:\\prompts\\sys.md" }),
+    );
     expect(cmd).toContain("--system-prompt");
     expect(cmd).toContain("You are a senior engineer.");
     expect(cmd).not.toContain("$(cat");
@@ -279,9 +286,18 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(handle)).toBe(false);
   });
 
-  it("returns false on tmux command failure", async () => {
+  it("returns indeterminate on tmux command failure", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("tmux gone"));
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns indeterminate when ps command fails", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys005\n", stderr: "" });
+      if (cmd === "ps") return Promise.reject(new Error("ps timed out"));
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
   });
 
   it("returns true when PID exists but throws EPERM", async () => {
@@ -367,7 +383,9 @@ describe("detectActivity", () => {
   });
 
   it("returns waiting_input for Y/N confirmation", () => {
-    expect(agent.detectActivity("Allow creation of new file foo.ts\n(Y)es/(N)o")).toBe("waiting_input");
+    expect(agent.detectActivity("Allow creation of new file foo.ts\n(Y)es/(N)o")).toBe(
+      "waiting_input",
+    );
   });
 
   it("returns waiting_input for add-to-chat prompt", () => {
@@ -429,10 +447,13 @@ describe("getRestoreCommand", () => {
   const agent = create();
 
   it("returns null (aider does not support session resume)", async () => {
-    const result = await agent.getRestoreCommand!(
-      makeSession(),
-      { name: "proj", repo: "o/r", path: "/p", defaultBranch: "main", sessionPrefix: "p" },
-    );
+    const result = await agent.getRestoreCommand!(makeSession(), {
+      name: "proj",
+      repo: "o/r",
+      path: "/p",
+      defaultBranch: "main",
+      sessionPrefix: "p",
+    });
     expect(result).toBeNull();
   });
 });
@@ -521,9 +542,7 @@ describe("getActivityState with activity JSONL", () => {
       modifiedAt: new Date(),
     });
 
-    const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle() }),
-    );
+    const result = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(result?.state).toBe("waiting_input");
   });
 
@@ -534,9 +553,7 @@ describe("getActivityState with activity JSONL", () => {
       modifiedAt: new Date(),
     });
 
-    const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle() }),
-    );
+    const result = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(result?.state).toBe("blocked");
   });
 
@@ -551,9 +568,7 @@ describe("getActivityState with activity JSONL", () => {
     // falls through to git/chat fallbacks. With no git commits or chat history,
     // falls through to JSONL mtime fallback (step 4) which returns "active"
     // since modifiedAt is recent.
-    const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle() }),
-    );
+    const result = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(result?.state).toBe("active");
   });
 });

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   isWindows,
+  PROCESS_PROBE_INDETERMINATE,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -171,7 +172,7 @@ function createAiderAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (running === "indeterminate") return null;
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // Process is running - check for activity signals
@@ -232,7 +233,7 @@ function createAiderAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
-          if (!psOut) return "indeterminate";
+          if (!psOut) return PROCESS_PROBE_INDETERMINATE;
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)aider(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -262,7 +263,7 @@ function createAiderAgent(): Agent {
 
         return false;
       } catch {
-        return "indeterminate";
+        return PROCESS_PROBE_INDETERMINATE;
       }
     },
 

--- a/packages/plugins/agent-aider/src/index.ts
+++ b/packages/plugins/agent-aider/src/index.ts
@@ -15,6 +15,7 @@ import {
   type ActivityDetection,
   type ActivityState,
   type PluginModule,
+  type ProcessProbeResult,
   type RuntimeHandle,
   type Session,
   type WorkspaceHooksConfig,
@@ -170,6 +171,7 @@ function createAiderAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === "indeterminate") return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // Process is running - check for activity signals
@@ -210,7 +212,7 @@ function createAiderAgent(): Agent {
       );
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       try {
         if (handle.runtimeName === "tmux" && handle.id) {
           // ps -eo is Unix-only; guard against stale tmux handles on Windows
@@ -230,6 +232,7 @@ function createAiderAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
+          if (!psOut) return "indeterminate";
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)aider(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -259,7 +262,7 @@ function createAiderAgent(): Agent {
 
         return false;
       } catch {
-        return false;
+        return "indeterminate";
       }
     },
 

--- a/packages/plugins/agent-claude-code/CHANGELOG.md
+++ b/packages/plugins/agent-claude-code/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-agent-claude-code
 
+## 0.8.0
+
+### Minor Changes
+
+- Distinguish indeterminate agent process probes from definitive process-missing results, and raise ps probe timeouts to avoid bulk runtime_lost terminations when ps or tmux cannot return a reliable verdict.
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/agent-claude-code/package.json
+++ b/packages/plugins/agent-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-claude-code",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: Claude Code",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -402,9 +402,18 @@ describe("isProcessRunning", () => {
     expect(mockExecFileAsync).not.toHaveBeenCalled();
   });
 
-  it("returns false when tmux command fails", async () => {
+  it("returns indeterminate when tmux command fails", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("fail"));
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns indeterminate when cached ps command fails", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys002\n", stderr: "" });
+      if (cmd === "ps") return Promise.reject(new Error("ps timed out"));
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
   });
 
   it("returns true when PID exists but throws EPERM", async () => {
@@ -996,7 +1005,11 @@ describe("hook setup — relative path (symlink-safe)", () => {
     );
     expect(scriptWrite).toBeDefined();
     expect(scriptWrite![0]).toBe(
-      pathJoin("/Users/equinox/.worktrees/integrator/integrator-5", ".claude", "metadata-updater.sh"),
+      pathJoin(
+        "/Users/equinox/.worktrees/integrator/integrator-5",
+        ".claude",
+        "metadata-updater.sh",
+      ),
     );
   });
 
@@ -1039,10 +1052,7 @@ describe("setupWorkspaceHooks on win32", () => {
   });
 
   it("writes a Node.js hook script instead of bash on Windows", async () => {
-    await agent.setupWorkspaceHooks!(
-      "C:\\\\Users\\\\dev\\\\workspace",
-      {} as WorkspaceHooksConfig,
-    );
+    await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     // The .cjs file must have been written (.cjs forces CJS mode in ESM workspaces)
     const cjsContent = getWrittenScriptContent("metadata-updater.cjs");
@@ -1063,10 +1073,7 @@ describe("setupWorkspaceHooks on win32", () => {
   });
 
   it("uses node command in settings.json hook command on Windows", async () => {
-    await agent.setupWorkspaceHooks!(
-      "C:\\\\Users\\\\dev\\\\workspace",
-      {} as WorkspaceHooksConfig,
-    );
+    await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     const hookCommand = getWrittenHookCommand();
     expect(hookCommand).toBe("node .claude/metadata-updater.cjs");
@@ -1074,10 +1081,7 @@ describe("setupWorkspaceHooks on win32", () => {
   });
 
   it("skips chmod on win32", async () => {
-    await agent.setupWorkspaceHooks!(
-      "C:\\\\Users\\\\dev\\\\workspace",
-      {} as WorkspaceHooksConfig,
-    );
+    await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     expect(mockChmod).not.toHaveBeenCalled();
   });
@@ -1119,10 +1123,7 @@ describe("setupWorkspaceHooks on win32", () => {
 
   it("does not add duplicate hook entry when called twice on Windows", async () => {
     // First call creates the hook
-    await agent.setupWorkspaceHooks!(
-      "C:\\\\Users\\\\dev\\\\workspace",
-      {} as WorkspaceHooksConfig,
-    );
+    await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     // Simulate second call: settings.json now contains the .cjs hook
     const firstSettings = mockWriteFile.mock.calls.find(
@@ -1134,10 +1135,7 @@ describe("setupWorkspaceHooks on win32", () => {
     mockIsWindows.mockReturnValue(true);
 
     // Second call — should UPDATE the existing hook, not add a duplicate
-    await agent.setupWorkspaceHooks!(
-      "C:\\\\Users\\\\dev\\\\workspace",
-      {} as WorkspaceHooksConfig,
-    );
+    await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     const secondSettings = mockWriteFile.mock.calls.find(
       ([path]: unknown[]) => typeof path === "string" && path.endsWith("settings.json"),
@@ -1146,9 +1144,9 @@ describe("setupWorkspaceHooks on win32", () => {
     const parsed = JSON.parse(secondSettings![1] as string);
     const hookEntries = parsed.hooks.PostToolUse as Array<{ hooks: Array<{ command: string }> }>;
     // Count all hook commands matching our metadata updater
-    const metadataHooks = hookEntries.flatMap((e) => e.hooks).filter(
-      (h) => h.command.includes("metadata-updater"),
-    );
+    const metadataHooks = hookEntries
+      .flatMap((e) => e.hooks)
+      .filter((h) => h.command.includes("metadata-updater"));
     // Must be exactly 1 — no duplicates
     expect(metadataHooks).toHaveLength(1);
   });

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -3,6 +3,7 @@ import {
   readLastJsonlEntry,
   normalizeAgentPermissionMode,
   isWindows,
+  PROCESS_PROBE_INDETERMINATE,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
   type Agent,
@@ -617,7 +618,7 @@ function extractCost(lines: JsonlLine[]): CostEstimate | undefined {
  * with many processes. The cache ensures `ps` is called at most once per TTL
  * window regardless of how many sessions are being enriched.
  */
-type ProcessListResult = string | "indeterminate";
+type ProcessListResult = string | typeof PROCESS_PROBE_INDETERMINATE;
 let psCache: {
   output: ProcessListResult;
   timestamp: number;
@@ -650,15 +651,15 @@ async function getCachedProcessList(): Promise<ProcessListResult> {
   })
     .then(({ stdout }) => {
       if (psCache?.promise === promise) {
-        psCache = { output: stdout || "indeterminate", timestamp: Date.now() };
+        psCache = { output: stdout || PROCESS_PROBE_INDETERMINATE, timestamp: Date.now() };
       }
-      return stdout || "indeterminate";
+      return stdout || PROCESS_PROBE_INDETERMINATE;
     })
     .catch(() => {
       if (psCache?.promise === promise) {
-        psCache = { output: "indeterminate", timestamp: Date.now() };
+        psCache = { output: PROCESS_PROBE_INDETERMINATE, timestamp: Date.now() };
       }
-      return "indeterminate" as const;
+      return PROCESS_PROBE_INDETERMINATE;
     });
 
   // Store the in-flight promise so concurrent callers share it
@@ -671,7 +672,9 @@ async function getCachedProcessList(): Promise<ProcessListResult> {
  * Check if a process named "claude" is running in the given runtime handle's context.
  * Uses ps to find processes by TTY (for tmux) or by PID.
  */
-async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null | "indeterminate"> {
+async function findClaudeProcess(
+  handle: RuntimeHandle,
+): Promise<number | null | typeof PROCESS_PROBE_INDETERMINATE> {
   try {
     // For tmux runtime, get the pane TTY and find claude on it
     if (handle.runtimeName === "tmux" && handle.id) {
@@ -690,7 +693,7 @@ async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null |
       if (ttys.length === 0) return null;
 
       const psOut = await getCachedProcessList();
-      if (psOut === "indeterminate") return "indeterminate";
+      if (psOut === PROCESS_PROBE_INDETERMINATE) return PROCESS_PROBE_INDETERMINATE;
 
       const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
       // Match "claude" as a word boundary — prevents false positives on
@@ -726,7 +729,7 @@ async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null |
     // No reliable way to identify the correct process for this session
     return null;
   } catch {
-    return "indeterminate";
+    return PROCESS_PROBE_INDETERMINATE;
   }
 }
 
@@ -946,7 +949,7 @@ function createClaudeCodeAgent(): Agent {
 
     async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       const pid = await findClaudeProcess(handle);
-      if (pid === "indeterminate") return "indeterminate";
+      if (pid === PROCESS_PROBE_INDETERMINATE) return PROCESS_PROBE_INDETERMINATE;
       return pid !== null;
     },
 
@@ -960,7 +963,7 @@ function createClaudeCodeAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (running === "indeterminate") return null;
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // Process is running - check JSONL session file for activity

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -13,6 +13,7 @@ import {
   type CostEstimate,
   type PluginModule,
   type ProjectConfig,
+  type ProcessProbeResult,
   type RuntimeHandle,
   type Session,
   type WorkspaceHooksConfig,
@@ -616,7 +617,12 @@ function extractCost(lines: JsonlLine[]): CostEstimate | undefined {
  * with many processes. The cache ensures `ps` is called at most once per TTL
  * window regardless of how many sessions are being enriched.
  */
-let psCache: { output: string; timestamp: number; promise?: Promise<string> } | null = null;
+type ProcessListResult = string | "indeterminate";
+let psCache: {
+  output: ProcessListResult;
+  timestamp: number;
+  promise?: Promise<ProcessListResult>;
+} | null = null;
 const PS_CACHE_TTL_MS = 5_000;
 
 /** Reset the ps cache. Exported for testing only. */
@@ -624,7 +630,7 @@ export function resetPsCache(): void {
   psCache = null;
 }
 
-async function getCachedProcessList(): Promise<string> {
+async function getCachedProcessList(): Promise<ProcessListResult> {
   // ps -eo is a Unix-only command; on Windows the tmux branch is never taken
   // in normal operation, but guard here to avoid a spurious spawn error if
   // a stale tmux handle is encountered.
@@ -640,41 +646,40 @@ async function getCachedProcessList(): Promise<string> {
   // Guard both callbacks so they only update psCache if it still belongs to
   // this request — a newer request may have replaced it while we were waiting.
   const promise = execFileAsync("ps", ["-eo", "pid,tty,args"], {
-    timeout: 5_000,
-  }).then(({ stdout }) => {
-    if (psCache?.promise === promise) {
-      psCache = { output: stdout, timestamp: Date.now() };
-    }
-    return stdout;
-  });
+    timeout: 30_000,
+  })
+    .then(({ stdout }) => {
+      if (psCache?.promise === promise) {
+        psCache = { output: stdout || "indeterminate", timestamp: Date.now() };
+      }
+      return stdout || "indeterminate";
+    })
+    .catch(() => {
+      if (psCache?.promise === promise) {
+        psCache = { output: "indeterminate", timestamp: Date.now() };
+      }
+      return "indeterminate" as const;
+    });
 
   // Store the in-flight promise so concurrent callers share it
   psCache = { output: "", timestamp: now, promise };
 
-  try {
-    return await promise;
-  } catch {
-    // On failure, clear cache so the next caller retries — but only if
-    // psCache still points to this request (avoid clobbering a newer entry)
-    if (psCache?.promise === promise) {
-      psCache = null;
-    }
-    return "";
-  }
+  return promise;
 }
 
 /**
  * Check if a process named "claude" is running in the given runtime handle's context.
  * Uses ps to find processes by TTY (for tmux) or by PID.
  */
-async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null> {
+async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null | "indeterminate"> {
   try {
     // For tmux runtime, get the pane TTY and find claude on it
     if (handle.runtimeName === "tmux" && handle.id) {
+      if (isWindows()) return null;
       const { stdout: ttyOut } = await execFileAsync(
         "tmux",
         ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
-        { timeout: 5_000 },
+        { timeout: 30_000 },
       );
       // Iterate all pane TTYs (multi-pane sessions) — succeed on any match
       const ttys = ttyOut
@@ -685,7 +690,7 @@ async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null> 
       if (ttys.length === 0) return null;
 
       const psOut = await getCachedProcessList();
-      if (!psOut) return null;
+      if (psOut === "indeterminate") return "indeterminate";
 
       const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
       // Match "claude" as a word boundary — prevents false positives on
@@ -721,7 +726,7 @@ async function findClaudeProcess(handle: RuntimeHandle): Promise<number | null> 
     // No reliable way to identify the correct process for this session
     return null;
   } catch {
-    return null;
+    return "indeterminate";
   }
 }
 
@@ -939,8 +944,9 @@ function createClaudeCodeAgent(): Agent {
       return classifyTerminalOutput(terminalOutput);
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       const pid = await findClaudeProcess(handle);
+      if (pid === "indeterminate") return "indeterminate";
       return pid !== null;
     },
 
@@ -954,6 +960,7 @@ function createClaudeCodeAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === "indeterminate") return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // Process is running - check JSONL session file for activity

--- a/packages/plugins/agent-codex/CHANGELOG.md
+++ b/packages/plugins/agent-codex/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-agent-codex
 
+## 0.8.0
+
+### Minor Changes
+
+- Distinguish indeterminate agent process probes from definitive process-missing results, and raise ps probe timeouts to avoid bulk runtime_lost terminations when ps or tmux cannot return a reliable verdict.
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/agent-codex/package.json
+++ b/packages/plugins/agent-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-codex",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: OpenAI Codex CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -479,9 +479,18 @@ describe("isProcessRunning", () => {
     expect(mockExecFileAsync).not.toHaveBeenCalled();
   });
 
-  it("returns false on tmux command failure", async () => {
+  it("returns indeterminate on tmux command failure", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("tmux not running"));
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns indeterminate when ps command fails", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") return Promise.reject(new Error("ps timed out"));
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
   });
 
   it("returns true when PID exists but throws EPERM", async () => {
@@ -639,11 +648,17 @@ describe("getActivityState", () => {
   });
 
   it("returns exited when process is not running", async () => {
-    mockExecFileAsync.mockRejectedValue(new Error("tmux not running"));
+    mockTmuxWithProcess("codex", false);
     const session = makeSession({ runtimeHandle: makeTmuxHandle() });
     const result = await agent.getActivityState(session);
     expect(result?.state).toBe("exited");
     expect(result?.timestamp).toBeInstanceOf(Date);
+  });
+
+  it("returns null when process probe is indeterminate", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux not running"));
+    const session = makeSession({ runtimeHandle: makeTmuxHandle() });
+    await expect(agent.getActivityState(session)).resolves.toBeNull();
   });
 
   it("returns null when process is running but no workspacePath", async () => {

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -9,6 +9,7 @@ import {
   getActivityFallbackState,
   recordTerminalActivity,
   isWindows,
+  PROCESS_PROBE_INDETERMINATE,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -600,7 +601,7 @@ function createCodexAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (running === "indeterminate") return null;
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       if (!session.workspacePath) return null;
@@ -722,7 +723,7 @@ function createCodexAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
-          if (!psOut) return "indeterminate";
+          if (!psOut) return PROCESS_PROBE_INDETERMINATE;
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)codex(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -752,7 +753,7 @@ function createCodexAgent(): Agent {
 
         return false;
       } catch {
-        return "indeterminate";
+        return PROCESS_PROBE_INDETERMINATE;
       }
     },
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -16,6 +16,7 @@ import {
   type ActivityDetection,
   type CostEstimate,
   type PluginModule,
+  type ProcessProbeResult,
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
@@ -599,6 +600,7 @@ function createCodexAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === "indeterminate") return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       if (!session.workspacePath) return null;
@@ -700,7 +702,7 @@ function createCodexAgent(): Agent {
       );
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       try {
         if (handle.runtimeName === "tmux" && handle.id) {
           // ps -eo is Unix-only; guard against stale tmux handles on Windows
@@ -720,6 +722,7 @@ function createCodexAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
+          if (!psOut) return "indeterminate";
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)codex(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -749,7 +752,7 @@ function createCodexAgent(): Agent {
 
         return false;
       } catch {
-        return false;
+        return "indeterminate";
       }
     },
 

--- a/packages/plugins/agent-cursor/CHANGELOG.md
+++ b/packages/plugins/agent-cursor/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-cursor
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/agent-cursor/package.json
+++ b/packages/plugins/agent-cursor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-cursor",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: Cursor CLI",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-kimicode/CHANGELOG.md
+++ b/packages/plugins/agent-kimicode/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-agent-kimicode
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/agent-kimicode/package.json
+++ b/packages/plugins/agent-kimicode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-kimicode",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: Kimi Code CLI (MoonshotAI)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/CHANGELOG.md
+++ b/packages/plugins/agent-opencode/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @aoagents/ao-plugin-agent-opencode
 
+## 0.8.0
+
+### Minor Changes
+
+- Distinguish indeterminate agent process probes from definitive process-missing results, and raise ps probe timeouts to avoid bulk runtime_lost terminations when ps or tmux cannot return a reliable verdict.
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/agent-opencode/package.json
+++ b/packages/plugins/agent-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-opencode",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Agent plugin: OpenCode",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-opencode/src/index.test.ts
+++ b/packages/plugins/agent-opencode/src/index.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createActivitySignal, type Session, type RuntimeHandle, type AgentLaunchConfig } from "@aoagents/ao-core";
+import {
+  createActivitySignal,
+  type Session,
+  type RuntimeHandle,
+  type AgentLaunchConfig,
+} from "@aoagents/ao-core";
 
 const {
   mockAppendActivityEntry,
@@ -49,7 +54,12 @@ vi.mock("node:child_process", () => ({
   },
 }));
 
-import { create, manifest, default as defaultExport, resetOpenCodeSessionListCache } from "./index.js";
+import {
+  create,
+  manifest,
+  default as defaultExport,
+  resetOpenCodeSessionListCache,
+} from "./index.js";
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -192,9 +202,7 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ subagent: "sisyphus", prompt: "fix bug" }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'");
     expect(cmd).toContain(
       "exec opencode --session \"$SES_ID\" --prompt 'fix bug' --agent 'sisyphus'",
     );
@@ -339,9 +347,7 @@ describe("getLaunchCommand", () => {
         prompt: "fix the bug",
       }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'");
     expect(cmd).toContain(
       `exec opencode --session "$SES_ID" --prompt 'fix the bug' --agent 'sisyphus'`,
     );
@@ -368,9 +374,7 @@ describe("getLaunchCommand", () => {
         prompt: "fix the bug",
       }),
     );
-    expect(cmd).toContain(
-      "opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'",
-    );
+    expect(cmd).toContain("opencode run --format json --title 'AO:sess-1' --agent 'sisyphus'");
     expect(cmd).toContain(
       `exec opencode --session "$SES_ID" --prompt 'fix the bug' --agent 'sisyphus'`,
     );
@@ -501,9 +505,18 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(handle)).toBe(false);
   });
 
-  it("returns false on tmux command failure", async () => {
+  it("returns indeterminate on tmux command failure", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("tmux not running"));
-    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns indeterminate when ps command fails", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") return Promise.reject(new Error("ps timed out"));
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
   });
 
   it("returns true when PID exists but throws EPERM", async () => {
@@ -778,10 +791,13 @@ describe("getRestoreCommand", () => {
 
   it("returns null when no session ID found", async () => {
     mockExecFileAsync.mockRejectedValue(new Error("opencode not found"));
-    const cmd = await agent.getRestoreCommand!(
-      makeSession({ metadata: {} }),
-      { name: "proj", repo: "o/r", path: "/p", defaultBranch: "main", sessionPrefix: "p" },
-    );
+    const cmd = await agent.getRestoreCommand!(makeSession({ metadata: {} }), {
+      name: "proj",
+      repo: "o/r",
+      path: "/p",
+      defaultBranch: "main",
+      sessionPrefix: "p",
+    });
     expect(cmd).toBeNull();
   });
 
@@ -796,10 +812,13 @@ describe("getRestoreCommand", () => {
       return Promise.reject(new Error("unexpected"));
     });
 
-    const cmd = await agent.getRestoreCommand!(
-      makeSession({ metadata: {} }),
-      { name: "proj", repo: "o/r", path: "/p", defaultBranch: "main", sessionPrefix: "p" },
-    );
+    const cmd = await agent.getRestoreCommand!(makeSession({ metadata: {} }), {
+      name: "proj",
+      repo: "o/r",
+      path: "/p",
+      defaultBranch: "main",
+      sessionPrefix: "p",
+    });
     expect(cmd).toBe("opencode --session 'ses_found'");
   });
 });
@@ -991,9 +1010,7 @@ describe("getActivityState with activity JSONL", () => {
       modifiedAt: new Date(),
     });
 
-    const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle() }),
-    );
+    const result = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(result?.state).toBe("waiting_input");
   });
 
@@ -1004,9 +1021,7 @@ describe("getActivityState with activity JSONL", () => {
       modifiedAt: new Date(),
     });
 
-    const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle() }),
-    );
+    const result = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
     expect(result?.state).toBe("blocked");
   });
 
@@ -1024,7 +1039,11 @@ describe("getActivityState with activity JSONL", () => {
       if (cmd === "opencode") {
         return Promise.resolve({
           stdout: JSON.stringify([
-            { id: "ses_abc123", title: "AO:test-1", updated: new Date(Date.now() - 5_000).toISOString() },
+            {
+              id: "ses_abc123",
+              title: "AO:test-1",
+              updated: new Date(Date.now() - 5_000).toISOString(),
+            },
           ]),
           stderr: "",
         });
@@ -1033,7 +1052,10 @@ describe("getActivityState with activity JSONL", () => {
     });
 
     const result = await agent.getActivityState(
-      makeSession({ runtimeHandle: makeTmuxHandle(), metadata: { opencodeSessionId: "ses_abc123" } }),
+      makeSession({
+        runtimeHandle: makeTmuxHandle(),
+        metadata: { opencodeSessionId: "ses_abc123" },
+      }),
       60_000,
     );
     expect(result?.state).toBe("active");
@@ -1067,7 +1089,11 @@ describe("getActivityState with activity JSONL", () => {
   it("falls back to JSONL entry with age decay — old entry becomes idle", async () => {
     mockTmuxWithProcess("opencode");
     mockReadLastActivityEntry.mockResolvedValueOnce({
-      entry: { ts: new Date(Date.now() - 120_000).toISOString(), state: "active", source: "terminal" },
+      entry: {
+        ts: new Date(Date.now() - 120_000).toISOString(),
+        state: "active",
+        source: "terminal",
+      },
       modifiedAt: new Date(Date.now() - 120_000),
     });
     mockExecFileAsync.mockImplementation((cmd: string) => {

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -8,6 +8,7 @@ import {
   recordTerminalActivity,
   asValidOpenCodeSessionId,
   isWindows,
+  PROCESS_PROBE_INDETERMINATE,
   getCachedOpenCodeSessionList,
   getOpenCodeChildEnv,
   ensureOpenCodeTmpDir,
@@ -300,7 +301,7 @@ function createOpenCodeAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (running === "indeterminate") return null;
+      if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // 1. Check AO activity JSONL first (written by recordActivity from terminal output).
@@ -363,7 +364,7 @@ function createOpenCodeAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
-          if (!psOut) return "indeterminate";
+          if (!psOut) return PROCESS_PROBE_INDETERMINATE;
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)opencode(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -393,7 +394,7 @@ function createOpenCodeAgent(): Agent {
 
         return false;
       } catch {
-        return "indeterminate";
+        return PROCESS_PROBE_INDETERMINATE;
       }
     },
 

--- a/packages/plugins/agent-opencode/src/index.ts
+++ b/packages/plugins/agent-opencode/src/index.ts
@@ -18,6 +18,7 @@ import {
   type ActivityDetection,
   type ActivityState,
   type PluginModule,
+  type ProcessProbeResult,
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
@@ -299,6 +300,7 @@ function createOpenCodeAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
+      if (running === "indeterminate") return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
       // 1. Check AO activity JSONL first (written by recordActivity from terminal output).
@@ -341,7 +343,7 @@ function createOpenCodeAgent(): Agent {
       );
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       try {
         if (handle.runtimeName === "tmux" && handle.id) {
           // tmux and ps are Unix-only; guard before any tmux calls on Windows.
@@ -361,6 +363,7 @@ function createOpenCodeAgent(): Agent {
           const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
             timeout: 30_000,
           });
+          if (!psOut) return "indeterminate";
           const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
           const processRe = /(?:^|\/)opencode(?:\s|$)/;
           for (const line of psOut.split("\n")) {
@@ -390,7 +393,7 @@ function createOpenCodeAgent(): Agent {
 
         return false;
       } catch {
-        return false;
+        return "indeterminate";
       }
     },
 

--- a/packages/plugins/notifier-composio/CHANGELOG.md
+++ b/packages/plugins/notifier-composio/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-composio
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/notifier-composio/package.json
+++ b/packages/plugins/notifier-composio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-composio",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: Composio unified notifications (Slack, Discord, email)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-desktop/CHANGELOG.md
+++ b/packages/plugins/notifier-desktop/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-desktop
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/notifier-desktop/package.json
+++ b/packages/plugins/notifier-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-desktop",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: OS desktop notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-discord/CHANGELOG.md
+++ b/packages/plugins/notifier-discord/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-discord
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-discord/package.json
+++ b/packages/plugins/notifier-discord/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-discord",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: Discord webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-openclaw/CHANGELOG.md
+++ b/packages/plugins/notifier-openclaw/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-openclaw
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/notifier-openclaw/package.json
+++ b/packages/plugins/notifier-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-openclaw",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: OpenClaw webhook notifications",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-slack/CHANGELOG.md
+++ b/packages/plugins/notifier-slack/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-slack
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/notifier-slack/package.json
+++ b/packages/plugins/notifier-slack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-slack",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: Slack",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/notifier-webhook/CHANGELOG.md
+++ b/packages/plugins/notifier-webhook/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-notifier-webhook
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/notifier-webhook/package.json
+++ b/packages/plugins/notifier-webhook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-notifier-webhook",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Notifier plugin: generic webhook",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-process/CHANGELOG.md
+++ b/packages/plugins/runtime-process/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-runtime-process
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/runtime-process/package.json
+++ b/packages/plugins/runtime-process/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-process",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Runtime plugin: child processes",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/runtime-tmux/CHANGELOG.md
+++ b/packages/plugins/runtime-tmux/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-runtime-tmux
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/runtime-tmux/package.json
+++ b/packages/plugins/runtime-tmux/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-runtime-tmux",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Runtime plugin: tmux sessions",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-github/CHANGELOG.md
+++ b/packages/plugins/scm-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-scm-github
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/scm-github/package.json
+++ b/packages/plugins/scm-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-github",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SCM plugin: GitHub (PRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/scm-gitlab/CHANGELOG.md
+++ b/packages/plugins/scm-gitlab/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-scm-gitlab
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/scm-gitlab/package.json
+++ b/packages/plugins/scm-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-scm-gitlab",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "SCM plugin: GitLab (MRs, CI, reviews)",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-iterm2/CHANGELOG.md
+++ b/packages/plugins/terminal-iterm2/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-terminal-iterm2
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/terminal-iterm2/package.json
+++ b/packages/plugins/terminal-iterm2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-iterm2",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Terminal plugin: macOS iTerm2",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/terminal-web/CHANGELOG.md
+++ b/packages/plugins/terminal-web/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-terminal-web
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/terminal-web/package.json
+++ b/packages/plugins/terminal-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-terminal-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Terminal plugin: xterm.js web terminal",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-github/CHANGELOG.md
+++ b/packages/plugins/tracker-github/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-tracker-github
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/tracker-github/package.json
+++ b/packages/plugins/tracker-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-github",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Tracker plugin: GitHub Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-gitlab/CHANGELOG.md
+++ b/packages/plugins/tracker-gitlab/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @aoagents/ao-plugin-tracker-gitlab
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+  - @aoagents/ao-plugin-scm-gitlab@0.8.0
+
 ## 0.7.0
 
 ### Patch Changes

--- a/packages/plugins/tracker-gitlab/package.json
+++ b/packages/plugins/tracker-gitlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-gitlab",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Tracker plugin: GitLab Issues",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/tracker-linear/CHANGELOG.md
+++ b/packages/plugins/tracker-linear/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-tracker-linear
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/tracker-linear/package.json
+++ b/packages/plugins/tracker-linear/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-tracker-linear",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Tracker plugin: Linear",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-clone/CHANGELOG.md
+++ b/packages/plugins/workspace-clone/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-workspace-clone
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/workspace-clone/package.json
+++ b/packages/plugins/workspace-clone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-clone",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Workspace plugin: git clone",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/workspace-worktree/CHANGELOG.md
+++ b/packages/plugins/workspace-worktree/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @aoagents/ao-plugin-workspace-worktree
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes

--- a/packages/plugins/workspace-worktree/package.json
+++ b/packages/plugins/workspace-worktree/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-workspace-worktree",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Workspace plugin: git worktrees",
   "license": "MIT",
   "type": "module",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @aoagents/ao-web
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies
+  - @aoagents/ao-core@0.8.0
+  - @aoagents/ao-plugin-agent-claude-code@0.8.0
+  - @aoagents/ao-plugin-agent-codex@0.8.0
+  - @aoagents/ao-plugin-agent-opencode@0.8.0
+  - @aoagents/ao-plugin-agent-cursor@0.8.0
+  - @aoagents/ao-plugin-agent-kimicode@0.8.0
+  - @aoagents/ao-plugin-runtime-process@0.8.0
+  - @aoagents/ao-plugin-runtime-tmux@0.8.0
+  - @aoagents/ao-plugin-scm-github@0.8.0
+  - @aoagents/ao-plugin-tracker-github@0.8.0
+  - @aoagents/ao-plugin-tracker-linear@0.8.0
+  - @aoagents/ao-plugin-workspace-worktree@0.8.0
+
 ## 0.7.0
 
 ### Minor Changes
@@ -41,14 +59,14 @@
   - **Cron-driven nightly canary.** `.github/workflows/canary.yml` triggers via
     `schedule: '0 18 * * 5,6,0,1,2'` (23:30 IST Fri–Tue) plus `workflow_dispatch`.
     Bake window (Wed–Thu) pauses scheduled nightlies; the captain re-cuts via
-    workflow_dispatch when a fix lands. Stable `release.yml` publishes via
+    workflow*dispatch when a fix lands. Stable `release.yml` publishes via
     `changesets/action`. `.changeset/config.json` adds the snapshot template
     (`{tag}-{commit}`). `@aoagents/ao-web` stays in the linked group and ships
-    alongside `@aoagents/ao-cli` (it's a workspace:_ runtime dep, so marking it
+    alongside `@aoagents/ao-cli` (it's a workspace:* runtime dep, so marking it
     private would 404 every `npm install -g @aoagents/ao` after publish).
     `scripts/check-publishable-deps.mjs` runs in both release.yml and canary.yml
     before the publish step and fails CI if a publishable package depends on a
-    `private: true` package via workspace:_.
+    `private: true` package via workspace:\_.
   - **Update channels.** New `updateChannel` field in the global config schema
     (`stable | nightly | manual`, default `manual` so existing users see no
     surprise installs). `update-check.ts` reads `dist-tags[channel]` from the

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Web dashboard for agent-orchestrator",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Closes #1838.

## Summary
- Adds a tri-state agent process probe model via `ProcessProbeResult = boolean | "indeterminate"` on the core `Agent.isProcessRunning` interface.
- Updates claude-code, codex, aider, and opencode agents so:
  - `ps` OK + regex match → `true` (alive)
  - `ps` OK + regex miss → `false` (dead)
  - `ps`/`tmux` failure or empty process-list output → `"indeterminate"` (no verdict)
- Extends claude-code's shared `ps` cache to cache failed process-list probes as `indeterminate`, so every per-session probe sharing that pass gets the same no-verdict result instead of independently collapsing to dead.
- Raises the claude-code `ps` and `tmux list-panes` timeouts from 5s to 30s; the other three affected plugins were already at 30s for their `ps` probes on current `main`.
- Makes lifecycle/session-manager callers treat indeterminate as a no-op verdict: do not write `runtime_lost`, do not mutate persisted lifecycle metadata, and do not restore/terminate based on that single failed probe.
- Updates integration tests to compare explicitly against `true`/`false` so `"indeterminate"` is never treated as truthy liveness.

## Before / after for the repro
Before: one slow or failed shared `ps -eo pid,tty,args` call was swallowed as `null`/`false`, so a single `sm.list()` pass could persist `state: terminated / reason: runtime_lost` across all active sessions.

After: the same slow/failed `ps` call returns `"indeterminate"`; lifecycle and list enrichment skip the write for that pass and leave existing runtime/session lifecycle metadata untouched.

## Version bump rationale
Ran `pnpm changeset version` after adding a minor changeset for the affected packages. Because this repo links package versions in `.changeset/config.json`, the release train package versions moved from `0.7.0` to `0.8.0`; the affected core/agent package versions and changelogs are included for install verification.

## Verification
- `pnpm install` (completed; local Node 25 caused `better-sqlite3` native rebuild to fail during optional install output, but install exited 0)
- `pnpm build` ✅
- `pnpm typecheck` ✅
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/lifecycle-manager.test.ts src/__tests__/session-manager/query.test.ts` ✅
- `pnpm --filter @aoagents/ao-plugin-agent-claude-code test` ✅
- `pnpm --filter @aoagents/ao-plugin-agent-codex test` ✅
- `pnpm --filter @aoagents/ao-plugin-agent-aider test` ✅
- `pnpm --filter @aoagents/ao-plugin-agent-opencode test` ✅
- `pnpm test --filter @aoagents/ao-core --filter @aoagents/ao-plugin-agent-claude-code --filter @aoagents/ao-plugin-agent-codex --filter @aoagents/ao-plugin-agent-aider --filter @aoagents/ao-plugin-agent-opencode` ⚠️ blocked locally before plugin packages by `packages/core/src/__tests__/events-fts-integration.test.ts` because `better-sqlite3` bindings are unavailable under Node v25.9.0 (`Could not locate the bindings file`).
