### PR TITLE
fix: use persisted session agent for enrichment

### DIFF
--- a/packages/cli/src/commands/send.ts
+++ b/packages/cli/src/commands/send.ts
@@ -32,7 +32,7 @@ async function resolveSessionContext(sessionName: string): Promise<{
     if (session) {
       const tmuxTarget = session.runtimeHandle?.id ?? sessionName;
       const project = config.projects[session.projectId];
-      const agentName = session.metadata["agent"] ?? project?.agent ?? config.defaults.agent;
+      const agentName = session.metadata["agent"]!;
       const runtimeName =
         session.runtimeHandle?.runtimeName ?? project?.runtime ?? config.defaults.runtime;
       return {

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -174,10 +174,12 @@ async function gatherSessionInfo(
           defaults: projectConfig.defaults,
           allSessionPrefixes,
         }).agentName
-      : projectConfig.defaults.agent;
-    const agent = getAgentByNameFromRegistry(registry, agentName);
-    const introspection = await agent.getSessionInfo(session);
-    claudeSummary = introspection?.summary ?? null;
+      : session.metadata["agent"];
+    if (agentName) {
+      const agent = getAgentByNameFromRegistry(registry, agentName);
+      const introspection = await agent.getSessionInfo(session);
+      claudeSummary = introspection?.summary ?? null;
+    }
   } catch {
     // Summary extraction failed — not critical
   }

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -3,7 +3,6 @@ import type { Command } from "commander";
 import {
   createInitialCanonicalLifecycle,
   createActivitySignal,
-  type Agent,
   type SCM,
   type Session,
   type PRInfo,
@@ -13,6 +12,8 @@ import {
   type Tracker,
   type ProjectConfig,
   type AgentReportAuditEntry,
+  type PluginRegistry,
+  resolveAgentSelectionForSession,
   isOrchestratorSession,
   isTerminalSession,
   isWindows,
@@ -127,7 +128,7 @@ function gatherProjectReviewStatus(projectId: string): ProjectReviewStatus {
 
 async function gatherSessionInfo(
   session: Session,
-  agent: Agent,
+  registry: PluginRegistry,
   scm: SCM,
   projectConfig: ReturnType<typeof loadConfig>,
   reportsLimit: number = 0,
@@ -160,9 +161,21 @@ async function gatherSessionInfo(
     lastActivity = activityTs ? formatAge(activityTs) : "-";
   }
 
-  // Get agent's auto-generated summary via introspection
+  // Get agent's auto-generated summary via introspection. Resolve per session so
+  // historical mixed-agent rows are not probed with the current project default.
   let claudeSummary: string | null = null;
   try {
+    const project = projectConfig.projects[session.projectId];
+    const agentName = project
+      ? resolveAgentSelectionForSession({
+          sessionId: session.id,
+          metadata: session.metadata,
+          project,
+          defaults: projectConfig.defaults,
+          allSessionPrefixes,
+        }).agentName
+      : projectConfig.defaults.agent;
+    const agent = getAgentByNameFromRegistry(registry, agentName);
     const introspection = await agent.getSessionInfo(session);
     claudeSummary = introspection?.summary ?? null;
   } catch {
@@ -500,9 +513,9 @@ export function registerStatus(program: Command): void {
           totalActiveReviewRuns += reviewStatus.activeRunCount;
           totalOpenReviewFindings += reviewStatus.openFindingCount;
 
-          // Resolve agent and SCM for this project via the shared registry
-          const agentName = projectConfig.agent ?? config.defaults.agent;
-          const agent = getAgentByNameFromRegistry(registry, agentName);
+          // Resolve SCM for this project via the shared registry. Agents are
+          // resolved per session because historical metadata may record a
+          // different agent than the current project default.
           const scm = getSCMFromRegistry(registry, config, projectId);
 
           if (!opts.json) {
@@ -519,7 +532,9 @@ export function registerStatus(program: Command): void {
           }
 
           // Gather all session info in parallel
-          const infoPromises = projectSessions.map((s) => gatherSessionInfo(s, agent, scm, config, reportsLimit));
+          const infoPromises = projectSessions.map((s) =>
+            gatherSessionInfo(s, registry, scm, config, reportsLimit),
+          );
           const sessionInfos = await Promise.all(infoPromises);
 
           const orchestrators = sessionInfos.filter((info) => info.role === "orchestrator");

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -13,7 +13,6 @@ import {
   type ProjectConfig,
   type AgentReportAuditEntry,
   type PluginRegistry,
-  resolveAgentSelectionForSession,
   isOrchestratorSession,
   isTerminalSession,
   isWindows,
@@ -161,20 +160,12 @@ async function gatherSessionInfo(
     lastActivity = activityTs ? formatAge(activityTs) : "-";
   }
 
-  // Get agent's auto-generated summary via introspection. Resolve per session so
-  // historical mixed-agent rows are not probed with the current project default.
+  // Get agent's auto-generated summary via introspection. The SessionManager
+  // normalizes session.metadata.agent on read, so never infer the session agent
+  // from current project/default config here.
   let claudeSummary: string | null = null;
   try {
-    const project = projectConfig.projects[session.projectId];
-    const agentName = project
-      ? resolveAgentSelectionForSession({
-          sessionId: session.id,
-          metadata: session.metadata,
-          project,
-          defaults: projectConfig.defaults,
-          allSessionPrefixes,
-        }).agentName
-      : session.metadata["agent"];
+    const agentName = session.metadata["agent"];
     if (agentName) {
       const agent = getAgentByNameFromRegistry(registry, agentName);
       const introspection = await agent.getSessionInfo(session);

--- a/packages/core/src/__tests__/lifecycle-manager-instrumentation.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager-instrumentation.test.ts
@@ -76,6 +76,7 @@ function persistSession(
     branch: session.branch ?? "main",
     status: session.status,
     project: "my-app",
+    agent: session.metadata["agent"] ?? "mock-agent",
     runtimeHandle: session.runtimeHandle ?? undefined,
     ...metaOverrides,
   };

--- a/packages/core/src/__tests__/lifecycle-manager.test.ts
+++ b/packages/core/src/__tests__/lifecycle-manager.test.ts
@@ -149,6 +149,7 @@ function setupCheck(
     branch: opts.session.branch ?? "main",
     status: opts.session.status,
     project: "my-app",
+    agent: opts.session.metadata["agent"] ?? "mock-agent",
     runtimeHandle: opts.session.runtimeHandle ?? undefined,
     ...opts.metaOverrides,
   };
@@ -225,6 +226,7 @@ function setupPollCheck(
     branch: opts.session.branch ?? "main",
     status: opts.session.status,
     project: "my-app",
+    agent: opts.session.metadata["agent"] ?? "mock-agent",
     runtimeHandle: opts.session.runtimeHandle ?? undefined,
     ...opts.metaOverrides,
   };
@@ -530,7 +532,7 @@ describe("check (single session)", () => {
     expect(lm.getStates().get("app-1")).toBe("detecting");
   });
 
-  it("uses worker-specific agent fallback when metadata does not persist an agent", async () => {
+  it("uses persisted session agent even when worker config differs", async () => {
     const codexAgent: Agent = {
       ...plugins.agent,
       name: "codex",
@@ -557,13 +559,13 @@ describe("check (single session)", () => {
         "my-app": {
           ...config.projects["my-app"],
           agent: "mock-agent",
-          worker: { agent: "codex" },
+          worker: { agent: "mock-agent" },
         },
       },
     };
 
     const lm = setupCheck("app-1", {
-      session: makeSession({ status: "working", metadata: {} }),
+      session: makeSession({ status: "working", metadata: { agent: "codex" } }),
       registry: registryWithMultipleAgents,
       configOverride: configWithWorkerAgent,
     });

--- a/packages/core/src/__tests__/recovery-actions.test.ts
+++ b/packages/core/src/__tests__/recovery-actions.test.ts
@@ -103,6 +103,7 @@ function makeAssessment(overrides: Partial<RecoveryAssessment> = {}): RecoveryAs
     metadataStatus: "working",
     rawMetadata: {
       project: "app",
+      agent: "claude-code",
       branch: "feat/test",
       issue: "123",
       pr: "https://github.com/org/repo/pull/42",
@@ -169,6 +170,7 @@ describe("recoverSession", () => {
     expect(result.session?.restoredAt).toBeInstanceOf(Date);
     expect(metadata?.["restoredAt"]).toBeDefined();
     expect(metadata?.["recoveredAt"]).toBeUndefined();
+    expect(metadata?.["agent"]).toBe("claude-code");
   });
 
   it("preserves project ownership when legacy metadata omits the project field", async () => {

--- a/packages/core/src/__tests__/recovery-validator.test.ts
+++ b/packages/core/src/__tests__/recovery-validator.test.ts
@@ -119,6 +119,7 @@ describe("recovery validator", () => {
     const assessment = await validateSession(scanned, config, registry);
 
     expect(assessment.agentProcessRunning).toBe(true);
+    expect(assessment.rawMetadata["agent"]).toBe("codex");
     expect(mockOrchestratorAgent.isProcessRunning).toHaveBeenCalled();
     expect(mockWorkerAgent.isProcessRunning).not.toHaveBeenCalled();
   });

--- a/packages/core/src/__tests__/session-manager/communication.test.ts
+++ b/packages/core/src/__tests__/session-manager/communication.test.ts
@@ -598,6 +598,7 @@ describe("remap", () => {
 
     expect(mapped).toBe("ses_project_agent");
     const meta = readMetadataRaw(sessionsDir, "app-1");
+    expect(meta?.["agent"]).toBe("opencode");
     expect(meta?.["opencodeSessionId"]).toBe("ses_project_agent");
   });
 });

--- a/packages/core/src/__tests__/session-manager/query.test.ts
+++ b/packages/core/src/__tests__/session-manager/query.test.ts
@@ -64,6 +64,21 @@ describe("list", () => {
     expect(sessions.map((s) => s.id).sort()).toEqual(["app-1", "app-2"]);
   });
 
+  it("backfills missing legacy agent metadata on read", async () => {
+    writeMetadata(sessionsDir, "app-1", {
+      worktree: "/tmp/w1",
+      branch: "feat/a",
+      status: "working",
+      project: "my-app",
+    });
+
+    const sm = createSessionManager({ config, registry: mockRegistry });
+    const sessions = await sm.list();
+
+    expect(sessions[0]?.metadata["agent"]).toBe("mock-agent");
+    expect(readMetadataRaw(sessionsDir, "app-1")?.["agent"]).toBe("mock-agent");
+  });
+
   it("skips dead-runtime agent metadata discovery when native restore metadata is already persisted", async () => {
     writeMetadata(sessionsDir, "app-1", {
       worktree: config.projects["my-app"]!.path,
@@ -474,6 +489,7 @@ describe("list", () => {
       branch: "a",
       status: "working",
       project: "my-app",
+      agent: "mock-agent",
       runtimeHandle,
       lifecycle,
     });

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -29,6 +29,11 @@ export function resolveSessionRole(
     : "worker";
 }
 
+/**
+ * Resolve the agent identity for a session metadata record. Normalized Session
+ * objects are expected to carry metadata.agent; fallback resolution exists only
+ * for legacy raw metadata read/repair boundaries.
+ */
 export function resolveAgentSelectionForSession(params: {
   sessionId: string;
   metadata?: Record<string, string>;

--- a/packages/core/src/agent-selection.ts
+++ b/packages/core/src/agent-selection.ts
@@ -29,6 +29,26 @@ export function resolveSessionRole(
     : "worker";
 }
 
+export function resolveAgentSelectionForSession(params: {
+  sessionId: string;
+  metadata?: Record<string, string>;
+  project: ProjectConfig;
+  defaults: DefaultPlugins;
+  allSessionPrefixes?: string[];
+}): ResolvedAgentSelection {
+  return resolveAgentSelection({
+    role: resolveSessionRole(
+      params.sessionId,
+      params.metadata,
+      params.project.sessionPrefix,
+      params.allSessionPrefixes,
+    ),
+    project: params.project,
+    defaults: params.defaults,
+    persistedAgent: params.metadata?.["agent"],
+  });
+}
+
 export function resolveAgentSelection(params: {
   role: SessionRole;
   project: ProjectConfig;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,13 @@ export {
   listMetadata,
 } from "./metadata.js";
 export { createInitialCanonicalLifecycle, deriveLegacyStatus } from "./lifecycle-state.js";
+export {
+  resolveAgentSelection,
+  resolveAgentSelectionForSession,
+  resolveSessionRole,
+  type ResolvedAgentSelection,
+  type SessionRole,
+} from "./agent-selection.js";
 export { sessionFromMetadata } from "./utils/session-from-metadata.js";
 
 // AO-local code review store

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -70,7 +70,7 @@ import {
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveNotifierTarget } from "./notifier-resolution.js";
 import { recordNotificationDelivery } from "./notification-observability.js";
-import { resolveAgentSelectionForSession, resolveSessionRole } from "./agent-selection.js";
+import { resolveSessionRole } from "./agent-selection.js";
 import {
   DETECTING_MAX_ATTEMPTS,
   createDetectingDecision,
@@ -910,14 +910,8 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     const lifecycle = cloneLifecycle(session.lifecycle);
     const nowIso = new Date().toISOString();
-    const agentName = resolveAgentSelectionForSession({
-      sessionId: session.id,
-      metadata: session.metadata,
-      project,
-      defaults: config.defaults,
-      allSessionPrefixes: Object.values(config.projects).map((p) => p.sessionPrefix),
-    }).agentName;
-    const agent = registry.get<Agent>("agent", agentName);
+    const agentName = session.metadata["agent"];
+    const agent = agentName ? registry.get<Agent>("agent", agentName) : null;
     const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;
     let detectedIdleTimestamp: Date | null = null;
     let idleWasBlocked = false;

--- a/packages/core/src/lifecycle-manager.ts
+++ b/packages/core/src/lifecycle-manager.ts
@@ -70,7 +70,7 @@ import {
 import { createCorrelationId, createProjectObserver } from "./observability.js";
 import { resolveNotifierTarget } from "./notifier-resolution.js";
 import { recordNotificationDelivery } from "./notification-observability.js";
-import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import { resolveAgentSelectionForSession, resolveSessionRole } from "./agent-selection.js";
 import {
   DETECTING_MAX_ATTEMPTS,
   createDetectingDecision,
@@ -910,18 +910,12 @@ export function createLifecycleManager(deps: LifecycleManagerDeps): LifecycleMan
 
     const lifecycle = cloneLifecycle(session.lifecycle);
     const nowIso = new Date().toISOString();
-    const allSessionPrefixes = Object.values(config.projects).map((p) => p.sessionPrefix);
-    const sessionRole = resolveSessionRole(
-      session.id,
-      session.metadata,
-      project.sessionPrefix,
-      allSessionPrefixes,
-    );
-    const agentName = resolveAgentSelection({
-      role: sessionRole,
+    const agentName = resolveAgentSelectionForSession({
+      sessionId: session.id,
+      metadata: session.metadata,
       project,
       defaults: config.defaults,
-      persistedAgent: session.metadata["agent"],
+      allSessionPrefixes: Object.values(config.projects).map((p) => p.sessionPrefix),
     }).agentName;
     const agent = registry.get<Agent>("agent", agentName);
     const scm = project.scm?.plugin ? registry.get<SCM>("scm", project.scm.plugin) : null;

--- a/packages/core/src/recovery/actions.ts
+++ b/packages/core/src/recovery/actions.ts
@@ -51,6 +51,12 @@ function buildLifecycleRecoveryPatch(
   return buildLifecycleMetadataPatch(updated);
 }
 
+function preserveSessionAgentPatch(
+  rawMetadata: Record<string, string>,
+): Partial<Record<string, string>> {
+  return rawMetadata["agent"] ? { agent: rawMetadata["agent"] } : {};
+}
+
 export async function recoverSession(
   assessment: RecoveryAssessment,
   config: OrchestratorConfig,
@@ -101,6 +107,7 @@ export async function recoverSession(
         escalatedAt: now,
         escalationReason: `Exceeded max recovery attempts (${context.recoveryConfig.maxRecoveryAttempts})`,
         recoveryCount: String(recoveryCount),
+        ...preserveSessionAgentPatch(rawMetadata),
         ...buildLifecycleRecoveryPatch(rawMetadata, {
           state: "stuck",
           reason: "probe_failure",
@@ -121,6 +128,7 @@ export async function recoverSession(
       status: preservedStatus,
       restoredAt: now,
       recoveryCount: String(recoveryCount),
+      ...preserveSessionAgentPatch(rawMetadata),
     });
     context.invalidateCache?.();
 
@@ -225,6 +233,7 @@ export async function cleanupSession(
       status: "terminated",
       terminatedAt: cleanupAt,
       terminationReason: "cleanup",
+      ...preserveSessionAgentPatch(rawMetadata),
       ...buildLifecycleRecoveryPatch(rawMetadata, {
         state: "terminated",
         reason: "auto_cleanup",
@@ -284,6 +293,7 @@ export async function escalateSession(
       status: "stuck",
       escalatedAt: new Date().toISOString(),
       escalationReason: reason,
+      ...preserveSessionAgentPatch(rawMetadata),
       ...buildLifecycleRecoveryPatch(rawMetadata, {
         state: "stuck",
         reason: "probe_failure",

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -51,16 +51,19 @@ export async function validateSession(
     defaults: config.defaults,
     allSessionPrefixes: Object.values(config.projects).map((p) => p.sessionPrefix),
   }).agentName;
+  const normalizedMetadata = rawMetadata["agent"]
+    ? rawMetadata
+    : { ...rawMetadata, agent: agentName };
   const workspaceName = project.workspace ?? config.defaults.workspace;
 
   const runtime = registry.get<Runtime>("runtime", runtimeName);
   const agent = registry.get<Agent>("agent", agentName);
   const workspace = registry.get<Workspace>("workspace", workspaceName);
 
-  const workspacePath = rawMetadata["worktree"] || null;
-  const runtimeHandleStr = rawMetadata["runtimeHandle"];
+  const workspacePath = normalizedMetadata["worktree"] || null;
+  const runtimeHandleStr = normalizedMetadata["runtimeHandle"];
   const runtimeHandle = runtimeHandleStr ? safeJsonParse<RuntimeHandle>(runtimeHandleStr) : null;
-  const metadataStatus = validateStatus(rawMetadata["status"]);
+  const metadataStatus = validateStatus(normalizedMetadata["status"]);
   const recoveryConfig: RecoveryConfig = {
     ...DEFAULT_RECOVERY_CONFIG,
     ...(recoveryConfigInput ?? {}),
@@ -116,15 +119,15 @@ export async function validateSession(
         activity: null,
         activitySignal: createActivitySignal("unavailable"),
         lifecycle,
-        branch: rawMetadata["branch"] ?? null,
-        issueId: rawMetadata["issue"] ?? null,
+        branch: normalizedMetadata["branch"] ?? null,
+        issueId: normalizedMetadata["issue"] ?? null,
         pr: null,
         workspacePath,
         runtimeHandle,
         agentInfo: null,
-        createdAt: new Date(rawMetadata["createdAt"] ?? Date.now()),
-        lastActivityAt: new Date(rawMetadata["lastActivityAt"] ?? Date.now()),
-        metadata: rawMetadata,
+        createdAt: new Date(normalizedMetadata["createdAt"] ?? Date.now()),
+        lastActivityAt: new Date(normalizedMetadata["lastActivityAt"] ?? Date.now()),
+        metadata: normalizedMetadata,
       };
       const detection = await agent.getActivityState(probeSession, config.readyThresholdMs);
       agentActivity = detection?.state ?? null;
@@ -143,7 +146,7 @@ export async function validateSession(
     }
   }
 
-  const metadataValid = Object.keys(rawMetadata).length > 0;
+  const metadataValid = Object.keys(normalizedMetadata).length > 0;
   const classification = classifySession(
     runtimeAlive,
     workspaceExists,
@@ -191,7 +194,7 @@ export async function validateSession(
     agentActivity,
     metadataValid,
     metadataStatus,
-    rawMetadata,
+    rawMetadata: normalizedMetadata,
   };
 }
 

--- a/packages/core/src/recovery/validator.ts
+++ b/packages/core/src/recovery/validator.ts
@@ -21,7 +21,7 @@ import {
   type RecoveryAction,
   type RecoveryConfig,
 } from "./types.js";
-import { resolveAgentSelection, resolveSessionRole } from "../agent-selection.js";
+import { resolveAgentSelectionForSession } from "../agent-selection.js";
 import { createInitialCanonicalLifecycle } from "../lifecycle-state.js";
 import { createActivitySignal } from "../activity-signal.js";
 
@@ -44,16 +44,12 @@ export async function validateSession(
   const { sessionId, projectId, project, rawMetadata } = scanned;
 
   const runtimeName = project.runtime ?? config.defaults.runtime;
-  const agentName = resolveAgentSelection({
-    role: resolveSessionRole(
-      sessionId,
-      rawMetadata,
-      project.sessionPrefix,
-      Object.values(config.projects).map((p) => p.sessionPrefix),
-    ),
+  const agentName = resolveAgentSelectionForSession({
+    sessionId,
+    metadata: rawMetadata,
     project,
     defaults: config.defaults,
-    persistedAgent: rawMetadata["agent"],
+    allSessionPrefixes: Object.values(config.projects).map((p) => p.sessionPrefix),
   }).agentName;
   const workspaceName = project.workspace ?? config.defaults.workspace;
 

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -538,6 +538,21 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionCache = null;
   }
 
+  function repairSessionAgentMetadataOnRead(
+    sessionsDir: string,
+    record: ActiveSessionRecord,
+    project: ProjectConfig,
+  ): ActiveSessionRecord {
+    if (record.raw["agent"]) return record;
+
+    const agent = resolveSelectionForSession(project, record.sessionName, record.raw).agentName;
+    updateMetadataPreservingMtime(sessionsDir, record.sessionName, { agent }, record.modifiedAt);
+    return {
+      ...record,
+      raw: applyMetadataUpdatesToRaw(record.raw, { agent }),
+    };
+  }
+
   function repairSingleSessionMetadataOnRead(
     sessionsDir: string,
     record: ActiveSessionRecord,
@@ -599,7 +614,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
   function repairSessionMetadataOnRead(
     sessionsDir: string,
     records: ActiveSessionRecord[],
-    sessionPrefix?: string,
+    project: ProjectConfig,
   ): ActiveSessionRecord[] {
     const repaired = records.map((record) => ({ ...record, raw: { ...record.raw } }));
     const duplicatePRAttachments = new Map<string, ActiveSessionRecord[]>();
@@ -611,7 +626,11 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
             sessionId: record.sessionName,
             status: validateStatus(record.raw["status"]),
             createdAt: record.raw["createdAt"] ? new Date(record.raw["createdAt"]) : undefined,
-            sessionKind: isOrchestratorSessionRecord(record.sessionName, record.raw, sessionPrefix)
+            sessionKind: isOrchestratorSessionRecord(
+              record.sessionName,
+              record.raw,
+              project.sessionPrefix,
+            )
               ? "orchestrator"
               : "worker",
           }),
@@ -626,10 +645,13 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         record.raw = applyMetadataUpdatesToRaw(record.raw, canonicalUpdates);
       }
 
-      if (isOrchestratorSessionRecord(record.sessionName, record.raw, sessionPrefix)) {
-        record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record, sessionPrefix).raw;
+      if (isOrchestratorSessionRecord(record.sessionName, record.raw, project.sessionPrefix)) {
+        record.raw = repairSingleSessionMetadataOnRead(sessionsDir, record, project.sessionPrefix).raw;
+        record.raw = repairSessionAgentMetadataOnRead(sessionsDir, record, project).raw;
         continue;
       }
+
+      record.raw = repairSessionAgentMetadataOnRead(sessionsDir, record, project).raw;
 
       const prUrl = record.raw["pr"];
       if (!prUrl) continue;
@@ -705,7 +727,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
       return [{ sessionName, raw, modifiedAt } satisfies ActiveSessionRecord];
     });
 
-    return repairSessionMetadataOnRead(sessionsDir, records, project.sessionPrefix);
+    return repairSessionMetadataOnRead(sessionsDir, records, project);
   }
 
   function sortSessionIdsForReuse(ids: string[]): string[] {
@@ -943,10 +965,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         modifiedAt = undefined;
       }
 
-      const repaired = repairSingleSessionMetadataOnRead(
+      const repaired = repairSessionAgentMetadataOnRead(
         sessionsDir,
-        { sessionName: sessionId, raw, modifiedAt },
-        project.sessionPrefix,
+        repairSingleSessionMetadataOnRead(
+          sessionsDir,
+          { sessionName: sessionId, raw, modifiedAt },
+          project.sessionPrefix,
+        ),
+        project,
       );
 
       return { raw: repaired.raw, sessionsDir, project, projectId };
@@ -2376,10 +2402,14 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
         // If stat fails, timestamps will fall back to current time
       }
 
-      const repaired = repairSingleSessionMetadataOnRead(
+      const repaired = repairSessionAgentMetadataOnRead(
         sessionsDir,
-        { sessionName: sessionId, raw, modifiedAt },
-        project.sessionPrefix,
+        repairSingleSessionMetadataOnRead(
+          sessionsDir,
+          { sessionName: sessionId, raw, modifiedAt },
+          project.sessionPrefix,
+        ),
+        project,
       );
 
       const session = metadataToSession(
@@ -3546,6 +3576,7 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
 
     updateMetadata(sessionsDir, sessionId, {
       ...buildLifecycleMetadataPatch(restoredLifecycle),
+      agent: selection.agentName,
       restoredAt: now,
       mergedPendingCleanupSince: "",
     });

--- a/packages/core/src/session-manager.ts
+++ b/packages/core/src/session-manager.ts
@@ -94,7 +94,7 @@ import {
 import { sessionFromMetadata } from "./utils/session-from-metadata.js";
 import { safeJsonParse, validateStatus } from "./utils/validation.js";
 import { isGitBranchNameSafe } from "./utils.js";
-import { resolveAgentSelection, resolveSessionRole } from "./agent-selection.js";
+import { resolveAgentSelection, resolveAgentSelectionForSession } from "./agent-selection.js";
 import {
   buildAgentPath,
   setupPathWrapperWorkspace,
@@ -900,16 +900,12 @@ export function createSessionManager(deps: SessionManagerDeps): OpenCodeSessionM
     sessionId: string,
     metadata: Record<string, string>,
   ) {
-    return resolveAgentSelection({
-      role: resolveSessionRole(
-        sessionId,
-        metadata,
-        project.sessionPrefix,
-        Object.values(config.projects).map((p) => p.sessionPrefix),
-      ),
+    return resolveAgentSelectionForSession({
+      sessionId,
+      metadata,
       project,
       defaults: config.defaults,
-      persistedAgent: metadata["agent"],
+      allSessionPrefixes: Object.values(config.projects).map((p) => p.sessionPrefix),
     });
   }
 

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -1268,24 +1268,6 @@ describe("enrichSessionsMetadata", () => {
     expect(dashboard.summary).toBe("Orphan Goose summary");
   });
 
-  it("falls back to the default agent for projectless legacy sessions without persisted agent", async () => {
-    const agent = mockAgent("Default summary");
-    const registry = mockRegistry(null, agent);
-    const noProjectsConfig = {
-      ...testConfig,
-      projects: {},
-    } as OrchestratorConfig;
-
-    const core = createCoreSession({ projectId: "deleted", metadata: {} });
-    const dashboard = sessionToDashboard(core);
-
-    await enrichSessionsMetadata([core], [dashboard], noProjectsConfig, registry);
-
-    expect(registry.get).toHaveBeenCalledWith("agent", "mock-agent");
-    expect(agent.getSessionInfo).toHaveBeenCalledWith(core);
-    expect(dashboard.summary).toBe("Default summary");
-  });
-
   it("should use default agent when project has no agent override", async () => {
     const tracker = mockTracker();
     const agent = mockAgent("From default agent");

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -31,6 +31,7 @@ import type { DashboardSession } from "../types";
 
 // Helper to create a minimal Session for testing
 function createCoreSession(overrides?: Partial<Session>): Session {
+  const { metadata: overrideMetadata, ...sessionOverrides } = overrides ?? {};
   const lifecycle = createInitialCanonicalLifecycle("worker", new Date("2025-01-01T00:00:00Z"));
   lifecycle.session.state = "working";
   lifecycle.session.reason = "task_in_progress";
@@ -57,8 +58,8 @@ function createCoreSession(overrides?: Partial<Session>): Session {
     agentInfo: null,
     createdAt: new Date("2025-01-01T00:00:00Z"),
     lastActivityAt: new Date("2025-01-01T01:00:00Z"),
-    metadata: {},
-    ...overrides,
+    metadata: { agent: "mock-agent", ...(overrideMetadata ?? {}) },
+    ...sessionOverrides,
   };
 }
 
@@ -1268,7 +1269,7 @@ describe("enrichSessionsMetadata", () => {
     expect(dashboard.summary).toBe("Orphan Goose summary");
   });
 
-  it("should use default agent when project has no agent override", async () => {
+  it("uses normalized session agent metadata when project has no agent override", async () => {
     const tracker = mockTracker();
     const agent = mockAgent("From default agent");
     const registry = mockRegistry(tracker, agent);
@@ -1284,7 +1285,7 @@ describe("enrichSessionsMetadata", () => {
 
     await enrichSessionsMetadata([core], [dashboard], configNoProjectAgent, registry);
 
-    // Falls back to config.defaults.agent
+    // Uses the normalized Session metadata, not project/default inference.
     expect(registry.get).toHaveBeenCalledWith("agent", "mock-agent");
     expect(dashboard.summary).toBe("From default agent");
   });

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -1196,6 +1196,43 @@ describe("enrichSessionsMetadata", () => {
     expect(agent.getSessionInfo).toHaveBeenCalledTimes(2); // sessions 1 and 2 only
   });
 
+  it("uses persisted session agent instead of project default for summary enrichment", async () => {
+    const codexAgent = mockAgent("Wrong Codex summary");
+    codexAgent.name = "codex";
+    const gooseAgent = mockAgent("Goose summary");
+    gooseAgent.name = "goose";
+    const registry = {
+      get: vi.fn((slot: string, name: string) => {
+        if (slot !== "agent") return null;
+        if (name === "codex") return codexAgent;
+        if (name === "goose") return gooseAgent;
+        return null;
+      }),
+      register: vi.fn(),
+      list: vi.fn().mockReturnValue([]),
+      loadBuiltins: vi.fn(),
+      loadFromConfig: vi.fn(),
+    } as unknown as PluginRegistry;
+    const mixedAgentConfig = {
+      ...testConfig,
+      defaults: { ...testConfig.defaults, agent: "codex" },
+      projects: {
+        test: { ...testProject, agent: "codex" } as ProjectConfig,
+      },
+    } as OrchestratorConfig;
+
+    const core = createCoreSession({ metadata: { agent: "goose" } });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], mixedAgentConfig, registry);
+
+    expect(registry.get).toHaveBeenCalledWith("agent", "goose");
+    expect(registry.get).not.toHaveBeenCalledWith("agent", "codex");
+    expect(codexAgent.getSessionInfo).not.toHaveBeenCalled();
+    expect(gooseAgent.getSessionInfo).toHaveBeenCalledWith(core);
+    expect(dashboard.summary).toBe("Goose summary");
+  });
+
   it("should use default agent when project has no agent override", async () => {
     const tracker = mockTracker();
     const agent = mockAgent("From default agent");

--- a/packages/web/src/lib/__tests__/serialize.test.ts
+++ b/packages/web/src/lib/__tests__/serialize.test.ts
@@ -1233,6 +1233,59 @@ describe("enrichSessionsMetadata", () => {
     expect(dashboard.summary).toBe("Goose summary");
   });
 
+  it("uses persisted session agent when no project can be resolved", async () => {
+    const codexAgent = mockAgent("Wrong Codex summary");
+    codexAgent.name = "codex";
+    const gooseAgent = mockAgent("Orphan Goose summary");
+    gooseAgent.name = "goose";
+    const registry = {
+      get: vi.fn((slot: string, name: string) => {
+        if (slot !== "agent") return null;
+        if (name === "codex") return codexAgent;
+        if (name === "goose") return gooseAgent;
+        return null;
+      }),
+      register: vi.fn(),
+      list: vi.fn().mockReturnValue([]),
+      loadBuiltins: vi.fn(),
+      loadFromConfig: vi.fn(),
+    } as unknown as PluginRegistry;
+    const noProjectsConfig = {
+      ...testConfig,
+      defaults: { ...testConfig.defaults, agent: "codex" },
+      projects: {},
+    } as OrchestratorConfig;
+
+    const core = createCoreSession({ projectId: "deleted", metadata: { agent: "goose" } });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], noProjectsConfig, registry);
+
+    expect(registry.get).toHaveBeenCalledWith("agent", "goose");
+    expect(registry.get).not.toHaveBeenCalledWith("agent", "codex");
+    expect(codexAgent.getSessionInfo).not.toHaveBeenCalled();
+    expect(gooseAgent.getSessionInfo).toHaveBeenCalledWith(core);
+    expect(dashboard.summary).toBe("Orphan Goose summary");
+  });
+
+  it("falls back to the default agent for projectless legacy sessions without persisted agent", async () => {
+    const agent = mockAgent("Default summary");
+    const registry = mockRegistry(null, agent);
+    const noProjectsConfig = {
+      ...testConfig,
+      projects: {},
+    } as OrchestratorConfig;
+
+    const core = createCoreSession({ projectId: "deleted", metadata: {} });
+    const dashboard = sessionToDashboard(core);
+
+    await enrichSessionsMetadata([core], [dashboard], noProjectsConfig, registry);
+
+    expect(registry.get).toHaveBeenCalledWith("agent", "mock-agent");
+    expect(agent.getSessionInfo).toHaveBeenCalledWith(core);
+    expect(dashboard.summary).toBe("Default summary");
+  });
+
   it("should use default agent when project has no agent override", async () => {
     const tracker = mockTracker();
     const agent = mockAgent("From default agent");

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -559,7 +559,7 @@ function prepareSessionMetadataEnrichment(
           defaults: config.defaults,
           allSessionPrefixes,
         }).agentName
-      : (core.metadata["agent"] ?? config.defaults.agent);
+      : core.metadata["agent"];
     if (!agentName) return Promise.resolve();
     const agent = registry.get<Agent>("agent", agentName);
     if (!agent) return Promise.resolve();

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -551,14 +551,15 @@ function prepareSessionMetadataEnrichment(
   const summaryPromises = coreSessions.map((core, i) => {
     if (dashboardSessions[i].summary) return Promise.resolve();
     const project = projects[i];
-    if (!project) return Promise.resolve();
-    const agentName = resolveAgentSelectionForSession({
-      sessionId: core.id,
-      metadata: core.metadata,
-      project,
-      defaults: config.defaults,
-      allSessionPrefixes,
-    }).agentName;
+    const agentName = project
+      ? resolveAgentSelectionForSession({
+          sessionId: core.id,
+          metadata: core.metadata,
+          project,
+          defaults: config.defaults,
+          allSessionPrefixes,
+        }).agentName
+      : (core.metadata["agent"] ?? config.defaults.agent);
     if (!agentName) return Promise.resolve();
     const agent = registry.get<Agent>("agent", agentName);
     if (!agent) return Promise.resolve();

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -17,6 +17,7 @@ import {
   type ProjectConfig,
   type OrchestratorConfig,
   type PluginRegistry,
+  resolveAgentSelectionForSession,
 } from "@aoagents/ao-core";
 import {
   type DashboardSession,
@@ -544,10 +545,20 @@ function prepareSessionMetadataEnrichment(
     enrichSessionIssue(dashboardSessions[i], tracker, project);
   });
 
+  const allSessionPrefixes = Object.values(config.projects).map((project) => project.sessionPrefix);
+
   // Agent summaries (local disk I/O — reads agent JSONL)
   const summaryPromises = coreSessions.map((core, i) => {
     if (dashboardSessions[i].summary) return Promise.resolve();
-    const agentName = projects[i]?.agent ?? config.defaults.agent;
+    const project = projects[i];
+    if (!project) return Promise.resolve();
+    const agentName = resolveAgentSelectionForSession({
+      sessionId: core.id,
+      metadata: core.metadata,
+      project,
+      defaults: config.defaults,
+      allSessionPrefixes,
+    }).agentName;
     if (!agentName) return Promise.resolve();
     const agent = registry.get<Agent>("agent", agentName);
     if (!agent) return Promise.resolve();

--- a/packages/web/src/lib/serialize.ts
+++ b/packages/web/src/lib/serialize.ts
@@ -17,7 +17,6 @@ import {
   type ProjectConfig,
   type OrchestratorConfig,
   type PluginRegistry,
-  resolveAgentSelectionForSession,
 } from "@aoagents/ao-core";
 import {
   type DashboardSession,
@@ -545,21 +544,10 @@ function prepareSessionMetadataEnrichment(
     enrichSessionIssue(dashboardSessions[i], tracker, project);
   });
 
-  const allSessionPrefixes = Object.values(config.projects).map((project) => project.sessionPrefix);
-
   // Agent summaries (local disk I/O — reads agent JSONL)
   const summaryPromises = coreSessions.map((core, i) => {
     if (dashboardSessions[i].summary) return Promise.resolve();
-    const project = projects[i];
-    const agentName = project
-      ? resolveAgentSelectionForSession({
-          sessionId: core.id,
-          metadata: core.metadata,
-          project,
-          defaults: config.defaults,
-          allSessionPrefixes,
-        }).agentName
-      : core.metadata["agent"];
+    const agentName = core.metadata["agent"];
     if (!agentName) return Promise.resolve();
     const agent = registry.get<Agent>("agent", agentName);
     if (!agent) return Promise.resolve();


### PR DESCRIPTION
Fixes #1995

## Summary
- Added a shared core `resolveAgentSelectionForSession()` helper for legacy raw metadata repair/backfill boundaries.
- Backfilled missing legacy `agent` metadata on session-manager reads, attached the resolved agent in recovery validation, and preserved it when recovery actions rewrite metadata.
- Tightened normalized `Session` consumers (web enrichment, CLI status/send, lifecycle polling) to use `session.metadata["agent"]` as the session-agent identity instead of inferring from current project/default config.
- Updated new/restored session writes so persisted metadata carries the selected agent.

## Audit findings
- `packages/web/src/lib/serialize.ts` was the bug source: it selected the current project/default agent for dashboard summary enrichment. Fixed; web now reads the normalized persisted session agent.
- `packages/cli/src/commands/status.ts` had the same root pattern for status-summary introspection. Fixed; it no longer falls back to current project/default config for a loaded `Session`.
- `packages/cli/src/commands/send.ts` still had a session-specific project/default fallback after `sessionManager.get()`. Fixed to rely on normalized `session.metadata["agent"]`.
- `packages/core/src/lifecycle-manager.ts` was a normalized-Session consumer and no longer re-resolves agent identity from project config.
- Recovery scanner/validator reads raw metadata directly, so that is a legacy normalization boundary. It now attaches the resolved agent to the assessment metadata, and recovery actions persist that agent during repair/escalation/cleanup writes.
- Remaining direct project/default agent lookups are not same-root session-loading bugs: spawn paths intentionally use current spawn/project config for new sessions; `doctor` and settings UI are config inspection/editing; plugin config reads are runtime launch config; fallback tmux status has no AO metadata record to resolve from.

## Tests
- `pnpm --filter @aoagents/ao-core test -- src/__tests__/session-manager/query.test.ts src/__tests__/session-manager/communication.test.ts src/__tests__/lifecycle-manager.test.ts src/__tests__/recovery-validator.test.ts src/__tests__/recovery-actions.test.ts`
- `pnpm --filter @aoagents/ao-web test -- src/lib/__tests__/serialize.test.ts src/__tests__/api-routes.test.ts`
- `pnpm --filter @aoagents/ao-cli test -- __tests__/commands/status.test.ts __tests__/commands/send.test.ts`
- `pnpm --filter @aoagents/ao-core build && pnpm --filter './packages/plugins/*' build`
- `pnpm --filter @aoagents/ao-core typecheck && pnpm --filter @aoagents/ao-web typecheck && pnpm --filter @aoagents/ao-cli typecheck`
- `git diff --check`

## Notes
- Before building core/plugin packages, web typecheck could not resolve workspace package declarations from a fresh install. After building those dependency packages, the package typechecks passed.
