### PR TITLE
fix(claude-code): anchor workspace hook command paths to CLAUDE_PROJECT_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,11 @@ defaults:
   workspace: worktree
   notifiers: [desktop]
 
+# AO-local code reviewer backend (`ao review run`). Optional — defaults to the
+# worker agent when it has a reviewer adapter, otherwise codex.
+review:
+  agent: claude-code  # claude-code | codex (or `command:` for a custom shell reviewer)
+
 projects:
   my-app:
     repo: owner/my-app
@@ -167,6 +172,8 @@ reactions:
 ```
 
 CI fails → agent gets the logs and fixes it. Reviewer requests changes → agent addresses them. PR approved with green CI → you get a notification to merge.
+
+The AO-local reviewer (`ao review run`) picks its backend in this order: a `--command` flag, then `projects.<id>.review`, then the global `review` block, then your worker agent (`defaults.agent`) if it ships a reviewer adapter, and finally codex. Set `review.agent: claude-code` to review with Claude Code on hosts without Codex/OpenAI credentials.
 
 Keep the `$schema` line so editors can autocomplete and validate against [`schema/config.schema.json`](schema/config.schema.json).
 

--- a/agent-orchestrator.yaml.example
+++ b/agent-orchestrator.yaml.example
@@ -42,6 +42,14 @@ defaults:
   workspace: worktree     # worktree | clone
   notifiers: [desktop]    # desktop | slack | discord | webhook | composio | openclaw
 
+# AO-local code reviewer backend (`ao review run`). Optional.
+# Resolution precedence: `--command` flag > project.review > this block >
+# worker agent (defaults.agent, when it has a reviewer adapter) > codex.
+# `agent` and `command` are mutually exclusive.
+# review:
+#   agent: claude-code    # claude-code | codex
+#   # command: "bash ~/.config/agent-orchestrator/claude-reviewer.sh main"
+
 # Installer-managed external plugins (optional)
 # plugins:
 #   - name: owasp-auditor
@@ -107,6 +115,10 @@ projects:
     #   agent: codex
     #   agentConfig:
     #     model: gpt-5-codex
+
+    # Per-project reviewer backend override (see top-level `review:` for keys)
+    # review:
+    #   agent: claude-code
 
     # Inline rules included in every agent prompt for this project
     # agentRules: |

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -1,7 +1,6 @@
 import chalk from "chalk";
 import type { Command } from "commander";
 import {
-  createShellCodeReviewRunner,
   createCodeReviewStore,
   executeCodeReviewRun,
   loadConfig,
@@ -91,7 +90,14 @@ function getNextQueuedRun(
 }
 
 export function registerReview(program: Command): void {
-  const review = program.command("review").description("Manage AO-local reviewer runs");
+  const review = program
+    .command("review")
+    .description(
+      "Manage AO-local reviewer runs. The reviewer backend resolves in order: " +
+        "--command flag > project review config > global review config > worker agent > codex. " +
+        "Configure a persistent backend with `review.agent` (claude-code|codex) or " +
+        "`review.command` globally, or under `projects.<id>.review` per project.",
+    );
 
   review
     .command("run")
@@ -100,7 +106,10 @@ export function registerReview(program: Command): void {
     .option("--summary <text>", "Summary to store on the review run")
     .option("--status <status>", "Initial run status (defaults to queued)")
     .option("--execute", "Execute the review run immediately")
-    .option("--command <command>", "Shell command to execute as the reviewer")
+    .option(
+      "--command <command>",
+      "Shell command to execute as the reviewer (overrides review config)",
+    )
     .option("--json", "Output as JSON")
     .action(
       async (
@@ -128,11 +137,7 @@ export function registerReview(program: Command): void {
 
           if (opts.execute || opts.command) {
             run = await executeCodeReviewRun(
-              {
-                config,
-                sessionManager,
-                ...(opts.command ? { runReviewer: createShellCodeReviewRunner(opts.command) } : {}),
-              },
+              { config, sessionManager, reviewCommand: opts.command },
               { projectId: run.projectId, runId: run.id },
             );
           }
@@ -164,7 +169,10 @@ export function registerReview(program: Command): void {
     .description("Execute a queued AO-local reviewer run")
     .argument("[project]", "Project ID (searches all projects if omitted)")
     .option("--run <run>", "Review run ID or reviewer session ID")
-    .option("--command <command>", "Shell command to execute as the reviewer")
+    .option(
+      "--command <command>",
+      "Shell command to execute as the reviewer (overrides review config)",
+    )
     .option("--force", "Execute even if the run is not queued")
     .option("--json", "Output as JSON")
     .action(
@@ -194,7 +202,7 @@ export function registerReview(program: Command): void {
               config,
               sessionManager,
               force: opts.force,
-              ...(opts.command ? { runReviewer: createShellCodeReviewRunner(opts.command) } : {}),
+              reviewCommand: opts.command,
             },
             { projectId: target.projectId, runId: target.run.id },
           );

--- a/packages/cli/src/lib/config-instruction.ts
+++ b/packages/cli/src/lib/config-instruction.ts
@@ -38,6 +38,15 @@ defaults:
   worker:
     agent: claude-code        # Optional override for worker sessions
 
+# ── AO-local reviewer backend (optional) ───────────────────────────
+# Backend for 'ao review run'. Precedence: --command flag > project.review >
+# this block > worker agent (defaults.agent, if it has an adapter) > codex.
+# 'agent' and 'command' are mutually exclusive.
+
+review:
+  agent: claude-code          # claude-code | codex
+  # command: "bash ~/.config/agent-orchestrator/claude-reviewer.sh main"
+
 # ── Installer-managed marketplace plugins (optional) ───────────────
 # External plugins are declared here. Built-ins do not need entries.
 

--- a/packages/core/src/__tests__/code-review-backend.test.ts
+++ b/packages/core/src/__tests__/code-review-backend.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildClaudeCodeReviewArgs,
+  parseReviewerOutput,
+  resolveCodeReviewRunner,
+  runClaudeCodeReview,
+  runCodexCodeReview,
+  SUPPORTED_REVIEW_AGENTS,
+} from "../code-review-manager.js";
+import type { OrchestratorConfig, ProjectConfig, ReviewConfig } from "../types.js";
+
+function makeConfig(overrides: {
+  defaultAgent?: string;
+  review?: ReviewConfig;
+  projectReview?: ReviewConfig;
+}): { config: OrchestratorConfig; project: ProjectConfig } {
+  const project: ProjectConfig = {
+    name: "App",
+    path: "/tmp/app",
+    defaultBranch: "main",
+    sessionPrefix: "app",
+    ...(overrides.projectReview ? { review: overrides.projectReview } : {}),
+  };
+
+  const config: OrchestratorConfig = {
+    configPath: "/tmp/ao/agent-orchestrator.yaml",
+    readyThresholdMs: 300_000,
+    defaults: {
+      runtime: "tmux",
+      agent: overrides.defaultAgent ?? "claude-code",
+      workspace: "worktree",
+      notifiers: [],
+    },
+    projects: { app: project },
+    notifiers: {},
+    notificationRouting: { urgent: [], action: [], warning: [], info: [] },
+    reactions: {},
+    ...(overrides.review ? { review: overrides.review } : {}),
+  };
+
+  return { config, project };
+}
+
+describe("resolveCodeReviewRunner precedence", () => {
+  it("uses the explicit --command flag above everything else", () => {
+    const { config, project } = makeConfig({
+      defaultAgent: "claude-code",
+      review: { agent: "codex" },
+      projectReview: { agent: "codex" },
+    });
+    const runner = resolveCodeReviewRunner({ config, project, command: "echo hi" });
+    // Shell-command runners are fresh closures, distinct from the agent adapters.
+    expect(runner).not.toBe(runClaudeCodeReview);
+    expect(runner).not.toBe(runCodexCodeReview);
+  });
+
+  it("prefers the per-project review config over the global review config", () => {
+    const { config, project } = makeConfig({
+      defaultAgent: "claude-code",
+      review: { agent: "claude-code" },
+      projectReview: { agent: "codex" },
+    });
+    expect(resolveCodeReviewRunner({ config, project })).toBe(runCodexCodeReview);
+  });
+
+  it("prefers the global review config over the worker-agent fallback", () => {
+    const { config, project } = makeConfig({
+      defaultAgent: "claude-code",
+      review: { agent: "codex" },
+    });
+    expect(resolveCodeReviewRunner({ config, project })).toBe(runCodexCodeReview);
+  });
+
+  it("falls back to the worker agent when it has a known reviewer adapter", () => {
+    const { config, project } = makeConfig({ defaultAgent: "claude-code" });
+    expect(resolveCodeReviewRunner({ config, project })).toBe(runClaudeCodeReview);
+  });
+
+  it("falls back to Codex when the worker agent has no reviewer adapter", () => {
+    const { config, project } = makeConfig({ defaultAgent: "aider" });
+    expect(resolveCodeReviewRunner({ config, project })).toBe(runCodexCodeReview);
+  });
+
+  it("preserves Codex behavior when the worker agent is already codex", () => {
+    const { config, project } = makeConfig({ defaultAgent: "codex" });
+    expect(resolveCodeReviewRunner({ config, project })).toBe(runCodexCodeReview);
+  });
+
+  it("resolves review.command to a shell runner", () => {
+    const { config, project } = makeConfig({ review: { command: "echo hi" } });
+    const runner = resolveCodeReviewRunner({ config, project });
+    expect(runner).not.toBe(runClaudeCodeReview);
+    expect(runner).not.toBe(runCodexCodeReview);
+  });
+
+  it("throws a clear error for an unsupported review.agent", () => {
+    const { config, project } = makeConfig({ review: { agent: " collaborator" } });
+    expect(() => resolveCodeReviewRunner({ config, project })).toThrowError(
+      new RegExp(`Unsupported review.agent.*${SUPPORTED_REVIEW_AGENTS.join(", ")}`),
+    );
+  });
+
+  it("throws for an unsupported per-project review.agent", () => {
+    const { config, project } = makeConfig({ projectReview: { agent: "nope" } });
+    expect(() => resolveCodeReviewRunner({ config, project })).toThrow(/Unsupported review\.agent/);
+  });
+});
+
+describe("buildClaudeCodeReviewArgs", () => {
+  it("builds the expected read-only argv with the prompt", () => {
+    expect(buildClaudeCodeReviewArgs("REVIEW PROMPT")).toEqual([
+      "-p",
+      "REVIEW PROMPT",
+      "--permission-mode",
+      "bypassPermissions",
+      "--output-format",
+      "text",
+    ]);
+  });
+});
+
+describe("parseReviewerOutput (claude-code style responses)", () => {
+  const findings = [
+    {
+      severity: "error" as const,
+      title: "Null deref",
+      body: "`user` may be undefined.",
+      filePath: "src/app.ts",
+      startLine: 10,
+      endLine: 12,
+      confidence: 0.9,
+    },
+  ];
+
+  it("round-trips a plain JSON object response", () => {
+    const raw = JSON.stringify({ findings });
+    const parsed = parseReviewerOutput(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toMatchObject({
+      severity: "error",
+      title: "Null deref",
+      filePath: "src/app.ts",
+      startLine: 10,
+      endLine: 12,
+    });
+  });
+
+  it("round-trips a markdown-fenced JSON response", () => {
+    const raw = ["Here is my review:", "```json", JSON.stringify({ findings }), "```"].join("\n");
+    const parsed = parseReviewerOutput(raw);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]?.title).toBe("Null deref");
+  });
+
+  it("treats an empty findings array as no findings", () => {
+    expect(parseReviewerOutput('{"findings":[]}')).toEqual([]);
+  });
+});

--- a/packages/core/src/code-review-manager.ts
+++ b/packages/core/src/code-review-manager.ts
@@ -27,9 +27,11 @@ import {
   SessionNotFoundError,
   type OrchestratorConfig,
   type ProjectConfig,
+  type ReviewConfig,
   type Session,
   type SessionManager,
 } from "./types.js";
+import { resolveAgentSelection } from "./agent-selection.js";
 import { getShell, isWindows, killProcessTree } from "./platform.js";
 
 const REVIEW_COMMAND_TIMEOUT_MS = 10 * 60_000;
@@ -207,7 +209,14 @@ export interface ExecuteCodeReviewRunOptions {
   sessionManager: SessionManager;
   storeFactory?: (projectId: string) => CodeReviewStore;
   prepareWorkspace?: PrepareCodeReviewWorkspace;
+  /**
+   * Explicit reviewer override. When provided it wins over all configuration
+   * (used by tests and any caller that fully controls the runner). When
+   * omitted, the backend is resolved via {@link resolveCodeReviewRunner}.
+   */
   runReviewer?: CodeReviewRunner;
+  /** Shell command from the `--command` flag (highest configuration precedence). */
+  reviewCommand?: string;
   now?: () => Date;
   force?: boolean;
 }
@@ -761,6 +770,102 @@ export async function runCodexCodeReview(
   }
 }
 
+export function buildClaudeCodeReviewArgs(prompt: string): string[] {
+  return ["-p", prompt, "--permission-mode", "bypassPermissions", "--output-format", "text"];
+}
+
+export async function runClaudeCodeReview(
+  context: CodeReviewRunnerContext,
+): Promise<CodeReviewRunnerResult> {
+  const prompt = buildDefaultReviewPrompt(context);
+  const args = buildClaudeCodeReviewArgs(prompt);
+
+  try {
+    const { stdout, stderr } = await execFileWithClosedStdin("claude", args, {
+      cwd: context.workspacePath,
+      timeout: REVIEW_COMMAND_TIMEOUT_MS,
+      maxBuffer: REVIEW_COMMAND_MAX_BUFFER,
+      env: process.env,
+      shell: isWindows(),
+    });
+    return { rawOutput: stdout.trim() || stderr.trim() };
+  } catch (error) {
+    const details =
+      error instanceof Error && "stderr" in error && typeof error.stderr === "string"
+        ? error.stderr.trim()
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    throw new Error(`Claude Code review failed: ${details}`, { cause: error });
+  }
+}
+
+/**
+ * Agent plugins that ship a built-in reviewer adapter. Keyed by the plugin's
+ * manifest name (matches `defaults.agent` / `review.agent` values).
+ */
+const REVIEWER_ADAPTERS: Readonly<Record<string, CodeReviewRunner>> = {
+  "claude-code": runClaudeCodeReview,
+  codex: runCodexCodeReview,
+};
+
+export const SUPPORTED_REVIEW_AGENTS: readonly string[] = Object.keys(REVIEWER_ADAPTERS);
+
+function reviewerFromConfig(review: ReviewConfig | undefined): CodeReviewRunner | undefined {
+  if (!review) return undefined;
+  if (review.command) return createShellCodeReviewRunner(review.command);
+  if (review.agent) {
+    const adapter = REVIEWER_ADAPTERS[review.agent];
+    if (!adapter) {
+      throw new Error(
+        `Unsupported review.agent "${review.agent}". Valid values: ${SUPPORTED_REVIEW_AGENTS.join(", ")}.`,
+      );
+    }
+    return adapter;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the reviewer backend for a run using the documented precedence:
+ *
+ *   1. explicit `command` (the `--command` CLI flag)
+ *   2. per-project `project.review` (command or agent)
+ *   3. global `config.review` (command or agent)
+ *   4. the project's worker agent, when it has a known reviewer adapter
+ *   5. Codex (final fallback, preserving the original behavior)
+ *
+ * Throws when a configured `review.agent` names an agent without an adapter,
+ * so misconfiguration fails fast before any review run state is mutated.
+ */
+export function resolveCodeReviewRunner({
+  config,
+  project,
+  command,
+}: {
+  config: OrchestratorConfig;
+  project: ProjectConfig;
+  command?: string;
+}): CodeReviewRunner {
+  if (command) return createShellCodeReviewRunner(command);
+
+  const projectReviewer = reviewerFromConfig(project.review);
+  if (projectReviewer) return projectReviewer;
+
+  const globalReviewer = reviewerFromConfig(config.review);
+  if (globalReviewer) return globalReviewer;
+
+  const workerAgent = resolveAgentSelection({
+    role: "worker",
+    project,
+    defaults: config.defaults,
+  }).agentName;
+  const workerAdapter = workerAgent ? REVIEWER_ADAPTERS[workerAgent] : undefined;
+  if (workerAdapter) return workerAdapter;
+
+  return runCodexCodeReview;
+}
+
 function defaultReviewSummary(session: Session, source: CodeReviewRequestSource): string {
   const sourceLabel = source === "cli" ? "CLI" : source === "web" ? "dashboard" : "automation";
   return `Review requested from ${sourceLabel} for ${session.id}.`;
@@ -902,7 +1007,8 @@ export async function executeCodeReviewRun(
     sessionManager,
     storeFactory = createCodeReviewStore,
     prepareWorkspace = prepareGitReviewerWorkspace,
-    runReviewer = runCodexCodeReview,
+    runReviewer,
+    reviewCommand,
     now = () => new Date(),
     force = false,
   }: ExecuteCodeReviewRunOptions,
@@ -912,6 +1018,11 @@ export async function executeCodeReviewRun(
   if (!project) {
     throw new Error(`Unknown project: ${projectId}`);
   }
+
+  // Resolve the backend up front so a misconfigured `review.agent` fails fast,
+  // before any run is claimed or marked `preparing`.
+  const reviewer =
+    runReviewer ?? resolveCodeReviewRunner({ config, project, command: reviewCommand });
 
   const store = storeFactory(projectId);
   const claimed = await withReviewRunExecutionLock(store, runId, async () => {
@@ -946,7 +1057,7 @@ export async function executeCodeReviewRun(
       now(),
     );
     const baseRef = session.pr?.baseBranch?.trim() || project.defaultBranch;
-    const result = await runReviewer({ config, project, session, run, workspacePath, baseRef });
+    const result = await reviewer({ config, project, session, run, workspacePath, baseRef });
     const findings = result.findings ?? parseReviewerOutput(result.rawOutput ?? "");
 
     for (const finding of findings) {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -244,6 +244,16 @@ const RoleAgentConfigSchema = z
   })
   .optional();
 
+const ReviewConfigSchema = z
+  .object({
+    agent: z.string().optional(),
+    command: z.string().optional(),
+  })
+  .strict()
+  .refine((value) => !(value.agent && value.command), {
+    message: "review.agent and review.command are mutually exclusive",
+  });
+
 const ProjectConfigSchema = z.object({
   name: z.string().optional(),
   repo: z.string().optional(),
@@ -266,6 +276,7 @@ const ProjectConfigSchema = z.object({
   agentConfig: AgentSpecificConfigSchema.default({}),
   orchestrator: RoleAgentConfigSchema,
   worker: RoleAgentConfigSchema,
+  review: ReviewConfigSchema.optional(),
   reactions: z.record(ReactionConfigSchema.partial()).optional(),
   agentRules: z.string().optional(),
   agentRulesFile: z.string().optional(),
@@ -366,6 +377,7 @@ const OrchestratorConfigSchema = z.object({
   defaults: DefaultPluginsSchema.default({}),
   plugins: z.array(InstalledPluginConfigSchema).default([]),
   dashboard: DashboardConfigSchema.optional(),
+  review: ReviewConfigSchema.optional(),
   projects: z.record(
     z
       .string()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -70,14 +70,18 @@ export {
   CodeReviewNoOpenFindingsError,
   CodeReviewRunNotExecutableError,
   CodeReviewRunNotFoundError,
+  buildClaudeCodeReviewArgs,
   createShellCodeReviewRunner,
   executeCodeReviewRun,
   formatCodeReviewFindingsForAgent,
   markOutdatedCodeReviewRunsForSession,
   parseReviewerOutput,
   prepareGitReviewerWorkspace,
+  resolveCodeReviewRunner,
+  runClaudeCodeReview,
   runCodexCodeReview,
   sendCodeReviewFindingsToAgent,
+  SUPPORTED_REVIEW_AGENTS,
   triggerCodeReviewForSession,
 } from "./code-review-manager.js";
 export type {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1359,6 +1359,20 @@ export interface ObservabilityConfig {
 }
 
 /** Top-level orchestrator configuration (from agent-orchestrator.yaml) */
+/**
+ * Configuration for the AO-local code reviewer backend.
+ *
+ * `agent` and `command` are mutually exclusive:
+ * - `agent`: name of a registered agent plugin with a reviewer adapter
+ *   (currently "claude-code" or "codex").
+ * - `command`: an explicit shell command run in the reviewer workspace whose
+ *   stdout is parsed for findings (same contract as `ao review run --command`).
+ */
+export interface ReviewConfig {
+  agent?: string;
+  command?: string;
+}
+
 export interface OrchestratorConfig {
   /** Optional JSON Schema hint for editor autocomplete/validation. */
   "$schema"?: string;
@@ -1410,6 +1424,9 @@ export interface OrchestratorConfig {
 
   /** Dashboard UI configuration */
   dashboard?: DashboardConfig;
+
+  /** Global AO-local reviewer backend configuration */
+  review?: ReviewConfig;
 
   /** Notification channel configs */
   notifiers: Record<string, NotifierConfig>;
@@ -1575,6 +1592,9 @@ export interface ProjectConfig {
   orchestrator?: RoleAgentConfig;
 
   worker?: RoleAgentConfig;
+
+  /** Per-project AO-local reviewer backend override */
+  review?: ReviewConfig;
 
   /** Per-project reaction overrides */
   reactions?: Record<string, Partial<ReactionConfig>>;

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -902,14 +902,14 @@ describe("hook setup — relative path (symlink-safe)", () => {
     return parsed.hooks.PostToolUse[0].hooks[0].command;
   }
 
-  it("setupWorkspaceHooks writes a relative hook command (not absolute)", async () => {
+  it("setupWorkspaceHooks anchors the hook command to CLAUDE_PROJECT_DIR (not absolute)", async () => {
     await agent.setupWorkspaceHooks!(
       "/Users/equinox/.worktrees/integrator/integrator-5",
       {} as WorkspaceHooksConfig,
     );
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    expect(hookCommand).toBe('"$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.sh');
     expect(hookCommand).not.toMatch(/^\//);
   });
 
@@ -950,7 +950,7 @@ describe("hook setup — relative path (symlink-safe)", () => {
     expect(content1).toBe(content2);
   });
 
-  it("updates an existing absolute hook path to relative", async () => {
+  it("updates an existing absolute hook path to a CLAUDE_PROJECT_DIR-anchored one", async () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFile.mockResolvedValue(
       JSON.stringify({
@@ -978,7 +978,7 @@ describe("hook setup — relative path (symlink-safe)", () => {
     );
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe(".claude/metadata-updater.sh");
+    expect(hookCommand).toBe('"$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.sh');
   });
 
   it("still writes the script file to the correct absolute filesystem path", async () => {
@@ -1021,8 +1021,8 @@ describe("setupWorkspaceHooks — activity-updater (#1941)", () => {
   }
 
   /** Activity-updater command paths (unix vs win32) */
-  const ACTIVITY_CMD_UNIX = ".claude/activity-updater.sh";
-  const ACTIVITY_CMD_WIN = "node .claude/activity-updater.cjs";
+  const ACTIVITY_CMD_UNIX = '"$CLAUDE_PROJECT_DIR"/.claude/activity-updater.sh';
+  const ACTIVITY_CMD_WIN = 'node "$CLAUDE_PROJECT_DIR"/.claude/activity-updater.cjs';
 
   /**
    * Every Claude Code hook event the script knows how to translate into an
@@ -1326,7 +1326,7 @@ describe("setupWorkspaceHooks on win32", () => {
     await agent.setupWorkspaceHooks!("C:\\\\Users\\\\dev\\\\workspace", {} as WorkspaceHooksConfig);
 
     const hookCommand = getWrittenHookCommand();
-    expect(hookCommand).toBe("node .claude/metadata-updater.cjs");
+    expect(hookCommand).toBe('node "$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.cjs');
     expect(hookCommand).not.toContain(".sh");
   });
 

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -1009,8 +1009,8 @@ async function setupHookInWorkspace(workspacePath: string): Promise<void> {
     await writeFile(activityPath, ACTIVITY_UPDATER_SCRIPT_NODE, "utf-8");
     // .cjs forces CJS regardless of workspace package.json "type"; node
     // invocation is required on Windows because shebangs aren't honoured.
-    metadataCommand = "node .claude/metadata-updater.cjs";
-    activityCommand = "node .claude/activity-updater.cjs";
+    metadataCommand = 'node "$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.cjs';
+    activityCommand = 'node "$CLAUDE_PROJECT_DIR"/.claude/activity-updater.cjs';
   } else {
     const metadataPath = join(claudeDir, "metadata-updater.sh");
     const activityPath = join(claudeDir, "activity-updater.sh");
@@ -1018,8 +1018,8 @@ async function setupHookInWorkspace(workspacePath: string): Promise<void> {
     await writeFile(activityPath, ACTIVITY_UPDATER_SCRIPT, "utf-8");
     await chmod(metadataPath, 0o755);
     await chmod(activityPath, 0o755);
-    metadataCommand = ".claude/metadata-updater.sh";
-    activityCommand = ".claude/activity-updater.sh";
+    metadataCommand = '"$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.sh';
+    activityCommand = '"$CLAUDE_PROJECT_DIR"/.claude/activity-updater.sh';
   }
 
   let existingSettings: Record<string, unknown> = {};

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -57,6 +57,9 @@
     "dashboard": {
       "$ref": "#/$defs/dashboardConfig"
     },
+    "review": {
+      "$ref": "#/$defs/reviewConfig"
+    },
     "projects": {
       "type": "object",
       "description": "Project configs keyed by project ID.",
@@ -287,6 +290,25 @@
         }
       }
     },
+    "reviewConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "AO-local reviewer backend. `agent` and `command` are mutually exclusive.",
+      "properties": {
+        "agent": {
+          "type": "string",
+          "enum": ["claude-code", "codex"],
+          "description": "Registered agent plugin with a reviewer adapter."
+        },
+        "command": {
+          "type": "string",
+          "description": "Explicit shell command run in the reviewer workspace; its stdout is parsed for findings."
+        }
+      },
+      "not": {
+        "required": ["agent", "command"]
+      }
+    },
     "projectConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -354,6 +376,9 @@
         },
         "worker": {
           "$ref": "#/$defs/roleAgentConfig"
+        },
+        "review": {
+          "$ref": "#/$defs/reviewConfig"
         },
         "reactions": {
           "type": "object",


### PR DESCRIPTION
## Problem

The Claude Code hook installer (`setupHookInWorkspace` in `packages/plugins/agent-claude-code/src/index.ts`) wrote the hook `command` strings with **relative** script paths:

- POSIX: `.claude/metadata-updater.sh`, `.claude/activity-updater.sh`
- Windows: `node .claude/metadata-updater.cjs`, `node .claude/activity-updater.cjs`

Claude Code runs hook processes with an arbitrary working directory. As soon as a `Bash` tool command does `cd` into another directory, the hook process inherits that cwd, and the relative path no longer resolves. This surfaces as repeated non-blocking PreToolUse/PostToolUse hook errors:

```
.claude/activity-updater.sh: No such file or directory
.claude/metadata-updater.sh: No such file or directory
```

## Fix

Anchor all four command strings to the `$CLAUDE_PROJECT_DIR` environment variable that Claude Code sets for every hook process, quoted so paths containing spaces survive:

- POSIX: `"$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.sh`, `"$CLAUDE_PROJECT_DIR"/.claude/activity-updater.sh`
- Windows: `node "$CLAUDE_PROJECT_DIR"/.claude/metadata-updater.cjs`, `node "$CLAUDE_PROJECT_DIR"/.claude/activity-updater.cjs`

The `$CLAUDE_PROJECT_DIR` is written as a literal into the command string so the **shell** expands it at hook-run time (not at install time).

Note: the updater scripts themselves **already** resolve the workspace via `CLAUDE_PROJECT_DIR` internally (with a `pwd` fallback). This change therefore only fixes **locating** the script file; it does not change the scripts' behavior.

## Tests

Updated the exact-string assertions in `src/index.test.ts` to the new anchored command strings. Build + full test suite pass (271 tests).