### PR TITLE
fix(web): bound project page wrapper so dashboard body scrolls (closes #1923)

### DIFF
--- a/.changeset/fix-done-bar-scroll.md
+++ b/.changeset/fix-done-bar-scroll.md
@@ -2,4 +2,4 @@
 "@aoagents/ao-web": patch
 ---
 
-Fix Done/Terminated section on the dashboard not scrolling. The expanded cards grid now has an internal scroll container (mirroring the kanban column body pattern), so older terminated sessions are reachable when many accumulate.
+Fix Done/Terminated section on the dashboard not scrolling. The dashboard body now scrolls as a single page — kanban above, Done/Terminated below — so older terminated sessions are reachable when many accumulate. Restores the pre-Warm-Terminal-refresh behavior by dropping the `flex: 1` that was making `.kanban-board-wrap` greedily consume all remaining body height and defeat the body's `overflow-y: auto`.

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -5184,6 +5184,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   position: relative;
   margin-top: 14px;
   overflow-x: auto;
+  flex-shrink: 0;
 }
 
 .board-section-head {
@@ -5801,6 +5802,10 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
 }
 
 /* ── Done / Terminated collapsible bar ────────────────────────────────── */
+
+.done-bar {
+  flex-shrink: 0;
+}
 
 .done-bar__toggle {
   display: flex;

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -1545,7 +1545,6 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   padding: 0 16px 16px;
 }
 
-.dashboard-main__body .kanban-board-wrap,
 .dashboard-main__body .board-wrapper {
   flex: 1;
   min-height: 0;
@@ -5858,21 +5857,6 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 8px;
   margin-top: 12px;
-  /* 320px ≈ dashboard header + subhead + body padding + done-bar toggle/margins.
-     Mirrors the .kanban-board viewport-anchored height pattern (line 5107). */
-  max-height: calc(100vh - 320px);
-  overflow-y: auto;
-}
-
-.done-bar__cards::-webkit-scrollbar {
-  width: 4px;
-}
-.done-bar__cards::-webkit-scrollbar-track {
-  background: transparent;
-}
-.done-bar__cards::-webkit-scrollbar-thumb {
-  background: var(--color-scrollbar);
-  border-radius: 0;
 }
 
 /* ── Done card (compact grid card) ──────────────────────────────────── */

--- a/packages/web/src/app/projects/[projectId]/loading.tsx
+++ b/packages/web/src/app/projects/[projectId]/loading.tsx
@@ -24,7 +24,7 @@ export default function ProjectRouteLoading() {
         <div className="dashboard-app-header__spacer" />
       </header>
 
-      <main className="dashboard-main flex-1 min-h-0 overflow-hidden">
+      <main className="dashboard-main flex flex-col flex-1 min-h-0 overflow-hidden">
         <div className="board-wrapper" aria-hidden="true">
           <div className="kanban-ghost">
             {["Working", "Pending", "Review", "Respond", "Merge"].map((label) => (

--- a/packages/web/src/app/projects/[projectId]/loading.tsx
+++ b/packages/web/src/app/projects/[projectId]/loading.tsx
@@ -1,40 +1,46 @@
 export default function ProjectRouteLoading() {
   return (
-    <div className="dashboard-main--desktop">
-      <header className="dashboard-app-header" aria-hidden="true">
-        <button type="button" className="dashboard-app-sidebar-toggle" aria-label="Toggle sidebar">
-          <svg
-            width="14"
-            height="14"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.75"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-bg-canvas)]">
+      <div className="dashboard-main--desktop">
+        <header className="dashboard-app-header" aria-hidden="true">
+          <button
+            type="button"
+            className="dashboard-app-sidebar-toggle"
+            aria-label="Toggle sidebar"
           >
-            <rect x="3" y="3" width="18" height="18" rx="2" />
-            <path d="M9 3v18" />
-          </svg>
-        </button>
-        <div className="dashboard-app-header__brand dashboard-app-header__brand--hide-mobile">
-          <span>Agent Orchestrator</span>
-        </div>
-        <span className="dashboard-app-header__sep topbar-desktop-only" aria-hidden="true" />
-        <span className="dashboard-app-header__project">Loading project…</span>
-        <div className="dashboard-app-header__spacer" />
-      </header>
-
-      <main className="dashboard-main flex flex-col flex-1 min-h-0 overflow-hidden">
-        <div className="board-wrapper" aria-hidden="true">
-          <div className="kanban-ghost">
-            {["Working", "Pending", "Review", "Respond", "Merge"].map((label) => (
-              <div key={label} className="kanban-ghost__col">
-                <div className="kanban-ghost__head">{label}</div>
-              </div>
-            ))}
+            <svg
+              width="14"
+              height="14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.75"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <rect x="3" y="3" width="18" height="18" rx="2" />
+              <path d="M9 3v18" />
+            </svg>
+          </button>
+          <div className="dashboard-app-header__brand dashboard-app-header__brand--hide-mobile">
+            <span>Agent Orchestrator</span>
           </div>
-        </div>
-      </main>
+          <span className="dashboard-app-header__sep topbar-desktop-only" aria-hidden="true" />
+          <span className="dashboard-app-header__project">Loading project…</span>
+          <div className="dashboard-app-header__spacer" />
+        </header>
+
+        <main className="dashboard-main flex flex-col flex-1 min-h-0 overflow-hidden">
+          <div className="board-wrapper" aria-hidden="true">
+            <div className="kanban-ghost">
+              {["Working", "Pending", "Review", "Respond", "Merge"].map((label) => (
+                <div key={label} className="kanban-ghost__col">
+                  <div className="kanban-ghost__head">{label}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/packages/web/src/app/projects/[projectId]/page.test.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.test.tsx
@@ -36,6 +36,33 @@ vi.mock("@/components/Dashboard", () => ({
 import ProjectPage from "./page";
 
 describe("ProjectPage", () => {
+  it("renders the dashboard inside a bounded flex item owned by the project shell", async () => {
+    hoisted.getProjectRouteDataMock.mockResolvedValue({
+      projectId: "project-1",
+      project: { id: "project-1" },
+      projects: [{ id: "project-1", name: "Project 1" }],
+      degradedProject: null,
+    });
+    hoisted.getDashboardPageDataMock.mockResolvedValue({
+      sessions: [],
+      selectedProjectId: "project-1",
+      projectName: "Project 1",
+      projects: [{ id: "project-1", name: "Project 1" }],
+      orchestrators: [],
+      attentionZones: "simple",
+    });
+
+    render(await ProjectPage({ params: Promise.resolve({ projectId: "project-1" }) }));
+
+    expect(screen.getByTestId("dashboard").parentElement).toHaveClass(
+      "flex",
+      "min-h-0",
+      "min-w-0",
+      "flex-1",
+    );
+    expect(screen.getByTestId("dashboard").parentElement).not.toHaveClass("min-h-screen");
+  });
+
   it("renders degraded project state when the project is degraded", async () => {
     hoisted.getProjectRouteDataMock.mockResolvedValue({
       projectId: "broken",

--- a/packages/web/src/app/projects/[projectId]/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.tsx
@@ -29,7 +29,7 @@ export default async function ProjectPage(props: {
   const pageData = await getDashboardPageData(projectId);
 
   return (
-    <div className="flex-1 min-h-screen bg-[var(--color-bg-canvas)]">
+    <div className="flex min-h-0 min-w-0 flex-1 bg-[var(--color-bg-canvas)]">
       <Dashboard
         initialSessions={pageData.sessions}
         projectId={pageData.selectedProjectId}

--- a/packages/web/src/app/projects/[projectId]/page.tsx
+++ b/packages/web/src/app/projects/[projectId]/page.tsx
@@ -29,7 +29,7 @@ export default async function ProjectPage(props: {
   const pageData = await getDashboardPageData(projectId);
 
   return (
-    <div className="flex min-h-0 min-w-0 flex-1 bg-[var(--color-bg-canvas)]">
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col bg-[var(--color-bg-canvas)]">
       <Dashboard
         initialSessions={pageData.sessions}
         projectId={pageData.selectedProjectId}

--- a/packages/web/src/components/Dashboard.tsx
+++ b/packages/web/src/components/Dashboard.tsx
@@ -716,7 +716,7 @@ function DashboardInner({
           </div>
         </header>
 
-        <main className="dashboard-main flex-1 min-h-0 overflow-hidden">
+        <main className="dashboard-main flex flex-col flex-1 min-h-0 overflow-hidden">
           <DynamicFavicon attentionLevels={attentionLevels} projectName={projectName} />
           <div className="dashboard-main__subhead">
             <h1 className="dashboard-main__title">Dashboard</h1>


### PR DESCRIPTION
## Summary

Re-opens #1923. PR #1925 (merged as \`ee3fb5d3\`) added internal scroll on \`.done-bar__cards\` — that didn't work because the bug was in a layer of the layout tree neither of us inspected.

## Real root cause (found via devtools, credit @harshitsinghbhandari)

The clipper is **\`.dashboard-shell--desktop\`** (height 900px, \`overflow: hidden\`), not anything inside \`Dashboard\`. The project page wrapper at \`packages/web/src/app/projects/[projectId]/page.tsx:32\` was:

\`\`\`jsx
<div className=\"flex-1 min-h-screen bg-[var(--color-bg-canvas)]\">
\`\`\`

That's a non-flex block with \`min-height: 100vh\`. So \`.dashboard-main--desktop\` grew to its content height (~1411px) inside the shell row, and \`.dashboard-main__body\` — which has \`overflow-y: auto\` — also grew to content height (~1308px). Body never had a constrained height, so its \`overflow-y\` never triggered. The shell clipped everything past 900px and there was no scroll path anywhere.

## Fix

**1. Page wrapper** (\`packages/web/src/app/projects/[projectId]/page.tsx\`):

\`\`\`diff
- <div className=\"flex-1 min-h-screen bg-[var(--color-bg-canvas)]\">
+ <div className=\"flex min-h-0 min-w-0 flex-1 bg-[var(--color-bg-canvas)]\">
\`\`\`

Bounded flex item now. \`.dashboard-main--desktop\` inherits the shell row's 900px constraint instead of growing past it.

**2. Lock kanban + done from flex-shrink** (\`packages/web/src/app/globals.css\`):

\`\`\`css
.kanban-board-wrap { ...; flex-shrink: 0; }
.done-bar { flex-shrink: 0; }
\`\`\`

Without these, body's flex column would crush either the kanban or the done section to make room. With them, both assert their content size, body content exceeds body height, \`.dashboard-main__body { overflow-y: auto }\` activates, the whole dashboard scrolls as one unit — kanban above, Done below.

## Verification (browser, computed styles)

After fix:
- \`.dashboard-main__body\` — \`clientHeight: 797\`, \`scrollHeight: 1308\`, \`scrollTop\` reaches 511 ✓
- \`.kanban-board-wrap\` — 660px (preserved, not crushed) ✓

## Scope

- \`packages/web/src/app/projects/[projectId]/page.tsx\` — 1 line (wrapper className)
- \`packages/web/src/app/globals.css\` — +5 (\`flex-shrink: 0\` on \`.kanban-board-wrap\`, new \`.done-bar { flex-shrink: 0 }\` rule), −16 (revert #1925's internal scroll)
- \`packages/web/src/components/Dashboard.tsx\` — \`flex flex-col\` on \`<main>\` (also necessary so body's \`flex: 1\` resolves correctly inside main)
- \`packages/web/src/app/projects/[projectId]/loading.tsx\` — same \`flex flex-col\` on \`<main>\` for the loading skeleton
- \`.changeset/fix-done-bar-scroll.md\` — updated

## CLAUDE.md compliance

- C-01 ✓ no UI libs
- C-02 ✓ Tailwind classes only, no inline styles
- C-05 ✓ no design token / dark theme changes

## Test plan

- [x] Browser-verified scroll behavior (devtools clientHeight/scrollHeight numbers above)
- [x] Focused tests pass locally
- [ ] CI: \`pnpm typecheck\`, \`pnpm test\`, \`pnpm --filter @aoagents/ao-web test\`
- [ ] Manual: empty state still vertically centers CTA
- [ ] Manual: kanban still scrolls horizontally on narrow viewports
- [ ] Manual: loading skeleton renders correctly

## History

Three prior attempts addressed the wrong layer of the layout tree:
- #1925 — \`max-height\` + \`overflow-y: auto\` on \`.done-bar__cards\` (merged; didn't work; reverted here)
- This branch \`f7f843cd\` — dropped \`.kanban-board-wrap\` from \`flex: 1\` rule
- This branch \`9aa58691\` — added \`flex flex-col\` to \`<main>\`

The \`<main>\` and wrap changes turn out to be necessary too (so body's flex chain actually resolves), but were insufficient until the page wrapper itself was bounded. Lesson saved: for CSS scroll/flex/overflow bugs, open devtools and walk the FULL ancestor chain — including \`page.tsx\` / \`layout.tsx\` wrappers OUTSIDE the component file. Reasoning from CSS source produces confident wrong answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)