### PR TITLE
fix(web): break circular links in DegradedProjectState — Back to project and Open dashboard view both point to current page

### DIFF
--- a/packages/web/src/app/projects/[projectId]/page.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.test.tsx
@@ -53,5 +53,7 @@ describe("ProjectPage", () => {
     expect(screen.getByText("This project's config failed to load")).toBeInTheDocument();
     expect(screen.getByText("Local config failed validation")).toBeInTheDocument();
     expect(screen.queryByTestId("dashboard")).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute("href", "/");
+    expect(screen.queryByRole("link", { name: "Edit settings" })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/app/projects/[projectId]/settings/page.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/settings/page.test.tsx
@@ -77,5 +77,7 @@ describe("ProjectSettingsPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("Local config failed validation")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Save changes" })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Back to dashboard" })).toHaveAttribute("href", "/");
+    expect(screen.queryByRole("link", { name: "Edit settings" })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/DegradedProjectState.tsx
+++ b/packages/web/src/components/DegradedProjectState.tsx
@@ -66,12 +66,6 @@ export function DegradedProjectState({
           >
             Back to dashboard
           </Link>
-          <Link
-            href={`/projects/${encodeURIComponent(projectId)}/settings`}
-            className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
-          >
-            Edit settings
-          </Link>
         </div>
       </div>
     </div>

--- a/packages/web/src/components/DegradedProjectState.tsx
+++ b/packages/web/src/components/DegradedProjectState.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { projectDashboardPath } from "@/lib/routes";
+
 import { RepairDegradedProjectButton } from "./RepairDegradedProjectButton";
 
 interface DegradedProjectStateProps {
@@ -61,16 +61,16 @@ export function DegradedProjectState({
 
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
-            href={projectDashboardPath(projectId)}
+            href="/"
             className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
           >
-            Back to project
+            Back to dashboard
           </Link>
           <Link
-            href={projectDashboardPath(projectId)}
+            href={`/projects/${encodeURIComponent(projectId)}/settings`}
             className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
           >
-            Open dashboard view
+            Edit settings
           </Link>
         </div>
       </div>

--- a/packages/web/src/components/__tests__/DegradedProjectState.test.tsx
+++ b/packages/web/src/components/__tests__/DegradedProjectState.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { DegradedProjectState } from "@/components/DegradedProjectState";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    ...props
+  }: React.PropsWithChildren<React.AnchorHTMLAttributes<HTMLAnchorElement>>) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("@/components/RepairDegradedProjectButton", () => ({
+  RepairDegradedProjectButton: ({ projectId }: { projectId: string }) => (
+    <button>Repair {projectId}</button>
+  ),
+}));
+
+const baseProps = {
+  projectId: "my-project",
+  resolveError: "Local config at /tmp/my-project/agent-orchestrator.yaml failed validation: bad field",
+  projectPath: "/tmp/my-project",
+};
+
+describe("DegradedProjectState", () => {
+  it("renders the default heading", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    expect(screen.getByText("This project's config failed to load")).toBeInTheDocument();
+  });
+
+  it("renders a custom heading when provided", () => {
+    render(<DegradedProjectState {...baseProps} heading="Custom heading" />);
+    expect(screen.getByText("Custom heading")).toBeInTheDocument();
+  });
+
+  it("displays the resolve error", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    expect(screen.getByText(baseProps.resolveError)).toBeInTheDocument();
+  });
+
+  it("extracts and displays the config path from the resolve error", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    expect(
+      screen.getByText("/tmp/my-project/agent-orchestrator.yaml"),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the project path when the config path cannot be parsed from the error", () => {
+    render(
+      <DegradedProjectState
+        {...baseProps}
+        resolveError="Something went wrong"
+      />,
+    );
+    expect(
+      screen.getByText("/tmp/my-project/agent-orchestrator.yaml or .yml"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Back to dashboard' link pointing to /", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    const link = screen.getByRole("link", { name: "Back to dashboard" });
+    expect(link).toHaveAttribute("href", "/");
+  });
+
+  it("does not render an 'Edit settings' link", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    expect(screen.queryByRole("link", { name: "Edit settings" })).not.toBeInTheDocument();
+  });
+
+  it("does not show the repair button for a generic validation error", () => {
+    render(<DegradedProjectState {...baseProps} />);
+    expect(screen.queryByRole("button", { name: /repair/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the repair button when the error indicates a wrapped projects format", () => {
+    render(
+      <DegradedProjectState
+        {...baseProps}
+        resolveError="Local config at /tmp/x/agent-orchestrator.yaml still uses a wrapped projects: format"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /repair/i })).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes circular navigation links in \`DegradedProjectState\` component.

**Original bug:** Both \"Back to project\" and \"Open dashboard view\" linked to \`projectDashboardPath(projectId)\` — the exact same page the component is rendered on (\`/projects/{id}\`). Clicking either button did nothing (Next.js \`<Link>\` to current route = no-op).

**Secondary bug (found during testing):** After fixing the first button, \"Edit settings\" pointed to \`/projects/{id}/settings\` — which also renders \`DegradedProjectState\`. So on the settings page, \"Edit settings\" was itself a self-link. Removed the button entirely; it has no useful action when the project is degraded.

**Changes:**
- \"Back to project\" → **\"Back to dashboard\"** linking to \`/\` (global dashboard, works from both pages)
- \"Open dashboard view\" → removed **\"Edit settings\"** link entirely (was circular on settings page)
- Removed unused \`projectDashboardPath\` import
- Added \`DegradedProjectState\` component test suite (9 tests)
- Updated page-level tests to assert correct link targets and absence of \"Edit settings\"

Fixes [#1867](https://github.com/ComposioHQ/agent-orchestrator/issues/1867)

## Test

1. Add a project whose \`agent-orchestrator.yaml\` exists but is malformed (e.g. \`port: [unclosed\`)
2. Navigate to \`/projects/{id}\` — degraded state renders
3. Click \"Back to dashboard\" → navigates to \`/\` ✅
4. No \"Edit settings\" button present ✅
5. Navigate to \`/projects/{id}/settings\` directly — degraded state renders with different heading
6. Click \"Back to dashboard\" → navigates to \`/\` ✅
7. No \"Edit settings\" button present ✅

https://github.com/user-attachments/assets/8b44c712-832b-4d13-863b-288a5a89cb37

