### PR TITLE
fix(web): remove XDA chip from terminal header (closes #1962)

### DIFF
--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -8551,7 +8551,7 @@ html.light .xterm .xterm-viewport:hover::-webkit-scrollbar-thumb:active {
     margin-right: 2px;
   }
 
-  /* Stack: session name on top, status+XDA row below */
+  /* Stack: session name on top, status row below */
   .terminal-chrome-identity {
     flex-direction: column;
     align-items: flex-start;

--- a/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
+++ b/packages/web/src/components/__tests__/DirectTerminal.render.test.tsx
@@ -154,7 +154,7 @@ describe("DirectTerminal render", () => {
     await waitFor(() => expect(screen.getByText("Connected")).toBeInTheDocument());
 
     expect(screen.getByText("ao-orchestrator")).toHaveStyle({ color: "var(--color-accent)" });
-    expect(screen.getByText("XDA")).toHaveStyle({ color: "var(--color-accent)" });
+    expect(screen.queryByText("XDA")).toBeNull();
   });
 
   it("keeps restart and fullscreen actions available in chromeless mode", async () => {

--- a/packages/web/src/components/terminal/TerminalControls.tsx
+++ b/packages/web/src/components/terminal/TerminalControls.tsx
@@ -217,7 +217,7 @@ export function TerminalControls({
     <div className="terminal-chrome-bar flex items-center gap-2 border-b border-[var(--color-border-subtle)] bg-[var(--color-bg-elevated)] px-3 py-2">
       {/* Pane label — matches the workspace pane-header style used elsewhere */}
       <span className="terminal-chrome-pane-label">TERMINAL</span>
-      {/* Identity group: session name on top, status+XDA below on mobile */}
+      {/* Identity group: session name on top, status below on mobile */}
       <div className="terminal-chrome-identity">
         <span className="terminal-chrome-session-id font-[var(--font-mono)] text-[11px]" style={{ color: accentColor }}>
           {sessionId}
@@ -228,15 +228,6 @@ export function TerminalControls({
             className={cn("text-[10px] font-medium uppercase tracking-[0.06em]", statusTextColor)}
           >
             {statusText}
-          </span>
-          <span
-            className="px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em]"
-            style={{
-              color: accentColor,
-              background: `color-mix(in srgb, ${accentColor} 12%, transparent)`,
-            }}
-          >
-            XDA
           </span>
         </div>
       </div>


### PR DESCRIPTION
Closes #1962

## Summary
- Removed the user-facing `XDA` chip from the terminal header status row.
- Updated stale status-row comments to no longer describe a `status+XDA` layout.
- Updated the render expectation so terminal chrome no longer expects the protocol chip.

## Notes
Clipboard / OSC 52 support is unaffected: this only removes the visual chip, and the XDA handler in `terminal-clipboard.ts` continues to handle the tmux/xterm protocol behavior.

## Tests
- `pnpm --filter @aoagents/ao-web typecheck`
- `NODE_ENV=test pnpm --filter @aoagents/ao-web test`
