### PR TITLE
fix(web): resolve circular links in DegradedProjectState component

### DIFF
--- a/packages/web/src/components/DegradedProjectState.tsx
+++ b/packages/web/src/components/DegradedProjectState.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { projectDashboardPath } from "@/lib/routes";
+import { projectDashboardPath, projectSettingsPath } from "@/lib/routes";
 import { RepairDegradedProjectButton } from "./RepairDegradedProjectButton";
 
 interface DegradedProjectStateProps {
@@ -67,7 +67,7 @@ export function DegradedProjectState({
             Back to dashboard
           </Link>
           <Link
-            href={`${projectDashboardPath(projectId)}/settings`}
+            href={projectSettingsPath(projectId)}
             className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
           >
             Edit project settings

--- a/packages/web/src/components/DegradedProjectState.tsx
+++ b/packages/web/src/components/DegradedProjectState.tsx
@@ -61,16 +61,16 @@ export function DegradedProjectState({
 
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
-            href={projectDashboardPath(projectId)}
+            href="/"
             className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
           >
-            Back to project
+            Back to dashboard
           </Link>
           <Link
-            href={projectDashboardPath(projectId)}
+            href={`${projectDashboardPath(projectId)}/settings`}
             className="rounded-lg border border-[var(--color-border-default)] px-4 py-2 text-sm font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-bg-elevated-hover)]"
           >
-            Open dashboard view
+            Edit project settings
           </Link>
         </div>
       </div>

--- a/packages/web/src/lib/routes.ts
+++ b/packages/web/src/lib/routes.ts
@@ -6,6 +6,10 @@ export function projectSessionPath(projectId: string, sessionId: string): string
   return `${projectDashboardPath(projectId)}/sessions/${encodeURIComponent(sessionId)}`;
 }
 
+export function projectSettingsPath(projectId: string): string {
+  return `${projectDashboardPath(projectId)}/settings`;
+}
+
 export function projectSessionHashPath(projectId: string, sessionId: string, hash: string): string {
   return `${projectSessionPath(projectId, sessionId)}${hash}`;
 }


### PR DESCRIPTION
## Summary

- "Back to project" now navigates to `/` (global dashboard) instead of the current page
- "Open dashboard view" replaced with "Edit project settings" linking to `/projects/{id}/settings`
- Both links previously pointed to `projectDashboardPath(projectId)` which is the current URL, making them no-ops

## Root cause

Next.js `<Link>` to the current route is a no-op. Both buttons used the same destination as the page they rendered on.

## Test plan

- [ ] Navigate to a degraded project page (add project with missing/invalid YAML)
- [ ] "Back to dashboard" navigates to root `/` showing all projects
- [ ] "Edit project settings" navigates to `/projects/{id}/settings`
- [ ] Both links are visually distinct and semantically correct

Closes #1867