### PR TITLE
fix(web): coalesce session snapshot fetches

### DIFF
--- a/.changeset/session-broadcaster-fetch-oom.md
+++ b/.changeset/session-broadcaster-fetch-oom.md
@@ -1,0 +1,5 @@
+---
+"@aoagents/ao-web": patch
+---
+
+Fix mux session snapshot polling so rapid dashboard reconnects do not pile up duplicate uncancelled requests to the Next.js dashboard server. SessionBroadcaster now shares an in-flight snapshot fetch across subscribers, aborts it when the final subscriber disconnects, and keeps the timeout active until the response body is consumed.

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -179,7 +179,7 @@ describe("SessionBroadcaster", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it("does not start a second polling interval for additional subscribers", async () => {
+    it("shares the immediate snapshot request across additional subscribers", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
         json: async () => ({ sessions: [] }),
@@ -189,12 +189,85 @@ describe("SessionBroadcaster", () => {
       broadcaster.subscribe(vi.fn());
       await vi.advanceTimersByTimeAsync(0);
 
-      // 1 snapshot for sub1 + 1 snapshot for sub2 = 2
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      // Both subscribers can attach before the first snapshot resolves; they
+      // should share that in-flight request instead of doubling pressure on
+      // the Next.js API route.
+      expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // After 3 seconds, only one polling fetch happens
       await vi.advanceTimersByTimeAsync(3000);
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("aborts an in-flight snapshot request when the last subscriber leaves", async () => {
+      let signal: AbortSignal | undefined;
+      mockFetch.mockImplementationOnce((_url, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            "abort",
+            () => reject(new DOMException("The operation was aborted.", "AbortError")),
+            { once: true },
+          );
+        });
+      });
+
+      const unsub = broadcaster.subscribe(vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(signal?.aborted).toBe(false);
+
+      unsub();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(signal?.aborted).toBe(true);
+    });
+
+    it("does not reuse an aborted snapshot request for a later subscriber", async () => {
+      mockFetch.mockImplementationOnce(() => new Promise(() => {}));
+
+      const unsub = broadcaster.subscribe(vi.fn());
+      await vi.advanceTimersByTimeAsync(0);
+      unsub();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const patches = [makePatch("s1")];
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ sessions: patches }),
+      });
+
+      const callback = vi.fn();
+      broadcaster.subscribe(callback);
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenCalledWith(patches);
+    });
+
+    it("keeps the snapshot timeout active while reading the response body", async () => {
+      let signal: AbortSignal | undefined;
+      mockFetch.mockImplementationOnce((_url, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return Promise.resolve({
+          ok: true,
+          json: async () =>
+            new Promise((_resolve, reject) => {
+              signal?.addEventListener(
+                "abort",
+                () => reject(new DOMException("The operation was aborted.", "AbortError")),
+                { once: true },
+              );
+            }),
+        });
+      });
+
+      const onError = vi.fn();
+      broadcaster.subscribe(vi.fn(), onError);
+      await vi.advanceTimersByTimeAsync(4_010);
+
+      expect(signal?.aborted).toBe(true);
+      expect(onError).toHaveBeenCalledWith("Session fetch timed out after 4000ms");
     });
 
     it("returns an unsubscribe function that stops polling when last subscriber leaves", async () => {

--- a/packages/web/server/__tests__/mux-websocket.test.ts
+++ b/packages/web/server/__tests__/mux-websocket.test.ts
@@ -298,12 +298,7 @@ describe("SessionBroadcaster", () => {
     it("delivers patches to all subscribers on each poll", async () => {
       const patches = [makePatch("s1"), makePatch("s2")];
 
-      // Initial snapshot for first subscriber
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ sessions: patches }),
-      });
-      // Initial snapshot for second subscriber
+      // Shared initial snapshot for both subscribers
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ sessions: patches }),
@@ -324,6 +319,7 @@ describe("SessionBroadcaster", () => {
       // Both callbacks should have received initial snapshot
       expect(cb1).toHaveBeenCalledWith(patches);
       expect(cb2).toHaveBeenCalledWith(patches);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
 
       // Advance past poll interval (3s) and add buffer for promise resolution
       await vi.advanceTimersByTimeAsync(3010);
@@ -331,6 +327,7 @@ describe("SessionBroadcaster", () => {
       // Should be called again from polling
       expect(cb1).toHaveBeenCalledTimes(2);
       expect(cb2).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("isolates subscriber errors — one throw does not skip others", async () => {

--- a/packages/web/server/mux-websocket.ts
+++ b/packages/web/server/mux-websocket.ts
@@ -70,6 +70,21 @@ interface SessionPatch {
   lastActivityAt: string;
 }
 
+const SESSION_SNAPSHOT_TIMEOUT_MS = 4_000;
+
+type SessionSnapshotResult = {
+  sessions: SessionPatch[] | null;
+  error: string | null;
+};
+
+interface InFlightSessionSnapshot {
+  controller: AbortController;
+  promise: Promise<SessionSnapshotResult>;
+  timeoutId: ReturnType<typeof setTimeout>;
+  timedOut: boolean;
+  abortedByDisconnect: boolean;
+}
+
 /**
  * Manages polling of session patches from Next.js /api/sessions/patches.
  * Broadcasts to all subscribed callbacks.
@@ -80,6 +95,7 @@ export class SessionBroadcaster {
   private errorSubscribers = new Set<(error: string) => void>();
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private polling = false;
+  private inFlightSnapshot: InFlightSessionSnapshot | null = null;
   // Tracks the last fetch outcome so we only emit ui.session_broadcast_failed on
   // the healthy → failing transition (not every 3s during an outage).
   private lastFetchOk = true;
@@ -121,7 +137,7 @@ export class SessionBroadcaster {
     // Start polling if this is the first subscriber
     if (wasEmpty) {
       this.intervalId = setInterval(() => {
-        if (this.polling) return;
+        if (this.polling || this.inFlightSnapshot) return;
         this.polling = true;
         void this.fetchSnapshot()
           .then((result) => {
@@ -164,33 +180,60 @@ export class SessionBroadcaster {
   }
 
   /** One-shot HTTP fetch of the current session list. */
-  private async fetchSnapshot(): Promise<{
-    sessions: SessionPatch[] | null;
-    error: string | null;
-  }> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 4000);
-    try {
-      const res = await fetch(`${this.baseUrl}/api/sessions/patches`, {
-        signal: controller.signal,
-      });
-      clearTimeout(timeoutId);
-      if (!res.ok) {
-        const msg = `Session fetch failed: HTTP ${res.status}`;
-        console.warn(`[SessionBroadcaster] ${msg}`);
-        this.recordFetchFailure(msg, { httpStatus: res.status });
-        return { sessions: null, error: msg };
-      }
-      const data = (await res.json()) as { sessions?: SessionPatch[] };
-      this.lastFetchOk = true;
-      return { sessions: data.sessions ?? null, error: null };
-    } catch (err) {
-      clearTimeout(timeoutId);
-      const msg = err instanceof Error ? err.message : String(err);
-      console.warn("[SessionBroadcaster] fetchSnapshot error:", msg);
-      this.recordFetchFailure(msg);
-      return { sessions: null, error: msg };
+  private fetchSnapshot(): Promise<SessionSnapshotResult> {
+    if (this.inFlightSnapshot) {
+      return this.inFlightSnapshot.promise;
     }
+
+    const controller = new AbortController();
+    const snapshot: InFlightSessionSnapshot = {
+      controller,
+      promise: Promise.resolve({ sessions: null, error: null }),
+      timeoutId: setTimeout(() => {
+        snapshot.timedOut = true;
+        controller.abort();
+      }, SESSION_SNAPSHOT_TIMEOUT_MS),
+      timedOut: false,
+      abortedByDisconnect: false,
+    };
+
+    snapshot.promise = (async (): Promise<SessionSnapshotResult> => {
+      try {
+        const res = await fetch(`${this.baseUrl}/api/sessions/patches`, {
+          signal: controller.signal,
+        });
+        if (!res.ok) {
+          const msg = `Session fetch failed: HTTP ${res.status}`;
+          console.warn(`[SessionBroadcaster] ${msg}`);
+          this.recordFetchFailure(msg, { httpStatus: res.status });
+          return { sessions: null, error: msg };
+        }
+        const data = (await res.json()) as { sessions?: SessionPatch[] };
+        this.lastFetchOk = true;
+        return { sessions: data.sessions ?? null, error: null };
+      } catch (err) {
+        if (snapshot.abortedByDisconnect) {
+          return { sessions: null, error: null };
+        }
+
+        const msg = snapshot.timedOut
+          ? `Session fetch timed out after ${SESSION_SNAPSHOT_TIMEOUT_MS}ms`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+        console.warn("[SessionBroadcaster] fetchSnapshot error:", msg);
+        this.recordFetchFailure(msg);
+        return { sessions: null, error: msg };
+      } finally {
+        clearTimeout(snapshot.timeoutId);
+        if (this.inFlightSnapshot === snapshot) {
+          this.inFlightSnapshot = null;
+        }
+      }
+    })();
+
+    this.inFlightSnapshot = snapshot;
+    return snapshot.promise;
   }
 
   /**
@@ -218,6 +261,13 @@ export class SessionBroadcaster {
     if (this.intervalId !== null) {
       clearInterval(this.intervalId);
       this.intervalId = null;
+    }
+    const inFlightSnapshot = this.inFlightSnapshot;
+    if (inFlightSnapshot) {
+      inFlightSnapshot.abortedByDisconnect = true;
+      clearTimeout(inFlightSnapshot.timeoutId);
+      inFlightSnapshot.controller.abort();
+      this.inFlightSnapshot = null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Share one in-flight SessionBroadcaster snapshot fetch across mux subscribers instead of starting duplicate requests per reconnect/subscriber.
- Abort the active snapshot request when the final mux subscriber disconnects, and do not reuse that intentionally-aborted request for later subscribers.
- Keep the 4s timeout active through response body parsing so stalled `/api/sessions/patches` responses fail instead of hanging indefinitely.

Closes #1935

## Tests
- `pnpm --filter @aoagents/ao-web test -- server/__tests__/mux-websocket.test.ts`
- `pnpm --filter @aoagents/ao-web test`
- `pnpm --filter @aoagents/ao-web typecheck`
- `pnpm --filter @aoagents/ao-web... build`
- `pnpm exec prettier --check packages/web/server/mux-websocket.ts packages/web/server/__tests__/mux-websocket.test.ts .changeset/session-broadcaster-fetch-oom.md`

## Notes
- `pnpm install --frozen-lockfile` completed, with an existing non-fatal `node-pty` rebuild warning from the local Nix/Xcode toolchain (`fatal error: 'functional' file not found`). The package postinstall reports this as non-critical; tests/build above passed.
