### PR TITLE
feat: add Grok agent plugin

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,6 +39,7 @@
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
+    "@aoagents/ao-plugin-agent-grok": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-notifier-composio": "workspace:*",

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -29,7 +29,7 @@ observability:
 
 defaults:
   runtime: tmux               # tmux | process
-  agent: claude-code          # claude-code | aider | codex | cursor | kimicode | opencode
+  agent: claude-code          # claude-code | aider | codex | cursor | kimicode | grok | opencode
   workspace: worktree         # worktree | clone
   notifiers:
     - desktop                 # desktop | discord | slack | webhook | composio | openclaw
@@ -182,7 +182,7 @@ notificationRouting:
 
 # ── Available plugins ───────────────────────────────────────────────
 #
-# Agent:     claude-code, aider, codex, cursor, kimicode, opencode
+# Agent:     claude-code, aider, codex, cursor, kimicode, grok, opencode
 # Runtime:   tmux, process
 # Workspace: worktree, clone
 # SCM:       github, gitlab

--- a/packages/cli/src/lib/detect-agent.ts
+++ b/packages/cli/src/lib/detect-agent.ts
@@ -20,6 +20,7 @@ const AGENT_PLUGINS: Array<{ name: string; pkg: string }> = [
   { name: "codex", pkg: "@aoagents/ao-plugin-agent-codex" },
   { name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
+  { name: "grok", pkg: "@aoagents/ao-plugin-agent-grok" },
   { name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
 ];
 

--- a/packages/cli/src/lib/plugins.ts
+++ b/packages/cli/src/lib/plugins.ts
@@ -4,6 +4,7 @@ import codexPlugin from "@aoagents/ao-plugin-agent-codex";
 import aiderPlugin from "@aoagents/ao-plugin-agent-aider";
 import cursorPlugin from "@aoagents/ao-plugin-agent-cursor";
 import kimicodePlugin from "@aoagents/ao-plugin-agent-kimicode";
+import grokPlugin from "@aoagents/ao-plugin-agent-grok";
 import opencodePlugin from "@aoagents/ao-plugin-agent-opencode";
 import githubSCMPlugin from "@aoagents/ao-plugin-scm-github";
 
@@ -13,6 +14,7 @@ const agentPlugins: Record<string, { create(): Agent }> = {
   aider: aiderPlugin,
   cursor: cursorPlugin,
   kimicode: kimicodePlugin,
+  grok: grokPlugin,
   opencode: opencodePlugin,
 };
 

--- a/packages/core/src/__tests__/plugin-registry.test.ts
+++ b/packages/core/src/__tests__/plugin-registry.test.ts
@@ -151,11 +151,13 @@ describe("loadBuiltins", () => {
 
     const fakeClaudeCode = makePlugin("agent", "claude-code");
     const fakeCodex = makePlugin("agent", "codex");
+    const fakeGrok = makePlugin("agent", "grok");
     const fakeOpenCode = makePlugin("agent", "opencode");
 
     await registry.loadBuiltins(undefined, async (pkg: string) => {
       if (pkg === "@aoagents/ao-plugin-agent-claude-code") return fakeClaudeCode;
       if (pkg === "@aoagents/ao-plugin-agent-codex") return fakeCodex;
+      if (pkg === "@aoagents/ao-plugin-agent-grok") return fakeGrok;
       if (pkg === "@aoagents/ao-plugin-agent-opencode") return fakeOpenCode;
       throw new Error(`Not found: ${pkg}`);
     });
@@ -163,10 +165,12 @@ describe("loadBuiltins", () => {
     const agents = registry.list("agent");
     expect(agents).toContainEqual(expect.objectContaining({ name: "claude-code", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "codex", slot: "agent" }));
+    expect(agents).toContainEqual(expect.objectContaining({ name: "grok", slot: "agent" }));
     expect(agents).toContainEqual(expect.objectContaining({ name: "opencode", slot: "agent" }));
 
     expect(registry.get("agent", "codex")).not.toBeNull();
     expect(registry.get("agent", "claude-code")).not.toBeNull();
+    expect(registry.get("agent", "grok")).not.toBeNull();
     expect(registry.get("agent", "opencode")).not.toBeNull();
   });
 

--- a/packages/core/src/__tests__/session-manager/spawn.test.ts
+++ b/packages/core/src/__tests__/session-manager/spawn.test.ts
@@ -1113,6 +1113,18 @@ describe("spawn", () => {
     expect(mockRuntime.sendMessage).not.toHaveBeenCalled();
   });
 
+  it("delivers prompt after launch for post-launch prompt agents", async () => {
+    (mockAgent as Agent & { promptDelivery: "post-launch" }).promptDelivery = "post-launch";
+    const sm = createSessionManager({ config, registry: mockRegistry });
+
+    await sm.spawn({ projectId: "my-app", prompt: "Fix the bug" });
+
+    expect(mockRuntime.sendMessage).toHaveBeenCalledWith(
+      makeHandle("rt-1"),
+      expect.stringContaining("Fix the bug"),
+    );
+  });
+
   it("writes worker system prompt to file and passes only explicit task prompt to agent", async () => {
     const sm = createSessionManager({ config, registry: mockRegistry });
 
@@ -2383,6 +2395,18 @@ describe("spawn", () => {
       expect(existsSync(promptFile)).toBe(true);
       const { readFileSync } = await import("node:fs");
       expect(readFileSync(promptFile, "utf-8")).toBe("You are the orchestrator.");
+    });
+
+    it("delivers only a begin trigger after launch for post-launch orchestrator agents", async () => {
+      (mockAgent as Agent & { promptDelivery: "post-launch" }).promptDelivery = "post-launch";
+      const sm = createSessionManager({ config, registry: mockRegistry });
+
+      await sm.spawnOrchestrator({
+        projectId: "my-app",
+        systemPrompt: "You are the orchestrator.",
+      });
+
+      expect(mockRuntime.sendMessage).toHaveBeenCalledWith(makeHandle("rt-1"), "Begin.");
     });
 
     it("persists displayName derived from the orchestrator system prompt", async () => {

--- a/packages/core/src/plugin-registry.ts
+++ b/packages/core/src/plugin-registry.ts
@@ -46,6 +46,7 @@ const BUILTIN_PLUGINS: Array<{ slot: PluginSlot; name: string; pkg: string }> = 
   { slot: "agent", name: "aider", pkg: "@aoagents/ao-plugin-agent-aider" },
   { slot: "agent", name: "cursor", pkg: "@aoagents/ao-plugin-agent-cursor" },
   { slot: "agent", name: "kimicode", pkg: "@aoagents/ao-plugin-agent-kimicode" },
+  { slot: "agent", name: "grok", pkg: "@aoagents/ao-plugin-agent-grok" },
   { slot: "agent", name: "opencode", pkg: "@aoagents/ao-plugin-agent-opencode" },
   // Workspaces
   { slot: "workspace", name: "worktree", pkg: "@aoagents/ao-plugin-workspace-worktree" },

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -1504,6 +1504,10 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         await plugins.agent.postLaunchSetup(session);
       }
 
+      if (plugins.agent.promptDelivery === "post-launch" && agentLaunchConfig.prompt) {
+        await plugins.runtime.sendMessage(handle, agentLaunchConfig.prompt);
+      }
+
       if (
         plugins.agent.name === "opencode" &&
         opencodeIssueSessionStrategy === "reuse" &&
@@ -1977,6 +1981,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
       if (plugins.agent.postLaunchSetup) {
         await plugins.agent.postLaunchSetup(session);
+      }
+
+      if (plugins.agent.promptDelivery === "post-launch" && orchestratorConfig.systemPrompt) {
+        // The orchestrator prompt is already passed via systemPromptFile in the launch command.
+        // Send only a minimal trigger so interactive post-launch agents start without
+        // receiving their system instructions again as a user message.
+        await plugins.runtime.sendMessage(handle, "Begin.");
       }
 
       if (

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -475,6 +475,13 @@ export interface Agent {
   /** Process name to look for (e.g. "claude", "codex", "aider") */
   readonly processName: string;
 
+  /**
+   * How the initial user prompt is delivered.
+   * Defaults to inline, meaning the agent embeds the prompt in getLaunchCommand().
+   * Use post-launch for interactive CLIs that must start first and receive input over stdin.
+   */
+  readonly promptDelivery?: "inline" | "post-launch";
+
   /** Get the shell command to launch this agent */
   getLaunchCommand(config: AgentLaunchConfig): string;
 

--- a/packages/plugins/agent-grok/package.json
+++ b/packages/plugins/agent-grok/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@aoagents/ao-plugin-agent-grok",
+  "version": "0.1.0",
+  "description": "Agent plugin: Grok",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ComposioHQ/agent-orchestrator.git",
+    "directory": "packages/plugins/agent-grok"
+  },
+  "homepage": "https://github.com/ComposioHQ/agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@aoagents/ao-core": "workspace:*",
+    "which": "^6.0.1"
+  },
+  "devDependencies": {
+    "@types/which": "^3.0.4",
+    "@types/node": "^25.2.3",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/plugins/agent-grok/src/__tests__/index.test.ts
+++ b/packages/plugins/agent-grok/src/__tests__/index.test.ts
@@ -189,7 +189,7 @@ describe("getLaunchCommand", () => {
     const cmd = agent.getLaunchCommand(
       makeLaunchConfig({ projectConfig: { ...makeLaunchConfig().projectConfig, agentConfig: {} } }),
     );
-    expect(cmd).toBe("grok --no-alt-screen");
+    expect(cmd).toBe("grok --no-alt-screen --worktree");
   });
 
   it("uses configured model and rules file when provided", () => {
@@ -199,7 +199,9 @@ describe("getLaunchCommand", () => {
         systemPromptFile: "/tmp/ao prompt.md",
       }),
     );
-    expect(cmd).toBe("grok --no-alt-screen --model 'grok-4.1' --rules '@/tmp/ao prompt.md'");
+    expect(cmd).toBe(
+      "grok --no-alt-screen --worktree --model 'grok-4.1' --rules '@/tmp/ao prompt.md'",
+    );
   });
 
   it("uses --resume when a configured Grok session id is present", () => {
@@ -495,5 +497,23 @@ describe("workspace hooks", () => {
   it("runs post-launch workspace hook setup", async () => {
     await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
     expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("waits for Grok worktree readiness before post-launch prompt delivery", async () => {
+    mockExecFileAsync.mockResolvedValue({
+      stdout: "Worktree ready: /Users/me/.grok/worktrees/project/smoke\n",
+      stderr: "",
+    });
+
+    await agent.postLaunchSetup?.(
+      makeSession({ workspacePath: "/workspace/test", runtimeHandle: makeTmuxHandle("ao-smoke") }),
+    );
+
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+    expect(mockExecFileAsync).toHaveBeenCalledWith(
+      "tmux",
+      ["capture-pane", "-t", "ao-smoke", "-p", "-S", "-120"],
+      { timeout: 5_000 },
+    );
   });
 });

--- a/packages/plugins/agent-grok/src/__tests__/index.test.ts
+++ b/packages/plugins/agent-grok/src/__tests__/index.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentLaunchConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const {
+  mockReadLastActivityEntry,
+  mockRecordTerminalActivity,
+  mockSetupPathWrapperWorkspace,
+  mockExecFileAsync,
+  mockWhichSync,
+} = vi.hoisted(() => ({
+  mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
+  mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
+  mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
+  mockExecFileAsync: vi.fn(),
+  mockWhichSync: vi.fn(),
+}));
+
+vi.mock("@aoagents/ao-core", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    readLastActivityEntry: mockReadLastActivityEntry,
+    recordTerminalActivity: mockRecordTerminalActivity,
+    setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+  };
+});
+
+vi.mock("which", () => ({
+  default: {
+    sync: mockWhichSync,
+  },
+  sync: mockWhichSync,
+}));
+
+vi.mock("node:child_process", () => ({
+  execFile: (...args: unknown[]) => {
+    const callback = args[args.length - 1];
+    const result = mockExecFileAsync(...args.slice(0, -1));
+    if (typeof callback === "function" && result && typeof result.then === "function") {
+      result.then(
+        (value: { stdout: string; stderr: string }) => callback(null, value),
+        (err: Error) => callback(err),
+      );
+    }
+  },
+}));
+
+import { create, detect, manifest, default as defaultExport } from "../index.js";
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: "test-1",
+    projectId: "test-project",
+    status: "working",
+    activity: "active",
+    activitySignal: {
+      state: "valid",
+      activity: "active",
+      timestamp: new Date(),
+      source: "runtime",
+    },
+    lifecycle: {} as Session["lifecycle"],
+    branch: "feat/test",
+    issueId: null,
+    pr: null,
+    workspacePath: "/workspace/test",
+    runtimeHandle: null,
+    agentInfo: null,
+    createdAt: new Date(),
+    lastActivityAt: new Date(),
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeTmuxHandle(id = "test-session"): RuntimeHandle {
+  return { id, runtimeName: "tmux", data: {} };
+}
+
+function makeProcessHandle(pid?: number | string): RuntimeHandle {
+  return { id: "proc-1", runtimeName: "process", data: pid !== undefined ? { pid } : {} };
+}
+
+function makeLaunchConfig(overrides: Partial<AgentLaunchConfig> = {}): AgentLaunchConfig {
+  return {
+    sessionId: "sess-1",
+    projectConfig: {
+      name: "my-project",
+      repo: "owner/repo",
+      path: "/workspace/repo",
+      defaultBranch: "main",
+      sessionPrefix: "my",
+      agentConfig: {
+        model: "grok-4.1-fast",
+      },
+    },
+    ...overrides,
+  };
+}
+
+function makeActivityResult(
+  state: "active" | "ready" | "idle" | "waiting_input" | "blocked",
+  ts: Date,
+): {
+  entry: {
+    state: "active" | "ready" | "idle" | "waiting_input" | "blocked";
+    ts: string;
+    source: string;
+  };
+  modifiedAt: Date;
+} {
+  return {
+    entry: {
+      state,
+      ts: ts.toISOString(),
+      source: "terminal",
+    },
+    modifiedAt: ts,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockWhichSync.mockReset();
+  mockExecFileAsync.mockReset();
+});
+
+describe("manifest", () => {
+  it("has correct Grok manifest", () => {
+    expect(manifest).toEqual({
+      name: pluginName,
+      slot: "agent",
+      description: packageJson.description,
+      version: packageJson.version,
+      displayName: "Grok",
+    });
+  });
+});
+
+describe("create", () => {
+  it("uses grok as process name and post-launch prompt mode", () => {
+    const agent = create();
+    expect(agent.name).toBe(pluginName);
+    expect(agent.processName).toBe(pluginName);
+    expect(agent.promptDelivery).toBe("post-launch");
+  });
+
+  it("exports plugin module shape", () => {
+    expect(defaultExport.manifest).toBe(manifest);
+    expect(typeof defaultExport.create).toBe("function");
+  });
+});
+
+describe("detect", () => {
+  it("returns true when which resolves", () => {
+    mockWhichSync.mockReturnValue("/usr/local/bin/grok");
+    expect(detect()).toBe(true);
+  });
+
+  it("returns false when which fails", () => {
+    mockWhichSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    expect(detect()).toBe(false);
+  });
+});
+
+describe("getLaunchCommand", () => {
+  const agent = create();
+
+  it("uses interactive launch without a session id", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({ projectConfig: { ...makeLaunchConfig().projectConfig, agentConfig: {} } }),
+    );
+    expect(cmd).toBe("grok --no-alt-screen");
+  });
+
+  it("uses configured model and rules file when provided", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        model: "grok-4.1",
+        systemPromptFile: "/tmp/ao prompt.md",
+      }),
+    );
+    expect(cmd).toBe("grok --no-alt-screen --model 'grok-4.1' --rules '@/tmp/ao prompt.md'");
+  });
+
+  it("uses --resume when a configured Grok session id is present", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { grokSessionId: "01HXGROKSESSION" },
+        },
+      }),
+    );
+    expect(cmd).toBe("grok --no-alt-screen --resume '01HXGROKSESSION'");
+  });
+
+  it("does not include prompt flags when prompt delivery is post-launch", () => {
+    const cmd = agent.getLaunchCommand(
+      makeLaunchConfig({
+        prompt: "Do work",
+        systemPrompt: "You are helpful",
+      }),
+    );
+    expect(cmd).toContain("--rules 'You are helpful'");
+    expect(cmd).not.toContain("-p");
+    expect(cmd).not.toContain("--single");
+    expect(cmd).not.toContain("--prompt");
+  });
+});
+
+describe("getEnvironment", () => {
+  const agent = create();
+
+  it("writes AO session keys and leaves shared wrapper paths to session-manager", () => {
+    const env = agent.getEnvironment(makeLaunchConfig());
+    expect(env["AO_SESSION_ID"]).toBe("sess-1");
+    expect(env["AO_ISSUE_ID"]).toBeUndefined();
+    expect(env["PATH"]).toBeUndefined();
+    expect(env["GH_PATH"]).toBeUndefined();
+    expect(env["GROK_SANDBOX"]).toBeUndefined();
+  });
+
+  it("includes AO_ISSUE_ID and GROK_SANDBOX when provided", () => {
+    const env = agent.getEnvironment(
+      makeLaunchConfig({
+        issueId: "INT-42",
+        projectConfig: {
+          ...makeLaunchConfig().projectConfig,
+          agentConfig: { grokSandbox: "workspace-write" },
+        },
+      }),
+    );
+    expect(env["AO_ISSUE_ID"]).toBe("INT-42");
+    expect(env["GROK_SANDBOX"]).toBe("workspace-write");
+  });
+});
+
+describe("isProcessRunning", () => {
+  const agent = create();
+
+  it("returns true when grok is on tmux pane", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps") {
+        return Promise.resolve({
+          stdout: "  PID TT       ARGS\n  789 ttys003  /Users/me/.grok/bin/grok\n",
+          stderr: "",
+        });
+      }
+      return Promise.reject(new Error("unexpected"));
+    });
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(true);
+  });
+
+  it("returns false when tmux process is missing", async () => {
+    mockExecFileAsync.mockImplementation((cmd: string) => {
+      if (cmd === "tmux") return Promise.resolve({ stdout: "/dev/ttys003\n", stderr: "" });
+      if (cmd === "ps")
+        return Promise.resolve({ stdout: "  PID TT      ARGS\n  789 ttys003  bash\n", stderr: "" });
+      return Promise.reject(new Error("unexpected"));
+    });
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
+  });
+
+  it("returns true when process handle pid is alive", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    expect(killSpy).toHaveBeenCalledWith(123, 0);
+    killSpy.mockRestore();
+  });
+
+  it("treats EPERM as running for process handles", async () => {
+    const err = Object.assign(new Error("EPERM"), { code: "EPERM" });
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw err;
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
+    killSpy.mockRestore();
+  });
+
+  it("returns false when process handle pid is dead", async () => {
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("ESRCH");
+    });
+    expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
+    killSpy.mockRestore();
+  });
+});
+
+describe("recordActivity", () => {
+  const agent = create();
+
+  it("classifies idle terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "foo\n› ");
+    expect(mockRecordTerminalActivity).toHaveBeenCalledWith(
+      "/workspace/test",
+      "foo\n› ",
+      expect.any(Function),
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("foo\n› ")).toBe("idle");
+  });
+
+  it("classifies active terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "Thinking through the plan");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Thinking through the plan")).toBe("active");
+  });
+
+  it("classifies waiting_input terminal output when recording activity", async () => {
+    await agent.recordActivity?.(
+      makeSession(),
+      "Signing in with Grok...\n\nOpen this URL to sign in:\n  https://auth.x.ai/oauth2/authorize?...",
+    );
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Allow this command? y/N:")).toBe("waiting_input");
+    expect(classify?.("Open this URL to sign in: https://auth.x.ai/oauth2/authorize")).toBe(
+      "waiting_input",
+    );
+  });
+
+  it("classifies blocked terminal output when recording activity", async () => {
+    await agent.recordActivity?.(makeSession(), "Error: Device not configured");
+    const classify = mockRecordTerminalActivity.mock.calls[0]?.[2] as
+      | ((output: string) => string)
+      | undefined;
+    expect(classify?.("Error: Device not configured")).toBe("blocked");
+  });
+
+  it("skips recording when workspacePath is missing", async () => {
+    await agent.recordActivity?.(makeSession({ workspacePath: null }), "still running");
+    expect(mockRecordTerminalActivity).not.toHaveBeenCalled();
+  });
+});
+
+describe("getActivityState", () => {
+  const agent = create();
+
+  it("falls back to exited when runtime handle is missing", async () => {
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: null }));
+    expect(state).toMatchObject({ state: "exited" });
+  });
+
+  it("returns waiting_input from recent activity JSONL", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("waiting_input", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("waiting_input");
+    killSpy.mockRestore();
+  });
+
+  it("returns blocked from recent activity JSONL", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("blocked", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("blocked");
+    expect(state?.timestamp.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns active from JSONL fallback", async () => {
+    const activityAt = new Date();
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("active");
+    expect(state?.timestamp.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("decays JSONL fallback state to idle when the entry is stale", async () => {
+    const activityAt = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    mockReadLastActivityEntry.mockResolvedValue(makeActivityResult("active", activityAt));
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state?.state).toBe("idle");
+    expect(state?.timestamp.toISOString()).toBe(activityAt.toISOString());
+    killSpy.mockRestore();
+  });
+
+  it("returns null when no activity data is available", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
+    const state = await agent.getActivityState(
+      makeSession({ runtimeHandle: makeProcessHandle(101) }),
+    );
+    expect(state).toBeNull();
+    killSpy.mockRestore();
+  });
+});
+
+describe("getSessionInfo", () => {
+  const agent = create();
+
+  it("returns null without Grok session metadata", async () => {
+    expect(await agent.getSessionInfo(makeSession())).toBeNull();
+  });
+
+  it("returns a known Grok session id from metadata", async () => {
+    const info = await agent.getSessionInfo(
+      makeSession({ metadata: { grokSessionId: "01HXGROKSESSION" } }),
+    );
+    expect(info).toEqual({
+      agentSessionId: "01HXGROKSESSION",
+      summary: null,
+    });
+  });
+});
+
+describe("getRestoreCommand", () => {
+  const agent = create();
+
+  it("returns null without Grok session metadata", async () => {
+    const cmd = await agent.getRestoreCommand?.(makeSession(), makeLaunchConfig().projectConfig);
+    expect(cmd).toBeNull();
+  });
+
+  it("builds restore command using the Grok session id", async () => {
+    const cmd = await agent.getRestoreCommand?.(
+      makeSession({ metadata: { grokSessionId: "01HXGROKSESSION" } }),
+      makeLaunchConfig({ model: "grok-4.1" }).projectConfig,
+    );
+    expect(cmd).toBe("grok --no-alt-screen --model 'grok-4.1-fast' --resume '01HXGROKSESSION'");
+  });
+});
+
+describe("workspace hooks", () => {
+  const agent = create();
+
+  it("sets up PATH wrapper workspace hooks", async () => {
+    await agent.setupWorkspaceHooks?.("/workspace/test", { dataDir: "/sessions" });
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+
+  it("runs post-launch workspace hook setup", async () => {
+    await agent.postLaunchSetup?.(makeSession({ workspacePath: "/workspace/test" }));
+    expect(mockSetupPathWrapperWorkspace).toHaveBeenCalledWith("/workspace/test");
+  });
+});

--- a/packages/plugins/agent-grok/src/__tests__/index.test.ts
+++ b/packages/plugins/agent-grok/src/__tests__/index.test.ts
@@ -19,12 +19,14 @@ const {
   mockSetupPathWrapperWorkspace,
   mockExecFileAsync,
   mockWhichSync,
+  mockIsWindows,
 } = vi.hoisted(() => ({
   mockReadLastActivityEntry: vi.fn().mockResolvedValue(null),
   mockRecordTerminalActivity: vi.fn().mockResolvedValue(undefined),
   mockSetupPathWrapperWorkspace: vi.fn().mockResolvedValue(undefined),
   mockExecFileAsync: vi.fn(),
   mockWhichSync: vi.fn(),
+  mockIsWindows: vi.fn(() => false),
 }));
 
 vi.mock("@aoagents/ao-core", async (importOriginal) => {
@@ -34,6 +36,7 @@ vi.mock("@aoagents/ao-core", async (importOriginal) => {
     readLastActivityEntry: mockReadLastActivityEntry,
     recordTerminalActivity: mockRecordTerminalActivity,
     setupPathWrapperWorkspace: mockSetupPathWrapperWorkspace,
+    isWindows: mockIsWindows,
   };
 });
 
@@ -135,6 +138,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockWhichSync.mockReset();
   mockExecFileAsync.mockReset();
+  mockIsWindows.mockReset();
+  mockIsWindows.mockReturnValue(false);
 });
 
 describe("manifest", () => {
@@ -278,6 +283,19 @@ describe("isProcessRunning", () => {
     expect(await agent.isProcessRunning(makeTmuxHandle())).toBe(false);
   });
 
+  it("returns indeterminate when tmux probing fails", async () => {
+    mockExecFileAsync.mockRejectedValue(new Error("tmux unavailable"));
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+  });
+
+  it("returns indeterminate for tmux handles on Windows", async () => {
+    mockIsWindows.mockReturnValue(true);
+
+    expect(await agent.isProcessRunning(makeTmuxHandle())).toBe("indeterminate");
+    expect(mockExecFileAsync).not.toHaveBeenCalled();
+  });
+
   it("returns true when process handle pid is alive", async () => {
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => true);
     expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(true);
@@ -295,8 +313,9 @@ describe("isProcessRunning", () => {
   });
 
   it("returns false when process handle pid is dead", async () => {
+    const err = Object.assign(new Error("ESRCH"), { code: "ESRCH" });
     const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
-      throw new Error("ESRCH");
+      throw err;
     });
     expect(await agent.isProcessRunning(makeProcessHandle(123))).toBe(false);
     killSpy.mockRestore();
@@ -418,6 +437,15 @@ describe("getActivityState", () => {
     );
     expect(state).toBeNull();
     killSpy.mockRestore();
+  });
+
+  it("treats indeterminate process probes as no process verdict", async () => {
+    mockReadLastActivityEntry.mockResolvedValue(null);
+    mockExecFileAsync.mockRejectedValue(new Error("tmux unavailable"));
+
+    const state = await agent.getActivityState(makeSession({ runtimeHandle: makeTmuxHandle() }));
+
+    expect(state).toBeNull();
   });
 });
 

--- a/packages/plugins/agent-grok/src/index.ts
+++ b/packages/plugins/agent-grok/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from "@aoagents/ao-core";
 import { execFile } from "node:child_process";
 import { createRequire } from "node:module";
+import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import which from "which";
 
@@ -39,6 +40,8 @@ const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
 
 const execFileAsync = promisify(execFile);
 const GROK_EXECUTABLE = "grok";
+const GROK_STARTUP_READY_TIMEOUT_MS = 30_000;
+const GROK_STARTUP_POLL_MS = 500;
 const ANSI_ESCAPE_RE = new RegExp(
   `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
   "g",
@@ -79,7 +82,11 @@ function getConfiguredSandbox(config: AgentLaunchConfig): string | null {
 }
 
 function buildGrokCommand(config: AgentLaunchConfig, sessionId?: string | null): string {
+  const restoreSessionId = sessionId ?? getConfiguredGrokSessionId(config);
   const parts = [GROK_EXECUTABLE, "--no-alt-screen"];
+  if (!restoreSessionId) {
+    parts.push("--worktree");
+  }
   const model = getConfiguredModel(config);
   if (model) {
     parts.push("--model", shellEscape(model));
@@ -89,11 +96,33 @@ function buildGrokCommand(config: AgentLaunchConfig, sessionId?: string | null):
   } else if (config.systemPrompt) {
     parts.push("--rules", shellEscape(config.systemPrompt));
   }
-  const restoreSessionId = sessionId ?? getConfiguredGrokSessionId(config);
   if (restoreSessionId) {
     parts.push("--resume", shellEscape(restoreSessionId));
   }
   return parts.join(" ");
+}
+
+async function captureTmuxOutput(handle: RuntimeHandle): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "tmux",
+    ["capture-pane", "-t", handle.id, "-p", "-S", "-120"],
+    { timeout: 5_000 },
+  );
+  return stdout;
+}
+
+async function waitForGrokWorktreeReady(session: Session): Promise<void> {
+  const handle = session.runtimeHandle;
+  if (!handle || handle.runtimeName !== "tmux" || !handle.id) return;
+  if (isWindows()) return;
+  if (asGrokSessionId(session.metadata?.grokSessionId)) return;
+
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < GROK_STARTUP_READY_TIMEOUT_MS) {
+    const output = await captureTmuxOutput(handle);
+    if (/Worktree ready:/i.test(output)) return;
+    await sleep(GROK_STARTUP_POLL_MS);
+  }
 }
 
 function classifyGrokTerminalOutput(terminalOutput: string): ActivityState {
@@ -264,8 +293,10 @@ function createGrokAgent(): Agent {
     },
 
     async postLaunchSetup(session: Session): Promise<void> {
-      if (!session.workspacePath) return;
-      await setupPathWrapperWorkspace(session.workspacePath);
+      if (session.workspacePath) {
+        await setupPathWrapperWorkspace(session.workspacePath);
+      }
+      await waitForGrokWorktreeReady(session);
     },
   };
 }

--- a/packages/plugins/agent-grok/src/index.ts
+++ b/packages/plugins/agent-grok/src/index.ts
@@ -1,0 +1,280 @@
+import {
+  DEFAULT_READY_THRESHOLD_MS,
+  DEFAULT_ACTIVE_WINDOW_MS,
+  shellEscape,
+  readLastActivityEntry,
+  checkActivityLogState,
+  getActivityFallbackState,
+  recordTerminalActivity,
+  setupPathWrapperWorkspace,
+  isWindows,
+  type Agent,
+  type AgentSessionInfo,
+  type AgentLaunchConfig,
+  type ActivityDetection,
+  type ActivityState,
+  type PluginModule,
+  type ProjectConfig,
+  type RuntimeHandle,
+  type Session,
+  type WorkspaceHooksConfig,
+} from "@aoagents/ao-core";
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { promisify } from "node:util";
+import which from "which";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as {
+  name: string;
+  version: string;
+  description: string;
+};
+const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
+const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
+  ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
+  : packageJson.name;
+
+const execFileAsync = promisify(execFile);
+const GROK_EXECUTABLE = "grok";
+const ANSI_ESCAPE_RE = new RegExp(
+  `${String.fromCharCode(27)}(?:[@-Z\\-_]|\\[[0-?]*[ -/]*[@-~])`,
+  "g",
+);
+const GROK_CONFIRM_PROMPT_RE =
+  /(?:allow|approve|do you want to continue|continue anyway|proceed).*(?:y\/n|yes\/no|\[[YyNn]\/ ?[YyNn]\]|\([YyNn]\/ ?[YyNn]\)|\?)\s*:?$/i;
+const GROK_AUTH_PROMPT_RE = /(?:sign in with grok|open this url to sign in|oauth2\/authorize)/i;
+
+interface GrokAgentConfig {
+  grokSessionId?: unknown;
+  model?: unknown;
+  grokSandbox?: unknown;
+}
+
+function asGrokSessionId(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (/\p{C}/u.test(trimmed)) return null;
+  return trimmed.length <= 512 ? trimmed : null;
+}
+
+function getConfiguredGrokSessionId(config: AgentLaunchConfig): string | null {
+  return asGrokSessionId(
+    (config.projectConfig.agentConfig as GrokAgentConfig | undefined)?.grokSessionId,
+  );
+}
+
+function getConfiguredModel(config: AgentLaunchConfig): string | null {
+  const model =
+    config.model ?? (config.projectConfig.agentConfig as GrokAgentConfig | undefined)?.model;
+  return typeof model === "string" && model.trim() ? model.trim() : null;
+}
+
+function getConfiguredSandbox(config: AgentLaunchConfig): string | null {
+  const sandbox = (config.projectConfig.agentConfig as GrokAgentConfig | undefined)?.grokSandbox;
+  return typeof sandbox === "string" && sandbox.trim() ? sandbox.trim() : null;
+}
+
+function buildGrokCommand(config: AgentLaunchConfig, sessionId?: string | null): string {
+  const parts = [GROK_EXECUTABLE, "--no-alt-screen"];
+  const model = getConfiguredModel(config);
+  if (model) {
+    parts.push("--model", shellEscape(model));
+  }
+  if (config.systemPromptFile) {
+    parts.push("--rules", shellEscape(`@${config.systemPromptFile}`));
+  } else if (config.systemPrompt) {
+    parts.push("--rules", shellEscape(config.systemPrompt));
+  }
+  const restoreSessionId = sessionId ?? getConfiguredGrokSessionId(config);
+  if (restoreSessionId) {
+    parts.push("--resume", shellEscape(restoreSessionId));
+  }
+  return parts.join(" ");
+}
+
+function classifyGrokTerminalOutput(terminalOutput: string): ActivityState {
+  const normalizedOutput = terminalOutput.replaceAll(ANSI_ESCAPE_RE, "").trim();
+  if (!normalizedOutput) return "idle";
+
+  const lines = normalizedOutput.split("\n").map((line) => line.trim());
+  const lastLine = lines[lines.length - 1] ?? "";
+  const lastNonEmptyLine = [...lines].reverse().find(Boolean) ?? "";
+
+  if (/^[>$#›]\s*$/.test(lastLine)) return "idle";
+  if (GROK_AUTH_PROMPT_RE.test(normalizedOutput)) return "waiting_input";
+  if (GROK_CONFIRM_PROMPT_RE.test(lastNonEmptyLine)) return "waiting_input";
+  if (/\b(error|failed|exception|not authenticated|device not configured)\b/i.test(lastLine))
+    return "blocked";
+
+  return "active";
+}
+
+export const manifest = {
+  name: pluginName,
+  slot: "agent" as const,
+  description: packageJson.description,
+  version: packageJson.version,
+  displayName: "Grok",
+};
+
+function createGrokAgent(): Agent {
+  return {
+    name: pluginName,
+    processName: pluginName,
+    promptDelivery: "post-launch",
+
+    getLaunchCommand(config: AgentLaunchConfig): string {
+      return buildGrokCommand(config);
+    },
+
+    getEnvironment(config: AgentLaunchConfig): Record<string, string> {
+      const env: Record<string, string> = {};
+      env["AO_SESSION_ID"] = config.sessionId;
+      if (config.issueId) {
+        env["AO_ISSUE_ID"] = config.issueId;
+      }
+
+      const sandbox = getConfiguredSandbox(config);
+      if (sandbox) {
+        env["GROK_SANDBOX"] = sandbox;
+      }
+
+      return env;
+    },
+
+    detectActivity(terminalOutput: string): ActivityState {
+      return classifyGrokTerminalOutput(terminalOutput);
+    },
+
+    async getActivityState(
+      session: Session,
+      readyThresholdMs?: number,
+    ): Promise<ActivityDetection | null> {
+      const threshold = readyThresholdMs ?? DEFAULT_READY_THRESHOLD_MS;
+      const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+
+      const exitedAt = new Date();
+      if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
+      const running = await this.isProcessRunning(session.runtimeHandle);
+      if (!running) return { state: "exited", timestamp: exitedAt };
+
+      let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
+      if (session.workspacePath) {
+        activityResult = await readLastActivityEntry(session.workspacePath);
+        const activityState = checkActivityLogState(activityResult);
+        if (activityState) return activityState;
+      }
+
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
+
+      return null;
+    },
+
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output: string) =>
+        classifyGrokTerminalOutput(output),
+      );
+    },
+
+    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+      try {
+        if (handle.runtimeName === "tmux" && handle.id) {
+          if (isWindows()) return false;
+          const { stdout: ttyOut } = await execFileAsync(
+            "tmux",
+            ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
+            { timeout: 30_000 },
+          );
+          const ttys = ttyOut
+            .trim()
+            .split("\n")
+            .map((t) => t.trim())
+            .filter(Boolean);
+          if (ttys.length === 0) return false;
+
+          const { stdout: psOut } = await execFileAsync("ps", ["-eo", "pid,tty,args"], {
+            timeout: 30_000,
+          });
+          const ttySet = new Set(ttys.map((t) => t.replace(/^\/dev\//, "")));
+          const processRe = /(?:^|[\s/])\.?grok(?:\s|$)/;
+          for (const line of psOut.split("\n")) {
+            const cols = line.trimStart().split(/\s+/);
+            if (cols.length < 3 || !ttySet.has(cols[1] ?? "")) continue;
+            const args = cols.slice(2).join(" ");
+            if (processRe.test(args)) {
+              return true;
+            }
+          }
+          return false;
+        }
+
+        const rawPid = handle.data["pid"];
+        const pid = typeof rawPid === "number" ? rawPid : Number(rawPid);
+        if (Number.isFinite(pid) && pid > 0) {
+          try {
+            process.kill(pid, 0);
+            return true;
+          } catch (err: unknown) {
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
+              return true;
+            }
+            return false;
+          }
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
+      const grokSessionId = asGrokSessionId(session.metadata?.grokSessionId);
+      if (!grokSessionId) return null;
+      return {
+        agentSessionId: grokSessionId,
+        summary: null,
+      };
+    },
+
+    async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
+      const grokSessionId = asGrokSessionId(session.metadata?.grokSessionId);
+      if (!grokSessionId) return null;
+      return buildGrokCommand(
+        {
+          sessionId: session.id,
+          projectConfig: project,
+          workspacePath: session.workspacePath ?? undefined,
+          issueId: session.issueId ?? undefined,
+        },
+        grokSessionId,
+      );
+    },
+
+    async setupWorkspaceHooks(workspacePath: string, _config: WorkspaceHooksConfig): Promise<void> {
+      await setupPathWrapperWorkspace(workspacePath);
+    },
+
+    async postLaunchSetup(session: Session): Promise<void> {
+      if (!session.workspacePath) return;
+      await setupPathWrapperWorkspace(session.workspacePath);
+    },
+  };
+}
+
+export function create(): Agent {
+  return createGrokAgent();
+}
+
+export function detect(): boolean {
+  try {
+    return Boolean(which.sync(GROK_EXECUTABLE));
+  } catch {
+    return false;
+  }
+}
+
+export default { manifest, create, detect } satisfies PluginModule<Agent>;

--- a/packages/plugins/agent-grok/src/index.ts
+++ b/packages/plugins/agent-grok/src/index.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
+  PROCESS_PROBE_INDETERMINATE,
   shellEscape,
   readLastActivityEntry,
   checkActivityLogState,
@@ -14,6 +15,7 @@ import {
   type ActivityDetection,
   type ActivityState,
   type PluginModule,
+  type ProcessProbeResult,
   type ProjectConfig,
   type RuntimeHandle,
   type Session,
@@ -158,7 +160,7 @@ function createGrokAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (!running) return { state: "exited", timestamp: exitedAt };
+      if (running === false) return { state: "exited", timestamp: exitedAt };
 
       let activityResult: Awaited<ReturnType<typeof readLastActivityEntry>> = null;
       if (session.workspacePath) {
@@ -180,10 +182,10 @@ function createGrokAgent(): Agent {
       );
     },
 
-    async isProcessRunning(handle: RuntimeHandle): Promise<boolean> {
+    async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       try {
         if (handle.runtimeName === "tmux" && handle.id) {
-          if (isWindows()) return false;
+          if (isWindows()) return PROCESS_PROBE_INDETERMINATE;
           const { stdout: ttyOut } = await execFileAsync(
             "tmux",
             ["list-panes", "-t", handle.id, "-F", "#{pane_tty}"],
@@ -222,12 +224,15 @@ function createGrokAgent(): Agent {
             if (err instanceof Error && (err as NodeJS.ErrnoException).code === "EPERM") {
               return true;
             }
-            return false;
+            if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ESRCH") {
+              return false;
+            }
+            return PROCESS_PROBE_INDETERMINATE;
           }
         }
         return false;
       } catch {
-        return false;
+        return PROCESS_PROBE_INDETERMINATE;
       }
     },
 

--- a/packages/plugins/agent-grok/tsconfig.json
+++ b/packages/plugins/agent-grok/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.node.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,6 +47,7 @@
     "@aoagents/ao-plugin-agent-claude-code": "workspace:*",
     "@aoagents/ao-plugin-agent-codex": "workspace:*",
     "@aoagents/ao-plugin-agent-cursor": "workspace:*",
+    "@aoagents/ao-plugin-agent-grok": "workspace:*",
     "@aoagents/ao-plugin-agent-kimicode": "workspace:*",
     "@aoagents/ao-plugin-agent-opencode": "workspace:*",
     "@aoagents/ao-plugin-runtime-process": "workspace:*",

--- a/packages/web/src/__tests__/services.test.ts
+++ b/packages/web/src/__tests__/services.test.ts
@@ -10,6 +10,7 @@ const {
   tmuxPlugin,
   claudePlugin,
   codexPlugin,
+  grokPlugin,
   opencodePlugin,
   worktreePlugin,
   scmPlugin,
@@ -44,6 +45,7 @@ const {
     tmuxPlugin: { manifest: { name: "tmux" } },
     claudePlugin: { manifest: { name: "claude-code" } },
     codexPlugin: { manifest: { name: "codex" } },
+    grokPlugin: { manifest: { name: "grok" } },
     opencodePlugin: { manifest: { name: "opencode" } },
     worktreePlugin: { manifest: { name: "worktree" } },
     scmPlugin: { manifest: { name: "github" } },
@@ -70,6 +72,7 @@ vi.mock("@aoagents/ao-core", () => ({
 vi.mock("@aoagents/ao-plugin-runtime-tmux", () => ({ default: tmuxPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-claude-code", () => ({ default: claudePlugin }));
 vi.mock("@aoagents/ao-plugin-agent-codex", () => ({ default: codexPlugin }));
+vi.mock("@aoagents/ao-plugin-agent-grok", () => ({ default: grokPlugin }));
 vi.mock("@aoagents/ao-plugin-agent-opencode", () => ({ default: opencodePlugin }));
 vi.mock("@aoagents/ao-plugin-workspace-worktree", () => ({ default: worktreePlugin }));
 vi.mock("@aoagents/ao-plugin-scm-github", () => ({ default: scmPlugin }));
@@ -118,6 +121,14 @@ describe("services", () => {
     await getServices();
 
     expect(mockRegister).toHaveBeenCalledWith(codexPlugin);
+  });
+
+  it("registers the Grok agent plugin with web services", async () => {
+    const { getServices } = await import("../lib/services");
+
+    await getServices();
+
+    expect(mockRegister).toHaveBeenCalledWith(grokPlugin);
   });
 
   it("caches initialized services across repeated calls", async () => {

--- a/packages/web/src/lib/services.ts
+++ b/packages/web/src/lib/services.ts
@@ -39,6 +39,7 @@ import pluginAgentClaudeCode from "@aoagents/ao-plugin-agent-claude-code";
 import pluginAgentCodex from "@aoagents/ao-plugin-agent-codex";
 import pluginAgentCursor from "@aoagents/ao-plugin-agent-cursor";
 import pluginAgentKimicode from "@aoagents/ao-plugin-agent-kimicode";
+import pluginAgentGrok from "@aoagents/ao-plugin-agent-grok";
 import pluginAgentOpencode from "@aoagents/ao-plugin-agent-opencode";
 import pluginWorkspaceWorktree from "@aoagents/ao-plugin-workspace-worktree";
 import pluginScmGithub from "@aoagents/ao-plugin-scm-github";
@@ -111,6 +112,7 @@ async function initServices(): Promise<Services> {
   registry.register(pluginAgentCodex);
   registry.register(pluginAgentCursor);
   registry.register(pluginAgentKimicode);
+  registry.register(pluginAgentGrok);
   registry.register(pluginAgentOpencode);
   registry.register(pluginWorkspaceWorktree);
   registry.register(pluginScmGithub);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
+      '@aoagents/ao-plugin-agent-grok':
+        specifier: workspace:*
+        version: link:../plugins/agent-grok
       '@aoagents/ao-plugin-agent-kimicode':
         specifier: workspace:*
         version: link:../plugins/agent-kimicode
@@ -332,6 +335,28 @@ importers:
       '@types/node':
         specifier: ^25.2.3
         version: 25.6.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/node@25.6.0)(jiti@2.6.1)(jsdom@25.0.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  packages/plugins/agent-grok:
+    dependencies:
+      '@aoagents/ao-core':
+        specifier: workspace:*
+        version: link:../../core
+      which:
+        specifier: ^6.0.1
+        version: 6.0.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.2.3
+        version: 25.6.0
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -688,6 +713,9 @@ importers:
       '@aoagents/ao-plugin-agent-cursor':
         specifier: workspace:*
         version: link:../plugins/agent-cursor
+      '@aoagents/ao-plugin-agent-grok':
+        specifier: workspace:*
+        version: link:../plugins/agent-grok
       '@aoagents/ao-plugin-agent-kimicode':
         specifier: workspace:*
         version: link:../plugins/agent-kimicode
@@ -1974,6 +2002,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -5076,6 +5107,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/which@3.0.4': {}
 
   '@types/ws@8.18.1':
     dependencies:


### PR DESCRIPTION
## Summary
- add `@aoagents/ao-plugin-agent-grok` using the Forge-derived plugin shape: manifest/create/detect/default export, `which` detection, post-launch prompt delivery, PATH wrapper hooks, AO activity fallback, liveness probes, and conservative Grok session restore from existing `grokSessionId` metadata
- wire Grok into built-in plugin registration, CLI detection/direct imports, config help, web services, and workspace dependencies
- add core post-launch prompt delivery support plus focused tests for worker and orchestrator prompt sending

## Grok CLI surface verified
- executable/detection: `grok`, detected with `which.sync("grok")`
- launch: `grok --no-alt-screen` for interactive inline terminal UI; optional `--model`, `--rules @<systemPromptFile>`, and `--resume <SESSION_ID>` when configured
- restore: `grok --resume [<SESSION_ID>]` exists; plugin only uses it when AO already has `metadata.grokSessionId` or `agentConfig.grokSessionId`
- sessions/metadata: `grok sessions list/search` exists, but no documented machine-readable JSON output; unauthenticated local run entered OAuth sign-in, so the plugin does not scrape sessions
- metadata/statistics: `grok inspect --json` and `grok version --json` exist, but no documented per-session token/cost/summary command was found; `grok trace --json <SESSION_ID>` exports traces, not live status
- waiting-input signals: observed OAuth sign-in prompt; classifier also handles conservative allow/approve/continue prompts and terminal error lines

## Validation
- `pnpm --filter @aoagents/ao-plugin-agent-grok test`
- `pnpm --filter @aoagents/ao-plugin-agent-grok typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-grok build`
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/spawn.test.ts src/__tests__/plugin-registry.test.ts`
- `pnpm --filter @aoagents/ao-core typecheck`
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/services.test.ts`
- `pnpm --filter @aoagents/ao-cli typecheck`
- `pnpm --filter @aoagents/ao-web typecheck`
- `git diff --check`

## Unsupported / conservative assumptions
- No automatic Grok session-id discovery is implemented because the verified `sessions` help did not expose JSON and unauthenticated listing starts OAuth.
- No cost/token/summary lookup is implemented because no stable per-session statistics command was identified.
- Restore is available only when `grokSessionId` is already present in AO metadata/config.
