### PR TITLE
fix(agent-grok): load manifest metadata via JSON import

### DIFF
--- a/.changeset/clean-groks-smile.md
+++ b/.changeset/clean-groks-smile.md
@@ -1,0 +1,8 @@
+---
+"@aoagents/ao": minor
+"@aoagents/ao-cli": minor
+"@aoagents/ao-web": minor
+"@aoagents/ao-plugin-agent-grok": minor
+---
+
+Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Agent Orchestrator manages fleets of AI coding agents working in parallel on you
 
 ## Quick Start
 
-> **Prerequisites:** [Node.js 20+](https://nodejs.org), [Git 2.25+](https://git-scm.com), [`gh` CLI](https://cli.github.com), and:
+> **Prerequisites:** [Node.js 20.18.3+](https://nodejs.org), [Git 2.25+](https://git-scm.com), [`gh` CLI](https://cli.github.com), and:
 > - **macOS / Linux:** [tmux](https://github.com/tmux/tmux/wiki/Installing) — install via `brew install tmux` or `sudo apt install tmux`.
 > - **Windows:** PowerShell 7+ recommended. tmux is **not** required — AO uses native ConPTY via the `runtime-process` plugin (the default on Windows). Set `AO_SHELL=bash` if you have Git Bash and prefer it.
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -87,7 +87,7 @@ For AI agent-specific guidance (including high-risk files like `types.ts`, `life
 
 ## Getting Started
 
-**Prerequisites**: Node.js 20+, pnpm 9.15+, Git 2.25+
+**Prerequisites**: Node.js 20.18.3+, pnpm 9.15+, Git 2.25+
 
 ```bash
 git clone https://github.com/ComposioHQ/agent-orchestrator.git

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Orchestrate parallel AI coding agents across any runtime, any repo, any issue tracker",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.3"
   },
   "packageManager": "pnpm@9.15.4",
   "type": "module",

--- a/packages/ao/README.md
+++ b/packages/ao/README.md
@@ -25,7 +25,7 @@ npm install -g @aoagents/ao
 
 > **Nightly builds** (latest `main`): `npm install -g @aoagents/ao@nightly` — back to stable with `@latest`.
 
-**Prerequisites:** [Node.js 20+](https://nodejs.org), [Git 2.25+](https://git-scm.com), the [`gh` CLI](https://cli.github.com), and at least one coding-agent CLI (e.g. [Claude Code](https://www.anthropic.com/claude-code)).
+**Prerequisites:** [Node.js 20.18.3+](https://nodejs.org), [Git 2.25+](https://git-scm.com), the [`gh` CLI](https://cli.github.com), and at least one coding-agent CLI (e.g. [Claude Code](https://www.anthropic.com/claude-code)).
 
 - **macOS / Linux:** [tmux](https://github.com/tmux/tmux/wiki/Installing) — `brew install tmux` or `sudo apt install tmux`.
 - **Windows:** PowerShell 7+ recommended; tmux is **not** required (AO uses native ConPTY via the `process` runtime).

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.3"
   },
   "dependencies": {
     "@aoagents/ao-cli": "workspace:*"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.3"
   },
   "scripts": {
     "build": "tsc && node --input-type=commonjs -e \"require('fs').cpSync('src/assets','dist/assets',{recursive:true})\"",

--- a/packages/plugins/agent-grok/package.json
+++ b/packages/plugins/agent-grok/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=20.18.3"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/plugins/agent-grok/src/__tests__/index.test.ts
+++ b/packages/plugins/agent-grok/src/__tests__/index.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { AgentLaunchConfig, RuntimeHandle, Session } from "@aoagents/ao-core";
-import { createRequire } from "node:module";
+import packageJson from "../../package.json" with { type: "json" };
 
-const require = createRequire(import.meta.url);
-const packageJson = require("../../package.json") as {
-  name: string;
-  version: string;
-  description: string;
-};
 const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
 const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
   ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)
@@ -144,6 +138,7 @@ beforeEach(() => {
 
 describe("manifest", () => {
   it("has correct Grok manifest", () => {
+    expect(manifest.version).toBe(packageJson.version);
     expect(manifest).toEqual({
       name: pluginName,
       slot: "agent",

--- a/packages/plugins/agent-grok/src/__tests__/metadata-import.test.ts
+++ b/packages/plugins/agent-grok/src/__tests__/metadata-import.test.ts
@@ -1,0 +1,101 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+import packageJson from "../../package.json" with { type: "json" };
+import { manifest } from "../index.js";
+
+const testFilePath = fileURLToPath(import.meta.url);
+const packageRoot = path.resolve(path.dirname(testFilePath), "../..");
+const sourcePath = path.join(packageRoot, "src/index.ts");
+
+const forbiddenPackageMetadataLookups = [
+  "createRequire(import.meta.url)",
+  'require("../package.json")',
+  'readFileSync(new URL("../package.json", import.meta.url))',
+];
+
+function assertPackageMetadataImportPattern(label: string, source: string): void {
+  for (const forbidden of forbiddenPackageMetadataLookups) {
+    expect(source, `${label} must not contain ${forbidden}`).not.toContain(forbidden);
+  }
+
+  const packageJsonImports = [...source.matchAll(/from\s+["']\.\.\/package\.json["'][^;]*/g)].map(
+    (match) => match[0],
+  );
+
+  expect(packageJsonImports.length, `${label} imports ../package.json`).toBeGreaterThan(0);
+  for (const importStatement of packageJsonImports) {
+    expect(
+      importStatement,
+      `${label} package.json import must use a JSON import attribute`,
+    ).toMatch(/\swith\s*\{\s*type:\s*["']json["']\s*\}/);
+  }
+}
+
+function compileAgentGrokTo(outDir: string): void {
+  const configPath = path.join(packageRoot, "tsconfig.json");
+  const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (configFile.error) {
+    throw new Error(
+      ts.formatDiagnosticsWithColorAndContext([configFile.error], {
+        getCanonicalFileName: (fileName) => fileName,
+        getCurrentDirectory: ts.sys.getCurrentDirectory,
+        getNewLine: () => ts.sys.newLine,
+      }),
+    );
+  }
+
+  const parsedConfig = ts.parseJsonConfigFileContent(
+    configFile.config,
+    ts.sys,
+    packageRoot,
+    {
+      declaration: false,
+      declarationMap: false,
+      outDir,
+      sourceMap: false,
+    },
+    configPath,
+  );
+
+  const program = ts.createProgram(parsedConfig.fileNames, parsedConfig.options);
+  const emitResult = program.emit();
+  const diagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+  if (emitResult.emitSkipped || diagnostics.length > 0) {
+    const message =
+      diagnostics.length > 0
+        ? ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+            getCanonicalFileName: (fileName) => fileName,
+            getCurrentDirectory: ts.sys.getCurrentDirectory,
+            getNewLine: () => ts.sys.newLine,
+          })
+        : "TypeScript emit skipped without diagnostics.";
+    throw new Error(message);
+  }
+}
+
+describe("package metadata import", () => {
+  it("keeps manifest version in sync with package.json", () => {
+    expect(manifest.version).toBe(packageJson.version);
+  });
+
+  it("uses JSON import attributes in the source runtime module", async () => {
+    const source = await readFile(sourcePath, "utf8");
+    assertPackageMetadataImportPattern("src/index.ts", source);
+  });
+
+  it("uses JSON import attributes in the compiled runtime module", async () => {
+    const outDir = await mkdtemp(path.join(tmpdir(), "ao-agent-grok-"));
+
+    try {
+      compileAgentGrokTo(outDir);
+      const compiledSource = await readFile(path.join(outDir, "index.js"), "utf8");
+      assertPackageMetadataImportPattern("compiled index.js", compiledSource);
+    } finally {
+      await rm(outDir, { force: true, recursive: true });
+    }
+  });
+});

--- a/packages/plugins/agent-grok/src/index.ts
+++ b/packages/plugins/agent-grok/src/index.ts
@@ -22,17 +22,11 @@ import {
   type WorkspaceHooksConfig,
 } from "@aoagents/ao-core";
 import { execFile } from "node:child_process";
-import { createRequire } from "node:module";
 import { setTimeout as sleep } from "node:timers/promises";
 import { promisify } from "node:util";
 import which from "which";
+import packageJson from "../package.json" with { type: "json" };
 
-const require = createRequire(import.meta.url);
-const packageJson = require("../package.json") as {
-  name: string;
-  version: string;
-  description: string;
-};
 const PACKAGE_NAME_PREFIX = "@aoagents/ao-plugin-agent-";
 const pluginName = packageJson.name.startsWith(PACKAGE_NAME_PREFIX)
   ? packageJson.name.slice(PACKAGE_NAME_PREFIX.length)

--- a/packages/plugins/agent-grok/tsconfig.json
+++ b/packages/plugins/agent-grok/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../../../tsconfig.node.json",
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "outDir": "dist",
     "rootDir": "src"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,9 @@
   "bugs": {
     "url": "https://github.com/ComposioHQ/agent-orchestrator/issues"
   },
+  "engines": {
+    "node": ">=20.18.3"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary
- Replace agent-grok's top-level `createRequire(import.meta.url)("../package.json")` manifest metadata read with `import packageJson from "../package.json" with { type: "json" }`.
- Add the smallest package-scoped TypeScript config needed for that syntax by moving only agent-grok to `module`/`moduleResolution: "NodeNext"`.
- Add regression coverage for source and emitted runtime modules so package metadata cannot regress to `createRequire`, `require("../package.json")`, or `readFileSync(new URL("../package.json", import.meta.url))`, and any `../package.json` import must use a JSON import attribute.
- Align the affected product runtime package engines/docs to Node `>=20.18.3`, where JSON modules with import attributes are non-experimental.

Refs ComposioHQ/agent-orchestrator#2004.
Supersedes the generated-manifest direction from ComposioHQ/agent-orchestrator#2035.

## Root cause
`packages/web/src/lib/services.ts` statically imports the Grok plugin to register built-ins. The old Grok module read package metadata at module import time using `createRequire(import.meta.url)("../package.json")`. During the published Next.js web build, webpack inlined that module and rewrote `import.meta.url` to the publish host path (for example `/tmp/ao-publish-stable/packages/plugins/agent-grok/dist/index.js`). On a user machine, the bundled code then tried to resolve `../package.json` from that stale build-host path and failed with `MODULE_NOT_FOUND`, causing packaged `ao-web` startup to 500.

## Config changes
- `packages/plugins/agent-grok/tsconfig.json`: package-scoped `NodeNext` module settings so TypeScript accepts and preserves JSON import attributes.
- `package.json`, `packages/ao/package.json`, `packages/cli/package.json`, `packages/web/package.json`, `packages/plugins/agent-grok/package.json`: Node `>=20.18.3` for the affected AO runtime path.
- `README.md`, `packages/ao/README.md`, `docs/DEVELOPMENT.md`: prerequisite text updated to match the engine floor.
- `.changeset/clean-groks-smile.md`: patch release note for AO runtime packages and agent-grok.

## Verification
- `pnpm install`
- `pnpm --filter @aoagents/ao-core build`
- `pnpm --filter @aoagents/ao-plugin-agent-grok typecheck`
- `pnpm --filter @aoagents/ao-plugin-agent-grok test`
- `pnpm --filter @aoagents/ao-plugin-agent-grok build`
- `pnpm --filter @aoagents/ao-plugin-agent-grok... build`
- `pnpm --filter @aoagents/ao-web test -- src/__tests__/services.test.ts`
  - First run before building web dependencies failed because `@aoagents/ao-plugin-runtime-process` dist was missing; rerun after `pnpm --filter @aoagents/ao-web... build` passed.
- `pnpm --filter @aoagents/ao-web... build`
  - Existing warning only: `src/components/terminal/useXtermTerminal.ts` has a pre-existing forbidden non-null assertion.
- `npm pack ./packages/web --pack-destination <tmp> --json`
- Scanned `packages/web/.next/server`, packed `.next/server`, and packed `dist-server` for `/tmp/ao-publish-stable`, absolute agent-grok source paths, `createRequire(import.meta.url)` package-json lookups, `require("../package.json")`, and `readFileSync(new URL("../package.json", import.meta.url))`: all zero hits.
- `git diff --check`

## Remaining risks
- The Next trace `.nft.json` files still contain relative build-trace references such as `plugins/agent-grok/package.json`; the runtime JS chunks inline the Grok manifest metadata as data rather than performing a package.json lookup, and the stale absolute publish-host lookup is gone.
- This PR intentionally updates only the agent-grok implementation plus the config needed for JSON import attributes. The rest of the `agent-*` plugins are left for follow-up PRs after this foundation lands.
