### PR TITLE
fix(agent-claude-code): remove invalid PostToolBatch hook event

### DIFF
--- a/packages/plugins/agent-claude-code/src/activity-updater.integration.test.ts
+++ b/packages/plugins/agent-claude-code/src/activity-updater.integration.test.ts
@@ -106,7 +106,6 @@ for (const variant of variants) {
       "PreCompact",
       "PostCompact",
       "SubagentStart",
-      "PostToolBatch",
     ])("writes active for %s", (event) => {
       const { lastEntry } = runHook(variant, { hook_event_name: event });
       expect(lastEntry).not.toBeNull();

--- a/packages/plugins/agent-claude-code/src/index.test.ts
+++ b/packages/plugins/agent-claude-code/src/index.test.ts
@@ -1035,7 +1035,6 @@ describe("setupWorkspaceHooks — activity-updater (#1941)", () => {
     "PreToolUse",
     "PostToolUse",
     "PostToolUseFailure",
-    "PostToolBatch",
     "Notification",
     "PermissionRequest",
     "Stop",

--- a/packages/plugins/agent-claude-code/src/index.ts
+++ b/packages/plugins/agent-claude-code/src/index.ts
@@ -436,7 +436,7 @@ process.exit(0);
  * JSONL entries. Registered on every event whose firing carries activity
  * information (SessionStart, UserPromptSubmit, PreToolUse, PostToolUse,
  * PermissionRequest, Notification, Stop, SubagentStop, StopFailure, PreCompact,
- * PostCompact, SubagentStart, PostToolBatch).
+ * PostCompact, SubagentStart).
  *
  * Reads the JSON payload from stdin, parses `hook_event_name`, maps it to an
  * activity state, and appends a single JSONL entry to
@@ -479,7 +479,7 @@ case "$event" in
     state="ready"
     trigger="$event"
     ;;
-  UserPromptSubmit|PreToolUse|PostToolUse|PostToolUseFailure|PreCompact|PostCompact|SubagentStart|PostToolBatch)
+  UserPromptSubmit|PreToolUse|PostToolUse|PostToolUseFailure|PreCompact|PostCompact|SubagentStart)
     state="active"
     trigger="$event"
     ;;
@@ -605,7 +605,6 @@ switch (event) {
   case "PreCompact":
   case "PostCompact":
   case "SubagentStart":
-  case "PostToolBatch":
     state = "active";
     trigger = event;
     break;
@@ -958,7 +957,6 @@ function buildHookRegistrations(
     "PreToolUse",
     "PostToolUse",
     "PostToolUseFailure",
-    "PostToolBatch",
     "Notification",
     "PermissionRequest",
     "Stop",


### PR DESCRIPTION
## Summary

- Remove `PostToolBatch` from the `activityEvents` array in the Claude Code agent plugin
- `PostToolBatch` is not recognized by Claude Code versions prior to ~v2.1.145
- On versions before v2.1.101, an unrecognized hook event name causes the **entire** `settings.json` to be rejected with `"Invalid key in record"`, which kills the agent session immediately in non-interactive (tmux) environments

## Root cause

Commit `7d9b862e` added `PostToolBatch` to the activity events list, verified against the current Claude Code docs. However, older Claude Code versions don't recognize this event. Before v2.1.101, Claude Code's settings validation was strict — any unknown key rejected the whole file, showing an interactive prompt that can't be answered in tmux, causing the process to exit.

## Impact

- On Claude Code >= v2.1.145: no issue (PostToolBatch is valid)
- On Claude Code v2.1.101–v2.1.144: silently ignored (harmless but hook never fires)
- On Claude Code < v2.1.101: **entire settings.json rejected**, all hooks broken, session exits immediately

## Why this is safe

`PostToolUse` already fires for each individual tool in a batch, so activity is still detected. `PostToolBatch` only adds one redundant "active" signal after the batch completes.

## Test plan

- [ ] Verify `pnpm test` passes in `packages/plugins/agent-claude-code`
- [ ] Verify `ao start` creates sessions that stay alive on Claude Code < v2.1.145
- [ ] Verify activity tracking still works without `PostToolBatch`