### PR TITLE
chore: add changeset for v0.9.1 hotfix

### DIFF
--- a/.changeset/hotfix-091.md
+++ b/.changeset/hotfix-091.md
@@ -1,0 +1,34 @@
+---
+"@aoagents/ao": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-core": patch
+"@aoagents/ao-web": patch
+"@aoagents/ao-notifier-macos": patch
+"@aoagents/ao-plugin-agent-aider": patch
+"@aoagents/ao-plugin-agent-claude-code": patch
+"@aoagents/ao-plugin-agent-codex": patch
+"@aoagents/ao-plugin-agent-cursor": patch
+"@aoagents/ao-plugin-agent-grok": patch
+"@aoagents/ao-plugin-agent-kimicode": patch
+"@aoagents/ao-plugin-agent-opencode": patch
+"@aoagents/ao-plugin-notifier-composio": patch
+"@aoagents/ao-plugin-notifier-dashboard": patch
+"@aoagents/ao-plugin-notifier-desktop": patch
+"@aoagents/ao-plugin-notifier-discord": patch
+"@aoagents/ao-plugin-notifier-openclaw": patch
+"@aoagents/ao-plugin-notifier-slack": patch
+"@aoagents/ao-plugin-notifier-webhook": patch
+"@aoagents/ao-plugin-runtime-process": patch
+"@aoagents/ao-plugin-runtime-tmux": patch
+"@aoagents/ao-plugin-scm-github": patch
+"@aoagents/ao-plugin-scm-gitlab": patch
+"@aoagents/ao-plugin-terminal-iterm2": patch
+"@aoagents/ao-plugin-terminal-web": patch
+"@aoagents/ao-plugin-tracker-github": patch
+"@aoagents/ao-plugin-tracker-gitlab": patch
+"@aoagents/ao-plugin-tracker-linear": patch
+"@aoagents/ao-plugin-workspace-clone": patch
+"@aoagents/ao-plugin-workspace-worktree": patch
+---
+
+Fix canary nightly to include all publishable packages and fix Next.js import.meta.url build path issue


### PR DESCRIPTION
## Summary
- Add patch changeset for the v0.9.1 hotfix release across publishable AO packages
- Covers the canary nightly package discovery fix and Next.js import.meta.url build path issue

## Notes
- Direct push to main is blocked by repository rules, so this changeset needs to land via PR.