### PR TITLE
fix: exclude orchestrator sessions from active-session guard in /api/update

### DIFF
--- a/packages/web/src/app/api/update/route.ts
+++ b/packages/web/src/app/api/update/route.ts
@@ -13,7 +13,7 @@
 
 import { spawn } from "node:child_process";
 import { NextResponse, type NextRequest } from "next/server";
-import { isWindows } from "@aoagents/ao-core";
+import { isOrchestratorSession, isWindows } from "@aoagents/ao-core";
 import { getServices } from "@/lib/services";
 
 export const dynamic = "force-dynamic";
@@ -39,7 +39,11 @@ export async function POST(_req: NextRequest) {
   try {
     const { sessionManager } = await getServices();
     const sessions = await sessionManager.list();
-    activeCount = sessions.filter((s) => ACTIVE_STATUSES.has(s.status)).length;
+    activeCount = sessions.filter(
+      (s) =>
+        ACTIVE_STATUSES.has(s.status) &&
+        !isOrchestratorSession(s),
+    ).length;
   } catch (err) {
     return NextResponse.json<UpdateResponse>(
       {


### PR DESCRIPTION
The POST /api/update route returns 409 Conflict when any session is active (working/idle/needs_input/stuck). The orchestrator session itself is always idle while the dashboard is running, making the Update button permanently unusable through the web UI.

This fix filters out orchestrator sessions (identified via `isOrchestratorSession()`) from the active session count, so only genuine worker sessions block the update.