### PR TITLE
fix(agent-claude-code): add AO-JSONL safety net cascade (closes #1897)

### DIFF
--- a/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
+++ b/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
@@ -1,9 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { toClaudeProjectPath, create } from "../index.js";
-import { createActivitySignal, type Session, type RuntimeHandle } from "@aoagents/ao-core";
+import {
+  createActivitySignal,
+  readLastActivityEntry,
+  type ActivityState,
+  type Session,
+  type RuntimeHandle,
+} from "@aoagents/ao-core";
 
 // Mock homedir() so getActivityState looks in our temp dir
 vi.mock("node:os", async (importOriginal) => {
@@ -55,6 +61,16 @@ function writeJsonl(
     const past = new Date(Date.now() - ageMs);
     utimesSync(filePath, past, past);
   }
+}
+
+function writeActivityLog(state: ActivityState, ageMs = 0): void {
+  const ts = new Date(Date.now() - ageMs).toISOString();
+  const aoDir = join(workspacePath, ".ao");
+  mkdirSync(aoDir, { recursive: true });
+  writeFileSync(
+    join(aoDir, "activity.jsonl"),
+    JSON.stringify({ ts, state, source: "terminal" }) + "\n",
+  );
 }
 
 // =============================================================================
@@ -141,23 +157,55 @@ describe("Claude Code Activity Detection", () => {
     // Fallback cases (no JSONL data available)
     // -----------------------------------------------------------------------
 
-    it("returns 'idle' when no session file exists yet", async () => {
-      // projectDir exists but is empty — no .jsonl files yet (freshly spawned session)
-      const session = makeSession();
-      const result = await agent.getActivityState(session);
-      expect(result?.state).toBe("idle");
-      // timestamp must be session.createdAt so stuck-detection can fire eventually
-      expect(result?.timestamp).toBe(session.createdAt);
+    it("returns null when no session file or AO activity entry exists yet", async () => {
+      // projectDir exists but is empty, and the AO safety-net log is absent.
+      expect(await agent.getActivityState(makeSession())).toBeNull();
     });
 
     it("returns null when no workspacePath", async () => {
       expect(await agent.getActivityState(makeSession({ workspacePath: null }))).toBeNull();
     });
 
-    it("returns 'idle' when project directory does not exist", async () => {
-      // Process is running but no Claude project dir yet — treat as idle
+    it("returns null when project directory does not exist and AO activity is unavailable", async () => {
       const badPath = join(fakeHome, "nonexistent-workspace");
-      expect((await agent.getActivityState(makeSession({ workspacePath: badPath })))?.state).toBe("idle");
+      expect(await agent.getActivityState(makeSession({ workspacePath: badPath }))).toBeNull();
+    });
+
+    it("recordActivity writes to .ao/activity.jsonl when workspacePath is set", async () => {
+      await agent.recordActivity?.(makeSession(), "Do you want to proceed?\n(Y)es / (N)o");
+
+      const result = await readLastActivityEntry(workspacePath);
+      expect(result?.entry.state).toBe("waiting_input");
+      expect(result?.entry.source).toBe("terminal");
+      expect(result?.entry.trigger).toContain("Do you want to proceed?");
+    });
+
+    it("recordActivity is a no-op when workspacePath is null", async () => {
+      await agent.recordActivity?.(
+        makeSession({ workspacePath: null }),
+        "Do you want to proceed?\n(Y)es / (N)o",
+      );
+
+      expect(existsSync(join(workspacePath, ".ao", "activity.jsonl"))).toBe(false);
+    });
+
+    it("keeps native JSONL as primary when AO activity JSONL also exists", async () => {
+      writeJsonl([{ type: "assistant", message: { content: "Done!" } }]);
+      writeActivityLog("waiting_input");
+
+      expect((await agent.getActivityState(makeSession()))?.state).toBe("ready");
+    });
+
+    it("falls back to AO JSONL waiting_input when native session lookup is unavailable", async () => {
+      await agent.recordActivity?.(makeSession(), "Do you want to proceed?\n(Y)es / (N)o");
+
+      expect((await agent.getActivityState(makeSession()))?.state).toBe("waiting_input");
+    });
+
+    it("falls back to AO JSONL age-decay when native session lookup is unavailable", async () => {
+      writeActivityLog("active", 400_000);
+
+      expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
     });
 
     // -----------------------------------------------------------------------
@@ -306,8 +354,8 @@ describe("Claude Code Activity Detection", () => {
 
       it("ignores agent- prefixed JSONL files", async () => {
         writeJsonl([{ type: "user" }], 0, "agent-toolkit.jsonl");
-        // No real session file → process is running, treat as idle
-        expect((await agent.getActivityState(makeSession()))?.state).toBe("idle");
+        // No real session file and no AO activity fallback.
+        expect(await agent.getActivityState(makeSession())).toBeNull();
       });
 
       it("reads last entry from multi-entry JSONL (not first)", async () => {

--- a/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
+++ b/packages/plugins/agent-claude-code/src/__tests__/activity-detection.test.ts
@@ -202,6 +202,25 @@ describe("Claude Code Activity Detection", () => {
       expect((await agent.getActivityState(makeSession()))?.state).toBe("waiting_input");
     });
 
+    it("falls back to AO JSONL waiting_input when native session entry predates this session", async () => {
+      writeJsonl([{ type: "assistant", message: { content: "Previous session done" } }], 120_000);
+      const session = makeSession({ createdAt: new Date() });
+
+      await agent.recordActivity?.(session, "Do you want to proceed?\n(Y)es / (N)o");
+
+      expect((await agent.getActivityState(session))?.state).toBe("waiting_input");
+    });
+
+    it("returns idle for stale native session entry when AO JSONL is unavailable", async () => {
+      writeJsonl([{ type: "assistant", message: { content: "Previous session done" } }], 120_000);
+      const session = makeSession({ createdAt: new Date() });
+
+      const result = await agent.getActivityState(session);
+
+      expect(result?.state).toBe("idle");
+      expect(result?.timestamp).toBe(session.createdAt);
+    });
+
     it("falls back to AO JSONL age-decay when native session lookup is unavailable", async () => {
       writeActivityLog("active", 400_000);
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -6,6 +6,10 @@ import {
   PROCESS_PROBE_INDETERMINATE,
   DEFAULT_READY_THRESHOLD_MS,
   DEFAULT_ACTIVE_WINDOW_MS,
+  readLastActivityEntry,
+  checkActivityLogState,
+  getActivityFallbackState,
+  recordTerminalActivity,
   type Agent,
   type AgentSessionInfo,
   type AgentLaunchConfig,
@@ -947,6 +951,13 @@ function createClaudeCodeAgent(): Agent {
       return classifyTerminalOutput(terminalOutput);
     },
 
+    async recordActivity(session: Session, terminalOutput: string): Promise<void> {
+      if (!session.workspacePath) return;
+      await recordTerminalActivity(session.workspacePath, terminalOutput, (output) =>
+        this.detectActivity(output),
+      );
+    },
+
     async isProcessRunning(handle: RuntimeHandle): Promise<ProcessProbeResult> {
       const pid = await findClaudeProcess(handle);
       if (pid === PROCESS_PROBE_INDETERMINATE) return PROCESS_PROBE_INDETERMINATE;
@@ -976,51 +987,62 @@ function createClaudeCodeAgent(): Agent {
       const projectDir = join(homedir(), ".claude", "projects", projectPath);
 
       const sessionFile = await findLatestSessionFile(projectDir);
-      if (!sessionFile) {
-        // No session file yet — process is running but no conversation started.
-        // Treat as idle (waiting for first task).
-        return { state: "idle", timestamp: session.createdAt };
+      if (sessionFile) {
+        const entry = await readLastJsonlEntry(sessionFile);
+        if (entry) {
+          // If the JSONL entry predates this session, it's from a previous session
+          // in the same worktree. Treat as no data (agent hasn't written yet).
+          if (session.createdAt && entry.modifiedAt < session.createdAt) {
+            return { state: "idle", timestamp: session.createdAt };
+          }
+
+          const ageMs = Date.now() - entry.modifiedAt.getTime();
+          const timestamp = entry.modifiedAt;
+
+          const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+          switch (entry.lastType) {
+            case "user":
+            case "tool_use":
+            case "progress":
+              if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+
+            case "assistant":
+            case "system":
+            case "summary":
+            case "result":
+              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+
+            case "permission_request":
+              return { state: "waiting_input", timestamp };
+
+            case "error":
+              return { state: "blocked", timestamp };
+
+            default:
+              if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+          }
+        }
+
+        // Session file exists but no parseable entry — fall through to AO JSONL
+        // checks below instead of returning early, so terminal-derived
+        // waiting_input/blocked can still be detected.
       }
 
-      const entry = await readLastJsonlEntry(sessionFile);
-      if (!entry) {
-        // Empty file or read error — cannot determine activity
-        return null;
-      }
+      // Fallback: check AO activity JSONL (terminal-derived) for
+      // waiting_input/blocked when Claude's native JSONL is unavailable.
+      const activityResult = await readLastActivityEntry(session.workspacePath);
+      const activityState = checkActivityLogState(activityResult);
+      if (activityState) return activityState;
 
-      // If the JSONL entry predates this session, it's from a previous session
-      // in the same worktree. Treat as no data (agent hasn't written yet).
-      if (session.createdAt && entry.modifiedAt < session.createdAt) {
-        return { state: "idle", timestamp: session.createdAt };
-      }
-
-      const ageMs = Date.now() - entry.modifiedAt.getTime();
-      const timestamp = entry.modifiedAt;
-
+      // Last fallback: use the AO entry with age-based decay when native
+      // session lookup is missing or unparseable (e.g. Claude project slug drift).
       const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
-      switch (entry.lastType) {
-        case "user":
-        case "tool_use":
-        case "progress":
-          if (ageMs <= activeWindowMs) return { state: "active", timestamp };
-          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+      const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
+      if (fallback) return fallback;
 
-        case "assistant":
-        case "system":
-        case "summary":
-        case "result":
-          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
-
-        case "permission_request":
-          return { state: "waiting_input", timestamp };
-
-        case "error":
-          return { state: "blocked", timestamp };
-
-        default:
-          if (ageMs <= activeWindowMs) return { state: "active", timestamp };
-          return { state: ageMs > threshold ? "idle" : "ready", timestamp };
-      }
+      return null;
     },
 
     async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -987,41 +987,44 @@ function createClaudeCodeAgent(): Agent {
       const projectDir = join(homedir(), ".claude", "projects", projectPath);
 
       const sessionFile = await findLatestSessionFile(projectDir);
+      let staleNativeState: ActivityDetection | null = null;
       if (sessionFile) {
         const entry = await readLastJsonlEntry(sessionFile);
         if (entry) {
           // If the JSONL entry predates this session, it's from a previous session
-          // in the same worktree. Treat as no data (agent hasn't written yet).
+          // in the same worktree. Fall through to the AO safety net first: the
+          // terminal may have already surfaced waiting_input/blocked before
+          // Claude writes this session's first native JSONL entry.
           if (session.createdAt && entry.modifiedAt < session.createdAt) {
-            return { state: "idle", timestamp: session.createdAt };
-          }
+            staleNativeState = { state: "idle", timestamp: session.createdAt };
+          } else {
+            const ageMs = Date.now() - entry.modifiedAt.getTime();
+            const timestamp = entry.modifiedAt;
 
-          const ageMs = Date.now() - entry.modifiedAt.getTime();
-          const timestamp = entry.modifiedAt;
+            const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
+            switch (entry.lastType) {
+              case "user":
+              case "tool_use":
+              case "progress":
+                if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+                return { state: ageMs > threshold ? "idle" : "ready", timestamp };
 
-          const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
-          switch (entry.lastType) {
-            case "user":
-            case "tool_use":
-            case "progress":
-              if (ageMs <= activeWindowMs) return { state: "active", timestamp };
-              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+              case "assistant":
+              case "system":
+              case "summary":
+              case "result":
+                return { state: ageMs > threshold ? "idle" : "ready", timestamp };
 
-            case "assistant":
-            case "system":
-            case "summary":
-            case "result":
-              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+              case "permission_request":
+                return { state: "waiting_input", timestamp };
 
-            case "permission_request":
-              return { state: "waiting_input", timestamp };
+              case "error":
+                return { state: "blocked", timestamp };
 
-            case "error":
-              return { state: "blocked", timestamp };
-
-            default:
-              if (ageMs <= activeWindowMs) return { state: "active", timestamp };
-              return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+              default:
+                if (ageMs <= activeWindowMs) return { state: "active", timestamp };
+                return { state: ageMs > threshold ? "idle" : "ready", timestamp };
+            }
           }
         }
 
@@ -1041,6 +1044,8 @@ function createClaudeCodeAgent(): Agent {
       const activeWindowMs = Math.min(DEFAULT_ACTIVE_WINDOW_MS, threshold);
       const fallback = getActivityFallbackState(activityResult, activeWindowMs, threshold);
       if (fallback) return fallback;
+
+      if (staleNativeState) return staleNativeState;
 
       return null;
     },


### PR DESCRIPTION
## Problem

Claude Code activity detection depended only on Claude's native `~/.claude/projects/<slug>/*.jsonl` lookup. If Claude changes that project slug format again, AO silently loses Claude activity detection. Codex already has an AO-JSONL safety-net cascade for this class of failure; Claude did not.

Closes #1897. References umbrella #1899. This is wave 1 alongside PR-A (#1902).

## Scope

- Import the shared AO activity-log helpers into `agent-claude-code`.
- Add `recordActivity()` so terminal observations are written to `<workspace>/.ao/activity.jsonl`.
- Keep native Claude JSONL as primary.
- When native lookup has no usable entry, fall back to:
  1. `checkActivityLogState()` for `waiting_input` / `blocked`
  2. `getActivityFallbackState()` for age-decay
  3. `null` if both are unavailable

No Codex native-file mtime fallback was added.

## Tests

Added coverage for:

1. `recordActivity` writes to `.ao/activity.jsonl` when `workspacePath` is set, and no-ops when null.
2. Native Claude JSONL succeeds and remains primary over AO JSONL.
3. Missing native session file plus fresh AO `waiting_input` returns `waiting_input`.
4. Missing native session file plus aged AO `active` entry decays to `idle`.
5. Both native and AO activity unavailable returns `null`.

## Verification

- `pnpm build`
- `pnpm typecheck`
- `pnpm lint` (passes with existing warnings)
- `pnpm --filter @aoagents/ao-plugin-agent-claude-code test`
