### PR TITLE
revert: undo v0.10.0 version bump, retarget release as v0.9.2

### DIFF
--- a/.changeset/clean-groks-smile.md
+++ b/.changeset/clean-groks-smile.md
@@ -1,0 +1,8 @@
+---
+"@aoagents/ao": patch
+"@aoagents/ao-cli": patch
+"@aoagents/ao-web": patch
+"@aoagents/ao-plugin-agent-grok": patch
+---
+
+Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.

--- a/packages/ao/CHANGELOG.md
+++ b/packages/ao/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @aoagents/ao
 
-## 0.10.0
-
-### Minor Changes
-
-- cdd1030: Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.
-
-### Patch Changes
-
-- Updated dependencies [cdd1030]
-  - @aoagents/ao-cli@0.10.0
-
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/ao/package.json
+++ b/packages/ao/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "description": "Orchestrate parallel AI coding agents — global CLI wrapper",
   "keywords": [
     "ai",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @aoagents/ao-cli
 
-## 0.10.0
-
-### Minor Changes
-
-- cdd1030: Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.
-
-### Patch Changes
-
-- Updated dependencies [cdd1030]
-  - @aoagents/ao-web@0.10.0
-  - @aoagents/ao-plugin-agent-grok@0.2.0
-
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-cli",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "description": "CLI for agent-orchestrator — the `ao` command",
   "license": "MIT",
   "type": "module",

--- a/packages/plugins/agent-grok/CHANGELOG.md
+++ b/packages/plugins/agent-grok/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @aoagents/ao-plugin-agent-grok
 
-## 0.2.0
-
-### Minor Changes
-
-- cdd1030: Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.
-
 ## 0.1.2
 
 ### Patch Changes

--- a/packages/plugins/agent-grok/package.json
+++ b/packages/plugins/agent-grok/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-plugin-agent-grok",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "description": "Agent plugin: Grok",
   "license": "MIT",
   "type": "module",

--- a/packages/web/CHANGELOG.md
+++ b/packages/web/CHANGELOG.md
@@ -1,16 +1,5 @@
 # @aoagents/ao-web
 
-## 0.10.0
-
-### Minor Changes
-
-- cdd1030: Load agent-grok package metadata through JSON import attributes so packaged web and CLI runtimes do not keep a publish-host package.json lookup. This also raises the Node.js engine floor to 20.18.3+, where JSON modules with import attributes are non-experimental.
-
-### Patch Changes
-
-- Updated dependencies [cdd1030]
-  - @aoagents/ao-plugin-agent-grok@0.2.0
-
 ## 0.9.1
 
 ### Patch Changes

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aoagents/ao-web",
-  "version": "0.10.0",
+  "version": "0.9.1",
   "description": "Web dashboard for agent-orchestrator",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- Reverts #2043 (chore: version packages — bumped @aoagents/ao to 0.10.0).
- Reclassifies the restored agent-grok changeset from `minor` → `patch` so the changesets bot will regenerate a v0.9.2 release PR instead of v0.10.0.

## Why

The v0.10.0 release was cut and the GitHub release published, but before the npm cron picked it up we decided to ship this as v0.9.2 instead. The v0.10.0 tag and GitHub release have already been deleted. npm is still on 0.9.1, so undoing on the source side leaves npm consistent.

## What this triggers

Once merged:
1. CI runs against main, then the Release workflow's `workflow_run` trigger fires.
2. The changesets bot regenerates a `chore: version packages` PR — this time targeting 0.9.2 (because the changeset is now `patch`).
3. Approving + merging that PR cuts v0.9.2.

## Test plan

- [x] CI green on this branch
- [ ] After merge, verify bot opens a new Version Packages PR with `0.9.1 → 0.9.2`
- [ ] After that PR merges, verify `v0.9.2` tag + GitHub release are created
- [ ] Verify npm picks up `@aoagents/ao@0.9.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)