### PR TITLE
feat: add dashboard mock data and SSE events

### DIFF
--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -691,12 +691,8 @@ describe("API Routes", () => {
 
       expect(res.status).toBe(200);
       expect(enrichSpy).toHaveBeenCalledTimes(2);
-      expect(enrichSpy.mock.calls[0]).toEqual([
-        expect.objectContaining({ id: "worker-live" }),
-      ]);
-      expect(enrichSpy.mock.calls[1]).toEqual([
-        expect.objectContaining({ id: "worker-killed" }),
-      ]);
+      expect(enrichSpy.mock.calls[0]).toEqual([expect.objectContaining({ id: "worker-live" })]);
+      expect(enrichSpy.mock.calls[1]).toEqual([expect.objectContaining({ id: "worker-killed" })]);
 
       metadataSpy.mockRestore();
       enrichSpy.mockRestore();
@@ -748,9 +744,7 @@ describe("API Routes", () => {
 
       expect(res.status).toBe(200);
       expect(enrichSpy).toHaveBeenCalledTimes(1);
-      expect(enrichSpy.mock.calls[0]).toEqual([
-        expect.objectContaining({ id: "worker-open-pr" }),
-      ]);
+      expect(enrichSpy.mock.calls[0]).toEqual([expect.objectContaining({ id: "worker-open-pr" })]);
 
       metadataSpy.mockRestore();
       enrichSpy.mockRestore();
@@ -1517,8 +1511,25 @@ describe("API Routes", () => {
   // ── GET /api/events ────────────────────────────────────────────────
 
   describe("GET /api/events", () => {
-    it("streams dashboard events as SSE", async () => {
-      const res = eventsGET();
+    it("streams live-mode SSE without mock sessions by default", async () => {
+      const res = eventsGET(makeRequest("http://localhost:3000/api/events"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+      const reader = res.body?.getReader();
+      expect(reader).toBeDefined();
+      if (!reader) return;
+
+      const firstChunk = await reader.read();
+      await reader.cancel();
+      const text = new TextDecoder().decode(firstChunk.value);
+      expect(text).toContain("event: connected");
+      expect(text).toContain('"mode":"live"');
+      expect(text).not.toContain("event: sessions");
+    });
+
+    it("streams seeded mock sessions only when mock mode is requested", async () => {
+      const res = eventsGET(makeRequest("http://localhost:3000/api/events?mock=true"));
       expect(res.status).toBe(200);
       expect(res.headers.get("Content-Type")).toContain("text/event-stream");
 
@@ -1531,7 +1542,7 @@ describe("API Routes", () => {
       await reader.cancel();
       const decoder = new TextDecoder();
       const text = `${decoder.decode(firstChunk.value)}${decoder.decode(secondChunk.value)}`;
-      expect(text).toContain("event: connected");
+      expect(text).toContain('"mode":"mock"');
       expect(text).toContain("event: sessions");
     });
   });

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -245,6 +245,7 @@ import { GET as observabilityGET } from "@/app/api/observability/route";
 import { GET as runtimeTerminalGET } from "@/app/api/runtime/terminal/route";
 import { GET as verifyGET, POST as verifyPOST } from "@/app/api/verify/route";
 import { GET as patchesGET } from "@/app/api/sessions/patches/route";
+import { GET as eventsGET } from "@/app/api/events/route";
 
 function makeRequest(url: string, init?: RequestInit): NextRequest {
   return new NextRequest(
@@ -296,6 +297,15 @@ describe("API Routes", () => {
       expect(session).toHaveProperty("status");
       expect(session).toHaveProperty("activity");
       expect(session).toHaveProperty("createdAt");
+    });
+
+    it("returns seeded mock sessions when mock mode is requested", async () => {
+      const res = await sessionsGET(makeRequest("http://localhost:3000/api/sessions?mock=true"));
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.sessions).toHaveLength(12);
+      expect(data.sessions.map((session: { id: string }) => session.id)).toContain("backend-3");
+      expect(data.stats.totalSessions).toBe(12);
     });
 
     it("skips PR enrichment when metadata enrichment hits timeout", async () => {
@@ -1503,6 +1513,28 @@ describe("API Routes", () => {
     });
   });
   // ── GET /api/sessions/patches ──────────────────────────────────────────
+
+  // ── GET /api/events ────────────────────────────────────────────────
+
+  describe("GET /api/events", () => {
+    it("streams dashboard events as SSE", async () => {
+      const res = eventsGET();
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toContain("text/event-stream");
+
+      const reader = res.body?.getReader();
+      expect(reader).toBeDefined();
+      if (!reader) return;
+
+      const firstChunk = await reader.read();
+      const secondChunk = await reader.read();
+      await reader.cancel();
+      const decoder = new TextDecoder();
+      const text = `${decoder.decode(firstChunk.value)}${decoder.decode(secondChunk.value)}`;
+      expect(text).toContain("event: connected");
+      expect(text).toContain("event: sessions");
+    });
+  });
 
   describe("GET /api/sessions/patches", () => {
     it("returns patches array with lightweight fields", async () => {

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -1,4 +1,4 @@
-import { getMockDashboardPayload } from "@/lib/mock-dashboard-data";
+import { getMockDashboardPayload, isMockDashboardRequested } from "@/lib/mock-dashboard-data";
 
 export const dynamic = "force-dynamic";
 
@@ -12,20 +12,49 @@ function encodeEvent({ event, data }: SseEvent): string {
 }
 
 /** GET /api/events — SSE stream for dashboard refresh events. */
-export function GET() {
-  // TODO: wire to core services event bus once lifecycle updates are emitted centrally.
+export function GET(request: Request) {
+  const shouldUseMockData = isMockDashboardRequested(request.url);
   const encoder = new TextEncoder();
   let interval: ReturnType<typeof setInterval> | undefined;
+
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
-      const send = (event: SseEvent) => controller.enqueue(encoder.encode(encodeEvent(event)));
-      const payload = getMockDashboardPayload();
+      const cleanup = () => {
+        if (interval) {
+          clearInterval(interval);
+          interval = undefined;
+        }
+      };
+      const send = (event: SseEvent): boolean => {
+        try {
+          controller.enqueue(encoder.encode(encodeEvent(event)));
+          return true;
+        } catch (error) {
+          cleanup();
+          controller.error(error);
+          return false;
+        }
+      };
 
-      send({ event: "connected", data: { ok: true, timestamp: new Date().toISOString() } });
-      send({
-        event: "sessions",
-        data: { sessions: payload.sessions, stats: payload.stats },
+      // TODO: wire to core services event bus once lifecycle updates are emitted centrally.
+      const connected = send({
+        event: "connected",
+        data: {
+          ok: true,
+          mode: shouldUseMockData ? "mock" : "live",
+          timestamp: new Date().toISOString(),
+        },
       });
+      if (!connected) return;
+
+      if (shouldUseMockData) {
+        const payload = getMockDashboardPayload();
+        const sentSessions = send({
+          event: "sessions",
+          data: { sessions: payload.sessions, stats: payload.stats },
+        });
+        if (!sentSessions) return;
+      }
 
       interval = setInterval(() => {
         send({ event: "heartbeat", data: { timestamp: new Date().toISOString() } });

--- a/packages/web/src/app/api/events/route.ts
+++ b/packages/web/src/app/api/events/route.ts
@@ -1,0 +1,47 @@
+import { getMockDashboardPayload } from "@/lib/mock-dashboard-data";
+
+export const dynamic = "force-dynamic";
+
+type SseEvent = {
+  event: string;
+  data: unknown;
+};
+
+function encodeEvent({ event, data }: SseEvent): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** GET /api/events — SSE stream for dashboard refresh events. */
+export function GET() {
+  // TODO: wire to core services event bus once lifecycle updates are emitted centrally.
+  const encoder = new TextEncoder();
+  let interval: ReturnType<typeof setInterval> | undefined;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const send = (event: SseEvent) => controller.enqueue(encoder.encode(encodeEvent(event)));
+      const payload = getMockDashboardPayload();
+
+      send({ event: "connected", data: { ok: true, timestamp: new Date().toISOString() } });
+      send({
+        event: "sessions",
+        data: { sessions: payload.sessions, stats: payload.stats },
+      });
+
+      interval = setInterval(() => {
+        send({ event: "heartbeat", data: { timestamp: new Date().toISOString() } });
+      }, 5_000);
+    },
+    cancel() {
+      if (interval) clearInterval(interval);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/packages/web/src/app/api/sessions/route.ts
+++ b/packages/web/src/app/api/sessions/route.ts
@@ -11,6 +11,7 @@ import { getCorrelationId, jsonWithCorrelation, recordApiObservation } from "@/l
 import { filterProjectSessions } from "@/lib/project-utils";
 import { settlesWithin } from "@/lib/async-utils";
 import { type DashboardOrchestratorLink } from "@/lib/types";
+import { getMockDashboardPayload, isMockDashboardRequested } from "@/lib/mock-dashboard-data";
 
 const METADATA_ENRICH_TIMEOUT_MS = 3_000;
 
@@ -73,6 +74,11 @@ export async function GET(request: Request) {
   const correlationId = getCorrelationId(request);
   const startedAt = Date.now();
   try {
+    if (isMockDashboardRequested(request.url)) {
+      // TODO: wire mock mode to core services fixtures once the service layer exposes seeded projects.
+      return jsonWithCorrelation(getMockDashboardPayload(), { status: 200 }, correlationId);
+    }
+
     const { searchParams } = new URL(request.url);
     const projectFilter = searchParams.get("project");
     const activeOnly = searchParams.get("active") === "true";

--- a/packages/web/src/lib/mock-dashboard-data.ts
+++ b/packages/web/src/lib/mock-dashboard-data.ts
@@ -1,0 +1,260 @@
+import type { DashboardPR, DashboardSession } from "@/lib/types";
+import { computeStats } from "@/lib/serialize";
+
+const NOW = "2026-05-25T12:00:00.000Z";
+
+function ago(minutes: number): string {
+  return new Date(new Date(NOW).getTime() - minutes * 60_000).toISOString();
+}
+
+function makePR(overrides: Partial<DashboardPR> & { number: number; title: string }): DashboardPR {
+  const { number, title, ...rest } = overrides;
+  return {
+    number,
+    url: `https://github.com/ComposioHQ/agent-orchestrator/pull/${number}`,
+    title,
+    owner: "ComposioHQ",
+    repo: "agent-orchestrator",
+    branch: `feat/mock-${number}`,
+    baseBranch: "main",
+    isDraft: false,
+    state: "open",
+    additions: 128,
+    deletions: 24,
+    changedFiles: 6,
+    ciStatus: "passing",
+    ciChecks: [
+      { name: "build", status: "passed" },
+      { name: "typecheck", status: "passed" },
+      { name: "lint", status: "passed" },
+      { name: "test", status: "passed" },
+    ],
+    reviewDecision: "approved",
+    mergeability: {
+      mergeable: true,
+      ciPassing: true,
+      approved: true,
+      noConflicts: true,
+      blockers: [],
+    },
+    unresolvedThreads: 0,
+    unresolvedComments: [],
+    enriched: true,
+    ...rest,
+  };
+}
+
+function makeSession(overrides: Partial<DashboardSession> & { id: string }): DashboardSession {
+  const { id, ...rest } = overrides;
+  const lastActivityAt = rest.lastActivityAt ?? ago(5);
+  const status = rest.status ?? "working";
+  const activity = rest.activity ?? "active";
+  return {
+    id,
+    projectId: "agent-orchestrator",
+    status,
+    activity,
+    activitySignal: {
+      state: activity === null ? "unavailable" : "valid",
+      activity,
+      timestamp: activity === null ? null : lastActivityAt,
+      source: activity === null ? "none" : "native",
+    },
+    lifecycle: undefined,
+    branch: `feat/${id}`,
+    issueId: null,
+    issueUrl: "https://github.com/ComposioHQ/agent-orchestrator/issues/1",
+    issueLabel: "#1",
+    issueTitle: "feat: implement web dashboard with attention-zone UI and API routes",
+    userPrompt: null,
+    displayName: null,
+    displayNameUserSet: false,
+    summary: "Mock dashboard session for local UI development.",
+    summaryIsFallback: false,
+    createdAt: ago(180),
+    lastActivityAt,
+    pr: null,
+    metadata: { source: "mock" },
+    agentReportAudit: [],
+    ...rest,
+  };
+}
+
+export const mockDashboardSessions: DashboardSession[] = [
+  makeSession({
+    id: "backend-3",
+    status: "needs_input",
+    activity: "waiting_input",
+    summary: "Agent is waiting for confirmation before applying a database migration.",
+    lastActivityAt: ago(2),
+  }),
+  makeSession({
+    id: "frontend-2",
+    status: "stuck",
+    activity: "blocked",
+    summary: "Package install failed and needs a human retry decision.",
+    lastActivityAt: ago(7),
+  }),
+  makeSession({
+    id: "api-5",
+    status: "mergeable",
+    activity: "idle",
+    pr: makePR({ number: 101, title: "feat: add spawn API route" }),
+    summary: "PR is approved with green CI and ready to merge.",
+    lastActivityAt: ago(12),
+  }),
+  makeSession({
+    id: "dashboard-8",
+    status: "approved",
+    activity: "ready",
+    pr: makePR({ number: 102, title: "feat: attention-zone cards" }),
+    summary: "Review is approved and the merge button can clear this work.",
+    lastActivityAt: ago(18),
+  }),
+  makeSession({
+    id: "ci-1",
+    status: "ci_failed",
+    activity: "idle",
+    pr: makePR({
+      number: 103,
+      title: "fix: stabilize SSE stream tests",
+      ciStatus: "failing",
+      ciChecks: [
+        { name: "build", status: "passed" },
+        { name: "test", status: "failed" },
+        { name: "lint", status: "passed" },
+      ],
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: true,
+        noConflicts: true,
+        blockers: ["CI failing"],
+      },
+    }),
+    summary: "CI is failing and needs investigation.",
+    lastActivityAt: ago(24),
+  }),
+  makeSession({
+    id: "review-4",
+    status: "changes_requested",
+    activity: "idle",
+    pr: makePR({
+      number: 104,
+      title: "refactor: terminal placeholder component",
+      reviewDecision: "changes_requested",
+      mergeability: {
+        mergeable: false,
+        ciPassing: true,
+        approved: false,
+        noConflicts: true,
+        blockers: ["Changes requested"],
+      },
+      unresolvedThreads: 2,
+      unresolvedComments: [
+        {
+          url: "https://github.com/ComposioHQ/agent-orchestrator/pull/104#discussion_r1",
+          path: "packages/web/src/components/Terminal.tsx",
+          author: "reviewer",
+          body: "Please keep this as an xterm.js placeholder until PTY wiring lands.",
+        },
+      ],
+    }),
+    summary: "Reviewer requested changes on the terminal placeholder.",
+    lastActivityAt: ago(31),
+  }),
+  makeSession({
+    id: "review-6",
+    status: "review_pending",
+    activity: "ready",
+    pr: makePR({
+      number: 105,
+      title: "feat: session detail merge readiness",
+      reviewDecision: "pending",
+      mergeability: {
+        mergeable: false,
+        ciPassing: true,
+        approved: false,
+        noConflicts: true,
+        blockers: ["Needs review"],
+      },
+    }),
+    summary: "Waiting on reviewer approval.",
+    lastActivityAt: ago(45),
+  }),
+  makeSession({
+    id: "docs-7",
+    status: "pr_open",
+    activity: "ready",
+    pr: makePR({
+      number: 106,
+      title: "docs: dashboard test plan",
+      reviewDecision: "none",
+      ciStatus: "pending",
+      ciChecks: [
+        { name: "build", status: "running" },
+        { name: "test", status: "pending" },
+      ],
+      mergeability: {
+        mergeable: false,
+        ciPassing: false,
+        approved: false,
+        noConflicts: true,
+        blockers: ["CI pending", "Needs review"],
+      },
+    }),
+    summary: "CI and review are pending.",
+    lastActivityAt: ago(55),
+  }),
+  makeSession({
+    id: "worker-9",
+    status: "working",
+    activity: "active",
+    summary: "Implementing the dashboard home screen.",
+    lastActivityAt: ago(1),
+  }),
+  makeSession({
+    id: "worker-10",
+    status: "working",
+    activity: "ready",
+    summary: "Agent finished a turn and is ready for the next check-in.",
+    lastActivityAt: ago(9),
+  }),
+  makeSession({
+    id: "merged-11",
+    status: "merged",
+    activity: "exited",
+    pr: makePR({ number: 107, title: "feat: PR table", state: "merged" }),
+    summary: "Merged dashboard PR table work.",
+    lastActivityAt: ago(90),
+  }),
+  makeSession({
+    id: "killed-12",
+    status: "killed",
+    activity: "exited",
+    summary: "Terminated duplicate exploration session.",
+    lastActivityAt: ago(120),
+  }),
+];
+
+export function getMockDashboardPayload() {
+  return {
+    sessions: mockDashboardSessions,
+    stats: computeStats(mockDashboardSessions),
+    orchestratorId: "ao-mock-orchestrator",
+    orchestrators: [
+      {
+        id: "ao-mock-orchestrator",
+        projectId: "agent-orchestrator",
+        projectName: "Agent Orchestrator",
+        status: "working",
+        activity: "active",
+      },
+    ],
+  };
+}
+
+export function isMockDashboardRequested(url: string): boolean {
+  const requestUrl = new URL(url);
+  return requestUrl.searchParams.get("mock") === "true" || process.env.AO_WEB_MOCK_DATA === "true";
+}

--- a/packages/web/src/lib/mock-dashboard-data.ts
+++ b/packages/web/src/lib/mock-dashboard-data.ts
@@ -1,10 +1,8 @@
 import type { DashboardPR, DashboardSession } from "@/lib/types";
 import { computeStats } from "@/lib/serialize";
 
-const NOW = "2026-05-25T12:00:00.000Z";
-
 function ago(minutes: number): string {
-  return new Date(new Date(NOW).getTime() - minutes * 60_000).toISOString();
+  return new Date(Date.now() - minutes * 60_000).toISOString();
 }
 
 function makePR(overrides: Partial<DashboardPR> & { number: number; title: string }): DashboardPR {


### PR DESCRIPTION
## Summary\n- Add a reusable mock dashboard data layer with 12 sessions spanning merge/action/review/pending/working/done states\n- Support mock sessions from GET /api/sessions via ?mock=true (or AO_WEB_MOCK_DATA=true)\n- Add GET /api/events SSE endpoint streaming initial dashboard data plus 5s heartbeats\n\nCloses #1\n\n## Test plan\n- env -u NODE_ENV pnpm build\n- env -u NODE_ENV pnpm typecheck\n- env -u NODE_ENV pnpm lint\n- env -u NODE_ENV pnpm --filter @aoagents/ao-web test\n- env -u NODE_ENV pnpm --filter @aoagents/ao-web test -- src/__tests__/api-routes.test.ts\n\nNote: env -u NODE_ENV pnpm test currently fails in existing core tests (activity-events-migration timeout; lifecycle-manager branch adoption assertion), unrelated to these web changes.