### PR TITLE
fix(canary): list all 27 linked packages in dummy changeset

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -118,7 +118,7 @@ jobs:
               pkgs.forEach(p => body += '"' + p + '": patch\n');
               body += '---\n\nchore: canary build\n';
               require('fs').writeFileSync('.changeset/canary-temp.md', body);
-            SCRIPT
+          SCRIPT
           fi
           pnpm changeset version --snapshot nightly
         env:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -111,7 +111,19 @@ jobs:
           # create a minimal one. `changeset version --snapshot` consumes and
           # deletes it, so no cleanup is needed.
           if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -vi 'README')" ]; then
-            printf -- '---\n"@aoagents/ao": patch\n"@aoagents/ao-cli": patch\n"@aoagents/ao-core": patch\n"@aoagents/ao-plugin-agent-aider": patch\n"@aoagents/ao-plugin-agent-claude-code": patch\n"@aoagents/ao-plugin-agent-codex": patch\n"@aoagents/ao-plugin-agent-cursor": patch\n"@aoagents/ao-plugin-agent-kimicode": patch\n"@aoagents/ao-plugin-agent-opencode": patch\n"@aoagents/ao-plugin-notifier-composio": patch\n"@aoagents/ao-plugin-notifier-desktop": patch\n"@aoagents/ao-plugin-notifier-discord": patch\n"@aoagents/ao-plugin-notifier-openclaw": patch\n"@aoagents/ao-plugin-notifier-slack": patch\n"@aoagents/ao-plugin-notifier-webhook": patch\n"@aoagents/ao-plugin-runtime-process": patch\n"@aoagents/ao-plugin-runtime-tmux": patch\n"@aoagents/ao-plugin-scm-github": patch\n"@aoagents/ao-plugin-scm-gitlab": patch\n"@aoagents/ao-plugin-terminal-iterm2": patch\n"@aoagents/ao-plugin-terminal-web": patch\n"@aoagents/ao-plugin-tracker-github": patch\n"@aoagents/ao-plugin-tracker-gitlab": patch\n"@aoagents/ao-plugin-tracker-linear": patch\n"@aoagents/ao-plugin-workspace-clone": patch\n"@aoagents/ao-plugin-workspace-worktree": patch\n"@aoagents/ao-web": patch\n---\n\nchore: canary build\n' > .changeset/canary-temp.md
+            node -e "
+              const cfg = require('./.changeset/config.json');
+              const pkgs = cfg.linked.flat();
+              let body = '---
+';
+              pkgs.forEach(p => body += '"' + p + '": patch
+');
+              body += '---
+
+chore: canary build
+';
+              require('fs').writeFileSync('.changeset/canary-temp.md', body);
+            "
           fi
           pnpm changeset version --snapshot nightly
         env:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -111,7 +111,7 @@ jobs:
           # create a minimal one. `changeset version --snapshot` consumes and
           # deletes it, so no cleanup is needed.
           if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -vi 'README')" ]; then
-            node -e "
+            node << 'SCRIPT'
               const cfg = require('./.changeset/config.json');
               const pkgs = cfg.linked.flat();
               let body = '---
@@ -123,7 +123,7 @@ jobs:
 chore: canary build
 ';
               require('fs').writeFileSync('.changeset/canary-temp.md', body);
-            "
+            SCRIPT
           fi
           pnpm changeset version --snapshot nightly
         env:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -111,7 +111,7 @@ jobs:
           # create a minimal one. `changeset version --snapshot` consumes and
           # deletes it, so no cleanup is needed.
           if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -vi 'README')" ]; then
-            printf -- '---\n"@aoagents/ao": patch\n---\n\nchore: canary build\n' > .changeset/canary-temp.md
+            printf -- '---\n"@aoagents/ao": patch\n"@aoagents/ao-cli": patch\n"@aoagents/ao-core": patch\n"@aoagents/ao-plugin-agent-aider": patch\n"@aoagents/ao-plugin-agent-claude-code": patch\n"@aoagents/ao-plugin-agent-codex": patch\n"@aoagents/ao-plugin-agent-cursor": patch\n"@aoagents/ao-plugin-agent-kimicode": patch\n"@aoagents/ao-plugin-agent-opencode": patch\n"@aoagents/ao-plugin-notifier-composio": patch\n"@aoagents/ao-plugin-notifier-desktop": patch\n"@aoagents/ao-plugin-notifier-discord": patch\n"@aoagents/ao-plugin-notifier-openclaw": patch\n"@aoagents/ao-plugin-notifier-slack": patch\n"@aoagents/ao-plugin-notifier-webhook": patch\n"@aoagents/ao-plugin-runtime-process": patch\n"@aoagents/ao-plugin-runtime-tmux": patch\n"@aoagents/ao-plugin-scm-github": patch\n"@aoagents/ao-plugin-scm-gitlab": patch\n"@aoagents/ao-plugin-terminal-iterm2": patch\n"@aoagents/ao-plugin-terminal-web": patch\n"@aoagents/ao-plugin-tracker-github": patch\n"@aoagents/ao-plugin-tracker-gitlab": patch\n"@aoagents/ao-plugin-tracker-linear": patch\n"@aoagents/ao-plugin-workspace-clone": patch\n"@aoagents/ao-plugin-workspace-worktree": patch\n"@aoagents/ao-web": patch\n---\n\nchore: canary build\n' > .changeset/canary-temp.md
           fi
           pnpm changeset version --snapshot nightly
         env:

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -114,14 +114,9 @@ jobs:
             node << 'SCRIPT'
               const cfg = require('./.changeset/config.json');
               const pkgs = cfg.linked.flat();
-              let body = '---
-';
-              pkgs.forEach(p => body += '"' + p + '": patch
-');
-              body += '---
-
-chore: canary build
-';
+              let body = '---\n';
+              pkgs.forEach(p => body += '"' + p + '": patch\n');
+              body += '---\n\nchore: canary build\n';
               require('fs').writeFileSync('.changeset/canary-temp.md', body);
             SCRIPT
           fi


### PR DESCRIPTION
## Problem

The canary workflow creates a dummy changeset listing only `@aoagents/ao` when no pending changesets exist on main. Because changesets in linked mode only bumps packages mentioned in the changeset, `changeset version --snapshot nightly` only applies the nightly version to `@aoagents/ao`. The other 26 linked packages stay at their stable version (e.g. `0.8.0`) and `changeset publish --tag nightly` skips them as already published.

Additionally, the single-package changeset produces `0.0.0-nightly-<hash>` instead of `X.Y.Z-nightly-<hash>` because `useCalculatedVersionForSnapshots` has nothing to calculate from.

## Fix

List all 27 linked packages in the dummy changeset so they all get a proper nightly version bump.

## Before
```
---
@aoagents/ao: patch
---
```

## After
```
---
@aoagents/ao: patch
@aoagents/ao-cli: patch
@aoagents/ao-core: patch
...all 27 packages...
---
```