### PR TITLE
fix(kimicode): detect one-shot exit state

### DIFF
--- a/packages/plugins/agent-kimicode/src/index.test.ts
+++ b/packages/plugins/agent-kimicode/src/index.test.ts
@@ -579,6 +579,51 @@ describe("getActivityState", () => {
     expect(result?.state).toBe("exited");
   });
 
+  it("1a. treats a completed one-shot kimi transcript as ready after process exit", async () => {
+    mockTmuxWithProcess("zsh", false);
+    writeKimiSession(workspace, "sess-complete", {
+      wireContent:
+        [
+          '{"type":"metadata","protocol_version":"1.10"}',
+          '{"timestamp":1778503361,"message":{"type":"TurnBegin","payload":{"user_input":"say ready"}}}',
+          '{"timestamp":1778503366,"message":{"type":"ContentPart","payload":{"type":"text","text":"KIMI_AO_READY"}}}',
+          '{"timestamp":1778503366,"message":{"type":"TurnEnd","payload":{}}}',
+        ].join("\n") + "\n",
+    });
+
+    const result = await agent.getActivityState(
+      makeSession({
+        runtimeHandle: makeTmuxHandle(),
+        workspacePath: workspace,
+        createdAt: new Date(Date.now() - 60 * 1000),
+      }),
+    );
+    expect(result?.state).toBe("ready");
+  });
+
+  it("1c. treats an interrupted one-shot kimi transcript without content as blocked", async () => {
+    mockTmuxWithProcess("zsh", false);
+    writeKimiSession(workspace, "sess-interrupted", {
+      wireContent:
+        [
+          '{"type":"metadata","protocol_version":"1.10"}',
+          '{"timestamp":1778503177,"message":{"type":"TurnBegin","payload":{"user_input":"say ready"}}}',
+          '{"timestamp":1778503178,"message":{"type":"StepBegin","payload":{"n":1}}}',
+          '{"timestamp":1778503178,"message":{"type":"StepInterrupted","payload":{}}}',
+          '{"timestamp":1778503178,"message":{"type":"TurnEnd","payload":{}}}',
+        ].join("\n") + "\n",
+    });
+
+    const result = await agent.getActivityState(
+      makeSession({
+        runtimeHandle: makeTmuxHandle(),
+        workspacePath: workspace,
+        createdAt: new Date(Date.now() - 60 * 1000),
+      }),
+    );
+    expect(result?.state).toBe("blocked");
+  });
+
   it("1b. returns exited when runtimeHandle is null", async () => {
     const result = await agent.getActivityState(makeSession({ runtimeHandle: null }));
     expect(result?.state).toBe("exited");

--- a/packages/plugins/agent-kimicode/src/index.ts
+++ b/packages/plugins/agent-kimicode/src/index.ts
@@ -97,6 +97,56 @@ async function extractKimiSummary(sessionDir: string): Promise<string | null> {
   return summary;
 }
 
+async function detectCompletedOneShotKimiActivity(
+  sessionDir: string,
+  timestamp: Date,
+): Promise<ActivityDetection | null> {
+  const wirePath = join(sessionDir, "wire.jsonl");
+  if (!(await isKimiSessionFile(wirePath))) return null;
+
+  let sawAssistantContent = false;
+  let sawInterrupted = false;
+  let sawTurnEnd = false;
+  let sawError = false;
+
+  try {
+    const rl = createInterface({
+      input: createReadStream(wirePath, { encoding: "utf-8" }),
+      crlfDelay: Infinity,
+    });
+    let bytes = 0;
+    for await (const line of rl) {
+      bytes += line.length;
+      if (bytes > SUMMARY_SCAN_BYTE_LIMIT) break;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const parsed: unknown = JSON.parse(trimmed);
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) continue;
+        const entry = parsed as Record<string, unknown>;
+        const message = entry["message"];
+        if (!message || typeof message !== "object" || Array.isArray(message)) continue;
+        const msg = message as Record<string, unknown>;
+        const type = typeof msg["type"] === "string" ? msg["type"] : "";
+        if (type === "ContentPart") sawAssistantContent = true;
+        if (type === "StepInterrupted") sawInterrupted = true;
+        if (type === "TurnEnd") sawTurnEnd = true;
+        if (/error|exception|failed/i.test(line)) sawError = true;
+      } catch {
+        // Skip malformed line.
+      }
+    }
+    rl.close();
+  } catch {
+    return null;
+  }
+
+  if (!sawTurnEnd) return null;
+  if (sawAssistantContent) return { state: "ready", timestamp };
+  if (sawInterrupted || sawError) return { state: "blocked", timestamp };
+  return null;
+}
+
 // =============================================================================
 // Plugin Manifest
 // =============================================================================
@@ -257,7 +307,16 @@ function createKimicodeAgent(): Agent {
       const exitedAt = new Date();
       if (!session.runtimeHandle) return { state: "exited", timestamp: exitedAt };
       const running = await this.isProcessRunning(session.runtimeHandle);
-      if (!running) return { state: "exited", timestamp: exitedAt };
+      if (!running) {
+        if (session.workspacePath) {
+          const match = await findKimiSessionMatch(session);
+          if (match) {
+            const oneShotActivity = await detectCompletedOneShotKimiActivity(match.dir, match.mtime);
+            if (oneShotActivity) return oneShotActivity;
+          }
+        }
+        return { state: "exited", timestamp: exitedAt };
+      }
 
       if (!session.workspacePath) return null;
 


### PR DESCRIPTION
## Summary
- detect completed one-shot Kimi sessions after the process exits by reading the matched `wire.jsonl`
- return `ready` when the transcript has assistant content and `blocked` when it ended after interruption/error without content
- add focused tests for completed and interrupted one-shot transcripts

## Verification
- `corepack pnpm --filter @aoagents/ao-plugin-agent-kimicode exec vitest run src/index.test.ts -t "one-shot kimi transcript"`
- `corepack pnpm --filter @aoagents/ao-plugin-agent-kimicode typecheck`

Note: the full plugin test command still fails locally on Windows on existing session discovery/symlink cases unrelated to this change; the new targeted tests pass.