### PR TITLE
fix(web): externalize ao-core and better-sqlite3 from Next.js bundle

### DIFF
--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -22,6 +22,8 @@ const nextConfig = {
   serverExternalPackages: [
     "yaml",
     "zod",
+    "@aoagents/ao-core",
+    "better-sqlite3",
   ],
   webpack: (config, { isServer }) => {
     if (process.platform === "win32") {

--- a/packages/web/next.config.js
+++ b/packages/web/next.config.js
@@ -9,7 +9,6 @@ const homeDir = os.homedir().replace(/\\/g, "/");
 const nextConfig = {
   outputFileTracingRoot: path.join(__dirname, "../.."),
   transpilePackages: [
-    "@aoagents/ao-core",
     "@aoagents/ao-plugin-agent-claude-code",
     "@aoagents/ao-plugin-agent-codex",
     "@aoagents/ao-plugin-agent-opencode",


### PR DESCRIPTION
## Problem (Fixes #1930)

Next.js bundles `@aoagents/ao-core` (via `transpilePackages`) into the `.next/server/` output. During bundling, webpack resolves `import.meta.url` to the **build machine's absolute path** and bakes it in as a string literal:

```js
createRequire(file:///tmp/ao-publish-stable/packages/core/dist/events-db.js)
```

At runtime on any other machine — especially Windows — this path doesn't exist, causing:
- `TypeError: The argument 'filename' must be a file URL object, file URL string, or absolute path string`
- `[ao] activity-events DB unavailable — events will be dropped: Cannot find module 'better-sqlite3'`

**88 files** in `.next/` had the build path baked in.

## Fix

Add `@aoagents/ao-core` and `better-sqlite3` to `serverExternalPackages` in `next.config.js`. This tells Next.js to not bundle these packages — they're resolved at runtime from `node_modules/`, so `import.meta.url` resolves to the user's actual install path.

Precedent: #1057 / commit `3a108e9b` did the same for `@composio/core`.

## Affected source locations

1. `packages/core/src/events-db.ts` — `createRequire(import.meta.url)(better-sqlite3)`
2. `packages/core/src/update-cache.ts` — `createRequire(fileURLToPath(import.meta.url))`


`runtime-process/dist/index.ts` also uses `import.meta.url` but is NOT in `transpilePackages`, so it was never bundled and is unaffected.

## Impact on release pipeline

None. This is a code-only change. Goes through the normal changeset → PR → release flow.
