### PR TITLE
fix(canary): include all publishable packages

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -113,11 +113,22 @@ jobs:
           if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -vi 'README')" ]; then
             node << 'SCRIPT'
               const cfg = require('./.changeset/config.json');
-              const pkgs = cfg.linked.flat();
+              const glob = require('glob');
+              const fs = require('fs');
+              const linked = new Set(cfg.linked.flat());
+              const pkgs = [];
+              for (const m of glob.sync('packages/*/package.json')) {
+                const d = JSON.parse(fs.readFileSync(m, 'utf8'));
+                if (d.publishConfig?.access === 'public') pkgs.push(d.name);
+              }
+              for (const m of glob.sync('packages/plugins/*/package.json')) {
+                const d = JSON.parse(fs.readFileSync(m, 'utf8'));
+                if (d.publishConfig?.access === 'public') pkgs.push(d.name);
+              }
               let body = '---\n';
               pkgs.forEach(p => body += '"' + p + '": patch\n');
               body += '---\n\nchore: canary build\n';
-              require('fs').writeFileSync('.changeset/canary-temp.md', body);
+              fs.writeFileSync('.changeset/canary-temp.md', body);
           SCRIPT
           fi
           pnpm changeset version --snapshot nightly

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -118,15 +118,18 @@ jobs:
               const addPackage = (m) => {
                 if (!fs.existsSync(m)) return;
                 const d = JSON.parse(fs.readFileSync(m, 'utf8'));
-                if (d.publishConfig?.access === 'public') pkgs.push(d.name);
+                if (!d.private && d.publishConfig?.access === 'public') pkgs.push(d.name);
               };
 
-              for (const entry of fs.readdirSync('packages', { withFileTypes: true })) {
-                if (entry.isDirectory()) addPackage(`packages/${entry.name}/package.json`);
-              }
-              for (const entry of fs.readdirSync('packages/plugins', { withFileTypes: true })) {
-                if (entry.isDirectory()) addPackage(`packages/plugins/${entry.name}/package.json`);
-              }
+              const scanPackages = (dir) => {
+                if (!fs.existsSync(dir)) return;
+                for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                  if (entry.isDirectory()) addPackage(`${dir}/${entry.name}/package.json`);
+                }
+              };
+
+              scanPackages('packages');
+              scanPackages('packages/plugins');
 
               let body = '---\n';
               pkgs.forEach(p => body += '"' + p + '": patch\n');

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -112,19 +112,22 @@ jobs:
           # deletes it, so no cleanup is needed.
           if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -vi 'README')" ]; then
             node << 'SCRIPT'
-              const cfg = require('./.changeset/config.json');
-              const glob = require('glob');
               const fs = require('fs');
-              const linked = new Set(cfg.linked.flat());
               const pkgs = [];
-              for (const m of glob.sync('packages/*/package.json')) {
+
+              const addPackage = (m) => {
+                if (!fs.existsSync(m)) return;
                 const d = JSON.parse(fs.readFileSync(m, 'utf8'));
                 if (d.publishConfig?.access === 'public') pkgs.push(d.name);
+              };
+
+              for (const entry of fs.readdirSync('packages', { withFileTypes: true })) {
+                if (entry.isDirectory()) addPackage(`packages/${entry.name}/package.json`);
               }
-              for (const m of glob.sync('packages/plugins/*/package.json')) {
-                const d = JSON.parse(fs.readFileSync(m, 'utf8'));
-                if (d.publishConfig?.access === 'public') pkgs.push(d.name);
+              for (const entry of fs.readdirSync('packages/plugins', { withFileTypes: true })) {
+                if (entry.isDirectory()) addPackage(`packages/plugins/${entry.name}/package.json`);
               }
+
               let body = '---\n';
               pkgs.forEach(p => body += '"' + p + '": patch\n');
               body += '---\n\nchore: canary build\n';


### PR DESCRIPTION
## Summary
- Generate fallback canary changesets from all public publishable packages
- Include packages under packages/* and packages/plugins/* instead of only the linked changeset group

## Notes
- Direct push to main was blocked by repository rules requiring a PR.