### PR TITLE
feat: configurable merge method (ff-only + merge commit fallback)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -267,6 +267,8 @@ const ProjectConfigSchema = z.object({
   orchestrator: RoleAgentConfigSchema,
   worker: RoleAgentConfigSchema,
   reactions: z.record(ReactionConfigSchema.partial()).optional(),
+  /** Merge strategy for auto-merge and dashboard merge. Default: "squash". */
+  mergeMethod: z.enum(["merge", "squash", "rebase", "ff-only"]).default("squash"),
   agentRules: z.string().optional(),
   agentRulesFile: z.string().optional(),
   orchestratorRules: z.string().optional(),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -981,6 +981,12 @@ export const PR_STATE = {
   CLOSED: "closed" as const,
 } satisfies Record<string, PRState>;
 
+/**
+ * PR merge strategy. `merge` / `squash` / `rebase` map directly to native
+ * GitHub/GitLab merge methods. `ff-only` is an AO-specific composite strategy
+ * (not a native API value): attempt a fast-forward and fall back to a merge
+ * commit when the branch has diverged. Only the GitHub SCM implements it.
+ */
 export type MergeMethod = "merge" | "squash" | "rebase" | "ff-only";
 
 export interface SCMWebhookRequest {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -981,7 +981,7 @@ export const PR_STATE = {
   CLOSED: "closed" as const,
 } satisfies Record<string, PRState>;
 
-export type MergeMethod = "merge" | "squash" | "rebase";
+export type MergeMethod = "merge" | "squash" | "rebase" | "ff-only";
 
 export interface SCMWebhookRequest {
   method: string;
@@ -1578,6 +1578,9 @@ export interface ProjectConfig {
 
   /** Per-project reaction overrides */
   reactions?: Record<string, Partial<ReactionConfig>>;
+
+  /** Merge strategy for auto-merge and dashboard merge. Default: "squash". */
+  mergeMethod?: MergeMethod;
 
   /** Inline rules/instructions passed to every agent prompt */
   agentRules?: string;

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -103,6 +103,21 @@ async function git(args: string[], cwd: string): Promise<string> {
   return execCli("git", args, cwd);
 }
 
+/**
+ * True when a `gh pr merge --ff-only` failure is due to the branch not being
+ * fast-forwardable (so a merge-commit fallback is appropriate). Returns false
+ * for auth / network / not-found errors, which must propagate.
+ */
+function isFastForwardFailure(err: unknown): boolean {
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    message.includes("fast-forward") ||
+    message.includes("fast forward") ||
+    message.includes("not possible to merge") ||
+    message.includes("diverged")
+  );
+}
+
 function parseProjectRepo(projectRepo: string): [string, string] {
   const parts = projectRepo.split("/");
   if (parts.length !== 2 || !parts[0] || !parts[1]) {
@@ -850,7 +865,11 @@ function createGitHubSCM(): SCM {
             "--ff-only",
             "--delete-branch",
           ]);
-        } catch {
+        } catch (err) {
+          // Only fall back to a merge commit when the branch genuinely can't
+          // be fast-forwarded. Auth / network / not-found errors must surface
+          // as-is rather than be masked by a second failing merge attempt.
+          if (!isFastForwardFailure(err)) throw err;
           await gh([
             "pr",
             "merge",
@@ -862,9 +881,16 @@ function createGitHubSCM(): SCM {
           ]);
         }
       } else {
-        const flag =
-          method === "rebase" ? "--rebase" : method === "merge" ? "--merge" : "--squash";
-        await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), flag, "--delete-branch"]);
+        const flag = method === "rebase" ? "--rebase" : method === "merge" ? "--merge" : "--squash";
+        await gh([
+          "pr",
+          "merge",
+          String(pr.number),
+          "--repo",
+          repoFlag(pr),
+          flag,
+          "--delete-branch",
+        ]);
       }
       invalidatePRCache(pr);
     },

--- a/packages/plugins/scm-github/src/index.ts
+++ b/packages/plugins/scm-github/src/index.ts
@@ -839,9 +839,33 @@ function createGitHubSCM(): SCM {
     },
 
     async mergePR(pr: PRInfo, method: MergeMethod = "squash"): Promise<void> {
-      const flag = method === "rebase" ? "--rebase" : method === "merge" ? "--merge" : "--squash";
-
-      await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), flag, "--delete-branch"]);
+      if (method === "ff-only") {
+        try {
+          await gh([
+            "pr",
+            "merge",
+            String(pr.number),
+            "--repo",
+            repoFlag(pr),
+            "--ff-only",
+            "--delete-branch",
+          ]);
+        } catch {
+          await gh([
+            "pr",
+            "merge",
+            String(pr.number),
+            "--repo",
+            repoFlag(pr),
+            "--merge",
+            "--delete-branch",
+          ]);
+        }
+      } else {
+        const flag =
+          method === "rebase" ? "--rebase" : method === "merge" ? "--merge" : "--squash";
+        await gh(["pr", "merge", String(pr.number), "--repo", repoFlag(pr), flag, "--delete-branch"]);
+      }
       invalidatePRCache(pr);
     },
 

--- a/packages/plugins/scm-github/test/index.test.ts
+++ b/packages/plugins/scm-github/test/index.test.ts
@@ -576,6 +576,35 @@ describe("scm-github plugin", () => {
         expect.any(Object),
       );
     });
+
+    it("uses --ff-only when method is ff-only and the branch fast-forwards", async () => {
+      ghMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "ff-only");
+      expect(ghMock).toHaveBeenCalledTimes(1);
+      expect(ghMock).toHaveBeenCalledWith(
+        expect.stringMatching(/(?:^|[\\/])gh(?:\.(?:exe|cmd|bat))?$/i),
+        ["pr", "merge", "42", "--repo", "acme/repo", "--ff-only", "--delete-branch"],
+        expect.any(Object),
+      );
+    });
+
+    it("falls back to --merge when ff-only fails because the branch diverged", async () => {
+      ghMock.mockRejectedValueOnce(new Error("gh pr merge failed: not possible to fast-forward"));
+      ghMock.mockResolvedValueOnce({ stdout: "" });
+      await scm.mergePR(pr, "ff-only");
+      expect(ghMock).toHaveBeenCalledTimes(2);
+      expect(ghMock).toHaveBeenLastCalledWith(
+        expect.stringMatching(/(?:^|[\\/])gh(?:\.(?:exe|cmd|bat))?$/i),
+        ["pr", "merge", "42", "--repo", "acme/repo", "--merge", "--delete-branch"],
+        expect.any(Object),
+      );
+    });
+
+    it("propagates non-fast-forward errors (e.g. auth) without retrying", async () => {
+      ghMock.mockRejectedValueOnce(new Error("gh pr merge failed: HTTP 401: Bad credentials"));
+      await expect(scm.mergePR(pr, "ff-only")).rejects.toThrow(/Bad credentials/);
+      expect(ghMock).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ---- closePR -----------------------------------------------------------

--- a/packages/plugins/scm-gitlab/src/index.ts
+++ b/packages/plugins/scm-gitlab/src/index.ts
@@ -528,6 +528,16 @@ function createGitLabSCM(config?: Record<string, unknown>): SCM {
     },
 
     async mergePR(pr: PRInfo, method: MergeMethod = "squash"): Promise<void> {
+      if (method === "ff-only") {
+        // "ff-only" is an AO composite strategy (try fast-forward, fall back to
+        // a merge commit) that only the GitHub SCM implements. GitLab's
+        // fast-forward behavior is a project-level merge-method setting with no
+        // per-merge `glab` flag, so fail loudly instead of silently ignoring it.
+        throw new Error(
+          'mergeMethod "ff-only" is not supported by the GitLab SCM; ' +
+            'use "merge", "squash", or "rebase".',
+        );
+      }
       const args = ["mr", "merge", String(pr.number), "--repo", repoFlag(pr)];
       if (method === "squash") args.push("--squash");
       else if (method === "rebase") args.push("--rebase");

--- a/packages/plugins/scm-gitlab/test/index.test.ts
+++ b/packages/plugins/scm-gitlab/test/index.test.ts
@@ -514,6 +514,11 @@ describe("scm-gitlab plugin", () => {
       expect(args).not.toContain("--squash");
       expect(args).not.toContain("--rebase");
     });
+
+    it("throws for the unsupported ff-only method instead of silently ignoring it", async () => {
+      await expect(scm.mergePR(pr, "ff-only")).rejects.toThrow(/ff-only.*not supported/i);
+      expect(glabMock).not.toHaveBeenCalled();
+    });
   });
 
   // ---- closePR -----------------------------------------------------------

--- a/packages/web/src/__tests__/api-routes.test.ts
+++ b/packages/web/src/__tests__/api-routes.test.ts
@@ -1466,6 +1466,31 @@ describe("API Routes", () => {
       const data = await res.json();
       expect(data.error).toMatch(/merged/);
     });
+
+    it("defaults to squash when the project has no mergeMethod", async () => {
+      const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+      const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.method).toBe("squash");
+      expect(mockSCM.mergePR).toHaveBeenCalledWith(expect.anything(), "squash");
+    });
+
+    it("uses the project's configured mergeMethod", async () => {
+      const project = mockConfig.projects["my-app"];
+      const original = project.mergeMethod;
+      project.mergeMethod = "ff-only";
+      try {
+        const req = makeRequest("/api/prs/432/merge", { method: "POST" });
+        const res = await mergePOST(req, { params: Promise.resolve({ id: "432" }) });
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data.method).toBe("ff-only");
+        expect(mockSCM.mergePR).toHaveBeenCalledWith(expect.anything(), "ff-only");
+      } finally {
+        project.mergeMethod = original;
+      }
+    });
   });
 
   describe("GET /api/observability", () => {

--- a/packages/web/src/app/api/prs/[id]/merge/route.ts
+++ b/packages/web/src/app/api/prs/[id]/merge/route.ts
@@ -89,7 +89,8 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       );
     }
 
-    await scm.mergePR(targetPR, "squash");
+    const mergeMethod = project.mergeMethod ?? "squash";
+    await scm.mergePR(targetPR, mergeMethod);
     recordApiObservation({
       config,
       method: "POST",
@@ -108,10 +109,10 @@ export async function POST(_request: NextRequest, { params }: { params: Promise<
       source: "api",
       kind: "api.pr_merge_requested",
       summary: `PR ${prNumber} merge requested`,
-      data: { prNumber, method: "squash" },
+      data: { prNumber, method: mergeMethod },
     });
     return jsonWithCorrelation(
-      { ok: true, prNumber, method: "squash" },
+      { ok: true, prNumber, method: mergeMethod },
       { status: 200 },
       correlationId,
     );


### PR DESCRIPTION
## Summary

Adds a per-project `mergeMethod` config option so users can preserve full git history instead of always squashing. Default remains `"squash"` (backward compatible). Consumed by the dashboard merge button via `scm.mergePR`.

> **Note:** The `auto-merge` reaction is currently a notify-only stub (`lifecycle-manager.ts`) and does **not** call `scm.mergePR` yet, so it does not consume `mergeMethod`. This option only takes effect from the dashboard merge action today.

New `"ff-only"` strategy (GitHub SCM only):
1. Tries `gh pr merge --ff-only` (clean linear history)
2. Falls back to `--merge` (merge commit) only when the branch has genuinely diverged — other failures (auth, network, not-found) propagate

No squash, no rebase for `ff-only` — git history is preserved. `"ff-only"` is an AO composite strategy, not a native API value; the GitLab SCM throws an explicit error if it's configured there.

### Config Usage

```yaml
projects:
  my-app:
    repo: owner/my-app
    path: ~/my-app
    mergeMethod: ff-only    # try fast-forward, fall back to merge commit
```

Options: `"squash"` (default), `"merge"`, `"rebase"`, `"ff-only"`

## Files Changed

1. `packages/core/src/types.ts` — Add `"ff-only"` to `MergeMethod` (with JSDoc), add `mergeMethod?` to `ProjectConfig`
2. `packages/core/src/config.ts` — Add `mergeMethod` to `ProjectConfigSchema` (default `"squash"`)
3. `packages/plugins/scm-github/src/index.ts` — `mergePR()` handles `"ff-only"`: try `--ff-only`, fall back to `--merge` only on a non-fast-forward failure
4. `packages/plugins/scm-gitlab/src/index.ts` — `mergePR()` throws for unsupported `"ff-only"` instead of silently ignoring it
5. `packages/web/src/app/api/prs/[id]/merge/route.ts` — Reads `project.mergeMethod` instead of hardcoding `"squash"`

Closes #2095

🤖 Generated with [Claude Code](https://claude.com/claude-code)
