### PR TITLE
fix: copy CLI assets with Node during build

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc && cp -r src/assets dist/",
+    "build": "tsc && node -e \"fs.cpSync('src/assets','dist/assets', { recursive: true })\"",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
## Summary
- replace the CLI package build script's Unix-only cp call with Node fs.cpSync
- keep the asset copy working on Windows shells

## Verification
- corepack pnpm --filter @aoagents/ao-cli build