### PR TITLE
fix(core): waiting_input and blocked no longer decay to idle on wallclock (closes #1894)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,8 +450,8 @@ import {
   validateUrl,                  // Webhook URL validation
   readLastJsonlEntry,           // Efficient JSONL log tail (native agent JSONL)
   readLastActivityEntry,        // Read last AO activity JSONL entry
-  checkActivityLogState,        // Extract waiting_input/blocked from AO JSONL (with staleness cap)
-  getActivityFallbackState,     // Last-resort fallback: entry state + age-based decay
+  checkActivityLogState,        // Extract sticky waiting_input/blocked from AO JSONL
+  getActivityFallbackState,     // Last-resort fallback: actionable states + liveness age decay
   recordTerminalActivity,       // Shared recordActivity impl (classify + dedup + append)
   classifyTerminalActivity,     // Classify terminal output via detectActivity
   appendActivityEntry,          // Low-level JSONL append
@@ -460,7 +460,7 @@ import {
   normalizeAgentPermissionMode, // Normalize permission mode strings
   DEFAULT_READY_THRESHOLD_MS,   // 5 min — ready→idle threshold
   DEFAULT_ACTIVE_WINDOW_MS,     // 30s — active→ready window
-  ACTIVITY_INPUT_STALENESS_MS,  // 5 min — waiting_input/blocked expiry
+  ACTIVITY_INPUT_STALENESS_MS,  // Deprecated compatibility export; actionable states no longer expire by wallclock
   PREFERRED_GH_PATH,            // /usr/local/bin/gh
   CI_STATUS, ACTIVITY_STATE, SESSION_STATUS,  // Constants
   type Session, type ProjectConfig, type RuntimeHandle,

--- a/packages/core/src/__tests__/activity-log.test.ts
+++ b/packages/core/src/__tests__/activity-log.test.ts
@@ -9,9 +9,26 @@ import {
   appendActivityEntry,
   recordTerminalActivity,
   getActivityLogPath,
-  ACTIVITY_INPUT_STALENESS_MS,
+  getActivityFallbackState,
 } from "../activity-log.js";
-import type { ActivityState } from "../types.js";
+import type { ActivityDetection, ActivityLogEntry, ActivityState } from "../types.js";
+
+const minutesAgo = (minutes: number): string => new Date(Date.now() - minutes * 60_000).toISOString();
+
+const toActivityResult = (
+  entry: ActivityLogEntry,
+): { entry: ActivityLogEntry; modifiedAt: Date } => ({
+  entry,
+  modifiedAt: new Date(entry.ts),
+});
+
+const detectWithProcessCheck = (
+  isProcessRunning: boolean,
+  activityResult: { entry: ActivityLogEntry; modifiedAt: Date } | null,
+): ActivityDetection | null => {
+  if (!isProcessRunning) return { state: "exited", timestamp: new Date() };
+  return checkActivityLogState(activityResult) ?? getActivityFallbackState(activityResult, 30_000, 5 * 60_000);
+};
 
 describe("classifyTerminalActivity", () => {
   it("returns active state with no trigger", () => {
@@ -56,13 +73,20 @@ describe("checkActivityLogState", () => {
     expect(result?.state).toBe("blocked");
   });
 
-  it("returns null for stale waiting_input entry", () => {
-    const staleTs = new Date(Date.now() - ACTIVITY_INPUT_STALENESS_MS - 1000).toISOString();
+  it("returns waiting_input even when older than the former wallclock cap", () => {
     const result = checkActivityLogState({
-      entry: { ts: staleTs, state: "waiting_input", source: "terminal" },
+      entry: { ts: minutesAgo(10), state: "waiting_input", source: "terminal" },
       modifiedAt: new Date(),
     });
-    expect(result).toBeNull();
+    expect(result?.state).toBe("waiting_input");
+  });
+
+  it("returns blocked even when older than the former wallclock cap", () => {
+    const result = checkActivityLogState({
+      entry: { ts: minutesAgo(6), state: "blocked", source: "terminal" },
+      modifiedAt: new Date(),
+    });
+    expect(result?.state).toBe("blocked");
   });
 
   it("returns null for non-critical states", () => {
@@ -79,6 +103,77 @@ describe("checkActivityLogState", () => {
       modifiedAt: new Date(),
     });
     expect(result).toBeNull();
+  });
+});
+
+describe("getActivityFallbackState", () => {
+  it("returns waiting_input for a 10-minute-old entry instead of decaying to idle", () => {
+    const result = getActivityFallbackState(
+      toActivityResult({ ts: minutesAgo(10), state: "waiting_input", source: "terminal" }),
+      30_000,
+      5 * 60_000,
+    );
+
+    expect(result?.state).toBe("waiting_input");
+  });
+
+  it("returns blocked for a 6-minute-old entry instead of decaying to idle", () => {
+    const result = getActivityFallbackState(
+      toActivityResult({ ts: minutesAgo(6), state: "blocked", source: "terminal" }),
+      30_000,
+      5 * 60_000,
+    );
+
+    expect(result?.state).toBe("blocked");
+  });
+
+  it("returns blocked for a 1-minute-old entry with unchanged behavior", () => {
+    const result = getActivityFallbackState(
+      toActivityResult({ ts: minutesAgo(1), state: "blocked", source: "terminal" }),
+      30_000,
+      5 * 60_000,
+    );
+
+    expect(result?.state).toBe("blocked");
+  });
+
+  it("lets a newer active entry override an older waiting_input entry", async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), "ao-test-"));
+    try {
+      await mkdir(join(tmpDir, ".ao"), { recursive: true });
+      const waitingEntry: ActivityLogEntry = {
+        ts: minutesAgo(6),
+        state: "waiting_input",
+        source: "terminal",
+      };
+      const activeEntry: ActivityLogEntry = {
+        ts: new Date(Date.now() - 1000).toISOString(),
+        state: "active",
+        source: "terminal",
+      };
+      await writeFile(
+        getActivityLogPath(tmpDir),
+        `${JSON.stringify(waitingEntry)}\n${JSON.stringify(activeEntry)}\n`,
+        "utf-8",
+      );
+
+      const activityResult = await readLastActivityEntry(tmpDir);
+      const result = getActivityFallbackState(activityResult, 30_000, 5 * 60_000);
+
+      expect(activityResult?.entry.state).toBe("active");
+      expect(result?.state).toBe("active");
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns exited when the process check fails before a stale waiting_input can fall through", () => {
+    const result = detectWithProcessCheck(
+      false,
+      toActivityResult({ ts: minutesAgo(6), state: "waiting_input", source: "terminal" }),
+    );
+
+    expect(result?.state).toBe("exited");
   });
 });
 
@@ -143,6 +238,25 @@ describe("readLastActivityEntry", () => {
     await writeFile(getActivityLogPath(tmpDir), bad + "\n", "utf-8");
     const result = await readLastActivityEntry(tmpDir);
     expect(result).toBeNull();
+  });
+
+  it("falls back to the previous complete line when a read races a truncated tail", async () => {
+    await mkdir(join(tmpDir, ".ao"), { recursive: true });
+    const completeEntry: ActivityLogEntry = {
+      ts: minutesAgo(10),
+      state: "waiting_input",
+      source: "terminal",
+      trigger: "approve?",
+    };
+    await writeFile(
+      getActivityLogPath(tmpDir),
+      `${JSON.stringify(completeEntry)}\n{"ts":"${new Date().toISOString()}","state":`,
+      "utf-8",
+    );
+
+    const result = await readLastActivityEntry(tmpDir);
+
+    expect(result?.entry).toEqual(completeEntry);
   });
 });
 

--- a/packages/core/src/activity-log.ts
+++ b/packages/core/src/activity-log.ts
@@ -15,10 +15,8 @@ import { join, dirname } from "node:path";
 import type { ActivityState, ActivityLogEntry, ActivityDetection } from "./types.js";
 
 /**
- * Maximum age (ms) for `waiting_input`/`blocked` entries before they're
- * considered stale. If no new terminal output overwrites the entry within
- * this window, the state falls through to downstream fallbacks instead of
- * keeping the session stuck in `needs_input` on the dashboard forever.
+ * @deprecated Actionable states no longer decay on wallclock. Retained until
+ * the activity-reducer cleanup removes the old activity-log module.
  */
 export const ACTIVITY_INPUT_STALENESS_MS = 5 * 60 * 1000; // 5 minutes
 
@@ -129,7 +127,7 @@ export async function readLastActivityEntry(
 /**
  * Check the AO activity JSONL for actionable states only.
  *
- * Only returns `waiting_input`/`blocked` (with a staleness cap).
+ * Only returns `waiting_input`/`blocked`.
  * Non-critical states (`active`, `ready`, `idle`) always return `null` so
  * callers fall through to their native signals (git commits, chat history,
  * API queries, native JSONL). This prevents the lifecycle manager's
@@ -144,18 +142,12 @@ export function checkActivityLogState(
   const { entry } = activityResult;
 
   if (entry.state === "waiting_input" || entry.state === "blocked") {
-    // Use the entry's own timestamp for staleness — not file mtime, which
-    // gets refreshed every poll cycle by recordActivity and would prevent
-    // stale entries from ever being detected.
     const entryTs = new Date(entry.ts);
     if (Number.isNaN(entryTs.getTime())) return null;
-    const ageMs = Date.now() - entryTs.getTime();
-    if (ageMs <= ACTIVITY_INPUT_STALENESS_MS) {
-      return { state: entry.state, timestamp: entryTs };
-    }
+    return { state: entry.state, timestamp: entryTs };
   }
 
-  // Non-critical states and stale entries — fall through to native signals
+  // Non-critical states fall through to native signals
   return null;
 }
 
@@ -178,16 +170,8 @@ export function getActivityFallbackState(
   const entryTs = new Date(entry.ts);
   if (Number.isNaN(entryTs.getTime())) return null;
 
-  // Actionable states use the same staleness cap as checkActivityLogState.
-  // If the entry is stale, fall through to age-based decay instead of
-  // re-surfacing a waiting_input/blocked that checkActivityLogState already filtered.
   if (entry.state === "waiting_input" || entry.state === "blocked") {
-    const ageMs = Date.now() - entryTs.getTime();
-    if (ageMs <= ACTIVITY_INPUT_STALENESS_MS) {
-      return { state: entry.state, timestamp: entryTs };
-    }
-    // Stale actionable entry — treat as idle
-    return { state: "idle", timestamp: entryTs };
+    return { state: entry.state, timestamp: entryTs };
   }
 
   // Age-based decay: active→ready→idle, but never promote past the

--- a/website/content/docs/architecture.mdx
+++ b/website/content/docs/architecture.mdx
@@ -253,7 +253,7 @@ Step 4 (the JSONL entry fallback) is mandatory. Skipping it means `getActivitySt
 |---|---|---|
 | `DEFAULT_ACTIVE_WINDOW_MS` | 30 seconds | Activity newer than this is `active`; older is `ready` |
 | `DEFAULT_READY_THRESHOLD_MS` | 5 minutes | `ready` sessions older than this become `idle` |
-| `ACTIVITY_INPUT_STALENESS_MS` | 5 minutes | `waiting_input` / `blocked` JSONL entries expire after this duration |
+| `ACTIVITY_INPUT_STALENESS_MS` | 5 minutes | Deprecated compatibility export. `waiting_input` / `blocked` entries no longer expire by wallclock; they persist until process death or a newer entry overrides them. |
 
 ---
 

--- a/website/content/docs/plugins/authoring.mdx
+++ b/website/content/docs/plugins/authoring.mdx
@@ -468,7 +468,7 @@ All utilities are exported from `@aoagents/ao-core`. The source lives in `packag
 |--------|-------|
 | `DEFAULT_READY_THRESHOLD_MS` | `300_000` (5 min) — ready → idle threshold |
 | `DEFAULT_ACTIVE_WINDOW_MS` | `30_000` (30 s) — active → ready window |
-| `ACTIVITY_INPUT_STALENESS_MS` | `300_000` (5 min) — waiting_input/blocked expiry |
+| `ACTIVITY_INPUT_STALENESS_MS` | Deprecated compatibility export (`300_000`); waiting_input/blocked no longer expire by wallclock |
 | `PREFERRED_GH_PATH` | `/usr/local/bin/gh` |
 | `CI_STATUS` | `{ PENDING, PASSING, FAILING, NONE }` |
 | `ACTIVITY_STATE` | `{ ACTIVE, READY, IDLE, WAITING_INPUT, BLOCKED, EXITED }` |


### PR DESCRIPTION
## Problem

PR-A from umbrella #1899 fixes #1894: AO activity JSONL currently lets stale `waiting_input`/`blocked` entries decay to `idle` on wallclock after 5 minutes. That hides live agents that are still waiting on a human prompt or blocked on an error. This PR removes the wallclock cap in `packages/core/src/activity-log.ts` so actionable states persist until process death or a newer entry overrides them.

Closes #1894.
References #1899.

## PR-A test plan

1. Entry `waiting_input`, ts = 10 min ago, `isProcessRunning = true` → expect `waiting_input` (currently fails — returns `idle`).
2. Entry `blocked`, ts = 6 min ago, `isProcessRunning = true` → expect `blocked`.
3. Entry `waiting_input`, ts = 6 min ago, `isProcessRunning = false` → expect `exited` (already covered upstream by process check; assert no fall-through to `idle`).
4. Entry `blocked`, ts = 1 min ago → unchanged behavior.
5. **Override semantics (new):** entry `waiting_input` 6 min ago, then a fresh `active`-class entry appended (simulates the agent moving on without explicitly clearing the inbox) → expect the fresh entry wins.
6. **Concurrency (new):** simulate a `recordActivity` append racing with a `readLastActivityEntry` read. `readLastActivityEntry` already handles truncated tails; assert behavior is stable under load.

## PR-A risk callout

Removing the wallclock cap means `waiting_input`/`blocked` persists until process death or a newer entry overrides. Two failure modes:

1. Agent emits `permission_request` to JSONL but the process crashes mid-handling. Inbox stays sticky until the next process-probe (≤30s) catches it. That's fine — 30s is the existing latency floor.
2. Agent emits `permission_request`, the user answers, but the agent doesn't emit a clearing event (e.g., headless one-shot exits without writing `assistant_message`). Inbox would stick forever for that session. The current 5-min cap was the silent safety net here.

**Mitigation:** rely on process-probe to clear inbox on normal exit (already covered), AND have the reducer treat a fresh `liveness="active"` event with a timestamp newer than the inbox entry as evidence to clear stale inbox older than ~2 min. This preserves "agent moved on" semantics without re-introducing the wallclock cap.

## Backward-incompat callout

PR-A is a **behavior change visible to operators** who built mental models around the 5-min cap. Sessions waiting on a prompt will now stay in the "respond" zone indefinitely (until the prompt is answered, the agent moves on, or the process exits) instead of silently sliding back to the "working" zone. Worth a one-line note in the changeset and release notes.

**Notifier UX shift:** after PR-A, `waiting_input` no longer decays to `idle` → `hasPositiveIdleEvidence` stays false → the idle-beyond-threshold stuck escalation no longer fires for stuck-on-prompt sessions. That's correct (a sticky inbox is not "idle"), but operators currently get a stuck notification after ~5min + threshold. After PR-A they only get the `needs_input` notification at t=0 and nothing else for that prompt. Surface this in release notes.

## Testing

- `pnpm build` ✅ (passes; existing warnings about optional `@composio/core` resolution and `useXtermTerminal.ts` lint warning during Next build)
- `pnpm typecheck` ✅
- `pnpm lint` ✅ (0 errors, existing warnings)
- `pnpm --filter @aoagents/ao-core test` ✅
- `pnpm test` ⚠️ fails in `@aoagents/ao-plugin-tracker-linear` because optional `@composio/core` is not installed; unrelated to this core-only PR.
