### PR TITLE
fix(agent-codex): use thread id for JSONL lookup

### DIFF
--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -691,6 +691,56 @@ describe("getActivityState", () => {
     expect(await agent.getActivityState(session)).toBeNull();
   });
 
+  it("uses persisted codexThreadId filename without cwd-prefix open scans", async () => {
+    mockTmuxWithProcess("codex");
+    mockReaddir.mockResolvedValue(["rollout-2026-05-22T00-00-00-thread-fast-activity.jsonl"]);
+    const modifiedAt = new Date();
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "assistant_message",
+      modifiedAt,
+    });
+
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+      metadata: { codexThreadId: "thread-fast-activity" },
+    });
+    const result = await agent.getActivityState(session);
+
+    expect(result?.state).toBe("ready");
+    expect(mockReadLastJsonlEntry).toHaveBeenCalledWith(
+      pathJoin(
+        "/mock/home",
+        ".codex",
+        "sessions",
+        "rollout-2026-05-22T00-00-00-thread-fast-activity.jsonl",
+      ),
+    );
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("falls back to cwd-prefix scanning when codexThreadId lookup misses", async () => {
+    mockTmuxWithProcess("codex");
+    const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
+    mockReaddir.mockResolvedValue(["rollout-other-thread.jsonl"]);
+    setupMockOpen(content);
+    mockStat.mockResolvedValue({ mtimeMs: Date.now(), mtime: new Date() });
+    mockReadLastJsonlEntry.mockResolvedValue({
+      lastType: "assistant_message",
+      modifiedAt: new Date(),
+    });
+
+    const session = makeSession({
+      runtimeHandle: makeTmuxHandle(),
+      workspacePath: "/workspace/test",
+      metadata: { codexThreadId: "missing-thread" },
+    });
+    const result = await agent.getActivityState(session);
+
+    expect(result?.state).toBe("ready");
+    expect(mockOpen).toHaveBeenCalled();
+  });
+
   it("returns active when session file was recently modified", async () => {
     mockTmuxWithProcess("codex");
     const content = '{"type":"session_meta","cwd":"/workspace/test"}\n';
@@ -994,6 +1044,68 @@ describe("getSessionInfo", () => {
     expect(await agent.getSessionInfo(makeSession())).toBeNull();
   });
 
+  it("uses persisted codexThreadId filename without cwd-prefix open scans", async () => {
+    const sessionContent = jsonl(
+      {
+        type: "session_meta",
+        payload: {
+          id: "thread-fast-info",
+        },
+      },
+      {
+        type: "turn_context",
+        payload: {
+          model: "gpt-5.5",
+        },
+      },
+    );
+
+    mockReaddir.mockResolvedValue(["rollout-2026-05-22T00-00-00-thread-fast-info.jsonl"]);
+    setupMockStream(sessionContent);
+
+    const result = await agent.getSessionInfo(
+      makeSession({
+        workspacePath: "/workspace/test",
+        metadata: { codexThreadId: "thread-fast-info" },
+      }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentSessionId).toBe("rollout-2026-05-22T00-00-00-thread-fast-info");
+    expect(result!.summary).toBe("Codex session (gpt-5.5)");
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("caches codexThreadId filename lookups by thread id", async () => {
+    const sessionContent = jsonl({
+      type: "session_meta",
+      payload: {
+        id: "thread-cached-info",
+      },
+    });
+
+    mockReaddir.mockResolvedValue(["rollout-thread-cached-info.jsonl"]);
+    mockCreateReadStream.mockImplementation(() => makeContentStream(sessionContent));
+
+    const first = await agent.getSessionInfo(
+      makeSession({
+        workspacePath: "/workspace/first",
+        metadata: { codexThreadId: "thread-cached-info" },
+      }),
+    );
+    const second = await agent.getSessionInfo(
+      makeSession({
+        workspacePath: "/workspace/second",
+        metadata: { codexThreadId: "thread-cached-info" },
+      }),
+    );
+
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+    expect(mockReaddir).toHaveBeenCalledTimes(1);
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
   it("returns null when no session files match the workspace cwd", async () => {
     mockReaddir.mockResolvedValue(["session-abc.jsonl"]);
     const content = jsonl({ type: "session_meta", cwd: "/other/workspace", model: "gpt-4o" });
@@ -1002,6 +1114,25 @@ describe("getSessionInfo", () => {
     expect(
       await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" })),
     ).toBeNull();
+  });
+
+  it("falls back to cwd-prefix scanning when codexThreadId is absent", async () => {
+    const sessionContent = jsonl({
+      type: "session_meta",
+      cwd: "/workspace/test",
+      model: "gpt-5.4",
+    });
+
+    mockReaddir.mockResolvedValue(["rollout-cwd-fallback.jsonl"]);
+    setupMockOpen(sessionContent);
+    setupMockStream(sessionContent);
+    mockStat.mockResolvedValue({ mtimeMs: 1000 });
+
+    const result = await agent.getSessionInfo(makeSession({ workspacePath: "/workspace/test" }));
+
+    expect(result).not.toBeNull();
+    expect(result!.summary).toBe("Codex session (gpt-5.4)");
+    expect(mockOpen).toHaveBeenCalled();
   });
 
   it("returns session info with cost and model when matching session found", async () => {
@@ -1410,6 +1541,7 @@ describe("getRestoreCommand", () => {
     expect(cmd).toContain("--model 'gpt-5.3-codex'");
     expect(cmd).toContain("persisted-thread");
     expect(mockReaddir).not.toHaveBeenCalled();
+    expect(mockOpen).not.toHaveBeenCalled();
   });
 
   it("builds native resume command from payload-wrapped Codex session id", async () => {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -738,6 +738,7 @@ describe("getActivityState", () => {
     const result = await agent.getActivityState(session);
 
     expect(result?.state).toBe("ready");
+    expect(mockReaddir).toHaveBeenCalledTimes(1);
     expect(mockOpen).toHaveBeenCalled();
   });
 
@@ -1104,6 +1105,21 @@ describe("getSessionInfo", () => {
     expect(second).not.toBeNull();
     expect(mockReaddir).toHaveBeenCalledTimes(1);
     expect(mockOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not treat infix filename matches as thread-id hits", async () => {
+    mockReaddir.mockResolvedValue(["rollout-thread-fast-extra.jsonl"]);
+
+    const result = await agent.getSessionInfo(
+      makeSession({
+        workspacePath: null,
+        metadata: { codexThreadId: "fast" },
+      }),
+    );
+
+    expect(result).toBeNull();
+    expect(mockOpen).not.toHaveBeenCalled();
+    expect(mockCreateReadStream).not.toHaveBeenCalled();
   });
 
   it("returns null when no session files match the workspace cwd", async () => {

--- a/packages/plugins/agent-codex/src/index.test.ts
+++ b/packages/plugins/agent-codex/src/index.test.ts
@@ -1107,6 +1107,44 @@ describe("getSessionInfo", () => {
     expect(mockOpen).not.toHaveBeenCalled();
   });
 
+  it("chooses the newest duplicate codexThreadId filename match by mtime", async () => {
+    const oldContent = jsonl({
+      type: "session_meta",
+      payload: { id: "thread-dupe", model: "old-model" },
+    });
+    const newContent = jsonl({
+      type: "session_meta",
+      payload: { id: "thread-dupe", model: "new-model" },
+    });
+
+    mockReaddir.mockResolvedValue([
+      "rollout-old-thread-dupe.jsonl",
+      "rollout-new-thread-dupe.jsonl",
+    ]);
+    mockStat.mockImplementation((path: string) => {
+      if (path.includes("rollout-old-thread-dupe")) return Promise.resolve({ mtimeMs: 1000 });
+      if (path.includes("rollout-new-thread-dupe")) return Promise.resolve({ mtimeMs: 2000 });
+      return Promise.reject(new Error("ENOENT"));
+    });
+    mockCreateReadStream.mockImplementation((path: string) => {
+      if (path.includes("rollout-old-thread-dupe")) return makeContentStream(oldContent);
+      if (path.includes("rollout-new-thread-dupe")) return makeContentStream(newContent);
+      return makeContentStream("");
+    });
+
+    const result = await agent.getSessionInfo(
+      makeSession({
+        workspacePath: "/workspace/test",
+        metadata: { codexThreadId: "thread-dupe" },
+      }),
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.agentSessionId).toBe("rollout-new-thread-dupe");
+    expect(result!.summary).toBe("Codex session (new-model)");
+    expect(mockOpen).not.toHaveBeenCalled();
+  });
+
   it("does not treat infix filename matches as thread-id hits", async () => {
     mockReaddir.mockResolvedValue(["rollout-thread-fast-extra.jsonl"]);
 

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -252,6 +252,34 @@ async function findCodexSessionFile(workspacePath: string): Promise<string | nul
   return bestMatch?.path ?? null;
 }
 
+/**
+ * Find a Codex session file by persisted native thread id. Codex rollout
+ * filenames include the thread id, so this path only inspects filenames and
+ * avoids opening historical JSONL files to match session_meta.cwd.
+ */
+async function findCodexSessionFileByThreadId(threadId: string): Promise<string | null> {
+  const jsonlFiles = await collectJsonlFiles(CODEX_SESSIONS_DIR);
+  const matches = jsonlFiles.filter((filePath) => basename(filePath).includes(threadId));
+  if (matches.length === 0) return null;
+  if (matches.length === 1) return matches[0] ?? null;
+
+  let bestMatch: { path: string; mtime: number } | null = null;
+  let fallback: string | null = null;
+  for (const filePath of matches) {
+    fallback ??= filePath;
+    try {
+      const s = await stat(filePath);
+      if (!bestMatch || s.mtimeMs > bestMatch.mtime) {
+        bestMatch = { path: filePath, mtime: s.mtimeMs };
+      }
+    } catch {
+      // Keep a filename match as fallback; thread id in the filename is enough.
+    }
+  }
+
+  return bestMatch?.path ?? fallback;
+}
+
 /** Aggregated data extracted from a Codex session file via streaming */
 interface CodexSessionData {
   model: string | null;
@@ -499,21 +527,44 @@ function appendNoUpdateCheckFlag(parts: string[]): void {
 const SESSION_FILE_CACHE_TTL_MS = 30_000;
 
 /** Module-level session file cache shared across the agent instance lifetime.
- *  Keyed by workspace path, stores the resolved file path and an expiry timestamp. */
+ *  Keyed by Codex thread id when available, otherwise workspace path. */
 const sessionFileCache = new Map<string, { path: string | null; expiry: number }>();
 
-/** Find session file with caching to avoid double scans per refresh cycle */
-async function findCodexSessionFileCached(workspacePath: string): Promise<string | null> {
-  const cached = sessionFileCache.get(workspacePath);
+function getSessionMetadataString(session: Session, key: string): string | null {
+  const value = session.metadata?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function getCachedSessionFile(
+  cacheKey: string,
+  resolve: () => Promise<string | null>,
+): Promise<string | null> {
+  const cached = sessionFileCache.get(cacheKey);
   if (cached && Date.now() < cached.expiry) {
     return cached.path;
   }
-  const result = await findCodexSessionFile(workspacePath);
-  sessionFileCache.set(workspacePath, {
+  const result = await resolve();
+  sessionFileCache.set(cacheKey, {
     path: result,
     expiry: Date.now() + SESSION_FILE_CACHE_TTL_MS,
   });
   return result;
+}
+
+/** Find session file with caching to avoid double scans per refresh cycle */
+async function findCodexSessionFileCached(session: Session): Promise<string | null> {
+  const threadId = getSessionMetadataString(session, "codexThreadId");
+  if (threadId) {
+    const byThreadId = await getCachedSessionFile(`thread:${threadId}`, () =>
+      findCodexSessionFileByThreadId(threadId),
+    );
+    if (byThreadId) return byThreadId;
+  }
+
+  if (!session.workspacePath) return null;
+  return getCachedSessionFile(`cwd:${toComparablePath(session.workspacePath)}`, () =>
+    findCodexSessionFile(session.workspacePath!),
+  );
 }
 
 /**
@@ -611,11 +662,13 @@ function createCodexAgent(): Agent {
       if (running === PROCESS_PROBE_INDETERMINATE) return null;
       if (!running) return { state: "exited", timestamp: exitedAt };
 
-      if (!session.workspacePath) return null;
+      if (!session.workspacePath && !getSessionMetadataString(session, "codexThreadId")) {
+        return null;
+      }
 
       // 1. Try Codex's native JSONL first — it has richer 6-state detection
       //    (approval_request, error, tool_call, etc.) that terminal parsing can't match.
-      const sessionFile = await findCodexSessionFileCached(session.workspacePath);
+      const sessionFile = await findCodexSessionFileCached(session);
       if (sessionFile) {
         const entry = await readLastJsonlEntry(sessionFile);
         if (entry) {
@@ -676,7 +729,9 @@ function createCodexAgent(): Agent {
 
       // 2. Fallback: check AO activity JSONL (terminal-derived) for waiting_input/blocked
       //    that the native JSONL may not have captured.
-      const activityResult = await readLastActivityEntry(session.workspacePath);
+      const activityResult = session.workspacePath
+        ? await readLastActivityEntry(session.workspacePath)
+        : null;
       const activityState = checkActivityLogState(activityResult);
       if (activityState) return activityState;
 
@@ -765,9 +820,7 @@ function createCodexAgent(): Agent {
     },
 
     async getSessionInfo(session: Session): Promise<AgentSessionInfo | null> {
-      if (!session.workspacePath) return null;
-
-      const sessionFile = await findCodexSessionFileCached(session.workspacePath);
+      const sessionFile = await findCodexSessionFileCached(session);
       if (!sessionFile) return null;
 
       // Stream the file line-by-line to avoid loading potentially huge
@@ -806,13 +859,13 @@ function createCodexAgent(): Agent {
     },
 
     async getRestoreCommand(session: Session, project: ProjectConfig): Promise<string | null> {
-      let threadId = session.metadata?.["codexThreadId"]?.trim();
-      let model: string | null = session.metadata?.["codexModel"]?.trim() || null;
+      let threadId = getSessionMetadataString(session, "codexThreadId");
+      let model: string | null = getSessionMetadataString(session, "codexModel");
       if (!threadId) {
         if (!session.workspacePath) return null;
 
         // Find the Codex session file for this workspace
-        const sessionFile = await findCodexSessionFileCached(session.workspacePath);
+        const sessionFile = await findCodexSessionFileCached(session);
         if (!sessionFile) return null;
 
         // Stream the file line-by-line to avoid loading potentially huge

--- a/packages/plugins/agent-codex/src/index.ts
+++ b/packages/plugins/agent-codex/src/index.ts
@@ -229,8 +229,11 @@ async function sessionFileMatchesCwd(filePath: string, workspacePath: string): P
  * Recursively scans ~/.codex/sessions/ (date-sharded: YYYY/MM/DD/rollout-*.jsonl).
  * Returns the path to the most recently modified matching file, or null.
  */
-async function findCodexSessionFile(workspacePath: string): Promise<string | null> {
-  const jsonlFiles = await collectJsonlFiles(CODEX_SESSIONS_DIR);
+async function findCodexSessionFile(
+  workspacePath: string,
+  jsonlFiles?: string[],
+): Promise<string | null> {
+  jsonlFiles ??= await collectJsonlFiles(CODEX_SESSIONS_DIR);
   if (jsonlFiles.length === 0) return null;
 
   let bestMatch: { path: string; mtime: number } | null = null;
@@ -257,9 +260,14 @@ async function findCodexSessionFile(workspacePath: string): Promise<string | nul
  * filenames include the thread id, so this path only inspects filenames and
  * avoids opening historical JSONL files to match session_meta.cwd.
  */
-async function findCodexSessionFileByThreadId(threadId: string): Promise<string | null> {
-  const jsonlFiles = await collectJsonlFiles(CODEX_SESSIONS_DIR);
-  const matches = jsonlFiles.filter((filePath) => basename(filePath).includes(threadId));
+async function findCodexSessionFileByThreadId(
+  threadId: string,
+  jsonlFiles?: string[],
+): Promise<string | null> {
+  jsonlFiles ??= await collectJsonlFiles(CODEX_SESSIONS_DIR);
+  const matches = jsonlFiles.filter((filePath) =>
+    basename(filePath).endsWith(`-${threadId}.jsonl`),
+  );
   if (matches.length === 0) return null;
   if (matches.length === 1) return matches[0] ?? null;
 
@@ -553,17 +561,23 @@ async function getCachedSessionFile(
 
 /** Find session file with caching to avoid double scans per refresh cycle */
 async function findCodexSessionFileCached(session: Session): Promise<string | null> {
+  let jsonlFiles: string[] | null = null;
+  const getJsonlFiles = async (): Promise<string[]> => {
+    jsonlFiles ??= await collectJsonlFiles(CODEX_SESSIONS_DIR);
+    return jsonlFiles;
+  };
+
   const threadId = getSessionMetadataString(session, "codexThreadId");
   if (threadId) {
-    const byThreadId = await getCachedSessionFile(`thread:${threadId}`, () =>
-      findCodexSessionFileByThreadId(threadId),
+    const byThreadId = await getCachedSessionFile(`thread:${threadId}`, async () =>
+      findCodexSessionFileByThreadId(threadId, await getJsonlFiles()),
     );
     if (byThreadId) return byThreadId;
   }
 
   if (!session.workspacePath) return null;
-  return getCachedSessionFile(`cwd:${toComparablePath(session.workspacePath)}`, () =>
-    findCodexSessionFile(session.workspacePath!),
+  return getCachedSessionFile(`cwd:${toComparablePath(session.workspacePath)}`, async () =>
+    findCodexSessionFile(session.workspacePath!, await getJsonlFiles()),
   );
 }
 


### PR DESCRIPTION
## Summary
- resolve Codex JSONL files by persisted `session.metadata.codexThreadId` filename first
- cache successful/missing file lookups by thread id before falling back to cwd matching
- keep cwd-prefix JSONL open scans only for sessions without a thread id or when filename lookup misses

Fixes #1990

## Tests
- `pnpm --filter @aoagents/ao-core build` (needed because this worktree initially had no built core dist)
- `pnpm --filter @aoagents/ao-plugin-agent-codex test`
- `pnpm --filter @aoagents/ao-plugin-agent-codex typecheck`
- `git diff --check`
