### PR TITLE
test(cli): sandbox AO_GLOBAL_CONFIG in start.test.ts to stop ghost project leak

### DIFF
--- a/packages/cli/__tests__/commands/start.test.ts
+++ b/packages/cli/__tests__/commands/start.test.ts
@@ -282,6 +282,7 @@ import { registerStart, registerStop, autoCreateConfig } from "../../src/command
 let tmpDir: string;
 let program: Command;
 let cwdSpy: ReturnType<typeof vi.spyOn>;
+let origGlobalConfigEnv: string | undefined;
 
 function createSpawnChild(options?: {
   /** Emit `error` instead of `close`. */
@@ -319,6 +320,14 @@ function createSpawnChild(options?: {
 
 beforeEach(async () => {
   tmpDir = mkdtempSync(join(tmpdir(), "ao-start-test-"));
+
+  // Sandbox AO_GLOBAL_CONFIG into tmpDir so any code path that calls
+  // registerProjectInGlobalConfig (e.g. autoCreateConfig since PR #1766)
+  // cannot leak entries into the developer's real ~/.agent-orchestrator/config.yaml.
+  // Per-suite overrides further down still work — they save/restore against
+  // this value, and afterEach below restores the original.
+  origGlobalConfigEnv = process.env["AO_GLOBAL_CONFIG"];
+  process.env["AO_GLOBAL_CONFIG"] = join(tmpDir, "global-config.yaml");
 
   program = new Command();
   program.exitOverride();
@@ -437,6 +446,8 @@ beforeEach(async () => {
 afterEach(() => {
   if (cwdSpy) cwdSpy.mockRestore();
   rmSync(tmpDir, { recursive: true, force: true });
+  if (origGlobalConfigEnv === undefined) delete process.env["AO_GLOBAL_CONFIG"];
+  else process.env["AO_GLOBAL_CONFIG"] = origGlobalConfigEnv;
   vi.restoreAllMocks();
 });
 


### PR DESCRIPTION
## Summary

Closes #1841.

Stops the CLI test suite from leaking `ao-start-test-XXXXXX` entries into the contributor's real `~/.agent-orchestrator/config.yaml`. The leaks were surfacing in the dashboard sidebar as ghost projects with 0 sessions.

## Root cause

The `autoCreateConfig` describe block in `packages/cli/__tests__/commands/start.test.ts:2225-2273` calls `autoCreateConfig(tmpDir)` directly but never sets `AO_GLOBAL_CONFIG`. Once PR #1766 (`d95c9def`) added `registerProjectInGlobalConfig` to `autoCreateConfig` (`packages/cli/src/commands/start.ts:575-586`), every local run of the CLI test suite started writing a fresh `ao-start-test-XXXXXX_<hash>` entry into the real global config. `afterEach` removed `tmpDir` but never reverted the global-config mutation, so entries accumulated — one per test run.

Every other suite in `start.test.ts` (lines 2167, 2339, 2410, 2828) already redirects `AO_GLOBAL_CONFIG` into `tmpDir`. The `autoCreateConfig` suite was the only one missing that guard.

## Fix

Lift `AO_GLOBAL_CONFIG` sandboxing into the top-level `beforeEach`/`afterEach` of `start.test.ts` so that any future test which (intentionally or accidentally) reaches `registerProjectInGlobalConfig` writes into a `tmpDir`-scoped file instead of the real home dir. Per-suite overrides still work — they save/restore against this value.

This matches the spirit of CLAUDE.md's "fix the core first" principle: the test file's setup contract should make leaks structurally impossible, not rely on every test author remembering to add the guard.

## Test plan

- [x] `pnpm --filter @aoagents/ao-cli typecheck` — passes
- [x] `pnpm --filter @aoagents/ao-cli test -- start.test.ts` — 71 passed, 1 skipped
- [x] `pnpm lint` — no new warnings/errors
- [x] Manual: `grep -c ao-start-test ~/.agent-orchestrator/config.yaml` returns the same count before and after running the test suite (no new leaks)

## Cleanup for existing leaks

Run for each `ao-start-test-*` key in `~/.agent-orchestrator/config.yaml`:

```
ao project rm <projectId>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)