### PR TITLE
fix(web): make Done/Terminated dashboard section scrollable (#1923)

### DIFF
--- a/.changeset/fix-done-bar-scroll.md
+++ b/.changeset/fix-done-bar-scroll.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Fix Done/Terminated section on the dashboard not scrolling. The expanded cards grid now has an internal scroll container (mirroring the kanban column body pattern), so older terminated sessions are reachable when many accumulate.

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5302,6 +5302,8 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 8px;
   margin-top: 12px;
+  /* 320px ≈ dashboard header + subhead + body padding + done-bar toggle/margins.
+     Mirrors the .kanban-board viewport-anchored height pattern (line 5107). */
   max-height: calc(100vh - 320px);
   overflow-y: auto;
 }

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5302,6 +5302,19 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 8px;
   margin-top: 12px;
+  max-height: calc(100vh - 320px);
+  overflow-y: auto;
+}
+
+.done-bar__cards::-webkit-scrollbar {
+  width: 4px;
+}
+.done-bar__cards::-webkit-scrollbar-track {
+  background: transparent;
+}
+.done-bar__cards::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar);
+  border-radius: 0;
 }
 
 /* ── Done card (compact grid card) ──────────────────────────────────── */


### PR DESCRIPTION
## Summary

Closes #1923.

The Done/Terminated section on the dashboard had no way to scroll past the visible viewport, so older terminated sessions were unreachable when the list grew.

**Fix (single-line CSS):** drop `.kanban-board-wrap` from the `flex: 1; min-height: 0` rule in `.dashboard-main__body`. Now the wrap takes its content size (= the inner `.kanban-board`'s fixed `calc(100vh - 240px)`), and when the Done section expands below, body content exceeds body height and the existing `.dashboard-main__body { overflow-y: auto }` produces natural page scroll — kanban above, Done/Terminated below, scrolling as one unit.

**Regression origin:** PR #927 (`af2af115`, Warm Terminal design refresh, 2026-04-11) added `flex: 1; min-height: 0` to `.kanban-board-wrap`. That made the wrap greedily consume all remaining body height after the done-bar's natural content height — body content always equalled body height exactly, so `overflow-y: auto` never triggered. The Done/Terminated bar (added in `61721f8e`, 2026-04-06) was scrollable for 5 days, then silently broke.

`.board-wrapper` (loading skeleton + empty state) keeps its `flex: 1` — it relies on filling available space to vertically center the call-to-action.

## Scope

- `packages/web/src/app/globals.css` — 1-line removal (drop `.kanban-board-wrap` selector from the combined flex:1 rule)
- `.changeset/fix-done-bar-scroll.md` — patch-level changeset for `@aoagents/ao-web`

CSS-only. No JS/TSX changes.

## History

Earlier commits on this branch (`c3554de0`, `865b14a5`) attempted a self-contained-scroll fix (`max-height` + `overflow-y` on `.done-bar__cards`). Per user feedback, that produced internal scroll inside the cards container, not the desired page-level scroll. Latest commit (`54117063`) supersedes that approach with the root-cause fix above. Suggest squash-merge.

## Test plan

- [x] CSS-only change, builds clean
- [x] Format check clean
- [x] CLAUDE.md compliance — C-01 (no UI libs), C-02 (no inline styles), C-05 (dark theme preserved)
- [ ] Manual: dashboard with 10+ terminated sessions — expand Done/Terminated, scroll the page, confirm all cards reachable; kanban scrolls off the top, done section reveals below
- [ ] Manual: empty state still vertically centers the call-to-action (relies on `.board-wrapper { flex: 1 }` which is preserved)
- [ ] No drag-and-drop / virtualization impact (none in dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)