### PR TITLE
fix(web): hide unenriched PR diff stats

### DIFF
--- a/packages/web/src/components/SessionDetailPRCard.tsx
+++ b/packages/web/src/components/SessionDetailPRCard.tsx
@@ -178,6 +178,7 @@ export function SessionDetailPRCard({
   const allGreen = isPRMergeReady(pr);
   const blockerIssues = buildBlockerChips(pr, metadata, lifecyclePrReason);
   const fileCount = pr.changedFiles ?? 0;
+  const showDiffStats = !isPRUnenriched(pr);
   const showConflictActions = hasMergeConflicts(pr) && pr.state === "open";
   const compareUrl = showConflictActions ? buildGitHubCompareUrl(pr) : "";
 
@@ -213,10 +214,12 @@ export function SessionDetailPRCard({
         >
           PR #{pr.number}: {pr.title}
         </a>
-        <span className="session-detail-pr-card__diff-stats">
-          <span className="session-detail-diff--add">+{pr.additions}</span>{" "}
-          <span className="session-detail-diff--del">-{pr.deletions}</span>
-        </span>
+        {showDiffStats ? (
+          <span className="session-detail-pr-card__diff-stats">
+            <span className="session-detail-diff--add">+{pr.additions}</span>{" "}
+            <span className="session-detail-diff--del">-{pr.deletions}</span>
+          </span>
+        ) : null}
         {fileCount > 0 ? (
           <span className="session-detail-pr-card__diff-label">
             {fileCount} file{fileCount !== 1 ? "s" : ""}

--- a/packages/web/src/components/__tests__/SessionDetailPRCard.diffStats.test.tsx
+++ b/packages/web/src/components/__tests__/SessionDetailPRCard.diffStats.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SessionDetailPRCard } from "../SessionDetailPRCard";
+import { makePR } from "../../__tests__/helpers";
+
+describe("SessionDetailPRCard diff stats", () => {
+  it("shows diff stats for enriched PRs", () => {
+    render(
+      <SessionDetailPRCard
+        pr={makePR({
+          enriched: true,
+          additions: 629,
+          deletions: 44,
+        })}
+        metadata={{}}
+        onAskAgentToFix={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("+629")).toBeInTheDocument();
+    expect(screen.getByText("-44")).toBeInTheDocument();
+  });
+
+  it("hides diff stats for unenriched PRs", () => {
+    render(
+      <SessionDetailPRCard
+        pr={makePR({
+          enriched: false,
+          additions: 629,
+          deletions: 44,
+        })}
+        metadata={{}}
+        onAskAgentToFix={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("+629")).not.toBeInTheDocument();
+    expect(screen.queryByText("-44")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #1685\n\n## Summary\n- Hide the session detail PR diff stats when the PR is still unenriched\n- Add a regression test covering enriched vs unenriched PR rendering\n\n## Verification\n- NODE_ENV=test pnpm --filter @aoagents/ao-web test -- src/components/__tests__/SessionDetailPRCard.diffStats.test.tsx\n- NODE_ENV=test pnpm --filter @aoagents/ao-web test -- src/components/__tests__/SessionDetail.mergeConflictActions.test.tsx